### PR TITLE
Bump kubernetes-client-bom from 5.9.0 to 5.10.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -55,7 +55,7 @@
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.15.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>3.11.0</smallrye-reactive-messaging.version>
-        <smallrye-stork.version>1.0.0.Beta1</smallrye-stork.version>    
+        <smallrye-stork.version>1.0.0.Beta1</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.4</jakarta.el-impl.version>
@@ -169,7 +169,7 @@
         <okhttp.version>3.14.9</okhttp.version>
         <sentry.version>5.3.0</sentry.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.9.0</kubernetes-client.version>
+        <kubernetes-client.version>5.10.1</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerOnProfileTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerOnProfileTest.java
@@ -38,9 +38,9 @@ public class KubernetesTestServerOnProfileTest {
     private KubernetesServer mockServer;
 
     @Test
-    public void testConfiguration() throws InterruptedException {
+    public void testConfiguration() {
         // we can't really test CRUD, and HTTPS doesn't work
-        Assertions.assertEquals(10001, mockServer.getMockServer().getPort());
+        Assertions.assertEquals(10001, mockServer.getKubernetesMockServer().getPort());
         Assertions.assertSame(mockServer, setupServer);
     }
 

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesTestServerTest.java
@@ -38,9 +38,9 @@ public class KubernetesTestServerTest {
     private KubernetesServer mockServer;
 
     @Test
-    public void testConfiguration() throws InterruptedException {
+    public void testConfiguration() {
         // we can't really test CRUD, and HTTPS doesn't work
-        Assertions.assertEquals(10001, mockServer.getMockServer().getPort());
+        Assertions.assertEquals(10001, mockServer.getKubernetesMockServer().getPort());
         Assertions.assertSame(mockServer, setupServer);
     }
 


### PR DESCRIPTION
Kubernetes Client 5.10.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.10.0

Just speeding up the dependabot process to see if CI reports any issue.

/cc @metacosm
