### PR TITLE
Expose quarkus.hibernate-orm.database.default-catalog and quarkus.hibernate-orm.database.default-schema as runtime properties

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -316,18 +316,6 @@ public class HibernateOrmConfigPersistenceUnit {
         private static final String DEFAULT_CHARSET = "UTF-8";
 
         /**
-         * The default catalog to use for the database objects.
-         */
-        @ConfigItem
-        public Optional<String> defaultCatalog;
-
-        /**
-         * The default schema to use for the database objects.
-         */
-        @ConfigItem
-        public Optional<String> defaultSchema;
-
-        /**
          * The charset of the database.
          * <p>
          * Used for DDL generation and also for the SQL import scripts.
@@ -342,9 +330,7 @@ public class HibernateOrmConfigPersistenceUnit {
         public boolean globallyQuotedIdentifiers;
 
         public boolean isAnyPropertySet() {
-            return defaultCatalog.isPresent()
-                    || defaultSchema.isPresent()
-                    || !DEFAULT_CHARSET.equals(charset.name())
+            return !DEFAULT_CHARSET.equals(charset.name())
                     || globallyQuotedIdentifiers;
         }
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1039,12 +1039,6 @@ public final class HibernateOrmProcessor {
         descriptor.getProperties().setProperty(AvailableSettings.HBM2DDL_CHARSET_NAME,
                 persistenceUnitConfig.database.charset.name());
 
-        persistenceUnitConfig.database.defaultCatalog.ifPresent(
-                catalog -> descriptor.getProperties().setProperty(AvailableSettings.DEFAULT_CATALOG, catalog));
-
-        persistenceUnitConfig.database.defaultSchema.ifPresent(
-                schema -> descriptor.getProperties().setProperty(AvailableSettings.DEFAULT_SCHEMA, schema));
-
         if (persistenceUnitConfig.database.globallyQuotedIdentifiers) {
             descriptor.getProperties().setProperty(AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS, "true");
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -359,6 +359,12 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                     persistenceUnitConfig.scripts.generation.dropTarget.get());
         }
 
+        persistenceUnitConfig.database.defaultCatalog.ifPresent(
+                catalog -> runtimeSettingsBuilder.put(AvailableSettings.DEFAULT_CATALOG, catalog));
+
+        persistenceUnitConfig.database.defaultSchema.ifPresent(
+                schema -> runtimeSettingsBuilder.put(AvailableSettings.DEFAULT_SCHEMA, schema));
+
         // Logging
         if (persistenceUnitConfig.log.sql) {
             runtimeSettingsBuilder.put(AvailableSettings.SHOW_SQL, "true");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -45,8 +45,22 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         @ConfigItem
         public HibernateOrmConfigPersistenceUnitDatabaseGeneration generation = new HibernateOrmConfigPersistenceUnitDatabaseGeneration();
 
+        /**
+         * The default catalog to use for the database objects.
+         */
+        @ConfigItem
+        public Optional<String> defaultCatalog;
+
+        /**
+         * The default schema to use for the database objects.
+         */
+        @ConfigItem
+        public Optional<String> defaultSchema;
+
         public boolean isAnyPropertySet() {
-            return generation.isAnyPropertySet();
+            return generation.isAnyPropertySet()
+                    || defaultCatalog.isPresent()
+                    || defaultSchema.isPresent();
         }
     }
 

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -249,12 +249,6 @@ public final class HibernateReactiveProcessor {
         desc.getProperties().setProperty(AvailableSettings.HBM2DDL_CHARSET_NAME,
                 persistenceUnitConfig.database.charset.name());
 
-        persistenceUnitConfig.database.defaultCatalog.ifPresent(
-                catalog -> desc.getProperties().setProperty(AvailableSettings.DEFAULT_CATALOG, catalog));
-
-        persistenceUnitConfig.database.defaultSchema.ifPresent(
-                schema -> desc.getProperties().setProperty(AvailableSettings.DEFAULT_SCHEMA, schema));
-
         if (persistenceUnitConfig.database.globallyQuotedIdentifiers) {
             desc.getProperties().setProperty(AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS, "true");
         }

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -257,6 +257,12 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             runtimeSettingsBuilder.put(AvailableSettings.HBM2DDL_HALT_ON_ERROR, "true");
         }
 
