### PR TITLE
Avoid unnecessary synchronization in mapper code

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -12,11 +12,12 @@ import org.jboss.resteasy.reactive.common.util.URIDecoder;
 public class RequestMapper<T> {
 
     private final PathMatcher<List<RequestPath<T>>> requestPaths;
+    private final PathMatcher.Builder<List<RequestPath<T>>> pathMatcherBuilder;
     private final List<RequestPath<T>> templates;
     final int maxParams;
 
     public RequestMapper(List<RequestPath<T>> templates) {
-        this.requestPaths = new PathMatcher<>();
+        pathMatcherBuilder = new PathMatcher.Builder<>();
         this.templates = templates;
         int max = 0;
         Map<String, List<RequestPath<T>>> aggregates = new HashMap<>();
@@ -31,6 +32,7 @@ public class RequestMapper<T> {
         aggregates.forEach(this::sortAggregates);
         aggregates.forEach(this::addPrefixPaths);
         maxParams = max;
+        requestPaths = pathMatcherBuilder.build();
     }
 
     private void sortAggregates(String stem, List<RequestPath<T>> list) {
@@ -43,7 +45,7 @@ public class RequestMapper<T> {
     }
 
     private void addPrefixPaths(String stem, List<RequestPath<T>> list) {
-        requestPaths.addPrefixPath(stem, list);
+        pathMatcherBuilder.addPrefixPath(stem, list);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/SubstringMap.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/SubstringMap.java
@@ -14,21 +14,26 @@ import java.util.NoSuchElementException;
  *
  * @author Stuart Douglas
  */
-public class SubstringMap<V> {
+class SubstringMap<V> {
     private static final int ALL_BUT_LAST_BIT = ~1;
 
-    private volatile Object[] table = new Object[16];
-    private int size;
+    private final Object[] table;
+    private final int size;
 
-    public int size() {
+    public SubstringMap(Object[] table, int size) {
+        this.table = table;
+        this.size = size;
+    }
+
+    int size() {
         return size;
     }
 
-    public SubstringMatch<V> get(String key, int length) {
+    SubstringMatch<V> get(String key, int length) {
         return doGet(key, length);
     }
 
-    public SubstringMatch<V> get(String key) {
+    SubstringMatch<V> get(String key) {
         return doGet(key, key.length());
     }
 
@@ -55,8 +60,19 @@ public class SubstringMap<V> {
         return null;
     }
 
-    private int tablePos(Object[] table, int hash) {
+    private static int tablePos(Object[] table, int hash) {
         return (hash & (table.length - 1)) & ALL_BUT_LAST_BIT;
+    }
+
+    private static int hash(String value, int length) {
+        if (length == 0) {
+            return 0;
+        }
+        int h = 0;
+        for (int i = 0; i < length; i++) {
+            h = 31 * h + value.charAt(i);
+        }
+        return h;
     }
 
     private boolean doEquals(String s1, String s2, int length) {
@@ -71,52 +87,7 @@ public class SubstringMap<V> {
         return true;
     }
 
-    public synchronized void put(String key, V value) {
-        if (key == null) {
-            throw new NullPointerException();
-        }
-        Object[] newTable;
-        if (table.length / (double) size < 4 && table.length != Integer.MAX_VALUE) {
-            newTable = new Object[table.length << 1];
-            for (int i = 0; i < table.length; i += 2) {
-                if (table[i] != null) {
-                    doPut(newTable, (String) table[i], table[i + 1]);
-                }
-            }
-        } else {
-            newTable = new Object[table.length];
-            System.arraycopy(table, 0, newTable, 0, table.length);
-        }
-        doPut(newTable, key, new SubstringMap.SubstringMatch<>(key, value));
-        this.table = newTable;
-        size++;
-    }
-
-    private void doPut(Object[] newTable, String key, Object value) {
-        int hash = hash(key, key.length());
-        int pos = tablePos(newTable, hash);
-        while (newTable[pos] != null && !newTable[pos].equals(key)) {
-            pos += 2;
-            if (pos >= newTable.length) {
-                pos = 0;
-            }
-        }
-        newTable[pos] = key;
-        newTable[pos + 1] = value;
-    }
-
-    private static int hash(String value, int length) {
-        if (length == 0) {
-            return 0;
-        }
-        int h = 0;
-        for (int i = 0; i < length; i++) {
-            h = 31 * h + value.charAt(i);
-        }
-        return h;
-    }
-
-    public Iterable<String> keys() {
+    Iterable<String> keys() {
         return new Iterable<String>() {
             @Override
             public Iterator<String> iterator() {
@@ -160,6 +131,50 @@ public class SubstringMap<V> {
             }
         };
 
+    }
+
+    static class Builder<V> {
+
+        private Object[] table = new Object[16];
+        private int size;
+
+        SubstringMap<V> build() {
+            return new SubstringMap<>(table, size);
+        }
+
+        void put(String key, V value) {
+            if (key == null) {
+                throw new NullPointerException();
+            }
+            Object[] newTable;
+            if (table.length / (double) size < 4 && table.length != Integer.MAX_VALUE) {
+                newTable = new Object[table.length << 1];
+                for (int i = 0; i < table.length; i += 2) {
+                    if (table[i] != null) {
+                        doPut(newTable, (String) table[i], table[i + 1]);
+                    }
+                }
+            } else {
+                newTable = new Object[table.length];
+                System.arraycopy(table, 0, newTable, 0, table.length);
+            }
+            doPut(newTable, key, new SubstringMap.SubstringMatch<>(key, value));
+            this.table = newTable;
+            size++;
+        }
+
+        private void doPut(Object[] newTable, String key, Object value) {
+            int hash = hash(key, key.length());
+            int pos = tablePos(newTable, hash);
+            while (newTable[pos] != null && !newTable[pos].equals(key)) {
+                pos += 2;
+                if (pos >= newTable.length) {
+                    pos = 0;
+                }
+            }
+            newTable[pos] = key;
+            newTable[pos + 1] = value;
+        }
     }
 
     public static final class SubstringMatch<V> {


### PR DESCRIPTION
All the mappers are built up when RESTEasy Reactive starts, 
so by utilizing a builder approach
it is no longer necessary for the various methods
to be `synchronized` or the backing fields to be `volatile`