### PR TITLE
Avoid misunderstand `-Dsnap` with Maven snapshot

### DIFF
--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -244,7 +244,7 @@ The extension provides helpers to check the content:
 - You can use `AbstractPathAssert.satisfies(checkContains("some content"))` or any Path assert on the return of the methods above to also check the file contains a specific content.
 - `assertThatGeneratedTreeMatchSnapshots()`  lets you compare the project file structure (tree) for a specific language against its snapshot.
 
-NOTE: In order to first generate or update existing snapshots, you need to add `-Dsnap` when running the tests. They need to be added as part of the commit, else the tests will not pass on the CI.
+NOTE: In order to first generate or update existing snapshots files on your local filesystem, you need to add `-Dsnap` when running the tests locally while developing the codestart. They need to be added as part of the commit, else the tests will not pass on the CI.
 
 === Writing tips
 

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.TestInfo;
 
 /**
  * Test file content and directory tree to make sure they are valid by comparing them to their snapshots.
- * The snapshots can easily be updated when necessary and reviewed to confirm they are consistent with the changes.
+ * The snapshots files can easily be updated when necessary and reviewed to confirm they are consistent with the changes.
  * <br />
  * <br />
- * The snapshots will be created/updated using <code>-Dsnap</code> or
+ * The snapshots files will be created/updated using <code>-Dsnap</code> or
  * <code>-Dupdate-snapshots</code>
  * <br />
  * Snapshots are created in {@link #SNAPSHOTS_DIR}
@@ -39,10 +39,10 @@ public class SnapshotTesting {
     /**
      * Test file content to make sure it is valid by comparing it to its snapshots.
      * <br />
-     * The snapshot can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
+     * The snapshot file can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
      * <br />
      * <br />
-     * The snapshot will be created/updated using <code>-Dsnap</code> or
+     * The snapshot file will be created/updated using <code>-Dsnap</code> or
      * <code>-Dupdate-snapshots</code>
      * <br />
      * <br />
@@ -75,10 +75,10 @@ public class SnapshotTesting {
     /**
      * Test file content to make sure it is valid by comparing it to a snapshot.
      * <br />
-     * The snapshot can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
+     * The snapshot file can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
      * <br />
      * <br />
-     * The snapshot will be created/updated using <code>-Dsnap</code> or
+     * The snapshot file will be created/updated using <code>-Dsnap</code> or
      * <code>-Dupdate-snapshots</code>
      * <br />
      * <br />
@@ -103,7 +103,7 @@ public class SnapshotTesting {
             FileUtils.copyFile(fileToCheck.toFile(), snapshotFile.toFile());
         }
 
-        final String snapshotNotFoundDescription = "corresponding snapshot not found for " + snapshotIdentifier
+        final String snapshotNotFoundDescription = "corresponding snapshot file not found for " + snapshotIdentifier
                 + " (Use -Dsnap to create it automatically)";
         final String description = "Snapshot is not matching (use -Dsnap to udpate it automatically): " + snapshotIdentifier;
         if (isUTF8File(fileToCheck)) {
@@ -122,10 +122,10 @@ public class SnapshotTesting {
     /**
      * Test directory tree to make sure it is valid by comparing it to a snapshot.
      * <br />
-     * The snapshot can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
+     * The snapshot file can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
      * <br />
      * <br />
-     * The snapshot will be created/updated using <code>-Dsnap</code> or
+     * The snapshot file will be created/updated using <code>-Dsnap</code> or
      * <code>-Dupdate-snapshots</code>
      *
      * @param testInfo the {@link TestInfo} from the {@Link Test} parameter (used to get the current test class & method to
@@ -141,10 +141,10 @@ public class SnapshotTesting {
     /**
      * Test directory tree to make sure it is valid by comparing it to a snapshot.
      * <br />
-     * The snapshot can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
+     * The snapshot file can easily be updated when necessary and reviewed to confirm it is consistent with the changes.
      * <br />
      * <br />
-     * The snapshot will be created/updated using <code>-Dsnap</code> or
+     * The snapshot file will be created/updated using <code>-Dsnap</code> or
      * <code>-Dupdate-snapshots</code>
      *
      * @param snapshotDirName the snapshot dir name for storage
@@ -180,7 +180,7 @@ public class SnapshotTesting {
         }
 
         assertThat(snapshotFile)
-                .as("corresponding snapshot not found for " + snapshotName + " (Use -Dsnap to create it automatically)")
+                .as("corresponding snapshot file not found for " + snapshotName + " (Use -Dsnap to create it automatically)")
                 .isRegularFile();
 
         final List<String> content = Arrays.stream(getTextContent(snapshotFile).split("\\v"))


### PR DESCRIPTION
Hi @ia3andy as previously discussed in https://github.com/kiegroup/kogito-runtimes/pull/1668#issuecomment-946908794

>> Maybe here: [quarkus.io/guides/extension-codestart#snapshot-testing](https://quarkus.io/guides/extension-codestart#snapshot-testing) you can write instead of
>> 
>> > In order to first generate or udpate existing snapshots, you need to add -Dsnap when running the tests.
>> 
>> something ~like:
>> 
>> > In order to first generate or udpate existing snapshots files on your local filesystem, you need to add -Dsnap when running the tests locally while developing the codestart.
>
> Yeah that makes sense, would you provide a PR? this is repeated:
> - in the guide
> - in the javadoc
> - in the logs

This attempts to clarify the guide, the javadoc and the log where relevant, per previous discussion.

Wdyt ?
Hope this helps!