### PR TITLE
Initialise kubernetes client Utils class at runtime

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -24,6 +24,7 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.jackson.deployment.IgnoreJsonDeserializeClassBuildItem;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientProducer;
@@ -53,6 +54,12 @@ public class KubernetesClientProcessor {
             // wire up the KubernetesClient bean support
             additionalBeanBuildItemBuildItem.produce(AdditionalBeanBuildItem.unremovableOf(KubernetesClientProducer.class));
         }
+    }
+
+    @BuildStep
+    public void nativeImageSupport(BuildProducer<RuntimeReinitializedClassBuildItem> runtimeInitializedClassProducer) {
+        runtimeInitializedClassProducer
+                .produce(new RuntimeReinitializedClassBuildItem("io.fabric8.kubernetes.client.utils.Utils"));
     }
 
     @BuildStep

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/ConfigMapProperties.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/ConfigMapProperties.java
@@ -5,8 +5,17 @@ import javax.ws.rs.Path;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.fabric8.kubernetes.client.utils.Utils;
+
 @Path("/configMapProperties")
 public class ConfigMapProperties {
+
+    static {
+        // this is only done to ensure that Utils is reachable
+        // see https://github.com/quarkusio/quarkus/issues/21398
+        String osName = Utils.OS_NAME;
+        System.out.println(osName);
+    }
 
     @ConfigProperty(name = "dummy")
     String dummy;


### PR DESCRIPTION
This is needed because the class contains Random

Fixes: #21398