### PR TITLE
Run Native tests for Hibernate Validator + Resteasy Reactive

### DIFF
--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityInGraalITCase.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.hibernate.validator;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * Test various Bean Validation operations running in native mode
+ */
+@QuarkusIntegrationTest
+public class HibernateValidatorFunctionalityInGraalITCase extends HibernateValidatorFunctionalityTest {
+
+    @Override
+    protected boolean isTestsInJVM() {
+        return false;
+    }
+
+}


### PR DESCRIPTION
This follows the same approach as in the Hibernate Validator + Resteasy Classic.