### PR TITLE
Resteasy Reactive: Support produces Multipart FormData

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -406,8 +406,6 @@ that will hold this information like so:
 
 [source,java]
 ----
-import java.util.Map;
-
 import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.PartType;
@@ -474,6 +472,49 @@ Moreoever if `quarkus.http.body.delete-uploaded-files-on-end` is set to true, Qu
 the file will reside on the file system of the server (in the directory defined by the `quarkus.http.body.uploads-directory` configuration option), but as the uploaded files are saved
 with a UUID file name and no additional metadata is saved, these files are essentially a random dump of files.
 
+Similarly, RESTEasy Reactive can produce Multipart Form data to allow users download files from the server. For example, we could write a POJO
+that will hold the information we want to expose as:
+
+[source,java]
+----
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class DownloadFormData {
+
+    @RestForm
+    String name;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_OCTET_STREAM)
+    File file;
+}
+----
+
+And then expose this POJO via a Resource like so:
+
+[source,java]
+----
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("multipart")
+public class Endpoint {
+
+    @GET
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    @Path("file")
+    public DownloadFormData getFile() {
+        // return something
+    }
+}
+----
+
+WARNING: For the time being, returning Multipart data is limited to be blocking endpoints. 
 
 === Returning a response body
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/deployment/processor/ResteasyReactiveJaxbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/deployment/processor/ResteasyReactiveJaxbProcessor.java
@@ -25,7 +25,7 @@ public class ResteasyReactiveJaxbProcessor {
     void additionalProviders(BuildProducer<AdditionalBeanBuildItem> additionalBean,
             BuildProducer<MessageBodyReaderBuildItem> additionalReaders,
             BuildProducer<MessageBodyWriterBuildItem> additionalWriters) {
-        // make these beans to they can get instantiated with the Quarkus CDI configured Jsonb object
+        // make these beans to they can get instantiated with the Quarkus CDI
         additionalBean.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClass(JaxbMessageBodyReader.class.getName())
                 .addBeanClass(JaxbMessageBodyWriter.class.getName())

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/MultipartOutputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/MultipartOutputTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.resteasy.reactive.jaxb.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class MultipartOutputTest {
+    private static final String EXPECTED_CONTENT_DISPOSITION_PART = "Content-Disposition: form-data; name=\"%s\"";
+    private static final String EXPECTED_CONTENT_TYPE_PART = "Content-Type: %s";
+    private static final String EXPECTED_RESPONSE_NAME = "a name";
+    private static final String EXPECTED_RESPONSE_PERSON_NAME = "Michal";
+    private static final int EXPECTED_RESPONSE_PERSON_AGE = 23;
+    private static final String EXPECTED_RESPONSE_PERSON = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+            + "<person>\n"
+            + "    <age>" + EXPECTED_RESPONSE_PERSON_AGE + "</age>\n"
+            + "    <name>" + EXPECTED_RESPONSE_PERSON_NAME + "</name>\n"
+            + "</person>";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MultipartOutputResource.class, MultipartOutputResponse.class, Person.class));
+
+    @Test
+    public void testSimple() {
+        String response = RestAssured.get("/multipart/output")
+                .then()
+                .contentType(ContentType.MULTIPART)
+                .statusCode(200)
+                .extract().asString();
+
+        assertContains(response, "name", MediaType.TEXT_PLAIN, EXPECTED_RESPONSE_NAME);
+        assertContains(response, "person", MediaType.APPLICATION_XML, EXPECTED_RESPONSE_PERSON);
+    }
+
+    private void assertContains(String response, String name, String contentType, Object value) {
+        String[] lines = response.split("--");
+        assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_PART, name))
+                && line.contains(String.format(EXPECTED_CONTENT_TYPE_PART, contentType))
+                && line.contains(value.toString()));
+    }
+
+    @Path("/multipart/output")
+    private static class MultipartOutputResource {
+
+        @GET
+        @Produces(MediaType.MULTIPART_FORM_DATA)
+        public MultipartOutputResponse simple() {
+            MultipartOutputResponse response = new MultipartOutputResponse();
+            response.name = EXPECTED_RESPONSE_NAME;
+            response.person = new Person();
+            response.person.name = EXPECTED_RESPONSE_PERSON_NAME;
+            response.person.age = EXPECTED_RESPONSE_PERSON_AGE;
+            return response;
+        }
+
+    }
+
+    private static class MultipartOutputResponse {
+
+        @RestForm
+        String name;
+
+        @RestForm
+        @PartType(MediaType.APPLICATION_XML)
+        Person person;
+    }
+
+    private static class Person {
+        private String name;
+        private Integer age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/MultipartOutputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/MultipartOutputTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.resteasy.reactive.jsonb.deployment.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class MultipartOutputTest {
+    private static final String EXPECTED_CONTENT_DISPOSITION_PART = "Content-Disposition: form-data; name=\"%s\"";
+    private static final String EXPECTED_CONTENT_TYPE_PART = "Content-Type: %s";
+    private static final String EXPECTED_RESPONSE_NAME = "a name";
+    private static final String EXPECTED_RESPONSE_PERSON_NAME = "Michal";
+    private static final int EXPECTED_RESPONSE_PERSON_AGE = 23;
+    private static final String EXPECTED_RESPONSE_PERSON = "{\"age\":" + EXPECTED_RESPONSE_PERSON_AGE
+            + ",\"name\":\"" + EXPECTED_RESPONSE_PERSON_NAME + "\"}";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MultipartOutputResource.class, MultipartOutputResponse.class, Person.class));
+
+    @Test
+    public void testSimple() {
+        String response = RestAssured.get("/multipart/output")
+                .then()
+                .contentType(ContentType.MULTIPART)
+                .statusCode(200)
+                .log().all()
+                .extract().asString();
+
+        assertContains(response, "name", MediaType.TEXT_PLAIN, EXPECTED_RESPONSE_NAME);
+        assertContains(response, "person", MediaType.APPLICATION_JSON, EXPECTED_RESPONSE_PERSON);
+    }
+
+    private void assertContains(String response, String name, String contentType, Object value) {
+        String[] lines = response.split("--");
+        assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_PART, name))
+                && line.contains(String.format(EXPECTED_CONTENT_TYPE_PART, contentType))
+                && line.contains(value.toString()));
+    }
+
+    @Path("/multipart/output")
+    private static class MultipartOutputResource {
+
+        @GET
+        @Produces(MediaType.MULTIPART_FORM_DATA)
+        public MultipartOutputResponse simple() {
+            MultipartOutputResponse response = new MultipartOutputResponse();
+            response.name = EXPECTED_RESPONSE_NAME;
+            response.person = new Person();
+            response.person.name = EXPECTED_RESPONSE_PERSON_NAME;
+            response.person.age = EXPECTED_RESPONSE_PERSON_AGE;
+            return response;
+        }
+
+    }
+
+    private static class MultipartOutputResponse {
+
+        @RestForm
+        String name;
+
+        @RestForm
+        @PartType(MediaType.APPLICATION_JSON)
+        Person person;
+    }
+
+    public static class Person {
+        private String name;
+        private Integer age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FormDataOutputMapperGenerator.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FormDataOutputMapperGenerator.java
@@ -1,0 +1,255 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.FORM_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_FORM_PARAM;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
+
+import io.quarkus.deployment.bean.JavaBeanUtil;
+import io.quarkus.gizmo.AssignableResultHandle;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.resteasy.reactive.server.runtime.multipart.MultipartMessageBodyWriter;
+import io.quarkus.resteasy.reactive.server.runtime.multipart.MultipartOutputInjectionTarget;
+import io.quarkus.resteasy.reactive.server.runtime.multipart.PartItem;
+
+final class FormDataOutputMapperGenerator {
+
+    private static final Logger LOGGER = Logger.getLogger(FormDataOutputMapperGenerator.class);
+
+    private static final String TRANSFORM_METHOD_NAME = "mapFrom";
+    private static final String ARRAY_LIST_ADD_METHOD_NAME = "add";
+
+    private FormDataOutputMapperGenerator() {
+    }
+
+    /**
+     * Returns true whether the returning type uses either {@link org.jboss.resteasy.reactive.RestForm}
+     * or {@link org.jboss.resteasy.reactive.server.core.multipart.FormData} annotations.
+     */
+    public static boolean isReturnTypeCompatible(ClassInfo returnTypeClassInfo, IndexView index) {
+        // go up the class hierarchy until we reach Object
+        ClassInfo currentClassInHierarchy = returnTypeClassInfo;
+        while (true) {
+            List<FieldInfo> fields = currentClassInHierarchy.fields();
+            for (FieldInfo field : fields) {
+                if (Modifier.isStatic(field.flags())) { // nothing we need to do about static fields
+                    continue;
+                }
+
+                if (field.annotation(REST_FORM_PARAM) != null || field.annotation(FORM_PARAM) != null) {
+                    // Found either @RestForm or @FormParam in returning class, it's compatible.
+                    return true;
+                }
+            }
+
+            DotName superClassDotName = currentClassInHierarchy.superName();
+            if (superClassDotName.equals(DotNames.OBJECT_NAME)) {
+                break;
+            }
+            ClassInfo newCurrentClassInHierarchy = index.getClassByName(superClassDotName);
+            if (newCurrentClassInHierarchy == null) {
+                printWarningMessageForMissingJandexIndex(currentClassInHierarchy, superClassDotName);
+                break;
+            }
+
+            currentClassInHierarchy = newCurrentClassInHierarchy;
+        }
+
+        // if we reach this point then the returning type is not compatible.
+        return false;
+    }
+
+    /**
+     * Generates a class that map a Pojo into {@link PartItem} that is then used by {@link MultipartMessageBodyWriter}.
+     *
+     * <p>
+     * For example for a pojo like:
+     *
+     * <pre>
+     * public class FormData {
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.TEXT_PLAIN)
+     *     private String text;
+     *
+     *     &#64;RestForm
+     *     &#64;PartType(MediaType.APPLICATION_OCTET_STREAM)
+     *     public File file;
+     *
+     *     public String getText() {
+     *         return text;
+     *     }
+     *
+     *     public void setText(String text) {
+     *         this.text = text;
+     *     }
+     *
+     *     public File getFile() {
+     *         return file;
+     *     }
+     *
+     *     public void setFile(File file) {
+     *         this.file = file;
+     *     }
+     * }
+     * </pre>
+     *
+     * <p>
+     *
+     * The generated mapper would look like:
+     *
+     * <pre>
+     * public class FormData_generated_mapper implements MultipartOutputInjectionTarget {
+     *
+     *     public FormDataOutput mapFrom(Object var1) {
+     *         FormDataOutput var2 = new FormDataOutput();
+     *         FormData var4 = (FormData) var1;
+     *         File var3 = var4.data;
+     *         MultipartSupport.addPartItemToFormDataOutput(var2, "file", "application/octet-stream", var3);
+     *         File var5 = var4.text;
+     *         MultipartSupport.addPartItemToFormDataOutput(var2, "text", "text/plain", var5);
+     *         return var2;
+     *     }
+     * }
+     * </pre>
+     */
+    static String generate(ClassInfo returnTypeClassInfo, ClassOutput classOutput, IndexView index) {
+        String returnClassName = returnTypeClassInfo.name().toString();
+        String generateClassName = MultipartMessageBodyWriter.getGeneratedMapperClassNameFor(returnClassName);
+        String interfaceClassName = MultipartOutputInjectionTarget.class.getName();
+        try (ClassCreator cc = new ClassCreator(classOutput, generateClassName, null, Object.class.getName(),
+                interfaceClassName)) {
+            MethodCreator populate = cc.getMethodCreator(TRANSFORM_METHOD_NAME, List.class.getName(),
+                    Object.class);
+            populate.setModifiers(Modifier.PUBLIC);
+
+            ResultHandle listPartItemListInstanceHandle = populate.newInstance(MethodDescriptor.ofConstructor(ArrayList.class));
+            ResultHandle inputInstanceHandle = populate.checkCast(populate.getMethodParam(0), returnClassName);
+
+            // go up the class hierarchy until we reach Object
+            ClassInfo currentClassInHierarchy = returnTypeClassInfo;
+            while (true) {
+                List<FieldInfo> fields = currentClassInHierarchy.fields();
+                for (FieldInfo field : fields) {
+                    if (Modifier.isStatic(field.flags())) { // nothing we need to do about static fields
+                        continue;
+                    }
+
+                    AnnotationInstance formParamInstance = field.annotation(REST_FORM_PARAM);
+                    if (formParamInstance == null) {
+                        formParamInstance = field.annotation(FORM_PARAM);
+                    }
+                    if (formParamInstance == null) { // fields not annotated with @RestForm or @FormParam are completely ignored
+                        continue;
+                    }
+
+                    boolean useFieldAccess = false;
+                    String getterName = JavaBeanUtil.getGetterName(field.name(), field.type().name());
+                    Type fieldType = field.type();
+                    DotName fieldDotName = fieldType.name();
+                    MethodInfo getter = currentClassInHierarchy.method(getterName);
+                    if (getter == null) {
+                        // even if the field is private, it will be transformed to be made public
+                        useFieldAccess = true;
+                    }
+                    if (!useFieldAccess && !Modifier.isPublic(getter.flags())) {
+                        throw new IllegalArgumentException(
+                                "Getter '" + getterName + "' of class '" + returnTypeClassInfo + "' must be public");
+                    }
+
+                    String formAttrName = field.name();
+                    AnnotationValue formParamValue = formParamInstance.value();
+                    if (formParamValue != null) {
+                        formAttrName = formParamValue.asString();
+                    }
+
+                    // TODO: not sure this is correct, but it seems to be what RESTEasy does and it also makes most sense in the context of a POJO
+                    String partType = MediaType.TEXT_PLAIN;
+                    AnnotationInstance partTypeInstance = field.annotation(ResteasyReactiveDotNames.PART_TYPE_NAME);
+                    if (partTypeInstance != null) {
+                        AnnotationValue partTypeValue = partTypeInstance.value();
+                        if (partTypeValue != null) {
+                            partType = partTypeValue.asString();
+                        }
+                    }
+
+                    // Cast part type to MediaType.
+                    AssignableResultHandle partTypeHandle = populate.createVariable(MediaType.class);
+                    populate.assign(partTypeHandle,
+                            populate.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(MediaType.class, "valueOf", MediaType.class, String.class),
+                                    populate.load(partType)));
+
+                    // Continue with the value
+                    AssignableResultHandle resultHandle = populate.createVariable(Object.class);
+
+                    if (useFieldAccess) {
+                        populate.assign(resultHandle,
+                                populate.readInstanceField(
+                                        FieldDescriptor.of(currentClassInHierarchy.name().toString(), field.name(),
+                                                fieldDotName.toString()),
+                                        inputInstanceHandle));
+                    } else {
+                        populate.assign(resultHandle,
+                                populate.invokeVirtualMethod(
+                                        MethodDescriptor.ofMethod(currentClassInHierarchy.name().toString(),
+                                                getterName, fieldDotName.toString()),
+                                        inputInstanceHandle));
+                    }
+
+                    // Create Part Item instance
+                    ResultHandle partItemInstanceHandle = populate.newInstance(
+                            MethodDescriptor.ofConstructor(PartItem.class, String.class, MediaType.class, Object.class),
+                            populate.load(formAttrName), partTypeHandle, resultHandle);
+
+                    // Add it to the list
+                    populate.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(ArrayList.class, ARRAY_LIST_ADD_METHOD_NAME, boolean.class, Object.class),
+                            listPartItemListInstanceHandle, partItemInstanceHandle);
+                }
+
+                DotName superClassDotName = currentClassInHierarchy.superName();
+                if (superClassDotName.equals(DotNames.OBJECT_NAME)) {
+                    break;
+                }
+                ClassInfo newCurrentClassInHierarchy = index.getClassByName(superClassDotName);
+                if (newCurrentClassInHierarchy == null) {
+                    printWarningMessageForMissingJandexIndex(currentClassInHierarchy, superClassDotName);
+                    break;
+                }
+                currentClassInHierarchy = newCurrentClassInHierarchy;
+            }
+
+            populate.returnValue(listPartItemListInstanceHandle);
+        }
+        return generateClassName;
+    }
+
+    private static void printWarningMessageForMissingJandexIndex(ClassInfo currentClassInHierarchy, DotName superClassDotName) {
+        if (!superClassDotName.toString().startsWith("java.")) {
+            LOGGER.warn("Class '" + superClassDotName + "' which is a parent class of '"
+                    + currentClassInHierarchy.name()
+                    + "' is not part of the Jandex index so its fields will be ignored. If you intended to include these fields, consider making the dependency part of the Jandex index by following the advice at: https://quarkus.io/guides/cdi-reference#bean_discovery");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputFileResponse.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputFileResponse.java
@@ -1,0 +1,18 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import java.io.File;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class MultipartOutputFileResponse {
+
+    @RestForm
+    String name;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_OCTET_STREAM)
+    File file;
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import java.io.File;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/multipart/output")
+public class MultipartOutputResource {
+
+    public static final String RESPONSE_NAME = "a name";
+    public static final String RESPONSE_SURNAME = "a surname";
+    public static final Status RESPONSE_STATUS = Status.WORKING;
+    public static final List<String> RESPONSE_VALUES = List.of("one", "two");
+    public static final boolean RESPONSE_ACTIVE = true;
+
+    private final File TXT_FILE = new File("./src/test/resources/lorem.txt");
+
+    @GET
+    @Path("/simple")
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    public MultipartOutputResponse simple() {
+        MultipartOutputResponse response = new MultipartOutputResponse();
+        response.setName(RESPONSE_NAME);
+        response.setSurname(RESPONSE_SURNAME);
+        response.setStatus(RESPONSE_STATUS);
+        response.setValues(RESPONSE_VALUES);
+        response.active = RESPONSE_ACTIVE;
+        return response;
+    }
+
+    @GET
+    @Path("/string")
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    public String usingString() {
+        return RESPONSE_NAME;
+    }
+
+    @GET
+    @Path("/with-file")
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    public MultipartOutputFileResponse complex() {
+        MultipartOutputFileResponse response = new MultipartOutputFileResponse();
+        response.name = RESPONSE_NAME;
+        response.file = TXT_FILE;
+        return response;
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResponse.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResponse.java
@@ -1,0 +1,59 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import java.util.List;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+
+public class MultipartOutputResponse extends FormDataBase {
+
+    @RestForm
+    // don't set a part type, use the default
+    private String name;
+
+    @FormParam("custom-surname")
+    @PartType("text/plain")
+    private String surname;
+
+    @RestForm("custom-status")
+    @PartType(MediaType.TEXT_PLAIN)
+    private Status status;
+
+    @RestForm
+    private List<String> values;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingBlockingEndpointsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingBlockingEndpointsTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.multipart.other.OtherPackageFormDataBase;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class MultipartOutputUsingBlockingEndpointsTest extends AbstractMultipartTest {
+
+    private static final String EXPECTED_CONTENT_DISPOSITION_PART = "Content-Disposition: form-data; name=\"%s\"";
+    private static final String EXPECTED_CONTENT_DISPOSITION_FILE_PART = "Content-Disposition: form-data; name=\"%s\"; filename=\"%s\"";
+    private static final String EXPECTED_CONTENT_TYPE_PART = "Content-Type: %s";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MultipartOutputResource.class, MultipartOutputResponse.class,
+                            MultipartOutputFileResponse.class,
+                            Status.class, FormDataBase.class, OtherPackageFormDataBase.class));
+
+    @Test
+    public void testSimple() {
+        String response = RestAssured.get("/multipart/output/simple")
+                .then()
+                .contentType(ContentType.MULTIPART)
+                .statusCode(200)
+                .extract().asString();
+
+        assertContainsValue(response, "name", MediaType.TEXT_PLAIN, MultipartOutputResource.RESPONSE_NAME);
+        assertContainsValue(response, "custom-surname", MediaType.TEXT_PLAIN, MultipartOutputResource.RESPONSE_SURNAME);
+        assertContainsValue(response, "custom-status", MediaType.TEXT_PLAIN, MultipartOutputResource.RESPONSE_STATUS);
+        assertContainsValue(response, "active", MediaType.TEXT_PLAIN, MultipartOutputResource.RESPONSE_ACTIVE);
+        assertContainsValue(response, "values", MediaType.TEXT_PLAIN, "[one, two]");
+        assertContainsValue(response, "num", MediaType.TEXT_PLAIN, "0");
+    }
+
+    @Test
+    public void testString() {
+        RestAssured.get("/multipart/output/string")
+                .then()
+                .statusCode(200)
+                .body(equalTo(MultipartOutputResource.RESPONSE_NAME));
+    }
+
+    @Test
+    public void testWithFiles() {
+        String response = RestAssured
+                .given()
+                .get("/multipart/output/with-file")
+                .then()
+                .contentType(ContentType.MULTIPART)
+                .statusCode(200)
+                .log().all()
+                .extract().asString();
+
+        assertContainsValue(response, "name", MediaType.TEXT_PLAIN, MultipartOutputResource.RESPONSE_NAME);
+        assertContainsFile(response, "file", MediaType.APPLICATION_OCTET_STREAM, "lorem.txt");
+    }
+
+    private void assertContainsFile(String response, String name, String contentType, String fileName) {
+        String[] lines = response.split("--");
+        assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_FILE_PART, name, fileName))
+                && line.contains(String.format(EXPECTED_CONTENT_TYPE_PART, contentType)));
+    }
+
+    private void assertContainsValue(String response, String name, String contentType, Object value) {
+        String[] lines = response.split("--");
+        assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_PART, name))
+                && line.contains(String.format(EXPECTED_CONTENT_TYPE_PART, contentType))
+                && line.contains(value.toString()));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingReactiveEndpointTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingReactiveEndpointTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.resteasy.reactive.server.test.multipart.other.OtherPackageFormDataBase;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+/**
+ * Using '@Produces(MediaType.MULTIPART_FORM_DATA)' is not compatible with Non Blocking endpoints.
+ */
+public class MultipartOutputUsingReactiveEndpointTest extends AbstractMultipartTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MultipartOutputReactiveResource.class, OtherPackageFormDataBase.class))
+            .setExpectedException(DeploymentException.class);;
+
+    @Test
+    public void test() {
+        fail("Should never have been called");
+    }
+
+    @Path("/multipart/reactive")
+    public static class MultipartOutputReactiveResource {
+
+        @GET
+        @Produces(MediaType.MULTIPART_FORM_DATA)
+        public Multi<OtherPackageFormDataBase> simple() {
+            return Multi.createFrom().items(new OtherPackageFormDataBase());
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartMessageBodyWriter.java
@@ -1,0 +1,165 @@
+package io.quarkus.resteasy.reactive.server.runtime.multipart;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.reflection.ReflectionBeanFactoryCreator;
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.resteasy.reactive.spi.BeanFactory;
+
+public class MultipartMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
+
+    private static final String RESTEASY_DEFAULT_CHARSET_PROPERTY = "quarkus.resteasy-reactive.multipart.input-part.default-charset";
+    private static final Charset RESTEASY_DEFAULT_CHARSET_PROPERTY_DEFAULT = StandardCharsets.UTF_8;
+    private static final String DOUBLE_DASH = "--";
+    private static final String LINE_SEPARATOR = "\r\n";
+    private static final String BOUNDARY_PARAM = "boundary";
+
+    private final Charset defaultCharset;
+
+    public MultipartMessageBodyWriter() {
+        defaultCharset = ConfigProvider.getConfig().getOptionalValue(RESTEASY_DEFAULT_CHARSET_PROPERTY, Charset.class)
+                .orElse(RESTEASY_DEFAULT_CHARSET_PROPERTY_DEFAULT);
+    }
+
+    @Override
+    public void writeTo(Object o, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders, OutputStream outputStream)
+            throws IOException, WebApplicationException {
+        writeMultiformData(o, mediaType, outputStream);
+    }
+
+    @Override
+    public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+            throws WebApplicationException, IOException {
+        writeMultiformData(o, context.getResponseMediaType(), context.getOrCreateOutputStream());
+    }
+
+    public static final String getGeneratedMapperClassNameFor(String className) {
+        return className + "_generated_mapper";
+    }
+
+    private void writeMultiformData(Object o, MediaType mediaType, OutputStream outputStream) throws IOException {
+        ResteasyReactiveRequestContext requestContext = CurrentRequestManager.get();
+
+        String boundary = generateBoundary();
+        appendBoundaryIntoMediaType(requestContext, boundary, mediaType);
+        List<PartItem> formData = toFormData(o);
+        write(formData, boundary, outputStream, requestContext);
+    }
+
+    private List<PartItem> toFormData(Object o) {
+        String transformer = getGeneratedMapperClassNameFor(o.getClass().getName());
+        BeanFactory.BeanInstance instance = new ReflectionBeanFactoryCreator().apply(transformer).createInstance();
+        return ((MultipartOutputInjectionTarget) instance.getInstance()).mapFrom(o);
+    }
+
+    private void write(List<PartItem> parts, String boundary, OutputStream outputStream,
+            ResteasyReactiveRequestContext requestContext)
+            throws IOException {
+        String boundaryLine = "--" + boundary;
+        for (PartItem part : parts) {
+            // write boundary: --...
+            writeLine(outputStream, boundaryLine);
+            // write content disposition header
+            writeLine(outputStream, HttpHeaders.CONTENT_DISPOSITION + ": form-data; name=\"" + part.getName() + "\""
+                    + getFileNameIfFile(part.getValue()));
+            // write content content type
+            writeLine(outputStream, HttpHeaders.CONTENT_TYPE + ": " + part.getType());
+            // extra line
+            writeLine(outputStream);
+
+            // write content
+            write(outputStream, serialiseEntity(part.getValue(), part.getType(), requestContext));
+            // extra line
+            writeLine(outputStream);
+        }
+
+        // write boundary: -- ... --
+        write(outputStream, boundaryLine + DOUBLE_DASH);
+    }
+
+    private String getFileNameIfFile(Object value) {
+        if (value instanceof File) {
+            return "; filename=\"" + ((File) value).getName() + "\"";
+        }
+
+        return "";
+    }
+
+    private void writeLine(OutputStream os, String text) throws IOException {
+        write(os, text);
+        writeLine(os);
+    }
+
+    private void write(OutputStream os, String text) throws IOException {
+        write(os, text.getBytes(defaultCharset));
+    }
+
+    private void write(OutputStream os, byte[] bytes) throws IOException {
+        os.write(bytes);
+    }
+
+    private void writeLine(OutputStream os) throws IOException {
+        os.write(LINE_SEPARATOR.getBytes(defaultCharset));
+    }
+
+    private byte[] serialiseEntity(Object entity, MediaType mediaType, ResteasyReactiveRequestContext context)
+            throws IOException {
+        ServerSerialisers serializers = context.getDeployment().getSerialisers();
+        Class<?> entityClass = entity.getClass();
+        Type entityType = null;
+        @SuppressWarnings("unchecked")
+        MessageBodyWriter<Object>[] writers = (MessageBodyWriter<Object>[]) serializers
+                .findWriters(null, entityClass, mediaType, RuntimeType.SERVER)
+                .toArray(ServerSerialisers.NO_WRITER);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        boolean wrote = false;
+        for (MessageBodyWriter<Object> writer : writers) {
+            if (writer.isWriteable(entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType)) {
+                // FIXME: spec doesn't really say what headers we should use here
+                writer.writeTo(entity, entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType,
+                        Serialisers.EMPTY_MULTI_MAP, baos);
+                wrote = true;
+                break;
+            }
+        }
+
+        if (!wrote) {
+            throw new IllegalStateException("Could not find MessageBodyWriter for " + entityClass + " as " + mediaType);
+        }
+        return baos.toByteArray();
+    }
+
+    private String generateBoundary() {
+        return UUID.randomUUID().toString();
+    }
+
+    private void appendBoundaryIntoMediaType(ResteasyReactiveRequestContext requestContext, String boundary,
+            MediaType mediaType) {
+        requestContext.setResponseContentType(new MediaType(mediaType.getType(), mediaType.getSubtype(),
+                Collections.singletonMap(BOUNDARY_PARAM, boundary)));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartOutputInjectionTarget.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/MultipartOutputInjectionTarget.java
@@ -1,0 +1,7 @@
+package io.quarkus.resteasy.reactive.server.runtime.multipart;
+
+import java.util.List;
+
+public interface MultipartOutputInjectionTarget {
+    List<PartItem> mapFrom(Object pojo);
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/PartItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/multipart/PartItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.resteasy.reactive.server.runtime.multipart;
+
+import javax.ws.rs.core.MediaType;
+
+public final class PartItem {
+    private final String name;
+    private final MediaType type;
+    private final Object value;
+
+    public PartItem(String name, MediaType type, Object value) {
+        this.name = name;
+        this.type = type;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MediaType getType() {
+        return type;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartResource.java
+++ b/integration-tests/rest-client-reactive-multipart/src/main/java/io/quarkus/it/rest/client/multipart/MultipartResource.java
@@ -231,6 +231,23 @@ public class MultipartResource {
                         : "some-name".equals(fileWithPojo.pojo.getName()) && "some-value".equals(fileWithPojo.pojo.getValue()));
     }
 
+    @GET
+    @Path("/produces/multipart")
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    public MultipartBodyWithTextFile produceMultipart() throws IOException {
+        File tempFile = File.createTempFile("quarkus-test", ".bin");
+        tempFile.deleteOnExit();
+
+        try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
+            fileOutputStream.write(HELLO_WORLD.getBytes());
+        }
+
+        MultipartBodyWithTextFile data = new MultipartBodyWithTextFile();
+        data.file = tempFile;
+        data.number = String.valueOf(NUMBER);
+        return data;
+    }
+
     private boolean containsHelloWorld(File file) {
         try {
             String actual = new String(Files.readAllBytes(file.toPath()));


### PR DESCRIPTION
Add RESTEasy Reactive support to produce Multipart Form data.
- Updated RESTEasy Reactive documentation
- Supported both `@RestForm` and `@FormParam` annotations
- Added test coverage for text/plan, json and xml serialization
- Implementation is based on Resteasy Classic documentation

Resolves https://github.com/quarkusio/quarkus/issues/21009