### PR TITLE
Fix an exception when doing Quarkus Test using default method.

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DefaultMethodInterface.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DefaultMethodInterface.java
@@ -1,0 +1,10 @@
+package io.quarkus.it.main;
+
+import org.junit.jupiter.api.Test;
+
+public interface DefaultMethodInterface {
+
+    @Test
+    default void doTest() {
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/DefaultMethodTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/DefaultMethodTestCase.java
@@ -1,0 +1,67 @@
+package io.quarkus.it.main;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DefaultMethodTestCase implements DefaultMethodInterface {
+
+    @Nested
+    class NestedTestClass implements DefaultMethodInterface {
+    }
+
+    interface InnerTestInterface {
+        @Test
+        default void testInnerTestInterface() {
+
+        }
+    }
+
+    @Nested
+    class InnerTestInterfaceTest implements InnerTestInterface {
+
+    }
+
+    @Nested
+    class SomeTestInterfaceTest implements DefaultMethodInterface, InnerTestInterface {
+
+    }
+
+    interface NonTestInterface {
+        default void simpleMethod() {
+
+        }
+
+        void abstractMethod();
+    }
+
+    @Nested
+    class NonTestInterfaceTest implements NonTestInterface {
+
+        @Override
+        public void abstractMethod() {
+
+        }
+    }
+
+    interface SuperTestInterface {
+        @Test
+        default void superTestMethod() {
+
+        }
+    }
+
+    interface ChildTestInterface extends SuperTestInterface {
+        @Test
+        default void childTestMethod() {
+
+        }
+    }
+
+    @Nested
+    class HierarchyTest implements ChildTestInterface {
+
+    }
+}


### PR DESCRIPTION
## Before
In JUnit 5, you can test using the default method as follows.
[Test Interfaces and Default Methods](https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-interfaces-and-default-methods)

```java
public interface Testable {
  @Test
  void doTest() {  }
}

@QuarkusTest
class ExampleTest implements Testable {
}
```
When I run ExampleTest, I expect doTest to be run, but it actually throws a RuntimeException.

## After
QuarkusTestExtension resolves interface method and executes doTest method.

---
Where should I write my QuarkusTestExtension test?
If you need a test, please give me some advice.