### PR TITLE
Fix IllegalArgumentException in rest-assured if http and https ports are both random

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -713,7 +713,8 @@ public class VertxHttpRecorder {
         serverOptions.setSni(sslConfig.sni);
         serverOptions.setHost(httpConfiguration.host);
         int sslPort = httpConfiguration.determineSslPort(launchMode);
-        serverOptions.setPort(sslPort == 0 ? -1 : sslPort);
+        // -2 instead of -1 (see http) to have vert.x assign two different random ports if both http and https shall be random
+        serverOptions.setPort(sslPort == 0 ? -2 : sslPort);
         serverOptions.setClientAuth(buildTimeConfig.tlsClientAuth);
         serverOptions.setReusePort(httpConfiguration.soReusePort);
         serverOptions.setTcpQuickAck(httpConfiguration.tcpQuickAck);


### PR DESCRIPTION
Fixes #18154.

Before #21195, this setup didn't result in such an exception but in the same port for both http and https.