### PR TITLE
Correct var name in grpc example

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -172,7 +172,7 @@ public class StreamingEndpoint {
     @GET
     public Multi<String> invokeSource() {
         // Retrieve a stream
-        return client.source(Empty.newBuilder().build())
+        return streaming.source(Empty.newBuilder().build())
                 .onItem().transform(Item::getValue);
     }
 
@@ -183,7 +183,7 @@ public class StreamingEndpoint {
         Multi<Item> inputs = Multi.createFrom().range(0, max)
                 .map(i -> Integer.toString(i))
                 .map(i -> Item.newBuilder().setValue(i).build());
-        return client.sink(inputs).onItem().ignore().andContinueWithNull();
+        return streaming.sink(inputs).onItem().ignore().andContinueWithNull();
     }
 
     @GET
@@ -193,7 +193,7 @@ public class StreamingEndpoint {
         Multi<Item> inputs = Multi.createFrom().range(0, max)
                 .map(i -> Integer.toString(i))
                 .map(i -> Item.newBuilder().setValue(i).build());
-        return client.pipe(inputs).onItem().transform(Item::getValue);
+        return streaming.pipe(inputs).onItem().transform(Item::getValue);
     }
 
 }


### PR DESCRIPTION
The example is taken from [StreamingEndpoint.java](https://github.com/quarkusio/quarkus/blob/main/integration-tests/grpc-streaming/src/main/java/io/quarkus/grpc/example/streaming/StreamingEndpoint.java).

Using the client variable name is invalid/confusing.  Here pushing fix to correct it.
