### PR TITLE
Update DevServices for Keycloak to create authorization policies

### DIFF
--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -13,7 +13,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.keycloak.pep.runtime.KeycloakPoilcyEnforcerBuildTimeConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerAuthorizer;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder;
@@ -104,7 +103,7 @@ public class KeycloakPolicyEnforcerBuildStep {
     }
 
     public static class IsEnabled implements BooleanSupplier {
-        KeycloakPoilcyEnforcerBuildTimeConfig config;
+        KeycloakPolicyEnforcerBuildTimeConfig config;
 
         public boolean getAsBoolean() {
             return config.policyEnforcer.enable;

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildTimeConfig.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildTimeConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.keycloak.pep.runtime;
+package io.quarkus.keycloak.pep.deployment;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -8,7 +8,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  * Build time configuration for Keycloak Authorization.
  */
 @ConfigRoot(name = "keycloak")
-public class KeycloakPoilcyEnforcerBuildTimeConfig {
+public class KeycloakPolicyEnforcerBuildTimeConfig {
 
     /**
      * Policy enforcement enable status

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -177,6 +177,45 @@ public class DevServicesConfig {
     }
 
     /**
+     * Keycloak Authorization properties which are only used to create Keycloak authorization permissions when a default realm
+     * is
+     * created.
+     * Use 'quarkus-keycloak-authorization' to verify these permissions.
+     */
+    public Authorization authorization = new Authorization();
+
+    /**
+     * Keycloak Authorization properties
+     */
+    @ConfigGroup
+    public static class Authorization {
+
+        /**
+         * Keycloak Authorization resource paths containing the identity role and resource path pairs.
+         * For example, 'quarkus.keycloak.devservices.resource-paths.user=/api/users/*'.
+         */
+        @ConfigItem
+        public Map<String, String> paths;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Authorization that = (Authorization) o;
+            // grant.type is not checked since it only affects which grant is used by the Dev UI provider.html
+            // and as such the changes to this property should not cause restarting a container
+            return Objects.equals(paths, that.paths);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(paths);
+        }
+    }
+
+    /**
      * Optional fixed port the dev service will listen to.
      * <p>
      * If not defined, the port will be chosen randomly.
@@ -211,11 +250,12 @@ public class DevServicesConfig {
                 && Objects.equals(realmName, that.realmName)
                 && Objects.equals(users, that.users)
                 && Objects.equals(javaOpts, that.javaOpts)
-                && Objects.equals(roles, that.roles);
+                && Objects.equals(roles, that.roles)
+                && Objects.equals(authorization, that.authorization);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, imageName, port, realmPath, realmName, users, roles);
+        return Objects.hash(enabled, imageName, port, realmPath, realmName, users, roles, authorization);
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakBuildTimeConfig.java
@@ -4,7 +4,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
- * Build time configuration for OIDC.
+ * Build time configuration for Keycloak Dev Services.
  */
 @ConfigRoot
 public class KeycloakBuildTimeConfig {


### PR DESCRIPTION
Fixes #21040

This PR attempts to support running `keycloak-authorization` with `DevServices for Keycloak` without having to import a custom realm.
`DevServices for Keycloak` creates a default realm, client, users, roles when no custom realm is added. With this PR, authorization permissions will also be added, so given only a configuration like this one:

```
quarkus.keycloak.policy-enforcer.enable=true
quarkus.keycloak.devservices.authorization.paths.user=/api/users/me
quarkus.keycloak.devservices.authorization.paths.admin=/api/admin
```

`quarkus-quickstarts/security-keycloak-authoroization-quickstart` just works in the dev mode - a default user `alice` who has both `admin` and `user` roles can access both `api/admin` and `api/users/me`, while `bob` - with only a `user` role - can only access `api/users/me`.

@pedroigor, I've copied some code from `integration-tests/keycloak-authorization/.../KeycloakTestResource` to set up the basic permissions - for every configured `role` and `path` pair in `quarkus.keycloak.devservices.authorization.paths` [this code](https://github.com/quarkusio/quarkus/compare/main...sberyozkin:devservices_keycloak_authorization?expand=1#diff-67404a43520250b1ebd5a0c945e070e60d70d4a3ba06b15e3fac747f820320ccR604) is run, and more specifically [this one](https://github.com/quarkusio/quarkus/compare/main...sberyozkin:devservices_keycloak_authorization?expand=1#diff-67404a43520250b1ebd5a0c945e070e60d70d4a3ba06b15e3fac747f820320ccR635) (I'll clean it up a bit more - will try to generate unique names).

Now, starting  `quarkus-quickstarts/security-keycloak-authoroization-quickstart` with the above configuration and `mvn quarkus:dev` produces:

```
Could not obtain configuration from server [http://localhost:32783/auth/realms/quarkus/.well-known/uma2-configuration].
	at org.keycloak.authorization.client.AuthzClient.<init>(AuthzClient.java:266)
	at org.keycloak.authorization.client.AuthzClient.create(AuthzClient.java:105)
	at org.keycloak.adapters.authorization.PolicyEnforcer.<init>(PolicyEnforcer.java:65)
	at io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerRecorder.createPolicyEnforcer(KeycloakPolicyEnforcerRecorder.java:101)
```

Pedro, can you help a bit and recommend what else may have to be added to the client registration code ? I guess I need to copy something else from [KeycloakTestResource](https://github.com/quarkusio/quarkus/blob/main/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/KeycloakTestResource.java#L86) but I'm not sure what :-)

thanks