### PR TITLE
Update and relocate TCK versions, add to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,7 +134,41 @@ updates:
       - dependency-name: org.jetbrains.kotlin:*
       - dependency-name: org.jetbrains.kotlinx:*
       - dependency-name: org.jetbrains.dokka:*
+      # TCKs
+      - dependency-name: org.eclipse.microprofile.config:microprofile-config-tck
+      - dependency-name: org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck
+      - dependency-name: org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck
+      - dependency-name: org.eclipse.microprofile.graphql:microprofile-graphql-tck
+      - dependency-name: org.eclipse.microprofile.health:microprofile-health-tck
+      - dependency-name: org.eclipse.microprofile.jwt:microprofile-jwt-auth-tck
+      - dependency-name: org.eclipse.microprofile.metrics:microprofile-metrics-*-tck
+      - dependency-name: org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck
+      - dependency-name: org.eclipse.microprofile.openapi:microprofile-openapi-tck
+      - dependency-name: org.eclipse.microprofile.opentracing:microprofile-opentracing-tck*
+      - dependency-name: org.eclipse.microprofile.rest.client:microprofile-rest-client-tck
     ignore:
+      - dependency-name: org.eclipse.microprofile.config:microprofile-config-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.context-propagation:microprofile-context-propagation-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.graphql:microprofile-graphql-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.health:microprofile-health-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.jwt:microprofile-jwt-auth-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.metrics:microprofile-metrics-*-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.openapi:microprofile-openapi-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.opentracing:microprofile-opentracing-tck*
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: org.eclipse.microprofile.rest.client:microprofile-rest-client-tck
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: org.glassfish:jakarta-el
         update-types: ["version-update:semver-major"]
       - dependency-name: org.eclipse:yasson

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -69,18 +69,7 @@
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>
         <quarkus-maven-plugin.version>${project.version}</quarkus-maven-plugin.version>
 
-        <!-- MicroProfile TCK versions -->
-        <microprofile-health-api.version>3.1</microprofile-health-api.version>
-        <microprofile-config-api.version>2.0</microprofile-config-api.version>
-        <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
-        <microprofile-fault-tolerance-api.version>3.0</microprofile-fault-tolerance-api.version>
-        <microprofile-reactive-messaging-api.version>2.0</microprofile-reactive-messaging-api.version>
-        <microprofile-rest-client-api.version>2.0</microprofile-rest-client-api.version>
-        <microprofile-open-api.version>2.0.1-RC1</microprofile-open-api.version>
-        <microprofile-opentracing-api.version>2.0</microprofile-opentracing-api.version>
-        <microprofile-context-propagation.version>1.0.1</microprofile-context-propagation.version>
-        <microprofile-jwt-api.version>1.2</microprofile-jwt-api.version>
-        <microprofile-graphql-api.version>1.1.0</microprofile-graphql-api.version>
+        <!-- MicroProfile TCK versions used to be defined here but have moved to the concrete tck modules -->
 
         <!-- Antlr is used by the PanacheQL parser-->
         <antlr.version>4.9.2</antlr.version>

