### PR TITLE
Add clear screen shortcut key to dev-console

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -126,6 +126,7 @@ public class ConsoleStateManager {
                                 ? toLevel(((LogManager) LogManager.getLogManager()).getLogger("").getLevel()).toString()
                                 : currentLevel.toString())),
                 ConsoleStateManager.this::toggleLogLevel));
+        commands.add(new ConsoleCommand((char) 12, null, null, 10002, null, this::clearScreen));
         commands.add(new ConsoleCommand((char) 13, null, null, 10001, null, this::printBlankLine));
         commands.add(new ConsoleCommand('h', "Shows this help", "for more options", 10000, null, this::printHelp));
         commands.add(new ConsoleCommand('q', "Quits the application", null, this::exitQuarkus));
@@ -182,6 +183,10 @@ public class ConsoleStateManager {
             currentLevel = null;
             System.out.println("Restored log levels to configured values");
         }
+    }
+
+    private void clearScreen() {
+        System.out.println("\u001b[2J");
     }
 
     private void printBlankLine() {


### PR DESCRIPTION
In terminals, it's common to use Ctrl+L to clear the screen. This pull request adds this shortcut key command in the dev-console as well.