### PR TITLE
Remove logging related methods from QuarkusUnitTest that can't work

### DIFF
--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/GlobalAndServiceInterceptorsTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/GlobalAndServiceInterceptorsTest.java
@@ -60,7 +60,6 @@ public class GlobalAndServiceInterceptorsTest {
 
     @BeforeEach
     void cleanUp() {
-        config.getLogRecords();
         GlobalInterceptor.invoked = false;
         ServiceBInterceptor.invoked = false;
         FarewellInterceptor.invoked = false;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -265,14 +265,6 @@ public class QuarkusUnitTest
         return this;
     }
 
-    public List<LogRecord> getLogRecords() {
-        return inMemoryLogHandler.records;
-    }
-
-    public void clearLogRecords() {
-        inMemoryLogHandler.clearRecords();
-    }
-
     public QuarkusUnitTest assertLogRecords(Consumer<List<LogRecord>> assertLogRecords) {
         if (this.assertLogRecords != null) {
             throw new IllegalStateException("Don't set the a log record assertion twice"


### PR DESCRIPTION
These can't work because the handle the tests have is for the incorrect
QuarkusUnitTest object

Closes: #21225