### PR TITLE
Hibernate ORM: switch to the slightly more optimised UnmodifiableBatchBuilderInitiator

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/registry/PreconfiguredServiceRegistryBuilder.java
@@ -12,7 +12,7 @@ import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.internal.StrategySelectorImpl;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
-import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
+import org.hibernate.engine.jdbc.batch.internal.UnmodifiableBatchBuilderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.MultiTenantConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.cursor.internal.RefCursorSupportInitiator;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
@@ -190,7 +190,9 @@ public class PreconfiguredServiceRegistryBuilder {
         // Custom one: Dialect is injected explicitly
         serviceInitiators.add(new QuarkusStaticDialectFactoryInitiator(rs.getDialect()));
 
-        serviceInitiators.add(BatchBuilderInitiator.INSTANCE);
+        // Non-default implementation: optimised for lack of JMX management
+        serviceInitiators.add(UnmodifiableBatchBuilderInitiator.INSTANCE);
+
         serviceInitiators.add(JdbcServicesInitiator.INSTANCE);
         serviceInitiators.add(RefCursorSupportInitiator.INSTANCE);
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/service/StandardHibernateORMInitiatorListProvider.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
-import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
+import org.hibernate.engine.jdbc.batch.internal.UnmodifiableBatchBuilderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.MultiTenantConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.cursor.internal.RefCursorSupportInitiator;
 import org.hibernate.engine.jdbc.dialect.internal.DialectResolverInitiator;
@@ -75,7 +75,9 @@ public final class StandardHibernateORMInitiatorListProvider implements InitialI
 
         // Custom one!
         serviceInitiators.add(DialectFactoryInitiator.INSTANCE);
-        serviceInitiators.add(BatchBuilderInitiator.INSTANCE);
+
+        // Non-default implementation: optimised for lack of JMX management
+        serviceInitiators.add(UnmodifiableBatchBuilderInitiator.INSTANCE);
         serviceInitiators.add(JdbcServicesInitiator.INSTANCE);
         serviceInitiators.add(RefCursorSupportInitiator.INSTANCE);
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -12,7 +12,7 @@ import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.internal.StrategySelectorImpl;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
-import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
+import org.hibernate.engine.jdbc.batch.internal.UnmodifiableBatchBuilderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.MultiTenantConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.cursor.internal.RefCursorSupportInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
@@ -189,7 +189,8 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
         // Disabled: Dialect is injected explicitly
         // serviceInitiators.add( DialectFactoryInitiator.INSTANCE );
 
-        serviceInitiators.add(BatchBuilderInitiator.INSTANCE);
+        // Non-default implementation: optimised for lack of JMX management
+        serviceInitiators.add(UnmodifiableBatchBuilderInitiator.INSTANCE);
         serviceInitiators.add(JdbcServicesInitiator.INSTANCE);
         serviceInitiators.add(RefCursorSupportInitiator.INSTANCE);
 

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/ReactiveHibernateInitiatorListProvider.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
-import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
+import org.hibernate.engine.jdbc.batch.internal.UnmodifiableBatchBuilderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.MultiTenantConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.cursor.internal.RefCursorSupportInitiator;
 import org.hibernate.engine.jdbc.dialect.internal.DialectResolverInitiator;
@@ -87,7 +87,8 @@ public final class ReactiveHibernateInitiatorListProvider implements InitialInit
         // Custom Quarkus implementation !
         serviceInitiators.add(DialectFactoryInitiator.INSTANCE);
 
-        serviceInitiators.add(BatchBuilderInitiator.INSTANCE);
+        // Non-default implementation: optimised for lack of JMX management
+        serviceInitiators.add(UnmodifiableBatchBuilderInitiator.INSTANCE);
         serviceInitiators.add(JdbcServicesInitiator.INSTANCE);
         serviceInitiators.add(RefCursorSupportInitiator.INSTANCE);
 


### PR DESCRIPTION
The new `UnmodifiableBatchBuilderInitiator` will trigger use of a new `BatchBuilder` implementation introduced in Hibernate ORM 5.6.1 which is slightly more native-image friendly as it doesn't bind to JMX.

This is essentially a Quarkus optimised implementaiton of the Service, but I've decided to keep the implementation in ORM rather than in Quarkus like we commonly did in the past.