### PR TITLE
Add panache annotation processor before configuration is resolved

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
@@ -94,6 +94,14 @@ public class ExtensionDependency {
         return String.join(":", this.extensionId.getGroup(), this.extensionId.getName());
     }
 
+    public String getGroup() {
+        return extensionId.getGroup();
+    }
+
+    public String getName() {
+        return extensionId.getName();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)


### PR DESCRIPTION
This tries to avoid adding the panache annotation processor after the `annotationProcessor` configuration is resolved. 

Furthermore, it leverage the result of extracted quarkus extension. 

fix #19086 