### PR TITLE
Fix named queries with reactive panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -488,12 +488,17 @@ Order.update("update from Person set name = 'Mortal' where status = ?", Status.A
 
 === Named queries
 
-You can reference a named query instead of a (simplified) HQL query by prefixing its name with the '#' character.
+You can reference a named query instead of a (simplified) HQL query by prefixing its name with the '#' character. You can also use named queries for count, update and delete queries.
 
 [source,java]
 ----
 @Entity
-@NamedQuery(name = "Person.getByName", query = "from Person where name = :name")
+@NamedQueries({
+    @NamedQuery(name = "Person.getByName", query = "from Person where name = ?1"),
+    @NamedQuery(name = "Person.countByStatus", query = "select count(*) from Person p where p.status = :status"),
+    @NamedQuery(name = "Person.updateStatusById", query = "update Person p set p.status = :status where p.id = :id"),
+    @NamedQuery(name = "Person.deleteById", query = "delete from Person p where p.id = ?1")
+})
 public class Person extends PanacheEntity {
     public String name;
     public LocalDate birth;
@@ -501,6 +506,18 @@ public class Person extends PanacheEntity {
 
     public static Uni<Person> findByName(String name){
         return find("#Person.getByName", name).firstResult();
+    }
+
+    public static Uni<Long> countByStatus(Status status) {
+        return count("#Person.countByStatus", Parameters.with("status", status).map());
+    }
+
+    public static Uni<Long> updateStatusById(Status status, Long id) {
+        return update("#Person.updateStatusById", Parameters.with("status", status).and("id", id));
+    }
+
+    public static Uni<Long> deleteById(Long id) {
+        return delete("#Person.deleteById", id);
     }
 }
 ----

--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -309,6 +309,14 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Uni<Long> count(Class<?> entityClass, String query, Object... params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName, Long.class), params).getSingleResult();
+            });
+
         return (Uni) getSession().chain(session -> bindParameters(
                 session.createQuery(PanacheJpaUtil.createCountQuery(entityClass, query, paramCount(params))),
                 params).getSingleResult());
@@ -316,6 +324,14 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Uni<Long> count(Class<?> entityClass, String query, Map<String, Object> params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName, Long.class), params).getSingleResult();
+            });
+
         return (Uni) getSession().chain(session -> bindParameters(
                 session.createQuery(PanacheJpaUtil.createCountQuery(entityClass, query, paramCount(params))),
                 params).getSingleResult());
@@ -360,12 +376,28 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Object... params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate().map(Integer::longValue);
+            });
+
         return getSession().chain(session -> bindParameters(
                 session.createQuery(PanacheJpaUtil.createDeleteQuery(entityClass, query, paramCount(params))), params)
                         .executeUpdate().map(Integer::longValue));
     }
 
     public Uni<Long> delete(Class<?> entityClass, String query, Map<String, Object> params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate().map(Integer::longValue);
+            });
+
         return getSession().chain(session -> bindParameters(
                 session.createQuery(PanacheJpaUtil.createDeleteQuery(entityClass, query, paramCount(params))), params)
                         .executeUpdate().map(Integer::longValue));
@@ -397,11 +429,27 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
     }
 
     public Uni<Integer> executeUpdate(Class<?> entityClass, String query, Object... params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate();
+            });
+
         String updateQuery = PanacheJpaUtil.createUpdateQuery(entityClass, query, paramCount(params));
         return executeUpdate(updateQuery, params);
     }
 
     public Uni<Integer> executeUpdate(Class<?> entityClass, String query, Map<String, Object> params) {
+
+        if (PanacheJpaUtil.isNamedQuery(query))
+            return (Uni) getSession().chain(session -> {
+                String namedQueryName = query.substring(1);
+                NamedQueryUtil.checkNamedQuery(entityClass, namedQueryName);
+                return bindParameters(session.createNamedQuery(namedQueryName), params).executeUpdate();
+            });
+
         String updateQuery = PanacheJpaUtil.createUpdateQuery(entityClass, query, paramCount(params));
         return executeUpdate(updateQuery, params);
     }

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Person.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/Person.java
@@ -12,6 +12,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
@@ -31,7 +32,18 @@ import io.smallrye.mutiny.Uni;
 
 @XmlRootElement
 @Entity(name = "Person2")
