### PR TITLE
Avoid having '-' in the names of generated StartupTask classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/ExtensionLoader.java
@@ -852,7 +852,7 @@ public final class ExtensionLoader {
                                 BytecodeRecorderImpl bri = isRecorder
                                         ? new BytecodeRecorderImpl(recordAnnotation.value() == ExecutionTime.STATIC_INIT,
                                                 clazz.getSimpleName(), method.getName(),
-                                                Integer.toString(method.toString().hashCode()), identityComparison,
+                                                Integer.toString(Math.abs(method.toString().hashCode())), identityComparison,
                                                 s -> {
                                                     if (s instanceof Class) {
                                                         var cfg = ((Class<?>) s).getAnnotation(ConfigRoot.class);


### PR DESCRIPTION
This is just makes it a little easier on the eye when looking at
the decompiled code of ApplicationImpl