### PR TITLE
Reset vertx-http virtualConnection on shutdown

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -255,6 +255,7 @@ public class VertxHttpRecorder {
 
         if (startVirtual) {
             initializeVirtual(vertx.get());
+            shutdown.addShutdownTask(() -> virtualBootstrap = null);
         }
         HttpConfiguration httpConfiguration = this.httpConfiguration.getValue();
         if (startSocket && (httpConfiguration.hostEnabled || httpConfiguration.domainSocketEnabled)) {


### PR DESCRIPTION
Rerun of tests in test mode was failing because virtualConnection was not reset.