### PR TITLE
Temporary fix for failure to resolve 'sun.management.Util' when using GraalVM CE 21.3.0 Java 17  

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -24,14 +24,12 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
 
     public static class GraalVMVersion {
         private final String fullVersion;
-        private final int major;
-        private final int minor;
+        private final String version;
         private final String distribution;
 
-        public GraalVMVersion(String fullVersion, int major, int minor, String distribution) {
+        public GraalVMVersion(String fullVersion, String version, String distribution) {
             this.fullVersion = fullVersion;
-            this.major = major;
-            this.minor = minor;
+            this.version = version;
             this.distribution = distribution;
         }
 
@@ -39,12 +37,8 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
             return fullVersion;
         }
 
-        public int getMajor() {
-            return major;
-        }
-
-        public int getMinor() {
-            return minor;
+        public String getVersion() {
+            return version;
         }
 
         public String getDistribution() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -25,11 +25,13 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
     public static class GraalVMVersion {
         private final String fullVersion;
         private final String version;
+        private final int javaVersion;
         private final String distribution;
 
-        public GraalVMVersion(String fullVersion, String version, String distribution) {
+        public GraalVMVersion(String fullVersion, String version, int javaVersion, String distribution) {
             this.fullVersion = fullVersion;
             this.version = version;
+            this.javaVersion = javaVersion;
             this.distribution = distribution;
         }
 
@@ -39,6 +41,10 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
 
         public String getVersion() {
             return version;
+        }
+
+        public int getJavaVersion() {
+            return javaVersion;
         }
 
         public String getDistribution() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -8,22 +8,29 @@ import java.util.stream.Stream;
 final class GraalVM {
     static final class Version implements Comparable<Version> {
         private static final Pattern PATTERN = Pattern.compile(
-                "(GraalVM|native-image)( Version)? ([1-9][0-9]*(\\.([0-9]+))+(-dev\\p{XDigit}*)?)([^\n$]*)\\s*");
+                "(GraalVM|native-image)( Version)? (?<version>[1-9][0-9]*(\\.[0-9]+)+(-dev\\p{XDigit}*)?)(?<distro>[^\n$]*)(Java Version (?<javaVersion>[^)]+))?\\s*");
 
         static final Version UNVERSIONED = new Version("Undefined", "snapshot", Distribution.ORACLE);
         static final Version VERSION_21_2 = new Version("GraalVM 21.2", "21.2", Distribution.ORACLE);
         static final Version VERSION_21_3 = new Version("GraalVM 21.3", "21.3", Distribution.ORACLE);
+        static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
 
         static final Version MINIMUM = VERSION_21_2;
         static final Version CURRENT = VERSION_21_3;
 
         final String fullVersion;
         final org.graalvm.home.Version version;
+        final int javaVersion;
         final Distribution distribution;
 
         Version(String fullVersion, String version, Distribution distro) {
+            this(fullVersion, version, 11, distro);
+        }
+
+        Version(String fullVersion, String version, int javaVersion, Distribution distro) {
             this.fullVersion = fullVersion;
             this.version = org.graalvm.home.Version.parse(version);
+            this.javaVersion = javaVersion;
             this.distribution = distro;
         }
 
@@ -51,6 +58,10 @@ final class GraalVM {
             return this.compareTo(version) < 0;
         }
 
+        boolean is(Version version) {
+            return this.compareTo(version) == 0;
+        }
+
         @Override
         public int compareTo(Version o) {
             return this.version.compareTo(o.version);
@@ -61,12 +72,16 @@ final class GraalVM {
             while (it.hasNext()) {
                 final String line = it.next();
                 final Matcher matcher = PATTERN.matcher(line);
-                if (matcher.find() && matcher.groupCount() >= 3) {
-                    final String version = matcher.group(3);
-                    final String distro = matcher.group(7);
+                if (matcher.find()) {
+                    final String version = matcher.group("version");
+                    final String distro = matcher.group("distro");
+                    String javaVersionMatch = matcher.group("javaVersion");
+                    final int javaVersion = javaVersionMatch == null ? // Old GraalVM versions, like 19, didn't report the Java version
+                            11 : Integer.parseInt(javaVersionMatch.split("\\.")[0]);
                     return new Version(
                             line,
                             version,
+                            javaVersion,
                             isMandrel(distro) ? Distribution.MANDREL : Distribution.ORACLE);
                 }
             }
@@ -75,6 +90,9 @@ final class GraalVM {
         }
 
         private static boolean isMandrel(String s) {
+            if (s == null) {
+                return false;
+            }
             return s.contains("Mandrel Distribution");
         }
 
@@ -83,7 +101,12 @@ final class GraalVM {
             return "Version{" +
                     "version=" + version +
                     ", distribution=" + distribution +
+                    ", javaVersion=" + javaVersion +
                     '}';
+        }
+
+        public boolean isJava17() {
+            return javaVersion == 17;
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -720,6 +720,11 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add(excludeConfig.getResourceName());
                 }
 
+                // Work around https://github.com/quarkusio/quarkus/issues/21372
+                if (graalVMVersion.is(GraalVM.Version.VERSION_21_3_0) && graalVMVersion.isJava17()) {
+                    nativeImageArgs.add("-J--add-exports=java.management/sun.management=ALL-UNNAMED");
+                }
+
                 nativeImageArgs.add(nativeImageName);
 
                 //Make sure to have the -jar as last one, as it otherwise breaks "--exclude-config"

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -72,8 +72,7 @@ public class NativeImageBuildStep {
         NativeImageBuildItem.GraalVMVersion graalVMVersion = image.getGraalVMInfo();
         Map<String, Object> graalVMInfoProps = new HashMap<>();
         graalVMInfoProps.put("graalvm.version.full", graalVMVersion.getFullVersion());
-        graalVMInfoProps.put("graalvm.version.major", "" + graalVMVersion.getMajor());
-        graalVMInfoProps.put("graalvm.version.minor", "" + graalVMVersion.getMinor());
+        graalVMInfoProps.put("graalvm.version.version", graalVMVersion.getVersion());
         return new ArtifactResultBuildItem(image.getPath(), PackageConfig.NATIVE, graalVMInfoProps);
     }
 
@@ -175,8 +174,8 @@ public class NativeImageBuildStep {
         if (nativeConfig.reuseExisting) {
             if (Files.exists(finalExecutablePath)) {
                 return new NativeImageBuildItem(finalExecutablePath,
-                        new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion, graalVMVersion.major,
-                                graalVMVersion.minor,
+                        new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
+                                graalVMVersion.version.toString(),
                                 graalVMVersion.distribution.name()));
             }
         }
@@ -226,8 +225,8 @@ public class NativeImageBuildStep {
             System.setProperty("native.image.path", finalExecutablePath.toAbsolutePath().toString());
 
             return new NativeImageBuildItem(finalExecutablePath,
-                    new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion, graalVMVersion.major,
-                            graalVMVersion.minor,
+                    new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
+                            graalVMVersion.version.toString(),
                             graalVMVersion.distribution.name()));
         } catch (Exception e) {
             throw new RuntimeException("Failed to build native image", e);
@@ -373,10 +372,9 @@ public class NativeImageBuildStep {
     private void checkGraalVMVersion(GraalVM.Version version) {
         log.info("Running Quarkus native-image plugin on " + version.getFullVersion());
         if (version.isObsolete()) {
-            final int major = GraalVM.Version.CURRENT.major;
-            final int minor = GraalVM.Version.CURRENT.minor;
             throw new IllegalStateException("Out of date version of GraalVM detected: " + version.getFullVersion() + "."
-                    + " Quarkus currently supports " + major + "." + minor + ". Please upgrade GraalVM to this version.");
+                    + " Quarkus currently supports " + GraalVM.Version.CURRENT.version
+                    + ". Please upgrade GraalVM to this version.");
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -73,6 +73,8 @@ public class NativeImageBuildStep {
         Map<String, Object> graalVMInfoProps = new HashMap<>();
         graalVMInfoProps.put("graalvm.version.full", graalVMVersion.getFullVersion());
         graalVMInfoProps.put("graalvm.version.version", graalVMVersion.getVersion());
+        graalVMInfoProps.put("graalvm.version.javaVersion", "" + graalVMVersion.getJavaVersion());
+        graalVMInfoProps.put("graalvm.version.distribution", graalVMVersion.getDistribution());
         return new ArtifactResultBuildItem(image.getPath(), PackageConfig.NATIVE, graalVMInfoProps);
     }
 
@@ -176,6 +178,7 @@ public class NativeImageBuildStep {
                 return new NativeImageBuildItem(finalExecutablePath,
                         new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
                                 graalVMVersion.version.toString(),
+                                graalVMVersion.javaVersion,
                                 graalVMVersion.distribution.name()));
             }
         }
@@ -227,6 +230,7 @@ public class NativeImageBuildStep {
             return new NativeImageBuildItem(finalExecutablePath,
                     new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
                             graalVMVersion.version.toString(),
+                            graalVMVersion.javaVersion,
                             graalVMVersion.distribution.name()));
         } catch (Exception e) {
             throw new RuntimeException("Failed to build native image", e);

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -15,30 +15,30 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMVersionDetected() {
-        assertVersion(20, 1, ORACLE, Version.of(Stream.of("GraalVM Version 20.1.0 (Java Version 11.0.7)")));
-        assertVersion(20, 1, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(20, 1), ORACLE,
+                Version.of(Stream.of("GraalVM Version 20.1.0 (Java Version 11.0.7)")));
+        assertVersion(org.graalvm.home.Version.create(20, 1, 0, 1), MANDREL, Version
                 .of(Stream.of("GraalVM Version 20.1.0.1.Alpha2 56d4ee1b28 (Mandrel Distribution) (Java Version 11.0.8)")));
-        assertVersion(20, 1, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(20, 1, 0, 1), MANDREL, Version
                 .of(Stream.of("GraalVM Version 20.1.0.1-Final 56d4ee1b28 (Mandrel Distribution) (Java Version 11.0.8)")));
-        assertVersion(21, 0, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(21, 0), MANDREL, Version
                 .of(Stream.of("GraalVM Version 21.0.0.0-0b3 (Mandrel Distribution) (Java Version 11.0.8)")));
-        assertVersion(20, 3, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(20, 3, 1, 2), MANDREL, Version
                 .of(Stream.of("GraalVM Version 20.3.1.2-dev (Mandrel Distribution) (Java Version 11.0.8)")));
-        assertVersion(21, 1, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(21, 1), MANDREL, Version
                 .of(Stream.of("native-image 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)")));
-        assertVersion(21, 1, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(21, 1), MANDREL, Version
                 .of(Stream.of("GraalVM 21.1.0.0-Final (Mandrel Distribution) (Java Version 11.0.11+9)")));
-        assertVersion(21, 1, ORACLE, Version
+        assertVersion(org.graalvm.home.Version.create(21, 1), ORACLE, Version
                 .of(Stream.of("GraalVM 21.1.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)")));
-        assertVersion(21, 1, ORACLE, Version
+        assertVersion(org.graalvm.home.Version.create(21, 1), ORACLE, Version
                 .of(Stream.of("native-image 21.1.0.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)")));
-        assertVersion(21, 2, MANDREL, Version
+        assertVersion(org.graalvm.home.Version.create(21, 2), MANDREL, Version
                 .of(Stream.of("native-image 21.2.0.0-Final Mandrel Distribution (Java Version 11.0.12+7)")));
     }
 
-    static void assertVersion(int major, int minor, Distribution distro, Version version) {
-        assertThat(version.major).isEqualTo(major);
-        assertThat(version.minor).isEqualTo(minor);
+    static void assertVersion(org.graalvm.home.Version graalVmVersion, Distribution distro, Version version) {
+        assertThat(graalVmVersion.compareTo(version.version)).isEqualTo(0);
 
         assertThat(version.distribution).isEqualTo(distro);
         if (distro == MANDREL)
@@ -69,10 +69,10 @@ public class GraalVMTest {
     public void testGraalVMVersionsCompareEqualTo() {
         assertCompareEqualTo("GraalVM Version 20.1.0", "GraalVM Version 20.1.0");
         // Distributions don't impact newer/older/same comparisons
-        assertCompareEqualTo("GraalVM Version 20.1.0",
+        assertCompareEqualTo("GraalVM Version 20.1.0.1",
                 "GraalVM Version 20.1.0.1.Alpha2 56d4ee1b28 (Mandrel Distribution) (Java Version 11.0.8)");
-        // Micro versions ignored, hence two micros are considered the same right now
-        assertCompareEqualTo("GraalVM Version 19.3.0", "GraalVM Version 19.3.3");
+        // Don't ignore micro versions
+        assertCompareNotEqualTo("GraalVM Version 19.3.0", "GraalVM Version 19.3.3");
     }
 
     /**
@@ -80,6 +80,10 @@ public class GraalVMTest {
      */
     static void assertCompareEqualTo(String version, String other) {
         assertThat(Version.of(Stream.of(version)).compareTo(Version.of(Stream.of(other)))).isEqualTo(0);
+    }
+
+    static void assertCompareNotEqualTo(String version, String other) {
+        assertThat(Version.of(Stream.of(version)).compareTo(Version.of(Stream.of(other)))).isNotEqualTo(0);
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -54,8 +54,10 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMVersionsOlderThan() {
-        assertOlderThan("GraalVM Version 19.3.0", "GraalVM Version 20.2.0");
-        assertOlderThan("GraalVM Version 20.0.0", "GraalVM Version 20.1.0");
+        assertOlderThan("GraalVM Version 19.3.6 CE", "GraalVM Version 20.2.0 (Java Version 11.0.9)");
+        assertOlderThan("GraalVM Version 20.0.0 (Java Version 11.0.7)", "GraalVM Version 20.1.0 (Java Version 11.0.8)");
+        assertOlderThan("GraalVM Version 21.2.0 (Java Version 11.0.12)", Version.VERSION_21_3);
+        assertOlderThan("GraalVM Version 21.2.0 (Java Version 11.0.12)", Version.VERSION_21_3_0);
     }
 
     /**
@@ -65,14 +67,24 @@ public class GraalVMTest {
         assertThat(Version.of(Stream.of(version)).compareTo(Version.of(Stream.of(other)))).isLessThan(0);
     }
 
+    static void assertOlderThan(String version, GraalVM.Version other) {
+        assertThat(Version.of(Stream.of(version)).compareTo(other)).isLessThan(0);
+    }
+
     @Test
     public void testGraalVMVersionsCompareEqualTo() {
-        assertCompareEqualTo("GraalVM Version 20.1.0", "GraalVM Version 20.1.0");
+        assertCompareEqualTo("GraalVM Version 20.1.0 (Java Version 11.0.8)", "GraalVM Version 20.1.0 (Java Version 11.0.8)");
         // Distributions don't impact newer/older/same comparisons
-        assertCompareEqualTo("GraalVM Version 20.1.0.1",
+        assertCompareEqualTo("GraalVM Version 20.1.0.1 (Java Version 11.0.8)",
                 "GraalVM Version 20.1.0.1.Alpha2 56d4ee1b28 (Mandrel Distribution) (Java Version 11.0.8)");
         // Don't ignore micro versions
-        assertCompareNotEqualTo("GraalVM Version 19.3.0", "GraalVM Version 19.3.3");
+        assertCompareNotEqualTo("GraalVM Version 19.3.0", "GraalVM Version 19.3.6 CE");
+        // Trailing zeros don't affect comparison
+        assertCompareEqualTo("GraalVM 21.3 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)",
+                "GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
+        assertCompareEqualTo("GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)",
+                "GraalVM 21.3.0.0.0.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
+        assertThat(Version.VERSION_21_3.compareTo(Version.VERSION_21_3_0)).isEqualTo(0);
     }
 
     /**
@@ -88,9 +100,13 @@ public class GraalVMTest {
 
     @Test
     public void testGraalVMVersionsNewerThan() {
-        assertNewerThan("GraalVM Version 20.0.0", "GraalVM Version 19.3.0");
+        assertNewerThan("GraalVM Version 20.0.0 (Java Version 11.0.7)", "GraalVM Version 19.3.0");
         assertNewerThan("GraalVM Version 20.1.0.1.Alpha2 56d4ee1b28 (Mandrel Distribution) (Java Version 11.0.8)",
-                "GraalVM Version 20.0.0");
+                "GraalVM Version 20.0.0 (Java Version 11.0.7)");
+        assertNewerThan("GraalVM 21.3.1 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)",
+                "GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
+        assertNewerThan("GraalVM 21.3.1 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)",
+                "GraalVM 21.3 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)");
     }
 
     /**

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThan.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThan.java
@@ -22,43 +22,32 @@ public @interface DisableIfBuiltWithGraalVMOlderThan {
     GraalVMVersion value();
 
     enum GraalVMVersion {
-        GRAALVM_21_0(21, 0);
+        GRAALVM_21_0(org.graalvm.home.Version.create(21, 0));
 
-        private final int major;
-        private final int minor;
+        private final org.graalvm.home.Version version;
 
-        GraalVMVersion(int major, int minor) {
-            this.major = major;
-            this.minor = minor;
+        GraalVMVersion(org.graalvm.home.Version version) {
+            this.version = version;
         }
 
-        public int getMajor() {
-            return major;
-        }
-
-        public int getMinor() {
-            return minor;
+        public org.graalvm.home.Version getVersion() {
+            return version;
         }
 
         /**
-         * Compares this version with a tuple of major and minor parts representing another GraalVM version
+         * Compares this version with another GraalVM version
          * 
-         * @return {@code -1} if this version is older than the version represented by the supplied major and minor parts,
+         * @return {@code -1} if this version is older than the other version,
          *         {@code +1} if it's newer and {@code 0} if they represent the same version
          */
-        public int compareTo(int major, int minor) {
-            int majorComparison = Integer.compare(this.major, major);
-            if (majorComparison != 0) {
-                return majorComparison;
-            }
-            return Integer.compare(this.minor, minor);
+        public int compareTo(org.graalvm.home.Version version) {
+            return this.version.compareTo(version);
         }
 
         @Override
         public String toString() {
             return "GraalVMVersion{" +
-                    "major=" + major +
-                    ", minor=" + minor +
+                    "version=" + version.toString() +
                     '}';
         }
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
@@ -38,12 +38,12 @@ public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCon
         DisableIfBuiltWithGraalVMOlderThan.GraalVMVersion annotationValue = optional.get().value();
         Properties quarkusArtifactProperties = readQuarkusArtifactProperties(context);
         try {
-            int major = Integer.parseInt(quarkusArtifactProperties.getProperty("metadata.graalvm.version.major"));
-            int minor = Integer.parseInt(quarkusArtifactProperties.getProperty("metadata.graalvm.version.minor"));
-            int comparison = annotationValue.compareTo(major, minor);
+            org.graalvm.home.Version version = org.graalvm.home.Version
+                    .parse(quarkusArtifactProperties.getProperty("metadata.graalvm.version.version"));
+            int comparison = annotationValue.compareTo(version);
             if (comparison > 0) {
-                return ConditionEvaluationResult.disabled("Native binary was built with GraalVM{major=" + major + ", minor= "
-                        + minor + "} but the test is disabled for GraalVM versions older than " + annotationValue);
+                return ConditionEvaluationResult.disabled("Native binary was built with GraalVM{version=" + version.toString()
+                        + "} but the test is disabled for GraalVM versions older than " + annotationValue);
             }
             return ConditionEvaluationResult
                     .enabled("Native binary was built with a GraalVM version compatible with the required version by the test");


### PR DESCRIPTION
This PR:
1. updates the GraalVM.Version implementation to use `org.graalvm.home.Version` as its backend allowing us to perform comparisons beyond the major.minor part of the version without reinventing the wheel.
2. extends GraalVM.Version to include the base JDK version (e.g. 17) of GraalVM
3. Uses the above two to apply work around for issue #21372 only when using GraalVM 21.3.0 Java 17 

This work-around is only necessary for 21.3.0 as it is already fixed upstream with https://github.com/oracle/graal/pull/3949 which is expected to land in 22.0 and 21.3.1 ([pending confirmation](https://github.com/oracle/graal/pull/3949#issuecomment-967284443)) in January.

Closes: #21372