### PR TITLE
Misc code cleanup - usage of collection / files / map helper methods, for loops, Long casting

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -59,8 +56,7 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
                 classNames.add(line);
             }
         }
-        return new ServiceProviderBuildItem(serviceInterfaceClassName,
-                Collections.unmodifiableList(new ArrayList<>(classNames)), false);
+        return new ServiceProviderBuildItem(serviceInterfaceClassName, List.copyOf(classNames), false);
     }
 
     /**
@@ -84,7 +80,7 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
                     resourcePath);
             return new ServiceProviderBuildItem(
                     serviceInterfaceClassName,
-                    Collections.unmodifiableList(new ArrayList<>(implementations)),
+                    List.copyOf(implementations),
                     false);
         } catch (IOException e) {
             throw new RuntimeException("Could not read class path resources having path '" + resourcePath + "'", e);
@@ -100,7 +96,7 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
      * @param providerClassNames the list of provider class names that must already be mentioned in the file
      */
     public ServiceProviderBuildItem(String serviceInterfaceClassName, String... providerClassNames) {
-        this(serviceInterfaceClassName, Collections.unmodifiableList(Arrays.asList(providerClassNames)), false);
+        this(serviceInterfaceClassName, List.of(providerClassNames), false);
     }
 
     /**
@@ -112,7 +108,7 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
      * @param providers a collection of provider class names that must already be mentioned in the file
      */
     public ServiceProviderBuildItem(String serviceInterfaceClassName, Collection<String> providers) {
-        this(serviceInterfaceClassName, Collections.unmodifiableList(new ArrayList<>(providers)), false);
+        this(serviceInterfaceClassName, List.copyOf(providers), false);
     }
 
     /**
@@ -124,7 +120,7 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
      * @param providers the list of provider class names that must already be mentioned in the file
      */
     public ServiceProviderBuildItem(String serviceInterfaceClassName, List<String> providers) {
-        this(serviceInterfaceClassName, Collections.unmodifiableList(new ArrayList<>(providers)), false);
+        this(serviceInterfaceClassName, List.copyOf(providers), false);
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleProcessor.java
@@ -48,7 +48,7 @@ public class ConsoleProcessor {
                     launchModeBuildItem.isTest());
             ConsoleStateManager.init(QuarkusConsole.INSTANCE, launchModeBuildItem.getDevModeType().get());
             //note that this bit needs to be refactored so it is no longer tied to continuous testing
-            if (!TestSupport.instance().isPresent() || config.continuousTesting == TestConfig.Mode.DISABLED
+            if (TestSupport.instance().isEmpty() || config.continuousTesting == TestConfig.Mode.DISABLED
                     || config.flatClassPath) {
                 return ConsoleInstalledBuildItem.INSTANCE;
             }

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -291,13 +291,7 @@ public class ConsoleStateManager {
         public void reset(ConsoleCommand... command) {
             synchronized (commands) {
                 internal.clear();
-                var it = commands.entrySet().iterator();
-                while (it.hasNext()) {
-                    var holder = it.next();
-                    if (holder.getValue().context == this) {
-                        it.remove();
-                    }
-                }
+                commands.entrySet().removeIf(entry -> entry.getValue().context == this);
             }
             for (var i : command) {
                 addCommandInternal(i);

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestClassUsages.java
@@ -59,7 +59,7 @@ public class TestClassUsages implements Serializable {
                 if (testState.isFailed(testDescriptor)) {
                     return FilterResult.included("Test failed previously");
                 }
-                if (!testDescriptor.getSource().isPresent()) {
+                if (testDescriptor.getSource().isEmpty()) {
                     return FilterResult.included("No source information");
                 }
                 if (touchedIds.contains(testDescriptor.getUniqueId())) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -54,7 +54,7 @@ public class TestTracingProcessor {
     @Produce(ServiceStartBuildItem.class)
     void startTesting(TestConfig config, LiveReloadBuildItem liveReloadBuildItem,
             LaunchModeBuildItem launchModeBuildItem, List<TestListenerBuildItem> testListenerBuildItems) {
-        if (!TestSupport.instance().isPresent() || config.continuousTesting == TestConfig.Mode.DISABLED
+        if (TestSupport.instance().isEmpty() || config.continuousTesting == TestConfig.Mode.DISABLED
                 || config.flatClassPath) {
             return;
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -6,9 +6,7 @@ import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 import java.io.File;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,10 +88,8 @@ public class MainClassBuildStep {
     private static final String JAVAX_NET_SSL_TRUST_STORE_TYPE = "javax.net.ssl.trustStoreType";
     private static final String JAVAX_NET_SSL_TRUST_STORE_PROVIDER = "javax.net.ssl.trustStoreProvider";
     private static final String JAVAX_NET_SSL_TRUST_STORE_PASSWORD = "javax.net.ssl.trustStorePassword";
-    private static final List<String> BUILD_TIME_TRUST_STORE_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            JAVAX_NET_SSL_TRUST_STORE,
-            JAVAX_NET_SSL_TRUST_STORE_TYPE, JAVAX_NET_SSL_TRUST_STORE_PROVIDER,
-            JAVAX_NET_SSL_TRUST_STORE_PASSWORD));
+    private static final List<String> BUILD_TIME_TRUST_STORE_PROPERTIES = List.of(JAVAX_NET_SSL_TRUST_STORE,
+            JAVAX_NET_SSL_TRUST_STORE_TYPE, JAVAX_NET_SSL_TRUST_STORE_PROVIDER, JAVAX_NET_SSL_TRUST_STORE_PASSWORD);
 
     public static final String GENERATE_APP_CDS_SYSTEM_PROPERTY = "quarkus.appcds.generate";
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
@@ -19,7 +19,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -370,9 +369,7 @@ public class WebJarUtil {
     private static Path getCustomOverridePath(PathCollection paths, String filename, String modulename) {
 
         // First check if the developer supplied the files
-        Iterator<Path> iterator = paths.iterator();
-        while (iterator.hasNext()) {
-            Path root = iterator.next();
+        for (Path root : paths) {
             Path customModuleOverride = root.resolve(CUSTOM_MEDIA_FOLDER + modulename);
             if (Files.exists(customModuleOverride)) {
                 return customModuleOverride;
@@ -410,9 +407,7 @@ public class WebJarUtil {
     }
 
     private static boolean isCustomOverride(PathCollection paths, String filename, String modulename) {
-        Iterator<Path> iterator = paths.iterator();
-        while (iterator.hasNext()) {
-            Path root = iterator.next();
+        for (Path root : paths) {
             Path customModuleOverride = root.resolve(CUSTOM_MEDIA_FOLDER + modulename);
             if (Files.exists(customModuleOverride)) {
                 return true;

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
@@ -278,7 +278,7 @@ public class WebJarUtil {
     }
 
     public static void updateUrl(Path original, String path, String lineStartsWith, String format) throws IOException {
-        String content = new String(Files.readAllBytes(original), StandardCharsets.UTF_8);
+        String content = Files.readString(original);
         String result = updateUrl(content, path, lineStartsWith, format);
         if (result != null && !result.equals(content)) {
             Files.write(original, result.getBytes(StandardCharsets.UTF_8));

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/FsMap.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/FsMap.java
@@ -22,7 +22,7 @@ public class FsMap {
         final Path file = dir.resolve(key);
         if (Files.exists(file)) {
             try {
-                return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+                return Files.readString(file);
             } catch (IOException e) {
                 throw new RuntimeException("Could not read " + file, e);
             }
@@ -80,7 +80,7 @@ public class FsMap {
                         .forEach(f -> {
                             try {
                                 result.setProperty(f.getFileName().toString(),
-                                        new String(Files.readAllBytes(f), StandardCharsets.UTF_8));
+                                        Files.readString(f));
                             } catch (IOException e) {
                                 throw new IllegalStateException("Could not read from " + f, e);
                             }

--- a/core/runtime/src/main/java/io/quarkus/runtime/BlockingOperationControl.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/BlockingOperationControl.java
@@ -9,8 +9,8 @@ public class BlockingOperationControl {
     }
 
     public static boolean isBlockingAllowed() {
-        for (int i = 0; i < ioThreadDetectors.length; ++i) {
-            if (ioThreadDetectors[i].isInIOThread()) {
+        for (IOThreadDetector ioThreadDetector : ioThreadDetectors) {
+            if (ioThreadDetector.isInIOThread()) {
                 return false;
             }
         }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/DurationConverter.java
@@ -51,7 +51,7 @@ public class DurationConverter implements Converter<Duration>, Serializable {
             return null;
         }
         if (DIGITS.asPredicate().test(value)) {
-            return Duration.ofSeconds(Long.valueOf(value));
+            return Duration.ofSeconds(Long.parseLong(value));
         }
 
         try {

--- a/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
+++ b/core/test-extension/deployment/src/main/java/io/quarkus/extest/deployment/ClasspathEntryRecordingBuildStep.java
@@ -25,7 +25,7 @@ public class ClasspathEntryRecordingBuildStep {
     void registerRecordedClasspathEntries(ClasspathEntriesRecorder classpathEntriesRecorder,
             TestBuildTimeConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
         Optional<Path> recordFilePath = config.classpathRecording.recordFile;
-        if (!recordFilePath.isPresent()) {
+        if (recordFilePath.isEmpty()) {
             return;
         }
         syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(RecordedClasspathEntries.class)


### PR DESCRIPTION
Misc code cleanup - usage of collection / files / map helper methods, for loops, Long casting

 - Use List.copyOf and List.of instead of Collections.unmodifiableList
 - Use Optional.isEmpty() instead of negation of isPresent()
 - Use for loop instead of iterator or for cycle
 - Use Files.readString(file) to get file content
 - Use Map.removeIf to remove entry from map
 - Avoid Long to long casting using Long.parseLong(value)
