### PR TITLE
Provide access to id of container network in integration tests

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1336,3 +1336,10 @@ a utility class.
 `QuarkusTestResourceLifecycleManager` implementations can also implement `ContextAware` to get access to these properties,
 which allows you to setup the resource before Quarkus starts (e.g. configure a KeyCloak instance, add data to a database etc).
 
+
+[NOTE]
+====
+For `@QuarkusIntegrationTest` tests that result in launcher the application as a container, `io.quarkus.test.common.DevServicesContext` also provides access to the id of the container network on which the application container was launched (via the `containerNetworkId` method).
+This can be used by `QuarkusTestResourceLifecycleManager` that need to launch additional containers that the application will communicate with.
+====
+

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/DummyResource.java
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/DummyResource.java
@@ -1,0 +1,30 @@
+package org.acme;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DummyResource implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    public static final AtomicReference<Optional<String>> CONTAINER_NETWORK_ID = new AtomicReference<>(null);
+
+    @Override
+    public Map<String, String> start() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        CONTAINER_NETWORK_ID.set(context.containerNetworkId());
+    }
+}

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/FruitsEndpointIT.java
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/FruitsEndpointIT.java
@@ -1,9 +1,22 @@
 package org.acme;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusIntegrationTest
+@QuarkusTestResource(DummyResource.class)
 public class FruitsEndpointIT extends FruitsEndpointTest {
 
-
+    @Test
+    public void containerNetworkIdSet() {
+        Optional<String> optional = DummyResource.CONTAINER_NETWORK_ID.get();
+        assertNotNull(optional);
+        assertTrue(optional.isPresent());
+    }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DevServicesContext.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DevServicesContext.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.common;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Interface that can be used to get properties from DevServices for {@link QuarkusTest} and {@link QuarkusIntegrationTest}
@@ -17,6 +18,12 @@ public interface DevServicesContext {
      * If no dev services where launched, the map will be empty.
      */
     Map<String, String> devServicesProperties();
+
+    /**
+     * If the application is going to be launched in a container, this method returns the id of container network
+     * it will be launched on.
+     */
+    Optional<String> containerNetworkId();
 
     /**
      * Interface that can be implemented to allow automatic injection of the context.

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -47,11 +48,13 @@ public class TestResourceManager implements Closeable {
 
     public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
             boolean disableGlobalTestResources) {
-        this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, Collections.emptyMap());
+        this(testClass, profileClass, additionalTestResources, disableGlobalTestResources, Collections.emptyMap(),
+                Optional.empty());
     }
 
     public TestResourceManager(Class<?> testClass, Class<?> profileClass, List<TestResourceClassEntry> additionalTestResources,
-            boolean disableGlobalTestResources, Map<String, String> devServicesProperties) {
+            boolean disableGlobalTestResources, Map<String, String> devServicesProperties,
+            Optional<String> containerNetworkId) {
         this.parallelTestResourceEntries = new ArrayList<>();
         this.sequentialTestResourceEntries = new ArrayList<>();
 
@@ -72,6 +75,11 @@ public class TestResourceManager implements Closeable {
             @Override
             public Map<String, String> devServicesProperties() {
                 return devServicesProperties;
+            }
+
+            @Override
+            public Optional<String> containerNetworkId() {
+                return containerNetworkId;
             }
         };
         for (var i : allTestResourceEntries) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.junit.jupiter.api.Assertions;
@@ -142,12 +143,12 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
 
             //must be done after the TCCL has been set
             testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
-                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class)
+                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class)
                     .newInstance(context.getRequiredTestClass(),
                             profile != null ? profile : null,
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources(),
-                            startupAction.getDevServicesProperties());
+                            startupAction.getDevServicesProperties(), Optional.empty());
             testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
                     .invoke(testResourceManager);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -221,12 +221,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
             //must be done after the TCCL has been set
             testResourceManager = (Closeable) startupAction.getClassLoader().loadClass(TestResourceManager.class.getName())
-                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class)
+                    .getConstructor(Class.class, Class.class, List.class, boolean.class, Map.class, Optional.class)
                     .newInstance(requiredTestClass,
                             profile != null ? profile : null,
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources(),
-                            startupAction.getDevServicesProperties());
+                            startupAction.getDevServicesProperties(), Optional.empty());
             testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
                     .invoke(testResourceManager);


### PR DESCRIPTION
This is useful for integration tests that launch the application
as a container but also need to launch additional containers
to support the application.

Resolves: #21284