### PR TITLE
Fix resolution of media type for Hibernate Validator in Resteasy Reactive

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionMapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyViolationExceptionMapper.java
@@ -45,8 +45,10 @@ public class ResteasyViolationExceptionMapper implements ExceptionMapper<Validat
 
         // Check standard media types.
         MediaType mediaType = ValidatorMediaTypeUtil.getAcceptMediaType(headers.getAcceptableMediaTypes(),
-                exception.getAccept())
-                .orElse(MediaType.TEXT_PLAIN_TYPE);
+                exception.getAccept());
+        if (mediaType == null) {
+            mediaType = MediaType.TEXT_PLAIN_TYPE;
+        }
 
         if (MediaType.TEXT_PLAIN_TYPE.equals(mediaType)) {
             builder.entity(exception.toString());

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.validator.runtime.jaxrs;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import javax.ws.rs.core.MediaType;
 
@@ -11,11 +10,22 @@ import javax.ws.rs.core.MediaType;
  */
 public final class ValidatorMediaTypeUtil {
 
-    private static final List<MediaType> SUPPORTED_MEDIA_TYPES = Arrays.asList(MediaType.APPLICATION_XML_TYPE,
-            MediaType.APPLICATION_JSON_TYPE, MediaType.TEXT_PLAIN_TYPE);
+    private static final List<MediaType> SUPPORTED_MEDIA_TYPES = Arrays.asList(MediaType.APPLICATION_JSON_TYPE,
+            MediaType.APPLICATION_XML_TYPE,
+            MediaType.TEXT_PLAIN_TYPE);
 
     private ValidatorMediaTypeUtil() {
 
+    }
+
+    /**
+     * Look up the right media type taking into account the HTTP request and the supported media types.
+     *
+     * @param mediaTypesFromRequest list of media types in the HTTP request.
+     * @return one supported media type from either the HTTP request or the annotation.
+     */
+    public static MediaType getAcceptMediaTypeFromSupported(List<MediaType> mediaTypesFromRequest) {
+        return getAcceptMediaType(mediaTypesFromRequest, SUPPORTED_MEDIA_TYPES);
     }
 
     /**
@@ -26,23 +36,23 @@ public final class ValidatorMediaTypeUtil {
      * @param mediaTypesFromProducesAnnotation list of media types set in the `@Produces` annotation.
      * @return one supported media type from either the HTTP request or the annotation.
      */
-    public static Optional<MediaType> getAcceptMediaType(List<MediaType> mediaTypesFromRequest,
+    public static MediaType getAcceptMediaType(List<MediaType> mediaTypesFromRequest,
             List<MediaType> mediaTypesFromProducesAnnotation) {
 
         for (MediaType mediaType : mediaTypesFromRequest) {
             // It's supported and is included in the `@Produces` annotation
             if (isMediaTypeInList(mediaType, SUPPORTED_MEDIA_TYPES)
                     && isMediaTypeInList(mediaType, mediaTypesFromProducesAnnotation)) {
-                return Optional.of(mediaType);
+                return mediaType;
             }
         }
 
         // if none is found, then return the first from the annotation or empty if no produces annotation
         if (mediaTypesFromProducesAnnotation.isEmpty()) {
-            return Optional.empty();
+            return null;
         }
 
-        return Optional.of(mediaTypesFromProducesAnnotation.get(0));
+        return mediaTypesFromProducesAnnotation.get(0);
     }
 
     private static boolean isMediaTypeInList(MediaType mediaType, List<MediaType> list) {

--- a/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
+++ b/integration-tests/hibernate-validator-resteasy-reactive/pom.xml
@@ -20,6 +20,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
@@ -119,6 +123,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jaxb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -77,8 +77,14 @@ public class HibernateValidatorTestResource {
 
     @GET
     @Path("/rest-end-point-validation/{id}/")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN })
     public String testRestEndPointValidation(@Digits(integer = 5, fraction = 0) @RestPath("id") String id) {
+        return id;
+    }
+
+    @GET
+    @Path("/no-produces/{id}/")
+    public String testRestEndPointWithNoProduces(@Digits(integer = 5, fraction = 0) @RestPath("id") String id) {
         return id;
     }
 

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -22,6 +22,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 
 @QuarkusTest
@@ -108,8 +109,7 @@ public class HibernateValidatorFunctionalityTest {
         // are user errors and should be reported as such.
 
         // Bad request
-        RestAssured.when()
-                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+        RestAssured.get("/hibernate-validator/test/rest-end-point-validation/plop/")
                 .then()
                 .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
                 .body(containsString("numeric value out of bounds"));
@@ -125,6 +125,48 @@ public class HibernateValidatorFunctionalityTest {
                     .then()
                     .body(is("42"));
         }
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingTextMediaType() {
+        RestAssured.given()
+                .accept(ContentType.TEXT)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.TEXT)
+                .body(containsString("numeric value out of bounds"));
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingXmlMediaType() {
+        RestAssured.given()
+                .accept(ContentType.XML)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.XML)
+                .body("validationReport.violations.message", containsString("numeric value out of bounds"));
+    }
+
+    @Test
+    public void testRestEndPointValidationUsingJsonMediaType() {
+        RestAssured.given()
+                .accept(ContentType.JSON)
+                .get("/hibernate-validator/test/rest-end-point-validation/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .contentType(ContentType.JSON)
+                .body("violations[0].message", containsString("numeric value out of bounds"));
+    }
+
+    @Test
+    public void testNoProduces() {
+        RestAssured.given()
+                .get("/hibernate-validator/test/no-produces/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .body(containsString("numeric value out of bounds"));
     }
 
     @Test


### PR DESCRIPTION
As the Resteasy Reactive is adding the `text/plain` media type for endpoints returning String, we can't infer the media type that is defined in the produces annotation. Therefore, we'll always supply the media type from the user accept header if it's supported, or JSON by default (as it was working before).

Fix https://github.com/quarkusio/quarkus/issues/20888