### PR TITLE
Encryption support for Reactive Microsoft SQL Server Client

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -97,7 +97,7 @@ As SSL is de facto the standard nowadays, we decided to enable its support autom
  * the Reactive client for IBM DB2 extension (`quarkus-reactive-db2-client`),
  * the Reactive client for PostgreSQL extension (`quarkus-reactive-pg-client`),
  * the Reactive client for MySQL extension (`quarkus-reactive-mysql-client`),
- * the Reactive client for DB2 extension (`quarkus-reactive-db2-client`).
+ * the Reactive client for Microsoft SQL Server extension (`quarkus-reactive-mssql-client`),
  * the Redis client extension (`quarkus-redis-client`),
  * the REST Client extension (`quarkus-rest-client`),
  * the REST Client Reactive extension (`quarkus-rest-client-reactive`),

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -476,6 +476,11 @@ Navigate to http://localhost:8080/fruits.html and read/create/delete some fruits
 |`io.vertx.mutiny.mysqlclient.MySQLPool`
 |`?`
 
+|Microsoft SQL Server
+|`quarkus-reactive-mssql-client`
+|`io.vertx.mutiny.mssqlclient.MSSQLPool`
+|`@p1`, `@p2`, etc.
+
 |PostgreSQL
 |`quarkus-reactive-pg-client`
 |`io.vertx.mutiny.pgclient.PgPool`
@@ -703,6 +708,10 @@ include::{generated-dir}/config/quarkus-reactive-db2-client.adoc[opts=optional, 
 === MariaDB/MySQL
 
 include::{generated-dir}/config/quarkus-reactive-mysql-client.adoc[opts=optional, leveloffset=+1]
+
+=== Microsoft SQL Server
+
+include::{generated-dir}/config/quarkus-reactive-mssql-client.adoc[opts=optional, leveloffset=+1]
 
 === PostgreSQL
 

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -73,6 +73,9 @@ class ReactiveMSSQLClientProcessor {
                     curateOutcomeBuildItem);
         }
 
+        // Enable SSL support by default
+        sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.REACTIVE_MSSQL_CLIENT));
+
         return new ServiceStartBuildItem("reactive-mssql-client");
     }
 

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/DataSourceReactiveMSSQLConfig.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/DataSourceReactiveMSSQLConfig.java
@@ -14,4 +14,10 @@ public class DataSourceReactiveMSSQLConfig {
     @ConfigItem
     public OptionalInt packetSize = OptionalInt.empty();
 
+    /**
+     * Whether SSL/TLS is enabled.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean ssl = false;
+
 }

--- a/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
+++ b/extensions/reactive-mssql-client/runtime/src/main/java/io/quarkus/reactive/mssql/client/runtime/MSSQLPoolRecorder.java
@@ -2,6 +2,12 @@ package io.quarkus.reactive.mssql.client.runtime;
 
 import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
 import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksKeyCertOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configureJksTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemKeyCertOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePemTrustOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxKeyCertOptions;
+import static io.quarkus.vertx.core.runtime.SSLConfigHelper.configurePfxTrustOptions;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -126,6 +132,24 @@ public class MSSQLPoolRecorder {
         mssqlConnectOptions.setReconnectAttempts(dataSourceReactiveRuntimeConfig.reconnectAttempts);
 
         mssqlConnectOptions.setReconnectInterval(dataSourceReactiveRuntimeConfig.reconnectInterval.toMillis());
+
+        mssqlConnectOptions.setSsl(dataSourceReactiveMSSQLConfig.ssl);
+
+        mssqlConnectOptions.setTrustAll(dataSourceReactiveRuntimeConfig.trustAll);
+
+        configurePemTrustOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.trustCertificatePem);
+        configureJksTrustOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.trustCertificateJks);
+        configurePfxTrustOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.trustCertificatePfx);
+
+        configurePemKeyCertOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePem);
+        configureJksKeyCertOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificateJks);
+        configurePfxKeyCertOptions(mssqlConnectOptions, dataSourceReactiveRuntimeConfig.keyCertificatePfx);
+
+        if (dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm.isPresent()) {
+            mssqlConnectOptions.setHostnameVerificationAlgorithm(
+                    dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm.get());
+        }
+
         return mssqlConnectOptions;
     }
 

--- a/integration-tests/reactive-mssql-client/src/main/resources/application.properties
+++ b/integration-tests/reactive-mssql-client/src/main/resources/application.properties
@@ -2,3 +2,6 @@ quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=A_Str0ng_Required_Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
+#Uncomment to connect over SSL/TLS
+#quarkus.datasource.reactive.trust-all=true
+#quarkus.datasource.reactive.mssql.ssl=true

--- a/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
+++ b/integration-tests/reactive-mssql-client/src/test/resources/application-tl.properties
@@ -3,3 +3,6 @@ quarkus.datasource.username=sa
 quarkus.datasource.password=A_Str0ng_Required_Password
 quarkus.datasource.reactive.url=${reactive-mssql.url}
 quarkus.log.category."io.quarkus.reactive.datasource".level=DEBUG
+#Uncomment to connect over SSL/TLS
+#quarkus.datasource.reactive.trust-all=true
+#quarkus.datasource.reactive.mssql.ssl=true


### PR DESCRIPTION
With the latest Vert.x upgrade (see #21195) it is now possible to support SSL/TLS.

The reactive mssql client extension will now enable native SSL support by default.

Also, missing sections have been added in the doc:

- client details
- client specific config