### PR TITLE
Fix panache annotation processor registration

### DIFF
--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
@@ -13,6 +13,7 @@ test {
 }
 
 repositories {
+    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -20,7 +21,6 @@ repositories {
     } else {
         mavenLocal()
     }
-    mavenCentral()
 }
 
 dependencies {
@@ -28,6 +28,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-resteasy-jackson'
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
+    implementation 'io.quarkus:quarkus-hibernate-orm-panache'
 
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorSimpleModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorSimpleModuleTest.java
@@ -1,8 +1,9 @@
 package io.quarkus.gradle;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,5 +16,18 @@ public class AnnotationProcessorSimpleModuleTest extends QuarkusGradleWrapperTes
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "test");
 
         assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
+    @Test
+    public void shouldContainsPanacheMarkerFile() throws Exception {
+        final File projectDir = getProjectDir("annotation-processor-simple-module");
+
+        BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusBuild");
+
+        assertThat(buildResult.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        File buildDir = new File(projectDir, "build");
+
+        Path metaInfDir = buildDir.toPath().resolve("classes").resolve("java").resolve("main").resolve("META-INF");
+        assertThat(metaInfDir.resolve("panache-archive.marker")).exists();
     }
 }


### PR DESCRIPTION
While I was checking if the annotation processor was validating the presence of the panache marker file. I realized that it was not. when adding the check, the test failed because `quarkus-panache-common` is not an extension, just a project with a `deployment` and a `runtime` module. 

This branch use the resolved compile classpath to add the dependency if necessary in the annotation processor configuration before it is resolved. And we now have a test. Sorry for the regression introduced yesterday.