### PR TITLE
Disable requirePluginVersions enforcer rule due to MENFORCER-359

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -435,10 +435,12 @@
                                     <requireMavenVersion>
                                         <version>${supported-maven-versions}</version>
                                     </requireMavenVersion>
+                                    <!-- Disabled due to https://issues.apache.org/jira/browse/MENFORCER-359 (3.0.0-M3)
+                                         3.0.0 suffers from https://issues.apache.org/jira/browse/MENFORCER-394, so we need to wait for a fixed release.
                                     <requirePluginVersions>
                                         <phases>compile</phases>
                                         <unCheckedPluginList>io.quarkus:quarkus-bootstrap-maven-plugin,io.quarkus:quarkus-platform-descriptor-json-plugin,io.quarkus:quarkus-maven-plugin</unCheckedPluginList>
-                                    </requirePluginVersions>
+                                    </requirePluginVersions>-->
                                     <bannedDependencies>
                                         <excludes>
                                             <!-- Use Jakarta artifacts instead of JBoss specific ones -->


### PR DESCRIPTION
This should fix the incremental builds that are failing since #21022.

E.g.:
```
2021-10-29T07:31:06.2918593Z [WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:
2021-10-29T07:31:06.2921524Z Some plugins are missing valid versions: (LATEST RELEASE SNAPSHOT are not allowed)
2021-10-29T07:31:06.2923021Z de.thetaphi:forbiddenapis. 	The version currently in use is 3.1
```

See:
- https://github.com/quarkusio/quarkus/pull/21089#issuecomment-954801858 (and the following comments)
- https://issues.apache.org/jira/browse/MENFORCER-359 (fixed in enforcer 3.0.0)
- https://issues.apache.org/jira/browse/MENFORCER-394 (blocking upgrade to enforcer 3.0.0)

Btw, the problem can be reproduced easily via:
```
mvn verify -Dquickly -Denforcer.skip=false -pl :quarkus-devtools-base-codestarts -amd
```
(no GIB involved there)