### PR TITLE
Upstream graal dropped support for outdated JDK versions between 11 and 17

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LCMSSubstitutions.java
@@ -1,10 +1,12 @@
 package io.quarkus.runtime.graal;
 
 import java.awt.color.ICC_Profile;
+import java.util.function.BooleanSupplier;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK16OrEarlier;
+
+import io.quarkus.runtime.util.JavaVersionUtil;
 
 @TargetClass(className = "sun.java2d.cmm.lcms.LCMS", onlyWith = JDK16OrEarlier.class)
 final class Target_sun_java2d_cmm_lcms_LCMS {
@@ -73,4 +75,15 @@ final class Target_sun_java2d_cmm_lcms_LCMS {
     static final class LCMSTransform {
     }
 
+}
+
+/*
+ * Replacement for com.oracle.svm.core.jdk.JDK16OrEarlier which got
+ * removed after the 21.3 release.
+ */
+class JDK16OrEarlier implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.isJava16OrLower();
+    }
 }


### PR DESCRIPTION
Starting with GraalVM 22 JDK versions between 11 and 17 will no longer
be supported.  See oracle/graal#3924

This patch allows Quarkus to keep supporting JDK 16 (with GraalVM 21.2)
while working with GraalVM's tip as well.