### PR TITLE
Remove obsolete Java >= 11 check in jib AppCDS integration-test

### DIFF
--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/verify.groovy
@@ -1,12 +1,6 @@
 import io.quarkus.deployment.util.ExecUtil
-import io.quarkus.runtime.util.JavaVersionUtil
 
 import java.util.concurrent.ThreadLocalRandom
-
-if (!JavaVersionUtil.java11OrHigher) {
-    // AppCDS don't work in Java 8
-    return
-}
 
 try {
     ExecUtil.exec("docker", "version", "--format", "'{{.Server.Version}}'")


### PR DESCRIPTION
Nothing in CI runs with Java < 11 and hopefully nobody is using < 11 locally.