### PR TITLE
Fix flaky RabbitMQ integration tests

### DIFF
--- a/integration-tests/reactive-messaging-rabbitmq/src/main/java/io/quarkus/it/rabbitmq/PeopleProducer.java
+++ b/integration-tests/reactive-messaging-rabbitmq/src/main/java/io/quarkus/it/rabbitmq/PeopleProducer.java
@@ -1,21 +1,26 @@
 package io.quarkus.it.rabbitmq;
 
+import java.time.Duration;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class PeopleProducer {
     @Outgoing("people-out")
     public Multi<Person> generatePeople() {
-        return Multi.createFrom().items(
-                new Person("bob"),
-                new Person("alice"),
-                new Person("tom"),
-                new Person("jerry"),
-                new Person("anna"),
-                new Person("ken"));
+        return Uni.createFrom().nullItem()
+                .onItem().delayIt().by(Duration.ofSeconds(3))
+                .onItem().transformToMulti(n -> Multi.createFrom()
+                        .items(new Person("bob"),
+                                new Person("alice"),
+                                new Person("tom"),
+                                new Person("jerry"),
+                                new Person("anna"),
+                                new Person("ken")));
     }
 }


### PR DESCRIPTION
In RabbitMQ queues are what store messsages for processing, while exchanges are what messages are sent to. If an exchange has no bound queues, in most standard cases, any messages sent to the exchange are dropped.

The "incoming" RabbitMQ connector is what creates and binds a queue to an exchange. This fix adds a delay to the "outgoing" messages to ensure the "incoming" connector has time to create and bind the required queue to the required exchange.