### PR TITLE
CI - Always clean the Gradle temp directory

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -306,6 +306,7 @@ jobs:
         # Despite the pre-calculated run_jvm flag, GIB has to be re-run here to figure out the exact submodules to build.
         run: ./mvnw $COMMON_MAVEN_ARGS install -Dsurefire.timeout=1200 -pl !integration-tests/gradle -pl !integration-tests/maven -pl !integration-tests/devtools ${{ matrix.java.maven_args }} ${{ needs.build-jdk11.outputs.gib_args }}
       - name: Clean Gradle temp directory
+        if: always()
         shell: bash
         run: devtools/gradle/gradlew --stop && rm -rf devtools/gradle/gradle-extension-plugin/build/tmp
       - name: Prepare failure archive (if maven failed)


### PR DESCRIPTION
Otherwise in case of build failure, it's not cleaned up and we can end
up with errors when trying to upload the build reports.

Note: this was originally added because of weird Windows issues when uploading build artifacts (somehow the temp files are causing issues when assembling the artifact).