### PR TITLE
Use token endpoint URL as OIDC JWT authentication audience

### DIFF
--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-credentials-jwt-secret.properties
@@ -5,3 +5,4 @@ quarkus.oidc-client.jwt.auth-server-url=${quarkus.oidc.auth-server-url}
 quarkus.oidc-client.jwt.client-id=${quarkus.oidc.client-id}
 quarkus.oidc-client.jwt.credentials.jwt.secret-provider.key=secret-from-vault-for-jwt
 quarkus.oidc-client.jwt.credentials.jwt.signature-algorithm=HS512
+quarkus.oidc-client.jwt.credentials.jwt.audience=${quarkus.oidc.auth-server-url}

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -99,7 +99,8 @@ public class OidcClientImpl implements OidcClient {
                     // if it is a refresh then a map has already been copied
                     body = !refresh ? copyMultiMap(body) : body;
                     body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
-                    body.add(OidcConstants.CLIENT_ASSERTION, OidcCommonUtils.signJwtWithKey(oidcConfig, clientJwtKey));
+                    body.add(OidcConstants.CLIENT_ASSERTION,
+                            OidcCommonUtils.signJwtWithKey(oidcConfig, tokenRequestUri, clientJwtKey));
                 }
                 if (!additionalGrantParameters.isEmpty()) {
                     body = copyMultiMap(body);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -262,6 +262,13 @@ public class OidcCommonConfig {
             public String keyPassword;
 
             /**
+             * JWT audience ('aud') claim value.
+             * By default the audience is set to the address of the OpenId Connect Provider's token endpoint.
+             */
+            @ConfigItem
+            public Optional<String> audience = Optional.empty();
+
+            /**
              * Key identifier of the signing key added as a JWT 'kid' header
              */
             @ConfigItem
@@ -318,6 +325,14 @@ public class OidcCommonConfig {
 
             public void setSignatureAlgorithm(String signatureAlgorithm) {
                 this.signatureAlgorithm = Optional.of(signatureAlgorithm);
+            }
+
+            public Optional<String> getAudience() {
+                return audience;
+            }
+
+            public void setAudience(String audience) {
+                this.audience = Optional.of(audience);
             }
 
         }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -158,11 +158,11 @@ public class OidcCommonUtils {
     }
 
     public static String getAuthServerUrl(OidcCommonConfig oidcConfig) {
-        String authServerUrl = oidcConfig.getAuthServerUrl().get();
-        if (authServerUrl.endsWith("/")) {
-            authServerUrl = authServerUrl.substring(0, authServerUrl.length() - 1);
-        }
-        return authServerUrl;
+        return removeLastPathSeparator(oidcConfig.getAuthServerUrl().get());
+    }
+
+    private static String removeLastPathSeparator(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
     public static String getOidcEndpointUrl(String authServerUrl, Optional<String> endpointPath) {
@@ -276,16 +276,14 @@ public class OidcCommonUtils {
         }
     }
 
-    public static String signJwt(OidcCommonConfig oidcConfig) {
-        return signJwtWithKey(oidcConfig, clientJwtKey(oidcConfig.credentials));
-    }
-
-    public static String signJwtWithKey(OidcCommonConfig oidcConfig, Key key) {
+    public static String signJwtWithKey(OidcCommonConfig oidcConfig, String tokenRequestUri, Key key) {
         // 'jti' and 'iat' claim is created by default, iat - is set to the current time
         JwtSignatureBuilder builder = Jwt
                 .issuer(oidcConfig.clientId.get())
                 .subject(oidcConfig.clientId.get())
-                .audience(getAuthServerUrl(oidcConfig))
+                .audience(oidcConfig.credentials.jwt.getAudience().isPresent()
+                        ? removeLastPathSeparator(oidcConfig.credentials.jwt.getAudience().get())
+                        : tokenRequestUri)
                 .expiresIn(oidcConfig.credentials.jwt.lifespan)
                 .jws();
         if (oidcConfig.credentials.jwt.getTokenKeyId().isPresent()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -110,7 +110,8 @@ public class OidcProviderClient implements Closeable {
             request.putHeader(AUTHORIZATION_HEADER, clientSecretBasicAuthScheme);
         } else if (clientJwtKey != null) {
             formBody.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
-            formBody.add(OidcConstants.CLIENT_ASSERTION, OidcCommonUtils.signJwtWithKey(oidcConfig, clientJwtKey));
+            formBody.add(OidcConstants.CLIENT_ASSERTION,
+                    OidcCommonUtils.signJwtWithKey(oidcConfig, metadata.getTokenUri(), clientJwtKey));
         } else if (OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
             formBody.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
             formBody.add(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials));


### PR DESCRIPTION
Fixes #21310.

This PR is about improving (one may say about bug fixing of) the way OIDC JWT client authentication code sets the `audience`.

The client JWT authentication is specified here: https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication

Quarkus supports and tests all the options there. The only problem, which has been caught by #21310 is that the audience claim value is not a recommended token endpoint URL (per the spec text: `The Audience SHOULD be the URL of the Authorization Server's Token Endpoint.`).

Currently it is the value of either `quarkus.oidc.auth-server-url` or `quarkus.oidc-client.auth-server-url`, so for example, in case of Keycloak, it would be `http://localhost:8180/auth/realms/quarkus` vs the recommended `http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/token` (note the extra `/protocol/openid-connect/token` path).

Given that the OIDC spec does recommend using the token path and the token path is known to OIDC, suggesting as I did to fix #21310 with

```
quarkus.oidc-client.auth-server-url=https://dev.api.service.nhs.uk/oauth2
quarkus.oidc-client.discovery-enabled=false # token path MUST be set
quarkus.oidc-client.token-path=/token

#and now
quarkus.oidc-client.jwt.credentials.jwt.audience=https://dev.api.service.nhs.uk/oauth2/token
```
is a poor deal for the users - here this is just redundant - but worse is the case where the auto-discovery works and the OIDC provider is as strict as the one used in #21310 - despite the endpoint URLs being discovered, one would still have to type the token endpoint URL as the audience which may not be even easy to find.

So this PR just improves the code a tiny bit only to use the token endpoint URL as opposed to the base URL of the provider.
We have 4 tests with Keycloak (3 in the oidc client module, one in he oidc code flow tests) - all of them pass, but, just in case (which I doubt will happen) I've still added an `audience` property so that one can refer to the base URL and updated one of the OidcClient tests (note Keycloak does not like audience values with the trailing path separators - so I added the code to strip it).

It is hard to add the tests confirming the new audience property is effective - since the token does not reach Quarkus at all and goes directly into Keycloak, while trying to wiremock it would not be very useful - it is the behavior of Keycloak which is important to verify. So I can only confirm that the new property is effective - this is why I had to add the code to strip the path segment :-), otherwise Keycloak returns a failure. 