### PR TITLE
When launching a container via @QuarkusIntegrationTest make network available

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1215,6 +1215,47 @@ As a test annotated with `@QuarkusIntegrationTest` tests the result of the build
 These tests will **not** work if run in the same phase as `@QuarkusTest` as Quarkus has not yet created the final artifact.
 ====
 
+=== Launching containers
+
+When `@QuarkusIntegrationTest` results in launching a container (because the application was built with `quarkus.container-image.build` set to `true`), the container is launched on a predictable container network. This facilitates writing integration tests that need to launch services to support the application.
+This means that `@QuarkusIntegrationTest` works out of the box with containers launched via link:dev-services[Dev Services], but it also means that it enables using <<quarkus-test-resource,QuarkusTestLifecycleManager>> resources that launch additional containers.
+This can be achieved by having your `QuarkusTestLifecycleManager` implement `io.quarkus.test.common.DevServicesContext.ContextAware`. A simple example could be the following:
+
+[source,java]
+----
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class CustomResource implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    private Optional<String> containerNetworkId;
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        containerNetworkId = context.containerNetworkId();
+    }
+
+    @Override
+    public Map<String, String> start() {
+        // start a container making sure to call withNetworkMode() with the value of containerNetworkId if present
+
+        // return a map containing the configuration the application needs to use the service
+        return new HashMap<>();
+    }
+
+    @Override
+    public void stop() {
+        // close container
+    }
+}
+----
+
+`CustomResource` would be activated on a `@QuarkusIntegrationTest` using `@QuarkusTestResource` as is described in the corresponding section of this doc.
+
 === Executing against a running application
 
 [WARNING]

--- a/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/ArtifactLauncher.java
@@ -38,6 +38,8 @@ public interface ArtifactLauncher<T extends ArtifactLauncher.InitContext> extend
 
             String networkId();
 
+            boolean manageNetwork();
+
             void close();
         }
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -200,6 +200,11 @@ public class NativeTestExtension
                     }
 
                     @Override
+                    public boolean manageNetwork() {
+                        return false;
+                    }
+
+                    @Override
                     public void close() {
 
                     }


### PR DESCRIPTION
This is pretty much the same as we did in 21287, but it now works
regardless of the presence of DevServices.
The difference with containers launched by DevServices, is that in this
case we now need to manage the creation and deletion of the network,
whereas in the case of DevServices we got that for free
by utilizing testcontainers

Resolves: #19080