--- a/extensions/smallrye-metrics/spi/pom.xml
+++ b/extensions/smallrye-metrics/spi/pom.xml
@@ -20,13 +20,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>${microprofile-metrics-api.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.osgi</groupId>
-                    <artifactId>org.osgi.annotation.versioning</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/tcks/microprofile-config/pom.xml
+++ b/tcks/microprofile-config/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-tck-microprofile-config</artifactId>
     <name>Quarkus - TCK - MicroProfile Config</name>
 
+    <properties>
+        <microprofile-config-tck.version>2.0</microprofile-config-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -64,7 +68,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>${microprofile-config-api.version}</version>
+            <version>${microprofile-config-tck.version}</version>
         </dependency>
     </dependencies>
 

--- a/tcks/microprofile-context-propagation/pom.xml
+++ b/tcks/microprofile-context-propagation/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-tck-microprofile-context-propagation</artifactId>
     <name>Quarkus - TCK - MicroProfile Context Propagation</name>
 
+    <properties>
+        <microprofile-context-propagation-tck.version>1.2</microprofile-context-propagation-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -74,7 +78,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.context-propagation</groupId>
             <artifactId>microprofile-context-propagation-tck</artifactId>
-            <version>${microprofile-context-propagation.version}</version>
+            <version>${microprofile-context-propagation-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.enterprise</groupId>

--- a/tcks/microprofile-context-propagation/tck-tests.xml
+++ b/tcks/microprofile-context-propagation/tck-tests.xml
@@ -2,28 +2,34 @@
 <suite name="MP-CP TCK" verbose="0" configfailurepolicy="continue">
 
     <test name="MP-CP TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.context.tck.*"/>
+        </packages>
         <classes>
             <!-- 
                 If I use packages to scan for classes, they run in parallel which our arquillian integration
                 does not support so I end up with NPEs in MPConfigTest in our arquillian integration.
                 The only alternative is to list them all just to be able to exclude two methods.
+                Update by famod: Instead of listing all, just run MPConfigTest separately to avoid skipping
+                new tests when updating the tck dependency.
              -->
-            <class name="org.eclipse.microprofile.context.tck.cdi.BasicCDITest"/>
-            <class name="org.eclipse.microprofile.context.tck.cdi.CDIContextTest"/>
-            <class name="org.eclipse.microprofile.context.tck.cdi.JTACDITest"/>
-            <class name="org.eclipse.microprofile.context.tck.ContextManagerTest"/>
-            <class name="org.eclipse.microprofile.context.tck.ManagedExecutorTest"/>
-            <class name="org.eclipse.microprofile.context.tck.MPConfigTest"/>
-            <class name="org.eclipse.microprofile.context.tck.TckTest"/>
-            <class name="org.eclipse.microprofile.context.tck.ThreadContextTest">
+            <class name="org.eclipse.microprofile.context.tck.MPConfigTest">
                 <methods>
-                    <exclude name="withContextCaptureDependentCompletableFuturesRunWithContext"/>
-                    <exclude name="withContextCaptureDependentCompletionStagesRunWithContext"/>
+                    <exclude name=".*"/>
                 </methods>
             </class>
-
+            <!-- exclude propagateApplicationContext as per https://github.com/quarkusio/quarkus/pull/21254#discussion_r746688332 -->
+            <class name="org.eclipse.microprofile.context.tck.ManagedExecutorTest">
+                <methods>
+                    <exclude name="propagateApplicationContext"/>
+                </methods>
+            </class>
         </classes>
-
     </test>
 
+    <test name="MP-CP TCK MPConfigTest">
+        <classes>
+            <class name="org.eclipse.microprofile.context.tck.MPConfigTest"/>
+        </classes>
+    </test>
 </suite>

--- a/tcks/microprofile-fault-tolerance/pom.xml
+++ b/tcks/microprofile-fault-tolerance/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-tck-microprofile-fault-tolerance</artifactId>
     <name>Quarkus - TCK - MicroProfile Fault Tolerance</name>
 
+    <properties>
+        <microprofile-fault-tolerance-tck.version>3.0</microprofile-fault-tolerance-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -57,7 +61,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-tck</artifactId>
-            <version>${microprofile-fault-tolerance-api.version}</version>
+            <version>${microprofile-fault-tolerance-tck.version}</version>
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->

--- a/tcks/microprofile-graphql/pom.xml
+++ b/tcks/microprofile-graphql/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-tck-microprofile-graphql</artifactId>
     <name>Quarkus - TCK - MicroProfile GraphQL</name>
 
+    <properties>
+        <microprofile-graphql-tck.version>1.1.0</microprofile-graphql-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -42,7 +46,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.graphql</groupId>
             <artifactId>microprofile-graphql-tck</artifactId>
-            <version>${microprofile-graphql-api.version}</version>
+            <version>${microprofile-graphql-tck.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tcks/microprofile-health/pom.xml
+++ b/tcks/microprofile-health/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-tck-microprofile-health</artifactId>
     <name>Quarkus - TCK - MicroProfile Health</name>
 
+    <properties>
+        <microprofile-health-tck.version>3.1</microprofile-health-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -51,7 +55,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-tck</artifactId>
-            <version>${microprofile-health-api.version}</version>
+            <version>${microprofile-health-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.json</groupId>

--- a/tcks/microprofile-jwt/pom.xml
+++ b/tcks/microprofile-jwt/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-tck-microprofile-jwt</artifactId>
     <name>Quarkus - TCK - MicroProfile JWT</name>
 
+    <properties>
+        <microprofile-jwt-auth-tck.version>1.2.2</microprofile-jwt-auth-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -50,7 +54,7 @@
                                 <artifactItem>
                                     <groupId>org.eclipse.microprofile.jwt</groupId>
                                     <artifactId>microprofile-jwt-auth-tck</artifactId>
-                                    <version>${microprofile-jwt-api.version}</version>
+                                    <version>${microprofile-jwt-auth-tck.version}</version>
                                     <type>test-jar</type>
                                     <classifier>tests</classifier>
                                     <overWrite>false</overWrite>
@@ -85,7 +89,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>${microprofile-jwt-api.version}</version>
+            <version>${microprofile-jwt-auth-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>
@@ -104,7 +108,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>${microprofile-jwt-api.version}</version>
+            <version>${microprofile-jwt-auth-tck.version}</version>
             <type>test-jar</type>
             <exclusions>
                 <exclusion>

--- a/tcks/microprofile-metrics/api/pom.xml
+++ b/tcks/microprofile-metrics/api/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api-tck</artifactId>
-            <version>${microprofile-metrics-api.version}</version>
+            <version>${microprofile-metrics-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>

--- a/tcks/microprofile-metrics/optional/pom.xml
+++ b/tcks/microprofile-metrics/optional/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-optional-tck</artifactId>
-            <version>${microprofile-metrics-api.version}</version>
+            <version>${microprofile-metrics-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/tcks/microprofile-metrics/pom.xml
+++ b/tcks/microprofile-metrics/pom.xml
@@ -13,6 +13,10 @@
     <name>Quarkus - TCK - MicroProfile Metrics Parent</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <microprofile-metrics-tck.version>3.0</microprofile-metrics-tck.version>
+    </properties>
+
     <modules>
         <module>api</module>
         <module>rest</module>

--- a/tcks/microprofile-metrics/rest/pom.xml
+++ b/tcks/microprofile-metrics/rest/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-rest-tck</artifactId>
-            <version>${microprofile-metrics-api.version}</version>
+            <version>${microprofile-metrics-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/tcks/microprofile-openapi/pom.xml
+++ b/tcks/microprofile-openapi/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-tck-microprofile-openapi</artifactId>
     <name>Quarkus - TCK - MicroProfile OpenAPI</name>
 
+    <properties>
+        <microprofile-openapi-tck.version>2.0.1-RC1</microprofile-openapi-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -53,7 +57,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-tck</artifactId>
-            <version>${microprofile-open-api.version}</version>
+            <version>${microprofile-openapi-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/tcks/microprofile-opentracing/base/pom.xml
+++ b/tcks/microprofile-opentracing/base/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck</artifactId>
-            <version>${microprofile-opentracing-api.version}</version>
+            <version>${microprofile-opentracing-tck.version}</version>
         </dependency>
         <!-- For Dependency Converge - TCK users Arq 1.6.0 and Quarkus 1.5.0 -->
         <dependency>

--- a/tcks/microprofile-opentracing/pom.xml
+++ b/tcks/microprofile-opentracing/pom.xml
@@ -13,6 +13,10 @@
     <packaging>pom</packaging>
     <name>Quarkus - TCK - MicroProfile OpenTracing Parent</name>
 
+    <properties>
+        <microprofile-opentracing-tck.version>2.0</microprofile-opentracing-tck.version>
+    </properties>
+
     <modules>
         <module>base</module>
         <module>rest-client</module>

--- a/tcks/microprofile-opentracing/rest-client/pom.xml
+++ b/tcks/microprofile-opentracing/rest-client/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
-            <version>${microprofile-opentracing-api.version}</version>
+            <version>${microprofile-opentracing-tck.version}</version>
         </dependency>
     </dependencies>
 

--- a/tcks/microprofile-reactive-messaging/pom.xml
+++ b/tcks/microprofile-reactive-messaging/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-tck-microprofile-reactive-messaging</artifactId>
     <name>Quarkus - TCK - MicroProfile Reactive Messaging</name>
 
+    <properties>
+        <microprofile-reactive-messaging-tck.version>2.0.1</microprofile-reactive-messaging-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -58,20 +62,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
             <artifactId>microprofile-reactive-messaging-tck</artifactId>
-            <version>${microprofile-reactive-messaging-api.version}</version>
-            <exclusions>
-                <!-- fix convergence: assertj is bumped to >= 3.19.0 via Quarkus BOM which is too new (see futher down) -->
-                <exclusion>
-                    <groupId>org.assertj</groupId>
-                    <artifactId>assertj-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- latest version of assertj that is known to work -->
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
+            <version>${microprofile-reactive-messaging-tck.version}</version>
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>quarkus-tck-microprofile-rest-client-reactive</artifactId>
     <name>Quarkus - TCK - MicroProfile REST Client - RESTEasy Reactive</name>
 
+    <properties>
+        <wiremock.server.port>8766</wiremock.server.port>
+        <microprofile-rest-client-tck.version>2.0</microprofile-rest-client-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -121,7 +126,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-tck</artifactId>
-            <version>${microprofile-rest-client-api.version}</version>
+            <version>${microprofile-rest-client-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
@@ -154,7 +159,4 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
-    <properties>
-        <wiremock.server.port>8766</wiremock.server.port>
-    </properties>
 </project>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>quarkus-tck-microprofile-rest-client</artifactId>
     <name>Quarkus - TCK - MicroProfile REST Client</name>
 
+    <properties>
+        <microprofile-rest-client-tck.version>2.0</microprofile-rest-client-tck.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -90,7 +94,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-tck</artifactId>
-            <version>${microprofile-rest-client-api.version}</version>
+            <version>${microprofile-rest-client-tck.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This PR pushes down all TCK version properties as far as possible to the concrete tck module, updates a few of them and adds all those tck dependencies to dependabot, but only for patch-updates.

The trigger to do this was that `microprofile-reactive-messaging` updated assertj in 2.0.1 but we didn't catch it, thus still having to force an older assertj version when running the tck.