### PR TITLE
Fix handling of partial path param handling

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/PathMatcher.java
@@ -63,12 +63,9 @@ public class PathMatcher<T> implements Dumpable {
                     return new PathMatch<>(path, "", next.getValue());
                 }
             } else if (pathLength < length) {
-                char c = path.charAt(pathLength);
-                if (c == '/') {
-                    SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength);
-                    if (next != null) {
-                        return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
-                    }
+                SubstringMap.SubstringMatch<T> next = paths.get(path, pathLength);
+                if (next != null) {
+                    return new PathMatch<>(next.getKey(), path.substring(pathLength), next.getValue());
                 }
             }
         }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/GeneralResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/GeneralResource.java
@@ -15,4 +15,11 @@ public class GeneralResource {
     public String hello(@PathParam("id") String id) {
         return "general:" + id;
     }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("prefix-{id}")
+    public String prefixedHello(@PathParam("id") String id) {
+        return "prefix:" + id;
+    }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/StemMatchTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/StemMatchTest.java
@@ -30,6 +30,11 @@ public class StemMatchTest {
                 .statusCode(200)
                 .body(is("general:foo"));
         given()
+                .when().get("/hello/prefix-foo")
+                .then()
+                .statusCode(200)
+                .body(is("prefix:foo"));
+        given()
                 .when().get("/hello/foo/bar")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
Fixes: #21371

P.S. I am not sure why the check for `'/'` was there, but removing it does not have an effect on any of the RESTEasy Reactive or TCK tests