### PR TITLE
Exclude tomcat-embed-core

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2948,6 +2948,12 @@
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-thrift</artifactId>
                 <version>${jaeger.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.jaegertracing</groupId>
@@ -2961,6 +2967,10 @@
                     <exclusion>
                         <groupId>javax.annotation</groupId>
                         <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -516,6 +516,8 @@
                                             <exclude>org.jboss.resteasy:resteasy-context-propagation</exclude>
                                             <exclude>com.google.android:annotations</exclude>
                                             <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
+                                            <!-- Includes its own copy of an old version of the servlet API-->
+                                            <exclude>org.apache.tomcat.embed:tomcat-embed-core</exclude>
                                         </excludes>
                                         <includes>
                                             <!-- this is for REST Assured -->


### PR DESCRIPTION
It contains an old copy of the Servlet API and causes problems.

Fixes #20910