### PR TITLE
Implement dev-services support for the Oracle Database

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>quarkus-parent</artifactId>
         <groupId>io.quarkus</groupId>
@@ -627,6 +627,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devservices-mssql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devservices-oracle</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/extensions/devservices/oracle/pom.xml
+++ b/extensions/devservices/oracle/pom.xml
@@ -3,38 +3,48 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>quarkus-jdbc-oracle-parent</artifactId>
+        <artifactId>quarkus-devservices-parent</artifactId>
         <groupId>io.quarkus</groupId>
         <version>999-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
-    <name>Quarkus - JDBC - Oracle - Deployment</name>
-
+    <artifactId>quarkus-devservices-oracle</artifactId>
+    <name>Quarkus - DevServices - Oracle</name>
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-agroal-spi</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-deployment-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-oracle</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-devservices-oracle</artifactId>
+            <artifactId>quarkus-devservices-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager-embedded</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -1,0 +1,106 @@
+package io.quarkus.devservices.oracle.deployment;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.datasource.common.runtime.DatabaseKind;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProvider;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.runtime.LaunchMode;
+
+public class OracleDevServicesProcessor {
+
+    private static final Logger LOG = Logger.getLogger(OracleDevServicesProcessor.class);
+
+    public static final String IMAGE = "gvenzl/oracle-xe";
+    public static final String TAG = "18.4.0-slim";
+    public static final String DEFAULT_DATABASE_USER = "quarkus";
+    public static final String DEFAULT_DATABASE_PASSWORD = "quarkus";
+    public static final String DEFAULT_DATABASE_NAME = "quarkusdb";
+    public static final int PORT = 1521;
+
+    @BuildStep
+    DevServicesDatasourceProviderBuildItem setupOracle(
+            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+        return new DevServicesDatasourceProviderBuildItem(DatabaseKind.ORACLE, new DevServicesDatasourceProvider() {
+            @Override
+            public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
+                    Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
+                    OptionalInt fixedExposedPort, LaunchMode launchMode) {
+                QuarkusOracleServerContainer container = new QuarkusOracleServerContainer(imageName, fixedExposedPort,
+                        devServicesSharedNetworkBuildItem.isPresent());
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USER))
+                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
+                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+                additionalProperties.forEach(container::withUrlParam);
+                container.start();
+
+                LOG.info("Dev Services for Oracle started.");
+
+                return new RunningDevServicesDatasource(container.getEffectiveJdbcUrl(), container.getUsername(),
+                        container.getPassword(),
+                        new Closeable() {
+                            @Override
+                            public void close() throws IOException {
+                                container.stop();
+
+                                LOG.info("Dev Services for Oracle shut down.");
+                            }
+                        });
+            }
+        });
+    }
+
+    private static class QuarkusOracleServerContainer extends OracleContainer {
+        private final OptionalInt fixedExposedPort;
+        private final boolean useSharedNetwork;
+
+        private String hostName = null;
+
+        public QuarkusOracleServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
+                boolean useSharedNetwork) {
+            super(DockerImageName
+                    .parse(imageName.orElse(OracleDevServicesProcessor.IMAGE + ":" + OracleDevServicesProcessor.TAG))
+                    .asCompatibleSubstituteFor(OracleDevServicesProcessor.IMAGE));
+            this.fixedExposedPort = fixedExposedPort;
+            this.useSharedNetwork = useSharedNetwork;
+        }
+
+        @Override
+        protected void configure() {
+            super.configure();
+
+            if (useSharedNetwork) {
+                hostName = ConfigureUtil.configureSharedNetwork(this, "oracle");
+                return;
+            }
+
+            if (fixedExposedPort.isPresent()) {
+                addFixedExposedPort(fixedExposedPort.getAsInt(), OracleDevServicesProcessor.PORT);
+            }
+        }
+
+        // this is meant to be called by Quarkus code and is needed in order to not disrupt testcontainers
+        // from being able to determine the status of the container (which it does by trying to acquire a connection)
+        public String getEffectiveJdbcUrl() {
+            if (useSharedNetwork) {
+                // in this case we expose the URL using the network alias we created in 'configure'
+                // and the container port since the application communicating with this container
+                // won't be doing port mapping
+                return "jdbc:oracle:thin//" + hostName + ":" + PORT + ":" + getDatabaseName();
+            } else {
+                return super.getJdbcUrl();
+            }
+        }
+    }
+}

--- a/extensions/devservices/pom.xml
+++ b/extensions/devservices/pom.xml
@@ -25,6 +25,7 @@
         <module>derby</module>
         <module>mssql</module>
         <module>db2</module>
+        <module>oracle</module>
         <module>common</module>
     </modules>
 

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleProcessor.java
@@ -7,6 +7,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.datasource.deployment.spi.DevServicesDatasourceConfigurationHandlerBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -33,6 +34,11 @@ public class OracleProcessor {
     void registerDriver(BuildProducer<JdbcDriverBuildItem> jdbcDriver) {
         jdbcDriver.produce(new JdbcDriverBuildItem(DatabaseKind.ORACLE, "oracle.jdbc.driver.OracleDriver",
                 "oracle.jdbc.xa.client.OracleXADataSource"));
+    }
+
+    @BuildStep
+    DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
+        return DevServicesDatasourceConfigurationHandlerBuildItem.jdbc(DatabaseKind.ORACLE);
     }
 
     @BuildStep


### PR DESCRIPTION
This PR implements the Oracle dev-services (quarkusio#20930). However, there's an issue that looks exactly like an issue that the Micronaut team reported to the Hibernate project a few days ago:
An exception occurs when the application uses "drop-and-create" schema strategy and the tables to be dropped don't exist in the database.
See: https://hibernate.atlassian.net/browse/HHH-14889

The tables are created eventually and the application seems to work fine. But Hibernate logs a warning with ORA-00942 ("table or view does not exist") after the Oracle container has started.
At this point I don't quite see a way to work around this issue and I'm unsure whether this issue prevents a merge. I'm still creating a pull request in case you decide that it's still useful or can share some hints on how to fix the issue.