-@NamedQuery(name = "Person.getByName", query = "from Person2 where name = :name")
+@NamedQueries({
+        @NamedQuery(name = "Person.getByName", query = "from Person2 where name = :name"),
+        @NamedQuery(name = "Person.countAll", query = "select count(*) from Person2"),
+        @NamedQuery(name = "Person.countByName", query = "select count(*) from Person2 where name = :name"),
+        @NamedQuery(name = "Person.countByName.ordinal", query = "select count(*) from Person2 where name = ?1"),
+        @NamedQuery(name = "Person.updateAllNames", query = "Update Person2 p set p.name = :name"),
+        @NamedQuery(name = "Person.updateNameById", query = "Update Person2 p set p.name = :name where p.id = :id"),
+        @NamedQuery(name = "Person.updateNameById.ordinal", query = "Update Person2 p set p.name = ?1 where p.id = ?2"),
+        @NamedQuery(name = "Person.deleteAll", query = "delete from Person2"),
+        @NamedQuery(name = "Person.deleteById", query = "delete from Person2 p where p.id = :id"),
+        @NamedQuery(name = "Person.deleteById.ordinal", query = "delete from Person2 p where p.id = ?1"),
+})
 @FilterDef(name = "Person.hasName", defaultCondition = "name = :name", parameters = @ParamDef(name = "name", type = "string"))
 @FilterDef(name = "Person.isAlive", defaultCondition = "status = 'LIVING'")
 @Filter(name = "Person.isAlive")

--- a/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
+++ b/integration-tests/hibernate-reactive-panache/src/main/java/io/quarkus/it/panache/reactive/TestEndpoint.java
@@ -998,7 +998,111 @@ public class TestEndpoint {
                                 Assertions.assertEquals(0, count);
 
                                 return makeSavedPersonDao();
-                            });
+                            })
+
+                            .flatMap(v -> Person.count("#Person.countAll")
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.count("#Person.countByName", Parameters.with("name", "stef").map());
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.count("#Person.countByName", Parameters.with("name", "stef"));
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.count("#Person.countByName.ordinal", "stef");
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Uni.createFrom().voidItem();
+                                    }))
+                            .flatMap(voidUni -> Person.update("#Person.updateAllNames", Parameters.with("name", "stef2").map())
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("#Person.getByName", Parameters.with("name", "stef2")).list();
+                                    }).flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.update("#Person.updateAllNames", Parameters.with("name", "stef3"));
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("#Person.getByName", Parameters.with("name", "stef3")).list();
+                                    }).flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.update("#Person.updateNameById",
+                                                Parameters.with("name", "stef2").and("id", ((Person) persons.get(0)).id).map());
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("#Person.getByName", Parameters.with("name", "stef2")).list();
+                                    }).flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.update("#Person.updateNameById",
+                                                Parameters.with("name", "stef3").and("id", ((Person) persons.get(0)).id));
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("#Person.getByName", Parameters.with("name", "stef3")).list();
+                                    }).flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.update("#Person.updateNameById.ordinal", "stef",
+                                                ((Person) persons.get(0)).id);
+                                    }).flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("#Person.getByName", Parameters.with("name", "stef")).list();
+                                    }).flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Uni.createFrom().voidItem();
+                                    }))
+                            .flatMap(voidUni -> Dog.deleteAll()
+                                    .flatMap(v -> Person.delete("#Person.deleteAll"))
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("").list();
+                                    })
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(0, persons.size());
+                                        return Uni.createFrom().voidItem();
+                                    }))
+                            .flatMap(voidUni -> makeSavedPerson().flatMap(personToDelete -> Dog.deleteAll()
+                                    .flatMap(v -> Person.find("").list())
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.delete("#Person.deleteById",
+                                                Parameters.with("id", personToDelete.id).map());
+                                    })
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("").list();
+                                    })
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(0, persons.size());
+                                        return Uni.createFrom().voidItem();
+                                    })))
+                            .flatMap(voidUni -> makeSavedPerson().flatMap(personToDelete -> Dog.deleteAll()
+                                    .flatMap(v -> Person.find("").list())
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.delete("#Person.deleteById", Parameters.with("id", personToDelete.id));
+                                    })
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("").list();
+                                    })
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(0, persons.size());
+                                        return Uni.createFrom().voidItem();
+                                    })))
+                            .flatMap(voidUni -> makeSavedPerson().flatMap(personToDelete -> Dog.deleteAll()
+                                    .flatMap(v -> Person.find("").list())
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(1, persons.size());
+                                        return Person.delete("#Person.deleteById.ordinal", personToDelete.id);
+                                    })
+                                    .flatMap(count -> {
+                                        Assertions.assertEquals(1, count);
+                                        return Person.find("").list();
+                                    })
+                                    .flatMap(persons -> {
+                                        Assertions.assertEquals(0, persons.size());
+                                        return makeSavedPersonDao();
+                                    })));
+
                 }).flatMap(person -> {
 
                     return personDao.count()


### PR DESCRIPTION
@loicmathieu Here are fix to named queries with reactive panache.

Tests are skipped and I can't realize why. Could you help me with this? 
I am using this command `.\mvnw test -f .\integration-tests\hibernate-reactive-panache\` and having this output [maven.log](https://github.com/quarkusio/quarkus/files/7464756/maven.log)
