### PR TITLE
Fix MediaType resolution for Hibernate Validator when MediaType has components

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
@@ -29,15 +29,30 @@ public final class ValidatorMediaTypeUtil {
     public static Optional<MediaType> getAcceptMediaType(List<MediaType> mediaTypesFromRequest,
             List<MediaType> mediaTypesFromProducesAnnotation) {
 
-        Optional<MediaType> mediaType = mediaTypesFromRequest.stream()
-                // It's supported
-                .filter(SUPPORTED_MEDIA_TYPES::contains)
-                // It's included in the `@Produces` annotation
-                .filter(mediaTypesFromProducesAnnotation::contains)
-                .findFirst()
-                // if none is found, then return the first from the annotation
-                .or(mediaTypesFromProducesAnnotation.stream()::findFirst);
+        for (MediaType mediaType : mediaTypesFromRequest) {
+            // It's supported and is included in the `@Produces` annotation
+            if (isMediaTypeInList(mediaType, SUPPORTED_MEDIA_TYPES)
+                    && isMediaTypeInList(mediaType, mediaTypesFromProducesAnnotation)) {
+                return Optional.of(mediaType);
+            }
+        }
 
-        return mediaType;
+        // if none is found, then return the first from the annotation or empty if no produces annotation
+        if (mediaTypesFromProducesAnnotation.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(mediaTypesFromProducesAnnotation.get(0));
+    }
+
+    private static boolean isMediaTypeInList(MediaType mediaType, List<MediaType> list) {
+        for (MediaType item : list) {
+            if (mediaType.getType().equalsIgnoreCase(item.getType())
+                    && mediaType.getSubtype().equalsIgnoreCase(item.getSubtype())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -206,6 +206,18 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testRestEndPointValidationUsingXmlMediaTypeWithComponents() {
+        // The components of MediaType like "charset" should be ignored.
+        RestAssured.given()
+                .header("Accept", "application/xml;charset=UTF8")
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.XML)
+                .body("violationReport.parameterViolations.message", containsString("numeric value out of bounds"));
+    }
+
+    @Test
     public void testRestEndPointReturnValueValidation() {
         // https://github.com/quarkusio/quarkus/issues/9174
         // Constraint validation exceptions thrown by Resteasy and related to return values


### PR DESCRIPTION
When a media type has components, for example: "application/json;charset=UTF8", the mediatype resolution logic for hibernate validator is not working fine.
This is a regression due to this change: https://github.com/quarkusio/quarkus/pull/20863

Before we were using the MediaType.getType and MediaType.getSubType to check a matching media type. 
After https://github.com/quarkusio/quarkus/pull/20863 was done, it uses MediaType.equals which uses getType, getSubType **ang getComponents**.

This PR reverts this change by using again only the MediaType.getType and MediaType.getSubType methods.

++ I've also added a test case to avoid this issue happens again in the future.