+        persistenceUnitConfig.database.defaultCatalog.ifPresent(
+                catalog -> runtimeSettingsBuilder.put(AvailableSettings.DEFAULT_CATALOG, catalog));
+
+        persistenceUnitConfig.database.defaultSchema.ifPresent(
+                schema -> runtimeSettingsBuilder.put(AvailableSettings.DEFAULT_SCHEMA, schema));
+
         // Logging
         if (persistenceUnitConfig.log.sql) {
             runtimeSettingsBuilder.put(AvailableSettings.SHOW_SQL, "true");

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultCatalogAndSchemaResource.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultCatalogAndSchemaResource.java
@@ -1,0 +1,54 @@
+package io.quarkus.it.jpa.defaultcatalogandschema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hibernate.Session;
+import org.hibernate.type.LongType;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+@Path("/default-catalog-and-schema")
+@ApplicationScoped
+public class DefaultCatalogAndSchemaResource {
+
+    @Inject
+    Session session;
+
+    @GET
+    @Path("/test")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public String test(@QueryParam String expectedSchema) {
+        assertThat(findUsingNativeQuery(expectedSchema, "foo")).isEmpty();
+
+        EntityWithDefaultCatalogAndSchema entity = new EntityWithDefaultCatalogAndSchema();
+        entity.basic = "foo";
+        session.persist(entity);
+        session.flush();
+        session.clear();
+
+        assertThat(findUsingNativeQuery(expectedSchema, "foo")).containsExactly(entity.id);
+
+        return "OK";
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> findUsingNativeQuery(String schema, String value) {
+        return session
+                .createNativeQuery(
+                        "select id from \"" + schema + "\"." + EntityWithDefaultCatalogAndSchema.NAME
+                                + " where basic = :basic")
+                .addScalar("id", LongType.INSTANCE)
+                .setParameter("basic", value)
+                .getResultList();
+    }
+}

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/EntityWithDefaultCatalogAndSchema.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/EntityWithDefaultCatalogAndSchema.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.jpa.defaultcatalogandschema;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity(name = EntityWithDefaultCatalogAndSchema.NAME)
+public class EntityWithDefaultCatalogAndSchema {
+    public static final String NAME = "ent_with_defaults";
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    @Basic
+    public String basic;
+}

--- a/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/Schema1MetadataBuilderContributor.java
+++ b/integration-tests/jpa/src/main/java/io/quarkus/it/jpa/defaultcatalogandschema/Schema1MetadataBuilderContributor.java
@@ -1,0 +1,23 @@
+package io.quarkus.it.jpa.defaultcatalogandschema;
+
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.model.relational.AbstractAuxiliaryDatabaseObject;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.Dialect;
+
+public class Schema1MetadataBuilderContributor implements MetadataBuilderContributor {
+    @Override
+    public void contribute(MetadataBuilder metadataBuilder) {
+        metadataBuilder.applyAuxiliaryDatabaseObject(new AbstractAuxiliaryDatabaseObject(true) {
+            @Override
+            public String[] sqlCreateStrings(Dialect dialect) {
+                return new String[] { "create schema \"SCHEMA1\"" };
+            }
+
+            @Override
+            public String[] sqlDropStrings(Dialect dialect) {
+                return new String[0];
+            }
+        });
+    }
+}

--- a/integration-tests/jpa/src/main/resources/application.properties
+++ b/integration-tests/jpa/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+quarkus.hibernate-orm.metadata-builder-contributor=io.quarkus.it.jpa.defaultcatalogandschema.Schema1MetadataBuilderContributor

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultSchemaInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultSchemaInGraalITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.jpa.defaultcatalogandschema;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class DefaultSchemaInGraalITCase extends DefaultSchemaTest {
+}

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultSchemaTest.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/defaultcatalogandschema/DefaultSchemaTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.jpa.defaultcatalogandschema;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DefaultSchemaTest.DefaultSchema1Profile.class)
+public class DefaultSchemaTest {
+    public static class DefaultSchema1Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.hibernate-orm.database.default-schema", "SCHEMA1",
+                    // import.sql doesn't take our custom schema into account.
+                    // It should be modified in order to work in this test, but we simply don't need it.
+                    "quarkus.hibernate-orm.sql-load-script", "no-file");
+        }
+    }
+
+    @Test
+    public void test() {
+        given().queryParam("expectedSchema", "SCHEMA1")
+                .when().get("/jpa-test/default-catalog-and-schema/test").then()
+                .body(is("OK"))
+                .statusCode(200);
+    }
+
+}


### PR DESCRIPTION
Fixes #19660

Follow-up on  #22114, which upgrades to Hibernate ORM 5.6.2.Final.

But I confirmed locally that, when upgrading to a locally built version of ORM that includes https://github.com/hibernate/hibernate-orm/pull/4351, the test passes.