### PR TITLE
Restrict deployment classpath to first level extensions

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -1,15 +1,19 @@
 package io.quarkus.gradle.dependency;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalDependency;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 
-public class ApplicationDeploymentClasspathBuilder {
+import io.quarkus.gradle.tooling.ToolingUtils;
 
-    private static final String DEPLOYMENT_CONFIGURATION_SUFFIX = "Deployment";
+public class ApplicationDeploymentClasspathBuilder {
 
     private final Project project;
     private final Set<ExtensionDependency> alreadyProcessed = new HashSet<>();
@@ -18,15 +22,22 @@ public class ApplicationDeploymentClasspathBuilder {
         this.project = project;
     }
 
-    public static String toDeploymentConfigurationName(String baseConfigurationName) {
-        return baseConfigurationName + DEPLOYMENT_CONFIGURATION_SUFFIX;
-    }
-
-    public synchronized void createBuildClasspath(Set<ExtensionDependency> extensions, String baseConfigurationName) {
-        String deploymentConfigurationName = toDeploymentConfigurationName(baseConfigurationName);
+    public synchronized void createBuildClasspath(Set<ExtensionDependency> knownExtensions, String baseConfigurationName) {
+        String deploymentConfigurationName = ToolingUtils.toDeploymentConfigurationName(baseConfigurationName);
         project.getConfigurations().create(deploymentConfigurationName);
-
         DependencyHandler dependencies = project.getDependencies();
+
+        Set<ExtensionDependency> extensions = collectFirstMetQuarkusExtensions(
+                DependencyUtils.duplicateConfiguration(project, project.getConfigurations().getByName(baseConfigurationName)),
+                knownExtensions);
+
+        // Add conditional extensions
+        for (ExtensionDependency knownExtension : knownExtensions) {
+            if (knownExtension.isConditional) {
+                extensions.add(knownExtension);
+            }
+        }
+
         for (ExtensionDependency extension : extensions) {
             requireDeploymentDependency(deploymentConfigurationName, extension, dependencies);
             if (alreadyProcessed.contains(extension)) {
@@ -37,11 +48,59 @@ public class ApplicationDeploymentClasspathBuilder {
         }
     }
 
+    private Set<ExtensionDependency> collectFirstMetQuarkusExtensions(Configuration configuration,
+            Set<ExtensionDependency> knownExtensions) {
+
+        Set<ExtensionDependency> firstLevelExtensions = new HashSet<>();
+        Set<ResolvedDependency> firstLevelModuleDependencies = configuration.getResolvedConfiguration()
+                .getFirstLevelModuleDependencies();
+
+        Set<String> visitedArtifacts = new HashSet<>();
+        for (ResolvedDependency firstLevelModuleDependency : firstLevelModuleDependencies) {
+            firstLevelExtensions
+                    .addAll(collectQuarkusExtensions(firstLevelModuleDependency, visitedArtifacts, knownExtensions));
+        }
+        return firstLevelExtensions;
+    }
+
+    private Set<ExtensionDependency> collectQuarkusExtensions(ResolvedDependency dependency, Set<String> visitedArtifacts,
+            Set<ExtensionDependency> knownExtensions) {
+        String artifactKey = String.format("%s:%s", dependency.getModuleGroup(), dependency.getModuleName());
+        if (visitedArtifacts.contains(artifactKey)) {
+            return Collections.emptySet();
+        } else {
+            visitedArtifacts.add(artifactKey);
+        }
+
+        Set<ExtensionDependency> extensions = new LinkedHashSet<>();
+        ExtensionDependency extension = getExtensionOrNull(dependency.getModuleGroup(), dependency.getModuleName(),
+                dependency.getModuleVersion(), knownExtensions);
+        if (extension != null) {
+            extensions.add(extension);
+        } else {
+            for (ResolvedDependency child : dependency.getChildren()) {
+                extensions.addAll(collectQuarkusExtensions(child, visitedArtifacts, knownExtensions));
+            }
+        }
+        return extensions;
+    }
+
     private void requireDeploymentDependency(String deploymentConfigurationName, ExtensionDependency extension,
             DependencyHandler dependencies) {
         ExternalDependency dependency = (ExternalDependency) dependencies.add(deploymentConfigurationName,
                 extension.asDependencyNotation());
         dependency.capabilities(
                 handler -> handler.requireCapability(DependencyUtils.asCapabilityNotation(extension.deploymentModule)));
+    }
+
+    private ExtensionDependency getExtensionOrNull(String group, String artifact, String version,
+            Set<ExtensionDependency> knownExtensions) {
+        for (ExtensionDependency knownExtension : knownExtensions) {
+            if (group.equals(knownExtension.getGroup()) && artifact.equals(knownExtension.getName())
+                    && version.equals(knownExtension.getVersion())) {
+                return knownExtension;
+            }
+        }
+        return null;
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -81,6 +81,7 @@ public class ConditionalDependenciesEnabler {
                 if (DependencyUtils.exist(availableRuntimeArtifacts,
                         extensionDependency.dependencyConditions)) {
                     enableConditionalDependency(extensionDependency.extensionId);
+                    extensionDependency.setConditional(true);
                     allExtensions.add(extensionDependency);
                     if (!extensionDependency.conditionalDependencies.isEmpty()) {
                         featureVariants.putAll(extractFeatureVariants(Collections.singletonList(extensionDependency)));

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/DependencyUtils.java
@@ -157,7 +157,8 @@ public class DependencyUtils {
     public static ExtensionDependency getExtensionInfoOrNull(Project project, ResolvedArtifact artifact) {
         ModuleVersionIdentifier artifactId = artifact.getModuleVersion().getId();
         File artifactFile = artifact.getFile();
-        if (!artifactFile.exists() || !"jar".equals(artifact.getExtension())) {
+
+        if (!artifactFile.exists()) {
             return null;
         }
         if (artifactFile.isDirectory()) {
@@ -165,7 +166,7 @@ public class DependencyUtils {
             if (Files.exists(descriptorPath)) {
                 return loadExtensionInfo(project, descriptorPath, artifactId);
             }
-        } else {
+        } else if ("jar".equals(artifact.getExtension())) {
             try (FileSystem artifactFs = ZipUtils.newFileSystem(artifactFile.toPath())) {
                 Path descriptorPath = artifactFs.getPath(BootstrapConstants.DESCRIPTOR_PATH);
                 if (Files.exists(descriptorPath)) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
@@ -19,6 +19,7 @@ public class ExtensionDependency {
     AppArtifactCoords deploymentModule;
     List<Dependency> conditionalDependencies;
     List<ArtifactKey> dependencyConditions;
+    boolean isConditional;
 
     ExtensionDependency(ModuleVersionIdentifier extensionId, AppArtifactCoords deploymentModule,
             List<Dependency> conditionalDependencies,
@@ -100,6 +101,14 @@ public class ExtensionDependency {
 
     public String getName() {
         return extensionId.getName();
+    }
+
+    public String getVersion() {
+        return extensionId.getVersion();
+    }
+
+    public void setConditional(boolean isConditional) {
+        this.isConditional = isConditional;
     }
 
     @Override

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/deployment/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-core-deployment'
+    implementation project(':ext-g:deployment')
     implementation project(':ext-f:runtime')
 }
 


### PR DESCRIPTION
This branch rework the way the deployment classpath is built. 
This now goes down the dependency graph and stop on first level extension. 
conditional dependencies are added afterward. 

close #20767 