### PR TITLE
Update quarkus-bot metadata for Narayana projects

### DIFF
--- a/.github/quarkus-bot.yml
+++ b/.github/quarkus-bot.yml
@@ -375,8 +375,11 @@ triage:
       directories:
         - extensions/narayana-jta/
         - extensions/narayana-stm/
+        - extensions/narayana-lra/
         - integration-tests/narayana-jta/
         - integration-tests/narayana-stm/
+        - integration-tests/narayana-lra/
+      notify: [mmusgrov]
     - labels: [area/neo4j]
       title: "neo4j"
       notify: [michael-simons]


### PR DESCRIPTION
 - the LRA Narayana projects where missing in the bot metadata
 - @mmusgrov is now our primary contact point for the area