### PR TITLE
Allow to customize JWT token algorithm for OIDC and OIDC client

### DIFF
--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
@@ -4,3 +4,4 @@ quarkus.oidc-client.client-enabled=false
 quarkus.oidc-client.jwt.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.jwt.credentials.jwt.secret-provider.key=secret-from-vault-for-jwt
+quarkus.oidc-client.jwt.credentials.jwt.signature-algorithm=HS512

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -268,6 +268,13 @@ public class OidcCommonConfig {
             public Optional<String> tokenKeyId = Optional.empty();
 
             /**
+             * Signature algorithm.
+             * Supported values: RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512.
+             */
+            @ConfigItem
+            public Optional<String> signatureAlgorithm = Optional.empty();
+
+            /**
              * JWT life-span in seconds. It will be added to the time it was issued at to calculate the expiration time.
              */
             @ConfigItem(defaultValue = "10")
@@ -303,6 +310,14 @@ public class OidcCommonConfig {
 
             public void setSecretProvider(Provider secretProvider) {
                 this.secretProvider = secretProvider;
+            }
+
+            public Optional<String> getSignatureAlgorithm() {
+                return signatureAlgorithm;
+            }
+
+            public void setSignatureAlgorithm(String signatureAlgorithm) {
+                this.signatureAlgorithm = Optional.of(signatureAlgorithm);
             }
 
         }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -32,6 +32,7 @@ import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Tls.Verification;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 import io.smallrye.jwt.build.Jwt;
 import io.smallrye.jwt.build.JwtSignatureBuilder;
 import io.smallrye.jwt.util.KeyUtils;
@@ -289,6 +290,15 @@ public class OidcCommonUtils {
                 .jws();
         if (oidcConfig.credentials.jwt.getTokenKeyId().isPresent()) {
             builder.keyId(oidcConfig.credentials.jwt.getTokenKeyId().get());
+        }
+        if (oidcConfig.credentials.jwt.getSignatureAlgorithm().isPresent()) {
+            SignatureAlgorithm signatureAlgorithm;
+            try {
+                signatureAlgorithm = SignatureAlgorithm.fromAlgorithm(oidcConfig.credentials.jwt.getSignatureAlgorithm().get());
+            } catch (Exception ex) {
+                throw new ConfigurationException("Unsupported signature algorithm");
+            }
+            builder.algorithm(signatureAlgorithm);
         }
         if (key instanceof SecretKey) {
             return builder.sign((SecretKey) key);


### PR DESCRIPTION
This PR follows #21192 - makes it possible to customize a token signature algorithm by using `quarkus.oidc.credentials.jwt` or `quarkus.oidc-client.credentials.jwt` scoped `signature-algorithm` property to make it more flexible as opposed to relying on a global property.

We have already have 3 separate JWT authentication oidc-client and oidc tests so rather than creating a new one I just modified the existing one - the secret key which is used has length `512 bits` or more - so it just worked - I can confirm that if trim [this key](https://github.com/quarkusio/quarkus/blob/main/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/SecretProvider.java#L22) a bit then I see
```
org.jose4j.lang.InvalidKeyException: A key of the same size as the hash output (i.e. 512 bits for HS512) or larger MUST be used with the HMAC SHA algorithms but this key is only 336 bits
```

PR itself is very simple - just adds a `signature-algorithm` property and updates the JWT JWS builder if it is set