### PR TITLE
ArC - fix regression with repeatable interceptor bindings

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -469,6 +469,7 @@ public class ArcProcessor {
             public void registerField(FieldInfo fieldInfo) {
                 reflectiveFields.produce(new ReflectiveFieldBuildItem(fieldInfo));
             }
+
         }, existingClasses.existingClasses, bytecodeTransformerConsumer,
                 config.shouldEnableBeanRemoval() && config.detectUnusedFalsePositives);
         for (ResourceOutput.Resource resource : resources) {
@@ -495,6 +496,11 @@ public class ArcProcessor {
         // Register all qualifiers for reflection to support type-safe resolution at runtime in native image
         for (ClassInfo qualifier : beanProcessor.getBeanDeployment().getQualifiers()) {
             reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, qualifier.name().toString()));
+        }
+
+        // Register all interceptor bindings for reflection so that AnnotationLiteral.equals() works in a native image
+        for (ClassInfo binding : beanProcessor.getBeanDeployment().getInterceptorBindings()) {
+            reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, binding.name().toString()));
         }
 
         ArcContainer container = recorder.getContainer(shutdown);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AbstractGenerator.java
@@ -14,9 +14,15 @@ abstract class AbstractGenerator {
     static final String SYNTHETIC_SUFFIX = "Synthetic";
 
     protected final boolean generateSources;
+    protected final ReflectionRegistration reflectionRegistration;
+
+    public AbstractGenerator(boolean generateSources, ReflectionRegistration reflectionRegistration) {
+        this.generateSources = generateSources;
+        this.reflectionRegistration = reflectionRegistration;
+    }
 
     public AbstractGenerator(boolean generateSources) {
-        this.generateSources = generateSources;
+        this(generateSources, null);
     }
 
     /**

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -48,11 +48,8 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
 
     private static final Logger LOGGER = Logger.getLogger(AnnotationLiteralGenerator.class);
 
-    private final boolean generateSources;
-
     AnnotationLiteralGenerator(boolean generateSources) {
         super(generateSources);
-        this.generateSources = generateSources;
     }
 
     /**
@@ -72,7 +69,7 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
         return resources;
     }
 
-    static void createSharedAnnotationLiteral(ClassOutput classOutput, Key key, Literal literal, Set<String> existingClasses) {
+    void createSharedAnnotationLiteral(ClassOutput classOutput, Key key, Literal literal, Set<String> existingClasses) {
         // Ljavax/enterprise/util/AnnotationLiteral<Lcom/foo/MyQualifier;>;Lcom/foo/MyQualifier;
         String signature = String.format("Ljavax/enterprise/util/AnnotationLiteral<L%1$s;>;L%1$s;",
                 key.annotationName.toString().replace('.', '/'));
@@ -113,6 +110,7 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
         generateStaticFieldsWithDefaultValues(annotationLiteral, defaultOfClassType);
 
         annotationLiteral.close();
+
         LOGGER.debugf("Shared annotation literal generated: %s", literal.className);
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ClientProxyGenerator.java
@@ -57,15 +57,13 @@ public class ClientProxyGenerator extends AbstractGenerator {
 
     private final Predicate<DotName> applicationClassPredicate;
     private final boolean mockable;
-    private final ReflectionRegistration reflectionRegistration;
     private final Set<String> existingClasses;
 
     public ClientProxyGenerator(Predicate<DotName> applicationClassPredicate, boolean generateSources, boolean mockable,
             ReflectionRegistration reflectionRegistration, Set<String> existingClasses) {
-        super(generateSources);
+        super(generateSources, reflectionRegistration);
         this.applicationClassPredicate = applicationClassPredicate;
         this.mockable = mockable;
-        this.reflectionRegistration = reflectionRegistration;
         this.existingClasses = existingClasses;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
@@ -106,9 +106,8 @@ public class DecoratorGenerator extends BeanGenerator {
         implementGetIdentifier(decorator, decoratorCreator);
         implementSupplierGet(decoratorCreator);
         implementCreate(classOutput, decoratorCreator, decorator, providerType, baseName,
-                injectionPointToProviderField,
-                Collections.emptyMap(), Collections.emptyMap(),
-                reflectionRegistration, targetPackage, isApplicationClass);
+                injectionPointToProviderField, Collections.emptyMap(), Collections.emptyMap(),
+                targetPackage, isApplicationClass);
         implementGet(decorator, decoratorCreator, providerType, baseName);
         implementGetTypes(decoratorCreator, beanTypes.getFieldDescriptor());
         implementGetBeanClass(decorator, decoratorCreator);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -101,7 +101,7 @@ public class InterceptorGenerator extends BeanGenerator {
         implementCreate(classOutput, interceptorCreator, interceptor, providerType, baseName,
                 injectionPointToProviderField,
                 Collections.emptyMap(), Collections.emptyMap(),
-                reflectionRegistration, targetPackage, isApplicationClass);
+                targetPackage, isApplicationClass);
         implementGet(interceptor, interceptorCreator, providerType, baseName);
         implementGetTypes(interceptorCreator, beanTypes.getFieldDescriptor());
         implementGetBeanClass(interceptor, interceptorCreator);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -20,6 +20,7 @@ import io.quarkus.arc.impl.MapValueSupplier;
 import io.quarkus.arc.impl.Objects;
 import io.quarkus.arc.impl.Reflections;
 import io.quarkus.arc.impl.RemovedBeanImpl;
+import io.quarkus.arc.impl.Sets;
 import io.quarkus.gizmo.MethodDescriptor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -223,7 +224,7 @@ public final class MethodDescriptors {
     public static final MethodDescriptor COLLECTIONS_EMPTY_MAP = MethodDescriptor.ofMethod(Collections.class, "emptyMap",
             Map.class);
 
-    public static final MethodDescriptor SET_OF = MethodDescriptor.ofMethod(Set.class, "of", Set.class, Object[].class);
+    public static final MethodDescriptor SETS_OF = MethodDescriptor.ofMethod(Sets.class, "of", Set.class, Object[].class);
 
     public static final MethodDescriptor ARC_CONTAINER = MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class);
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -64,7 +64,6 @@ public class ObserverGenerator extends AbstractGenerator {
     private final AnnotationLiteralProcessor annotationLiterals;
     private final Predicate<DotName> applicationClassPredicate;
     private final PrivateMembersCollector privateMembers;
-    private final ReflectionRegistration reflectionRegistration;
     private final Set<String> existingClasses;
     private final Map<ObserverInfo, String> observerToGeneratedName;
     private final Predicate<DotName> injectionPointAnnotationsPredicate;
@@ -74,11 +73,10 @@ public class ObserverGenerator extends AbstractGenerator {
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses, Map<ObserverInfo, String> observerToGeneratedName,
             Predicate<DotName> injectionPointAnnotationsPredicate, boolean mockable) {
-        super(generateSources);
+        super(generateSources, reflectionRegistration);
         this.annotationLiterals = annotationLiterals;
         this.applicationClassPredicate = applicationClassPredicate;
         this.privateMembers = privateMembers;
-        this.reflectionRegistration = reflectionRegistration;
         this.existingClasses = existingClasses;
         this.observerToGeneratedName = observerToGeneratedName;
         this.injectionPointAnnotationsPredicate = injectionPointAnnotationsPredicate;
@@ -567,7 +565,7 @@ public class ObserverGenerator extends AbstractGenerator {
             constructor.writeInstanceField(
                     FieldDescriptor.of(observerCreator.getClassName(), "qualifiers", Set.class.getName()),
                     constructor.getThis(),
-                    constructor.invokeStaticInterfaceMethod(MethodDescriptors.SET_OF,
+                    constructor.invokeStaticMethod(MethodDescriptors.SETS_OF,
                             qualifiersArray));
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -77,7 +77,6 @@ public class SubclassGenerator extends AbstractGenerator {
             "bindings", Set.class);
 
     private final Predicate<DotName> applicationClassPredicate;
-    private final ReflectionRegistration reflectionRegistration;
     private final Set<String> existingClasses;
 
     static String generatedName(DotName providerTypeName, String baseName) {
@@ -90,10 +89,9 @@ public class SubclassGenerator extends AbstractGenerator {
     public SubclassGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
             boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses) {
-        super(generateSources);
+        super(generateSources, reflectionRegistration);
         this.applicationClassPredicate = applicationClassPredicate;
         this.annotationLiterals = annotationLiterals;
-        this.reflectionRegistration = reflectionRegistration;
         this.existingClasses = existingClasses;
     }
 
@@ -259,7 +257,7 @@ public class SubclassGenerator extends AbstractGenerator {
                         constructor.writeArrayValue(bindingsArray, bindingsIndex++,
                                 bindingsLiterals.computeIfAbsent(binding, bindingsLiteralFun));
                     }
-                    return constructor.invokeStaticInterfaceMethod(MethodDescriptors.SET_OF, bindingsArray);
+                    return constructor.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray);
                 }
             }
         };
@@ -817,7 +815,7 @@ public class SubclassGenerator extends AbstractGenerator {
             // InvocationContextImpl.preDestroy(this,predestroys)
             ResultHandle invocationContext = tryCatch.invokeStaticMethod(MethodDescriptors.INVOCATION_CONTEXTS_PRE_DESTROY,
                     tryCatch.getThis(), predestroysHandle,
-                    tryCatch.invokeStaticInterfaceMethod(MethodDescriptors.SET_OF, bindingsArray));
+                    tryCatch.invokeStaticMethod(MethodDescriptors.SETS_OF, bindingsArray));
 
             // InvocationContext.proceed()
             tryCatch.invokeInterfaceMethod(MethodDescriptors.INVOCATION_CONTEXT_PROCEED, invocationContext);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Sets.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Sets.java
@@ -1,0 +1,33 @@
+package io.quarkus.arc.impl;
+
+import java.util.Arrays;
+import java.util.Set;
+
+public final class Sets {
+
+    private Sets() {
+    }
+
+    /**
+     * Unlike {@link Set#of(Object...)} this method does not throw an {@link IllegalArgumentException} if there are duplicate
+     * elements.
+     * 
+     * @param <E>
+     * @param elements
+     * @return the set
+     */
+    @SafeVarargs
+    public static <E> Set<E> of(E... elements) {
+        switch (elements.length) {
+            case 0:
+                return Set.of();
+            case 1:
+                return Set.of(elements[0]);
+            case 2:
+                return elements[0].equals(elements[1]) ? Set.of(elements[0]) : Set.of(elements[0], elements[1]);
+            default:
+                return Set.copyOf(Arrays.asList(elements));
+        }
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/Simple.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/Simple.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.arc.interceptor;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+@Repeatable(Simple.List.class)
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@InterceptorBinding
+public @interface Simple {
+
+    @Nonbinding
+    String name();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface List {
+
+        Simple[] value();
+
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/SimpleBean.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/SimpleBean.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.arc.interceptor;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SimpleBean {
+
+    @Simple(name = "foo")
+    @Simple(name = "bar")
+    public String ping() {
+        return "OK";
+    }
+
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/SimpleInterceptor.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/SimpleInterceptor.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.arc.interceptor;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Simple(name = "")
+@Priority(1)
+@Interceptor
+public class SimpleInterceptor {
+
+    @AroundInvoke
+    Object mySuperCoolAroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/TestSimpleBeanEndpoint.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/arc/interceptor/TestSimpleBeanEndpoint.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.arc.interceptor;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/simple-bean")
+public class TestSimpleBeanEndpoint {
+
+    @Inject
+    SimpleBean simpleBean;
+
+    @GET
+    public String manualValidation() {
+        return simpleBean.ping();
+
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleBeanITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleBeanITCase.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.main;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class SimpleBeanITCase extends SimpleBeanTestCase {
+
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleBeanTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleBeanTestCase.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.main;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class SimpleBeanTestCase {
+
+    @Test
+    public void testRequestScope() {
+        RestAssured.when().get("/simple-bean").then()
+                .body(is("OK"));
+    }
+
+}


### PR DESCRIPTION
- register all interceptor bindings for reflection so that
javax.enterprise.util.AnnotationLiteral.equals(Object) works in a native
image
- do not use java.util.Set#of(Object...) directly because it throws an
IAE if there are duplicate elements
- resolves #21174