### PR TITLE
Fix enforcer failure for Infinispan test module

### DIFF
--- a/test-framework/infinispan-client/pom.xml
+++ b/test-framework/infinispan-client/pom.xml
@@ -60,7 +60,18 @@
                     <groupId>net.spy</groupId>
                     <artifactId>spymemcached</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- needed to make the junit version converge -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Without this change, when `mvn install -f test-extension`
is executed, it fails because of:

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce) @ quarkus-test-infinispan-client ---
[WARNING]
Dependency convergence error for junit:junit:4.13.2 paths to dependency are:
+-io.quarkus:quarkus-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-testdriver-core:13.0.0.Final
    +-org.testcontainers:testcontainers:1.16.2
      +-junit:junit:4.13.2
and
+-io.quarkus:quarkus-test-infinispan-client:999-SNAPSHOT
  +-org.infinispan:infinispan-server-testdriver-core:13.0.0.Final
    +-junit:junit:4.13.1

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```