### PR TITLE
Upgrade to Hibernate ORM 5.6.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.0.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.6.1.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.0.0.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.7.Final</hibernate-search.version>


### PR DESCRIPTION
Fixes #5903, because ORM 5.6.1 fixes [HHH-13766](https://hibernate.atlassian.net/browse/HHH-13766). Though to be honest ORM 5.6.1 only adds a test to check that the bug is fixed; it most likely was fixed in a previous version. 

Fixes a few ORM bugs that must be fixed before we can consider merging #20708:

* https://hibernate.atlassian.net/browse/HHH-14880
* https://hibernate.atlassian.net/browse/HHH-14881
* https://hibernate.atlassian.net/browse/HHH-14869