### PR TITLE
Update OidcWiremockTestResource to configure a signing key location

### DIFF
--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -791,9 +791,6 @@ If you configure `mp.jwt.verify.publickey.location` to point to HTTPS or HTTP ba
 # keycloak.url is set by OidcWiremockTestResource
 mp.jwt.verify.publickey.location=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 mp.jwt.verify.issuer=${keycloak.url}/realms/quarkus
-
-# required to sign the tokens
-smallrye.jwt.sign.key.location=privateKey.jwk
 ----
 
 [[integration-testing-keycloak]]

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -620,8 +620,6 @@ Prepare the REST test endpoint, set `application.properties`, for example:
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.client-id=quarkus-service-app
 quarkus.oidc.application-type=service
-# required to sign the tokens
-smallrye.jwt.sign.key.location=privateKey.jwk
 ----
 
 and finally write the test code, for example:
@@ -665,6 +663,8 @@ public class BearerTokenAuthorizationTest {
     }
 }
 ----
+
+Note that the `quarkus-test-oidc-server` extension includes a signing RSA private key file in a `JSON Web Key` (`JWK`) format and points to it with a `smallrye.jwt.sign.key.location` configuration property. It allows to use a no argument `sign()` operation to sign the token.
 
 Testing your `quarkus-oidc` `service` application with `OidcWiremockTestResource` provides the best coverage as even the communication channel is tested against the Wiremock HTTP stubs.
 `OidcWiremockTestResource` will be enhanced going forward to support more complex Bearer token test scenarios.

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -42,6 +42,3 @@ quarkus.oidc.bearer-wrong-role-path.roles.role-claim-path=path
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
-
-smallrye.jwt.sign.key.location=privateKey.jwk
-

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -153,6 +153,7 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
         Map<String, String> conf = new HashMap<>();
         conf.put("keycloak.url", server.baseUrl() + "/auth");
+        conf.put("smallrye.jwt.sign.key.location", "privateKey.jwk");
 
         return conf;
     }


### PR DESCRIPTION
I've realized, while refactoring OIDC docs that the user configuration for OIDC wiremock tests can be simplified, so this PR does it 