### PR TITLE
NullPointerException in ResteasyReactiveViolationExceptionMapper

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationExceptionMapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationExceptionMapper.java
@@ -44,9 +44,11 @@ public class ResteasyReactiveViolationExceptionMapper implements ExceptionMapper
     }
 
     private boolean hasReturnValueViolation(Set<ConstraintViolation<?>> violations) {
-        for (ConstraintViolation<?> violation : violations) {
-            if (isReturnValueViolation(violation)) {
-                return true;
+        if (violations != null) {
+            for (ConstraintViolation<?> violation : violations) {
+                if (isReturnValueViolation(violation)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
In certain situations (mostly when writing tests where I am trying to "fake" throwing of exceptions), I'm getting this `NullPointerException` because `null` isn't being checked.

Regardless of how it happens, it shouldn't assume that the collection of `ConstraintViolation`s is not `null`, because the constructor of `ConstraintViolationException` allows passing `null` for the `Set` of `ConstraintViolation`s.

```shell
14:05:31 ERROR [io.qu.ve.ht.ru.QuarkusErrorHandler] (executor-thread-0) HTTP Request to /api/villains/1 failed, error id: 9655caa9-2ed6-413a-8a42-e08dc7745d9a-1: java.lang.NullPointerException
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.hasReturnValueViolation(ResteasyReactiveViolationExceptionMapper.java:39)
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.toResponse(ResteasyReactiveViolationExceptionMapper.java:30)
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.toResponse(ResteasyReactiveViolationExceptionMapper.java:18)
        at org.jboss.resteasy.reactive.server.core.ExceptionMapping.mapException(ExceptionMapping.java:76)
        at org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext.mapExceptionIfPresent(ResteasyReactiveRequestContext.java:340)
        at org.jboss.resteasy.reactive.server.handlers.ExceptionHandler.handle(ExceptionHandler.java:15)
        at org.jboss.resteasy.reactive.server.handlers.ExceptionHandler.handle(ExceptionHandler.java:9)
        at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:141)
        at io.quarkus.vertx.core.runtime.VertxCoreRecorder$13.runWith(VertxCoreRecorder.java:543)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
        at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
        at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:834)

14:05:31 ERROR [or.jb.re.re.co.co.AbstractResteasyReactiveContext] (executor-thread-0) Request failed: java.lang.NullPointerException
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.hasReturnValueViolation(ResteasyReactiveViolationExceptionMapper.java:39)
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.toResponse(ResteasyReactiveViolationExceptionMapper.java:30)
        at io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationExceptionMapper.toResponse(ResteasyReactiveViolationExceptionMapper.java:18)
        at org.jboss.resteasy.reactive.server.core.ExceptionMapping.mapException(ExceptionMapping.java:76)
        at org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext.mapExceptionIfPresent(ResteasyReactiveRequestContext.java:340)
        at org.jboss.resteasy.reactive.server.handlers.ExceptionHandler.handle(ExceptionHandler.java:15)
        at org.jboss.resteasy.reactive.server.handlers.ExceptionHandler.handle(ExceptionHandler.java:9)
        at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:141)
        at io.quarkus.vertx.core.runtime.VertxCoreRecorder$13.runWith(VertxCoreRecorder.java:543)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
        at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
        at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:834)
```