### PR TITLE
Check for Vault API to be ready in Vault tests

### DIFF
--- a/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSealStatusResult.java
+++ b/extensions/vault/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSealStatusResult.java
@@ -27,6 +27,7 @@ public class VaultSealStatusResult implements VaultModel {
         return "VaultSealStatus{" +
                 "type: '" + type + '\'' +
                 ", sealed: " + sealed +
+                ", initialized: " + initialized +
                 '}';
     }
 }

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/MutinyVertxClientFactory.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/client/MutinyVertxClientFactory.java
@@ -20,7 +20,7 @@ public class MutinyVertxClientFactory {
 
         WebClientOptions options = new WebClientOptions()
                 .setConnectTimeout((int) vaultBootstrapConfig.connectTimeout.toMillis())
-                .setIdleTimeout((int) vaultBootstrapConfig.readTimeout.getSeconds());
+                .setIdleTimeout((int) vaultBootstrapConfig.readTimeout.getSeconds() * 2);
 
         if (vaultBootstrapConfig.nonProxyHosts.isPresent()) {
             options.setNonProxyHosts(vaultBootstrapConfig.nonProxyHosts.get());


### PR DESCRIPTION
Waiting for the container to start is not enough to be able to initialize the vault instance. We need to check that the API is ready as well. 
In a slow environment, if we don't, we can get a read timeout on the first http request. Most likely vault has received it and processed it, but for some reason the client (i.e. vault test) does not receive the response. It is not clear why this happens. But to make tests more resilient we need to exercise the API before executing non idempotent calls. This can't be the `init(int,int)` service, because as soon as the vault is initialized, it cannot be reinitialized (if the first call went through), and the test cannot continue without the root token and unseal keys that come from the `init` call.
This fix consists in trying out multiple times executing `sys/seal-status` until we get a valid response. Once this is done, we can continue the normal flow of vault initialization.
Also changed the idle timeout to be 2 times the read timeout, otherwise we risk closing the connection before the `atMost` throws a timeout exception.
Fixes https://github.com/quarkusio/quarkus/issues/21095
With that we should not need anymore the increases read and connect timeouts that have been tried earlier to try fixing this issue.