### PR TITLE
Use Optional.orElseGet to fix OidcIdentityProvider bug

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -224,7 +224,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 && vertxContext.get(REFRESH_TOKEN_GRANT_RESPONSE) != Boolean.TRUE
                 && vertxContext.get(NEW_AUTHENTICATION) != Boolean.TRUE) {
             final long refreshTokenTimeSkew = (oidcConfig.token.getRefreshTokenTimeSkew()
-                    .orElse(oidcConfig.token.autoRefreshInterval.get())).getSeconds();
+                    .orElseGet(() -> oidcConfig.token.autoRefreshInterval.get())).getSeconds();
             final long expiry = tokenJson.getLong("exp");
             final long now = System.currentTimeMillis() / 1000;
             return now + refreshTokenTimeSkew > expiry;

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -91,7 +91,7 @@ quarkus.oidc.tenant-autorefresh.credentials.secret=secret
 quarkus.oidc.tenant-autorefresh.application-type=web-app
 quarkus.oidc.tenant-autorefresh.authentication.cookie-path=/tenant-autorefresh
 quarkus.oidc.tenant-autorefresh.token.refresh-expired=true
-quarkus.oidc.tenant-autorefresh.token.auto-refresh-interval=30S
+quarkus.oidc.tenant-autorefresh.token.refresh-token-time-skew=30S
 
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
 quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus


### PR DESCRIPTION
Fixes #21146 

@gsmet, @geoand If this bug fix can be picked up for 2.4.1.Final then it would be great, though not sure there is enough time for it.

I'm also going to remove the deprecated code from the main next after this PR is merged as it has been around for a while