### PR TITLE
Add the ability to run main class in test

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -100,10 +100,8 @@ public class ApplicationLifecycleManager {
         } finally {
             stateLock.unlock();
         }
-        boolean appStarted = false;
         try {
             application.start(args);
-            appStarted = true;
             //now we are started, we either run the main application or just wait to exit
             if (quarkusApplication != null) {
                 BeanManager beanManager = CDI.current().getBeanManager();

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -506,34 +506,95 @@ import io.quarkus.test.junit.QuarkusTestProfile.TestResourceEntry;
 
 public class MockGreetingProfile implements QuarkusTestProfile {
 
+    /**
+     * Returns additional config to be applied to the test. This
+     * will override any existing config (including in application.properties),
+     * however existing config will be merged with this (i.e. application.properties
+     * config will still take effect, unless a specific config key has been overridden).
+     *
+     * Here we are changing the JAX-RS root path.
+     */
     @Override
-    public Map<String, String> getConfigOverrides() { <1>
+    public Map<String, String> getConfigOverrides() {
         return Collections.singletonMap("quarkus.resteasy.path","/api");
     }
 
+    /**
+     * Returns enabled alternatives.
+     *
+     * This has the same effect as setting the 'quarkus.arc.selected-alternatives' config key,
+     * however it may be more convenient.
+     */
     @Override
-    public Set<Class<?>> getEnabledAlternatives() { <2>
+    public Set<Class<?>> getEnabledAlternatives() {
         return Collections.singleton(MockGreetingService.class);
     }
 
-
+    /**
+     * Allows the default config profile to be overridden. This basically just sets the quarkus.test.profile system
+     * property before the test is run.
+     *
+     * Here we are setting the profile to test-mocked
+     */
     @Override
-    public String getConfigProfile() { <3>
-        return "test";
+    public String getConfigProfile() {
+        return "test-mocked";
     }
 
+    /**
+     * Additional {@link QuarkusTestResourceLifecycleManager} classes (along with their init params) to be used from this
+     * specific test profile.
+     *
+     * If this method is not overridden, then only the {@link QuarkusTestResourceLifecycleManager} classes enabled via the {@link io.quarkus.test.common.QuarkusTestResource} class
+     * annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at all).
+     */
     @Override
-    public List<TestResourceEntry> testResources() { <4>
-        return Collections.singletonList(new TestResourceEntry(CustomWireMockServerManager.class));
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(new TestResourceEntry(CustomWireMockServerManager.class)); <4>
+    }
+
+
+    /**
+     * If this is returns true then only the test resources returned from {@link #testResources()} will be started,
+     * global annotated test resources will be ignored.
+     */
+    default boolean disableGlobalTestResources() {
+        return false;
+    }
+
+    /**
+     * The tags this profile is associated with.
+     * When the {@code quarkus.test.profile.tags} System property is set (its value is a comma separated list of strings)
+     * then Quarkus will only execute tests that are annotated with a {@code @TestProfile} that has at least one of the
+     * supplied (via the aforementioned system property) tags.
+     */
+    default Set<String> tags() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * The command line parameters that are passed to the main method on startup.
+     */
+    default String[] commandLineParameters() {
+        return new String[0];
+    }
+
+    /**
+     * If the main method should be run
+     */
+    default boolean runMainMethod() {
+        return false;
+    }
+
+    /**
+     * If this method returns true then all {@code StartupEvent} and {@code ShutdownEvent} observers declared on application
+     * beans should be disabled.
+     */
+    default boolean disableApplicationLifecycleObservers() {
+        return false;
     }
 }
 ----
-<1> This method allows us to override configuration properties. Here we are changing the JAX-RS root path.
-<2> This method allows us to enable CDI `@Alternative` beans. This makes it easy to mock out certain beans functionality.
-<3> This can be used to change the config profile. As this default is `test` this does nothing, but is included for completeness.
-<4> This method allows us to apply **additional** `QuarkusTestResourceLifecycleManager` classes, specific for this profile only. If this
-method is not overridden, then only the `QuarkusTestResourceLifecycleManager` classes enabled via the `@QuarkusTestResource` class
-annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at all).
 
 Now we have defined our profile we need to include it on our test class. We do this with `@TestProfile(MockGreetingProfile.class)`.
 

--- a/integration-tests/main/src/main/java/io/quarkus/it/Main.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/Main.java
@@ -1,0 +1,18 @@
+package io.quarkus.it;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.QuarkusApplication;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class Main implements QuarkusApplication {
+
+    public static volatile String[] PARAMS;
+
+    @Override
+    public int run(String... args) throws Exception {
+        PARAMS = args;
+        Quarkus.waitForExit();
+        return 0;
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/GreetingEndpoint.java
@@ -8,6 +8,8 @@ import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
+import io.quarkus.it.Main;
+
 @Path("/greeting")
 public class GreetingEndpoint {
 
@@ -18,6 +20,10 @@ public class GreetingEndpoint {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
     public String greet(@PathParam String name) {
+        String[] params = Main.PARAMS;
+        if (params != null && params.length > 0) {
+            return params[0] + " " + name;
+        }
         return greetingService.greet(name);
     }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
@@ -30,7 +30,7 @@ public class GreetingProfileTestCase {
                 .get("/greeting/Stu")
                 .then()
                 .statusCode(200)
-                .body(is("Bonjour Stu"));
+                .body(is("Hey Stu"));
     }
 
     @Test
@@ -60,6 +60,16 @@ public class GreetingProfileTestCase {
         public List<TestResourceEntry> testResources() {
             return Collections
                     .singletonList(new TestResourceEntry(DummyTestResource.class, Collections.singletonMap("num", "100")));
+        }
+
+        @Override
+        public String[] commandLineParameters() {
+            return new String[] { "Hey" };
+        }
+
+        @Override
+        public boolean runMainMethod() {
+            return true;
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestProfile.java
@@ -44,8 +44,13 @@ public interface QuarkusTestProfile {
     }
 
     /**
-     * {@link QuarkusTestResourceLifecycleManager} classes (along with their init params) to be used from this
-     * specific test profile
+     * Additional {@link QuarkusTestResourceLifecycleManager} classes (along with their init params) to be used from this
+     * specific test profile.
+     *
+     * If this method is not overridden, then only the {@link QuarkusTestResourceLifecycleManager} classes enabled via the
+     * {@link io.quarkus.test.common.QuarkusTestResource} class
+     * annotation will be used for the tests using this profile (which is the same behavior as tests that don't use a profile at
+     * all).
      */
     default List<TestResourceEntry> testResources() {
         return Collections.emptyList();
@@ -67,6 +72,24 @@ public interface QuarkusTestProfile {
      */
     default Set<String> tags() {
         return Collections.emptySet();
+    }
+
+    /**
+     * The command line parameters that are passed to the main method on startup.
+     *
+     * This is ignored for {@link io.quarkus.test.junit.main.QuarkusMainTest}, which has its own way of passing parameters.
+     */
+    default String[] commandLineParameters() {
+        return new String[0];
+    }
+
+    /**
+     * If the main method should be run.
+     *
+     * This is ignored for {@link io.quarkus.test.junit.main.QuarkusMainTest}, where the main method is always run.
+     */
+    default boolean runMainMethod() {
+        return false;
     }
 
     /**


### PR DESCRIPTION
This lets tests run a main class and specify command line arguments in a
profile. This was previously possible for short lived applications that
exit, but can now be used for long lived applications that use
@QuarkusTest.