### PR TITLE
Tweak runtime pdfbox packages to avoid needing all charsets in Tika

### DIFF
--- a/docs/src/main/asciidoc/tika.adoc
+++ b/docs/src/main/asciidoc/tika.adoc
@@ -11,6 +11,19 @@ This guide explains how your Quarkus application can use https://tika.apache.org
 
 https://tika.apache.org/[Apache Tika] is a content analysis toolkit which is used to parse the documents in PDF, Open Document, Excel and many other well known binary and text formats using a simple uniform API. Both the document text and properties (metadata) are available once the document has been parsed.
 
+[NOTE]
+====
+If you are planning to run the application as a native executable and parse documents that may have been created with charsets different than the standard ones supported in Java such as `UTF-8` then you should configure Quarkus to get the native image generator include all the charsets available to the JVM:
+[source,xml]
+----
+<properties>
+    <quarkus.package.type>native</quarkus.package.type>
+    <quarkus.native.add-all-charsets>true</quarkus.native.add-all-charsets>
+<properties>
+----
+====
+
+
 == Prerequisites
 
 To complete this guide, you need:

--- a/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
+++ b/extensions/tika/deployment/src/main/java/io/quarkus/tika/deployment/TikaProcessor.java
@@ -26,7 +26,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceDirectoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
@@ -86,11 +85,6 @@ public class TikaProcessor {
         resource.produce(new NativeImageResourceDirectoryBuildItem("org/apache/pdfbox/resources/glyphlist"));
         resource.produce(new NativeImageResourceDirectoryBuildItem("org/apache/fontbox/cmap"));
         resource.produce(new NativeImageResourceDirectoryBuildItem("org/apache/fontbox/unicode"));
-    }
-
-    @BuildStep
-    public NativeImageEnableAllCharsetsBuildItem registerAllCharsets() {
-        return new NativeImageEnableAllCharsetsBuildItem();
     }
 
     @BuildStep

--- a/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/graal/TikaFeature.java
+++ b/extensions/tika/runtime/src/main/java/io/quarkus/tika/runtime/graal/TikaFeature.java
@@ -12,7 +12,8 @@ public class TikaFeature implements Feature {
     public void afterRegistration(AfterRegistrationAccess access) {
         final RuntimeClassInitializationSupport runtimeInit = ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
         final String reason = "Quarkus run time init for Apache Tika";
-        runtimeInit.initializeAtRunTime("org.apache.pdfbox", reason);
+        runtimeInit.initializeAtRunTime("org.apache.pdfbox.pdmodel", reason);
+        runtimeInit.initializeAtRunTime("org.apache.pdfbox.rendering", reason);
         runtimeInit.initializeAtRunTime("org.apache.poi.hssf.util", reason);
         runtimeInit.initializeAtRunTime("org.apache.poi.ss.format", reason);
     }

--- a/integration-tests/tika/pom.xml
+++ b/integration-tests/tika/pom.xml
@@ -99,6 +99,10 @@
                     <name>native</name>
                 </property>
             </activation>
+            <!-- add some custom config, the rest comes from parent -->
+            <properties>
+                <quarkus.native.add-all-charsets>true</quarkus.native.add-all-charsets>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Closes #20839

I've tweaked the `pdfbox` packages that need to be runtime initialized. By doing that, the package that defines the charsets would go back to being build time initialized, so there wouldn't be a mandatory need to enable all charsets from the start. As before, those that need (e.g. Quarkus Tika testsuite) should do so.

I've verified the fix not only with the Quarkus Tika testsuite, but also the Camel Quarkus Tika testsuite and Quarkus Tika quickstart.