### PR TITLE
Bump smallrye-jwt version to 3.3.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -49,7 +49,7 @@
         <smallrye-graphql.version>1.3.5</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>3.3.0</smallrye-jwt.version>
+        <smallrye-jwt.version>3.3.1</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -110,6 +110,22 @@ import io.smallrye.jwt.build.Jwt;
 String jwt = Jwt.upn("Alice").jws().algorithm(SignatureAlgorithm.PS256).sign();
 ----
 
+Alternatively you can use a `smallrye.jwt.new-token.signature-algorithm` property:
+
+```properties
+smallrye.jwt.new-token.signature-algorithm=PS256
+```
+
+and write a simpler API sequence:
+
+[source, java]
+----
+import io.smallrye.jwt.build.Jwt;
+
+// Sign the claims using an RSA private key loaded from the location set with a 'smallrye.jwt.sign.key.location' property. Algorithm is PS256.
+String jwt = Jwt.upn("Alice").sign();
+----
+
 Note the `sign` step can be combined with the <<encrypt-claims, encrypt>> step to produce `inner-signed and encrypted` tokens, see <<innersign-encrypt-claims, Sign the claims and encrypt the nested JWT token>> section.
 
 [[encrypt-claims]]
@@ -156,6 +172,23 @@ String jwt = Jwt.subject("Bob").jwe()
     .encrypt();
 ----
 
+Alternatively, especially if the default `A256GCM` content encryption algorithm does not need to be changed, you can use a `smallrye.jwt.new-token.key-encryption-algorithm` property to customize a key encryption algorithm:
+
+```properties
+smallrye.jwt.new-token.key-encryption-algorithm=RSA-OAEP-256
+```
+
+and write a simpler API sequence:
+
+[source, java]
+----
+import io.smallrye.jwt.build.Jwt;
+
+// Encrypt the claims using an RSA public key loaded from the location set with a 'smallrye.jwt.encrypt.key.location' property.
+// Key encryption algorithm is RSA-OAEP-256, content encryption algorithm is A256GCM.
+String jwt = Jwt.subject("Bob").encrypt();
+----
+
 Note that when the token is directly encrypted by the public RSA or EC key it is not possible to verify which party sent the token.
 Therefore the secret keys should be preferred for directly encrypting the tokens, for example, when using JWT as cookies where a secret key is managed by the Quarkus endpoint with only this endpoint being both a producer and a consumer of the encrypted token.
 
@@ -170,7 +203,7 @@ The claims can be signed and then the nested JWT token encrypted by combining th
 import io.smallrye.jwt.build.Jwt;
 ...
 
-// Sign the claims and encrypt the nested token using the private and public keys loaded from the locations set with the 'smallrye.jwt.sign.key.location' and 'smallrye.jwt.encrypt.key.location' properties respectively.
+// Sign the claims and encrypt the nested token using the private and public keys loaded from the locations set with the 'smallrye.jwt.sign.key.location' and 'smallrye.jwt.encrypt.key.location' properties respectively. Signature algorithm is RS256, key encryption algorithm is RSA-OAEP-256.
 String jwt = Jwt.claims("/tokenClaims.json").innerSign().encrypt();
 ----
 
@@ -251,6 +284,8 @@ SmallRye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.sign.key.id|`none`|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.encrypt.key.location|`none`|Location of a public key which will be used to encrypt the claims or inner JWT when a no-argument `encrypt()` method is called.
 |smallrye.jwt.encrypt.key.id|`none`|Encryption key identifier which is checked only when JWK keys are used.
+|smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
+|smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.


### PR DESCRIPTION
This PR bumps the version to 3.3.1 (it just adds two new properties to customize the algorithms when creating the tokens and does some other minor cleanup) and updates the docs (I've also realized a minor follow up at the `smalrye-jwt` level is required: https://github.com/smallrye/smallrye-jwt/issues/519, will be in 3.3.2).

Also I've noticed #21189 was opened while I was preparing this PR so the new properties will help.

CC @gastaldi @gsmet 