### PR TITLE
Make it easy to access Neo4j browser

### DIFF
--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/DevServicesBuildTimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.neo4j.deployment;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -29,4 +30,20 @@ public class DevServicesBuildTimeConfig {
      */
     @ConfigItem
     public Map<String, String> additionalEnv;
+
+    /**
+     * This value can be used to specify the port to which the bolt-port of the container is exposed. It must be a free
+     * port, otherwise startup will fail. A random, free port will be used by default. Either way, a messsage will be
+     * logged on which port the Neo4j container is reachable over bolt.
+     */
+    @ConfigItem
+    public OptionalInt boltPort = OptionalInt.empty();
+
+    /**
+     * This value can be used to specify the port to which the http-port of the container is exposed. It must be a free
+     * port, otherwise startup will fail. A random, free port will be used by default. Either way, a messsage will be
+     * logged on which port the Neo4j Browser is available.
+     */
+    @ConfigItem
+    public OptionalInt httpPort = OptionalInt.empty();
 }

--- a/extensions/neo4j/deployment/src/main/resources/io/quarkus/neo4j/deployment/neo4j_dev_services_ext.sh
+++ b/extensions/neo4j/deployment/src/main/resources/io/quarkus/neo4j/deployment/neo4j_dev_services_ext.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+while [ ! -f /testcontainers_env ]; do sleep 0.1; done;
+source /testcontainers_env
+add_env_setting_to_conf "dbms.connector.bolt.advertised_address" "${NEO4J_dbms_connector_bolt_advertised__address}" "${NEO4J_HOME}"

--- a/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/PortUtils.java
+++ b/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/PortUtils.java
@@ -1,0 +1,35 @@
+package io.quarkus.neo4j.deployment;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Optional;
+
+/**
+ * Please keep it public to make the Quarkus class loader happy during test.
+ */
+public final class PortUtils {
+
+    public static boolean isFree(int port) {
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public static Optional<Integer> findFreePort() {
+
+        // There is always a chance that the port number will be allocated between
+        // the moment it was free and when the container is started, but that's a
+        // risk to agree on to enable a frictionless Neo4j browser experience without using
+        // a fixed bolt port.
+        try (var socket = new ServerSocket(0)) {
+            return Optional.of(socket.getLocalPort());
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    private PortUtils() {
+    }
+}


### PR DESCRIPTION
This changes the dev services for Neo4j in the following way:

- It adds an extension script to the Neo4j container (which is supported on all official images since 3.5) that waits until dev services adds a set of environment variables to the already running container
- At that moment, Neo4j has not yet been started and it's static configuration can be influenced. This is used to correctly configure the advertised bolt address needed by the Neo4j browser
- Several new log statements have been added: An explicit URL for the Neo4j browser to open and a copyable snippet to use the cypher-shell to connect to the container
- Last but not least the change adds two new config options to specify custom, fixed ports for both http and bolt

Logging will look like this:

```
INFO  [io.qua.neo.deployment] (build-30) Dev Services started a Neo4j container reachable at bolt://127.0.0.1:61766.
INFO  [io.qua.neo.deployment] (build-30) Neo4j Browser is reachable at http://127.0.0.1:61765/browser?dbms=bolt://neo4j@127.0.0.1:61766.
INFO  [io.qua.neo.deployment] (build-30) The username for both endpoints is `neo4j`, authenticated by `password`
INFO  [io.qua.neo.deployment] (build-30) Connect via Cypher-Shell: cypher-shell -u neo4j -p password -a bolt://127.0.0.1:61766
```

So that a user can click the browser URL in most IDEs.

This closes #20624