### PR TITLE
Exclude commons-logging from resteasy-client-microprofile

### DIFF
--- a/extensions/resteasy-classic/rest-client/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client/runtime/pom.xml
@@ -48,6 +48,10 @@
                     <groupId>org.jboss.weld</groupId>
                     <artifactId>weld-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This makes sure commons-logging does not end up in the compile classpath of a gradle project. 

close #20896 