### PR TITLE
Disallow public final methods on recorders

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -137,8 +137,13 @@ public class ProxyFactory<T> {
             if (methodInfo.getName().equals("finalize") && methodInfo.getParameterCount() == 0) {
                 continue;
             }
-            if (!Modifier.isStatic(methodInfo.getModifiers()) &&
-                    !Modifier.isFinal(methodInfo.getModifiers()) &&
+            int modifiers = methodInfo.getModifiers();
+            if (Modifier.isPublic(modifiers) && Modifier.isFinal(modifiers) && !Modifier.isStatic(modifiers)
+                    && clazz != Object.class) {
+                throw new RuntimeException("Public method " + methodInfo + " cannot be proxied as it is final");
+            }
+            if (!Modifier.isStatic(modifiers) &&
+                    !Modifier.isFinal(modifiers) &&
                     !methodInfo.getName().equals("<init>")) {
                 methods.add(methodInfo);
             }


### PR DESCRIPTION
These can cause problems as the results silently won't be recorded.

This is potentially a breaking change, although I don't think it should
cause issues in practice, as there is no real use case for final public
recorder methods.