### PR TITLE
Preserve the type of multi in the SecurityHandler

### DIFF
--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityHandler.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityHandler.java
@@ -41,7 +41,9 @@ public class SecurityHandler {
                     }).subscribeAsCompletionStage();
         } else if (Multi.class.isAssignableFrom(returnType)) {
             return constrainer.nonBlockingCheck(ic.getMethod(), ic.getParameters())
-                    .onItem().transformToMulti(new MultiContinuation(ic));
+                    // Do not use transformToMulti as we want to preserve the type of multi produced by the user method.
+                    // This is required for Reactive Routes to handle custom Multi serialization.
+                    .toMulti().plug(x -> new MultiContinuation(ic).apply(x));
         } else {
             constrainer.check(ic.getMethod(), ic.getParameters());
             return ic.proceed();


### PR DESCRIPTION
Avoid using `transformToMulti` as we want to preserve the type of multi produced by the user method. This is required for Reactive Routes to handle custom Multi serialization.

Fix https://github.com/quarkusio/quarkus/issues/21044.