### PR TITLE
Fix encoding of non-simple return types in RestEasy Reactive Clients

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -1348,7 +1348,7 @@ public class JaxrsClientReactiveProcessor {
                         genericReturnType = createGenericTypeFromParameterizedType(methodCreator,
                                 type.asParameterizedType());
                     } else {
-                        simpleReturnType = type.toString();
+                        simpleReturnType = type.name().toString();
                     }
                 }
             } else {
@@ -1388,7 +1388,7 @@ public class JaxrsClientReactiveProcessor {
                                 type = type.asWildcardType().extendsBound();
                             }
                         } else {
-                            simpleReturnType = type.toString();
+                            simpleReturnType = type.name().toString();
                             break;
                         }
                     }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
@@ -20,7 +20,8 @@ public class BasicRestClientTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(HelloClient.class, HelloResource.class, TestBean.class, HelloClient2.class))
+                    .addClasses(HelloClient.class, HelloResource.class, TestBean.class, HelloClient2.class,
+                            HelloNonSimpleClient.class))
             .withConfigurationResource("basic-test-application.properties");
 
     @Inject
@@ -47,5 +48,15 @@ public class BasicRestClientTest {
     @Test
     void shouldInvokeClientResponseOnSameContext() {
         assertThat(testBean.bug18977()).isEqualTo("Hello");
+    }
+
+    @Test
+    void shouldHelloBytes() {
+        assertThat(testBean.helloNonSimpleSyncBytes()).isEqualTo(new byte[] { 1, 2, 3 });
+    }
+
+    @Test
+    void shouldHelloInts() {
+        assertThat(testBean.helloNonSimpleSyncInts()).isEqualTo(new Integer[] { 1, 2, 3 });
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloNonSimpleClient.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloNonSimpleClient.java
@@ -1,0 +1,41 @@
+package io.quarkus.rest.client.reactive;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.smallrye.mutiny.Uni;
+
+// Test clients with non-simple type (e.g. primitive arrays)
+// are generated as valid classes.
+//
+// https://github.com/quarkusio/quarkus/issues/21375
+//
+@RegisterRestClient(configKey = "hello2")
+public interface HelloNonSimpleClient {
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/bytes")
+    byte[] echoSyncBytes(byte[] value);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/ints")
+    Integer[] echoSyncInts(Integer[] value);
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Path("/bytes")
+    Uni<byte[]> echoAsyncBytes(byte[] value);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/ints")
+    Uni<Integer[]> echoAsyncInts(Integer[] value);
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloResource.java
@@ -25,6 +25,20 @@ public class HelloResource {
         return "hello, " + name;
     }
 
+    @POST
+    @Path("/bytes")
+    public byte[] bytes(byte[] value) {
+        return value;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/ints")
+    public int[] bytes(int[] value) {
+        return value;
+    }
+
     @RestClient
     HelloClient2 client2;
 

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
@@ -17,6 +17,9 @@ public class TestBean {
     @RestClient
     HelloClient2 client2;
 
+    @RestClient
+    HelloNonSimpleClient clientNonSimple;
+
     String helloViaInjectedClient(String name) {
         return client2.echo(name);
     }
@@ -30,5 +33,13 @@ public class TestBean {
 
     String bug18977() {
         return client2.bug18977();
+    }
+
+    byte[] helloNonSimpleSyncBytes() {
+        return clientNonSimple.echoSyncBytes(new byte[] { 1, 2, 3 });
+    }
+
+    Integer[] helloNonSimpleSyncInts() {
+        return clientNonSimple.echoSyncInts(new Integer[] { 1, 2, 3 });
     }
 }


### PR DESCRIPTION
Fixes #21375

I tracked down the error but as I'm pretty unfamiliar with the generated client testing, this still needs tests.  

The issue actually seems to affect all non-parameterized and non-primitive types. This includes all Java array types which is why `byte[]` was affected.