### PR TITLE
Add new BOOTSTRAP recording phase

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/ExecutionTime.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/ExecutionTime.java
@@ -11,5 +11,18 @@ public enum ExecutionTime {
     /**
      * The bytecode is run from a main method
      */
-    RUNTIME_INIT
+    RUNTIME_INIT,
+    /**
+     * This is the first code that is executed when the application is started. For JVM based applications
+     * this is run before static init, while for native applications it is run before RUNTIME_INIT.
+     *
+     * Because it may be used after static init for results from a BOOTSTRAP_INIT recorder cannot be used in STATIC_INIT,
+     * and visa versa.
+     *
+     * This is an advanced option, it should only need to be used to setup things like logging that should happen as early
+     * as possible in the startup process.
+     *
+     */
+    BOOTSTRAP_INIT,
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeRecorderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/BytecodeRecorderBuildItem.java
@@ -1,21 +1,24 @@
 package io.quarkus.deployment.builditem;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 
-@Deprecated
-public final class MainBytecodeRecorderBuildItem extends MultiBuildItem {
+public final class BytecodeRecorderBuildItem extends MultiBuildItem {
 
     private final BytecodeRecorderImpl bytecodeRecorder;
     private final String generatedStartupContextClassName;
+    private final ExecutionTime executionTime;
 
-    public MainBytecodeRecorderBuildItem(BytecodeRecorderImpl bytecodeRecorder) {
+    public BytecodeRecorderBuildItem(BytecodeRecorderImpl bytecodeRecorder, ExecutionTime executionTime) {
         this.bytecodeRecorder = bytecodeRecorder;
+        this.executionTime = executionTime;
         this.generatedStartupContextClassName = null;
     }
 
-    public MainBytecodeRecorderBuildItem(String generatedStartupContextClassName) {
+    public BytecodeRecorderBuildItem(String generatedStartupContextClassName, ExecutionTime executionTime) {
         this.generatedStartupContextClassName = generatedStartupContextClassName;
+        this.executionTime = executionTime;
         this.bytecodeRecorder = null;
     }
 
@@ -25,5 +28,9 @@ public final class MainBytecodeRecorderBuildItem extends MultiBuildItem {
 
     public String getGeneratedStartupContextClassName() {
         return generatedStartupContextClassName;
+    }
+
+    public ExecutionTime getExecutionTime() {
+        return executionTime;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/RawCommandLineArgumentsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/RawCommandLineArgumentsBuildItem.java
@@ -27,8 +27,8 @@ public final class RawCommandLineArgumentsBuildItem extends SimpleBuildItem
     }
 
     @Override
-    public boolean __static$$init() {
-        return true;
+    public BytecodeRecorderImpl.Phase __quarkus$$phase() {
+        return BytecodeRecorderImpl.Phase.ALL;
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/ShutdownContextBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/ShutdownContextBuildItem.java
@@ -15,8 +15,8 @@ public final class ShutdownContextBuildItem extends SimpleBuildItem
     }
 
     @Override
-    public boolean __static$$init() {
-        return true;
+    public BytecodeRecorderImpl.Phase __quarkus$$phase() {
+        return BytecodeRecorderImpl.Phase.ALL;
     }
 
     @Override

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/StaticBytecodeRecorderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/StaticBytecodeRecorderBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.builditem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.recording.BytecodeRecorderImpl;
 
+@Deprecated
 public final class StaticBytecodeRecorderBuildItem extends MultiBuildItem {
 
     private final BytecodeRecorderImpl bytecodeRecorder;

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -143,6 +143,12 @@ public final class LoggingResourceProcessor {
     }
 
     @BuildStep
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
+    void setupLoggingRuntimeInit(LoggingSetupRecorder recorder, LogConfig log, LogBuildTimeConfig buildLog) {
+        recorder.initializeLoggingBoostrap(log, buildLog);
+    }
+
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     LoggingSetupBuildItem setupLoggingRuntimeInit(LoggingSetupRecorder recorder, LogConfig log, LogBuildTimeConfig buildLog,
             Optional<WebSocketLogHandlerBuildItem> logStreamHandlerBuildItem,

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/BootstrapConfigSetupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/BootstrapConfigSetupBuildStep.java
@@ -6,10 +6,11 @@ import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.builditem.BootstrapConfigSetupCompleteBuildItem;
+import io.quarkus.deployment.builditem.BytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.deployment.builditem.MainBytecodeRecorderBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.MethodCreator;
@@ -27,7 +28,7 @@ public class BootstrapConfigSetupBuildStep {
     @BuildStep
     @Produce(BootstrapConfigSetupCompleteBuildItem.class)
     void setupBootstrapConfig(BuildProducer<GeneratedClassBuildItem> generatedClass,
-            BuildProducer<MainBytecodeRecorderBuildItem> mainBytecodeRecorder) {
+            BuildProducer<BytecodeRecorderBuildItem> mainBytecodeRecorder) {
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
 
         try (ClassCreator clazz = ClassCreator.builder().classOutput(classOutput)
@@ -43,6 +44,7 @@ public class BootstrapConfigSetupBuildStep {
             }
         }
 
-        mainBytecodeRecorder.produce(new MainBytecodeRecorderBuildItem(BOOTSTRAP_CONFIG_STARTUP_TASK_CLASS_NAME));
+        mainBytecodeRecorder
+                .produce(new BytecodeRecorderBuildItem(BOOTSTRAP_CONFIG_STARTUP_TASK_CLASS_NAME, ExecutionTime.BOOTSTRAP_INIT));
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java
@@ -15,10 +15,11 @@ import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.builditem.BootstrapConfigSetupCompleteBuildItem;
+import io.quarkus.deployment.builditem.BytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
-import io.quarkus.deployment.builditem.MainBytecodeRecorderBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationSourceValueBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
@@ -49,7 +50,7 @@ public class RuntimeConfigSetupBuildStep {
     @Produce(RuntimeConfigSetupCompleteBuildItem.class)
     void setupRuntimeConfig(List<RunTimeConfigurationSourceValueBuildItem> runTimeConfigurationSourceValues,
             BuildProducer<GeneratedClassBuildItem> generatedClass,
-            BuildProducer<MainBytecodeRecorderBuildItem> mainBytecodeRecorder) {
+            BuildProducer<BytecodeRecorderBuildItem> mainBytecodeRecorder) {
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClass, true);
 
         try (ClassCreator clazz = ClassCreator.builder().classOutput(classOutput)
@@ -97,6 +98,7 @@ public class RuntimeConfigSetupBuildStep {
             }
         }
 
-        mainBytecodeRecorder.produce(new MainBytecodeRecorderBuildItem(RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME));
+        mainBytecodeRecorder
+                .produce(new BytecodeRecorderBuildItem(RUNTIME_CONFIG_STARTUP_TASK_CLASS_NAME, ExecutionTime.BOOTSTRAP_INIT));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -296,7 +296,9 @@ public class BytecodeRecorderTestCase {
     @Test
     public void testRecordingProxyToStringNotNull() {
         TestClassLoader tcl = new TestClassLoader(getClass().getClassLoader());
-        BytecodeRecorderImpl generator = new BytecodeRecorderImpl(tcl, false, TEST_CLASS);
+        BytecodeRecorderImpl generator = new BytecodeRecorderImpl.Builder().setClassLoader(tcl)
+                .setPhase(BytecodeRecorderImpl.Phase.RUNTIME_INIT)
+                .setClassName(TEST_CLASS).build();
         TestRecorder recorder = generator.getRecordingProxy(TestRecorder.class);
         assertNotNull(recorder.toString());
         assertTrue(recorder.toString().contains("$$RecordingProxyProxy"));
@@ -359,7 +361,9 @@ public class BytecodeRecorderTestCase {
     void runTest(Consumer<BytecodeRecorderImpl> generator, Object... expected) throws Exception {
         TestRecorder.RESULT.clear();
         TestClassLoader tcl = new TestClassLoader(getClass().getClassLoader());
-        BytecodeRecorderImpl recorder = new BytecodeRecorderImpl(tcl, false, TEST_CLASS);
+        BytecodeRecorderImpl recorder = new BytecodeRecorderImpl.Builder().setClassLoader(tcl)
+                .setPhase(BytecodeRecorderImpl.Phase.RUNTIME_INIT)
+                .setClassName(TEST_CLASS).build();
         generator.accept(recorder);
         recorder.writeBytecode(new TestClassOutput(tcl));
 

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
@@ -51,9 +51,11 @@ public class UnusedExclusionTest {
                     @Override
                     public void execute(BuildContext context) {
                         BeanContainer beanContainer = context.consume(BeanContainerBuildItem.class).getValue();
-                        BytecodeRecorderImpl bytecodeRecorder = new BytecodeRecorderImpl(true,
-                                TestRecorder.class.getSimpleName(),
-                                "test", "" + TestRecorder.class.hashCode(), true, s -> null);
+                        BytecodeRecorderImpl bytecodeRecorder = new BytecodeRecorderImpl.Builder()
+                                .setPhase(BytecodeRecorderImpl.Phase.STATIC_INIT)
+                                .setBuildStepName(TestRecorder.class.getSimpleName()).setMethodName("test")
+                                .setUniqueHash("" + TestRecorder.class.hashCode()).setUseIdentityComparison(true)
+                                .setConfigCreatorFunction(s -> null).build();
                         // We need to use reflection due to some class loading problems
                         Object recorderProxy = bytecodeRecorder.getRecordingProxy(TestRecorder.class);
                         try {

--- a/extensions/consul-config/deployment/src/main/java/io/quarkus/consul/config/ConsulConfigProcessor.java
+++ b/extensions/consul-config/deployment/src/main/java/io/quarkus/consul/config/ConsulConfigProcessor.java
@@ -30,7 +30,7 @@ public class ConsulConfigProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(ConsulConfigRecorder recorder) {
         return new RunTimeConfigurationSourceValueBuildItem(
                 recorder.configSources());

--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -22,7 +22,7 @@ import io.quarkus.runtime.TlsConfig;
 public class KubernetesConfigProcessor {
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(KubernetesConfigRecorder recorder,
             KubernetesConfigSourceConfig config, KubernetesConfigBuildTimeConfig buildTimeConfig,
             KubernetesClientBuildConfig clientConfig,

--- a/extensions/kubernetes-service-binding/deployment/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingProcessor.java
+++ b/extensions/kubernetes-service-binding/deployment/src/main/java/io/quarkus/kubernetes/service/binding/runtime/KubernetesServiceBindingProcessor.java
@@ -8,7 +8,7 @@ import io.quarkus.deployment.builditem.RunTimeConfigurationSourceValueBuildItem;
 public class KubernetesServiceBindingProcessor {
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(KubernetesServiceBindingRecorder recorder) {
         return new RunTimeConfigurationSourceValueBuildItem(recorder.configSources());
     }

--- a/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
+++ b/extensions/spring-cloud-config-client/deployment/src/main/java/io/quarkus/spring/cloud/config/client/SpringCloudConfigProcessor.java
@@ -34,7 +34,7 @@ public class SpringCloudConfigProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public RunTimeConfigurationSourceValueBuildItem configure(SpringCloudConfigClientRecorder recorder,
             SpringCloudConfigClientConfig springCloudConfigClientConfig,
             ApplicationConfig applicationConfig,

--- a/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
+++ b/extensions/vault/deployment/src/main/java/io/quarkus/vault/VaultProcessor.java
@@ -106,7 +106,7 @@ public class VaultProcessor {
                 .build();
     }
 
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     @BuildStep
     RunTimeConfigurationSourceValueBuildItem init(VaultRecorder recorder, VaultBootstrapConfig vaultBootstrapConfig) {
         return new RunTimeConfigurationSourceValueBuildItem(recorder.configure(vaultBootstrapConfig));

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -326,7 +326,7 @@ public class DevConsoleProcessor {
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     public void handler(BuildProducer<HistoryHandlerBuildItem> historyProducer,
             BuildProducer<WebSocketLogHandlerBuildItem> webSocketLogHandlerBuildItem,
             LogStreamRecorder recorder, DevUIConfig devUiConfig) {

--- a/integration-tests/bootstrap-config/extension/deployment/src/main/java/io/quarkus/it/bootstrap/config/extension/deployment/DummyBootstrapConfigBuildStep.java
+++ b/integration-tests/bootstrap-config/extension/deployment/src/main/java/io/quarkus/it/bootstrap/config/extension/deployment/DummyBootstrapConfigBuildStep.java
@@ -13,14 +13,14 @@ import io.quarkus.runtime.ApplicationConfig;
 public class DummyBootstrapConfigBuildStep {
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public RunTimeConfigurationSourceValueBuildItem dummyRecorder(DummyBootstrapRecorder recorder, DummyConfig dummyConfig,
             ApplicationConfig applicationConfig) {
         return new RunTimeConfigurationSourceValueBuildItem(recorder.create(dummyConfig, applicationConfig));
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.BOOTSTRAP_INIT)
     public void dummyRecorder2(DummyBootstrapRecorder2 recorder,
             BuildProducer<RunTimeConfigurationSourceValueBuildItem> producer) {
         producer.produce(new RunTimeConfigurationSourceValueBuildItem(recorder.create()));


### PR DESCRIPTION
This phase is guarenteed to run first when the application is started.
For JVM mode applications this means running before static init, for
native applications this means running before runtime init.

This allows logging to be setup as a priority, which means that logging
will work as expected while static init is being run. Without this
change applications that log a lot during static init (e.g. applications
with lots of Hibernate entities) will easily hit the dalyed handlers
limit, log messages will be dropped, and a warning printed to the
console.