### PR TITLE
Fallback to the default platform catalog if available registries do not provide any catalog

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -359,6 +359,24 @@ public class ExtensionCatalogResolver {
 
         ExtensionCatalog build() throws RegistryResolutionException {
             appendAllNonPlatformExtensions();
+            if (catalogs.isEmpty()) {
+                final List<RegistryExtensionResolver> registries = ExtensionCatalogResolver.this.registries;
+                if (registries.isEmpty()) {
+                    throw new RegistryResolutionException("Quarkus extension registry is not available");
+                }
+                if (registries.size() == 1) {
+                    throw new RegistryResolutionException("Quarkus extension registry " + registries.get(0).getId()
+                            + " did not provide any extension catalog");
+                }
+                final StringBuilder buf = new StringBuilder();
+                buf.append("Quarkus extension registries ");
+                buf.append(registries.get(0).getId());
+                for (int i = 1; i < registries.size(); ++i) {
+                    buf.append(", ").append(registries.get(i).getId());
+                }
+                buf.append(" did not provide any extension catalog");
+                throw new RegistryResolutionException(buf.toString());
+            }
             return JsonCatalogMerger.merge(catalogs);
         }
     }


### PR DESCRIPTION
Currently we are falling back to the default platform catalog (or suggesting user to do that manually) when we find that none of the configured registries is available.
However, today we had a case when the registry was returning its descriptor, indicating that it's available, but was failing to resolve the catalog artifacts. That would still be equivalent of the registry not being available, in which case we should also either fallback or suggest a workaround.

This change is adjusting the `quarkus:create` goal to fallback to the default platform if that happens.