### PR TITLE
Update JMS guide to not create generated [test] code that isn't used

### DIFF
--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -62,8 +62,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=jms-quickstart \
-    -DclassName="org.acme.jms.PriceResource" \
-    -Dpath="/prices" \
+    -DnoCode \
     -Dextensions="resteasy,qpid-jms"
 cd jms-quickstart
 ----


### PR DESCRIPTION
The JMS guide uses the maven plugin _create_ mojo to generate an initial maven project structure. This also generates some application and test code along with it. The guide directs people to create all the application files needed and gives full content, but the generated test bits are not used and so then dont actually work.

They simply shouldnt be generated to begin with. This change updates the create command to ensure they arent.