### PR TITLE
Handle local extension project dependency in gradle plugin

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -40,13 +40,16 @@ public class ApplicationDeploymentClasspathBuilder {
                 extensions.add(knownExtension);
             }
         }
-
         for (ExtensionDependency extension : extensions) {
-            requireDeploymentDependency(deploymentConfigurationName, extension, dependencies);
-            if (!alreadyProcessed.add(extension.extensionId)) {
-                continue;
+            if (extension instanceof LocalExtensionDependency) {
+                addLocalDeploymentDependency(deploymentConfigurationName, (LocalExtensionDependency) extension, dependencies);
+            } else {
+                requireDeploymentDependency(deploymentConfigurationName, extension, dependencies);
+                if (!alreadyProcessed.add(extension.extensionId)) {
+                    continue;
+                }
+                extension.installDeploymentVariant(dependencies);
             }
-            extension.createDeploymentVariant(dependencies);
         }
     }
 
@@ -85,6 +88,12 @@ public class ApplicationDeploymentClasspathBuilder {
             }
         }
         return extensions;
+    }
+
+    private void addLocalDeploymentDependency(String deploymentConfigurationName, LocalExtensionDependency extension,
+            DependencyHandler dependencies) {
+        dependencies.add(deploymentConfigurationName,
+                dependencies.project(Collections.singletonMap("path", extension.findDeploymentModulePath())));
     }
 
     private void requireDeploymentDependency(String deploymentConfigurationName, ExtensionDependency extension,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/ExtensionDependency.java
@@ -2,12 +2,10 @@ package io.quarkus.gradle.dependency;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 
 import io.quarkus.bootstrap.model.AppArtifactCoords;
@@ -30,15 +28,6 @@ public class ExtensionDependency {
         this.dependencyConditions = dependencyConditions;
     }
 
-    public boolean needsResolution(Set<ResolvedArtifact> resolvedArtifacts) {
-        for (Dependency dependency : conditionalDependencies) {
-            if (!DependencyUtils.exists(resolvedArtifacts, dependency)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public void importConditionalDependency(DependencyHandler dependencies, ModuleVersionIdentifier capability) {
         Dependency dependency = findConditionalDependency(capability);
 
@@ -52,7 +41,7 @@ public class ExtensionDependency {
                         .withDependencies(d -> d.add(DependencyUtils.asDependencyNotation(dependency))))));
     }
 
-    public void createDeploymentVariant(DependencyHandler dependencies) {
+    public void installDeploymentVariant(DependencyHandler dependencies) {
         dependencies.components(handler -> handler.withModule(toModuleName(),
                 componentMetadataDetails -> componentMetadataDetails
                         .addVariant(DependencyUtils.asDependencyNotation(deploymentModule),
@@ -71,10 +60,6 @@ public class ExtensionDependency {
                                                 d.add(DependencyUtils.asDependencyNotation(deploymentModule));
                                             });
                                 })));
-    }
-
-    public Dependency asDependency(DependencyHandler dependencies) {
-        return dependencies.create(asDependencyNotation());
     }
 
     public String asDependencyNotation() {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/LocalExtensionDependency.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/dependency/LocalExtensionDependency.java
@@ -1,0 +1,39 @@
+package io.quarkus.gradle.dependency;
+
+import java.util.List;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+
+import io.quarkus.bootstrap.model.AppArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+
+public class LocalExtensionDependency extends ExtensionDependency {
+
+    private static final String DEFAULT_DEPLOYMENT_PATH_SUFFIX = "deployment";
+
+    private Project localProject;
+
+    public LocalExtensionDependency(Project localProject, ModuleVersionIdentifier extensionId,
+            AppArtifactCoords deploymentModule,
+            List<Dependency> conditionalDependencies, List<ArtifactKey> dependencyConditions) {
+        super(extensionId, deploymentModule, conditionalDependencies, dependencyConditions);
+        this.localProject = localProject;
+    }
+
+    public String findDeploymentModulePath() {
+
+        String deploymentModuleName = DEFAULT_DEPLOYMENT_PATH_SUFFIX;
+        if (localProject.getParent().findProject(deploymentModule.getArtifactId()) != null) {
+            deploymentModuleName = deploymentModule.getArtifactId();
+        }
+
+        String parentPath = localProject.getParent().getPath();
+        if (parentPath.endsWith(":")) {
+            return parentPath + deploymentModuleName;
+        }
+
+        return parentPath + ":" + deploymentModuleName;
+    }
+}

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/application/build.gradle
@@ -13,17 +13,10 @@ dependencies {
 }
 
 test {
-    dependsOn 'publishAcmeExt'
     dependsOn 'cleanTest'
     useJUnitPlatform()
     forkEvery 1
 }
 
-quarkusGenerateCode {
-    dependsOn 'publishAcmeExt'
-}
-
-task publishAcmeExt {
-    dependsOn ':runtime:publishToMavenLocal'
-    dependsOn ':deployment:publishToMavenLocal'
-}
+quarkusGenerateCodeDev.dependsOn(":deployment:classes")
+quarkusGenerateCode.dependsOn(":deployment:classes")

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/deployment/build.gradle
@@ -1,22 +1,9 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
 }
 
 dependencies {
   implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
   implementation 'io.quarkus:quarkus-core-deployment'
   implementation project(":runtime")
-}
-
-publishing {
-    publications {
-        mavenJave(MavenPublication) {
-            groupId = 'org.acme'
-            artifactId = 'runtime-deployment'
-            version = '1.0-SNAPSHOT'
-
-            from components.java
-        }
-    }
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/runtime/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/runtime/build.gradle
@@ -1,20 +1,7 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
 }
 
 dependencies {
     implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-}
-
-publishing {
-    publications {
-        mavenJave(MavenPublication) {
-            groupId = 'org.acme'
-            artifactId = 'runtime'
-            version = '1.0-SNAPSHOT'
-
-            from components.java
-        }
-    }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestResourcesInBuildStepsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestResourcesInBuildStepsTest.java
@@ -16,7 +16,6 @@ public class TestResourcesInBuildStepsTest extends QuarkusGradleWrapperTestBase 
 
         final File projectDir = getProjectDir("test-resources-in-build-steps");
 
-        runGradleWrapper(projectDir, "clean", ":application:publishAcmeExt");
         runGradleWrapper(projectDir, "build");
 
         final Path buildDir = projectDir.toPath().resolve("application").resolve("build");

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/ResourcesInBuildStepsDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/ResourcesInBuildStepsDevModeTest.java
@@ -19,11 +19,6 @@ public class ResourcesInBuildStepsDevModeTest extends QuarkusDevGradleTestBase {
         return new String[] { "clean", ":application:quarkusDev", "-s" };
     }
 
-    @Override
-    protected void beforeQuarkusDev() throws Exception {
-        runGradleWrapper(projectDir, ":application:publishAcmeExt");
-    }
-
     protected void testDevMode() throws Exception {
 
         assertThat(getHttpResponse()).contains("homepage");


### PR DESCRIPTION
This branch introduce `LocalExtensionDependency` that allows to reference a module from multi-module project as extension. 

The only limitation is based on the name of the deployment module. I look for a project that match the name of the deployment artifact. if it does not exist, I use the default `deployment` name.

close #20953