### PR TITLE
Remove the .html from the guides URLs

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/codestart.yml
@@ -7,7 +7,7 @@ language:
       buildtool:
         build-dir: target
         cli: mvn
-        guide: https://quarkus.io/guides/maven-tooling.html
+        guide: https://quarkus.io/guides/maven-tooling
         guide-native: https://quarkus.io/guides/building-native-image
         cmd:
           dev: compile quarkus:dev

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/src/main/resources/META-INF/resources/index.tpl.qute.html
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/project/quarkus/base/src/main/resources/META-INF/resources/index.tpl.qute.html
@@ -165,7 +165,7 @@
             <h3>More reading</h3>
             <ul>
                 <li><a href="{buildtool.guide}" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io/guides/" target="_blank">All guides</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
@@ -45,4 +45,4 @@ mvn package -Pnative -Dquarkus.native.container-build=true
 
 You can then execute your native executable with: `./target/test-codestart-1.0.0-codestart-runner`
 
-If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
@@ -165,7 +165,7 @@
             <h3>More reading</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io/guides/" target="_blank">All guides</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateRESTEasyJavaCustom/src_main_resources_META-INF_resources_index.html
@@ -164,7 +164,7 @@
         <div class="right-section">
             <h3>More reading</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io/guides/" target="_blank">All guides</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>

--- a/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/elasticsearch-rest-high-level-client/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/elasticsearch-rest-high-level-client/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/elasticsearch-rest-high-level-client/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/elasticsearch-rest-high-level-client/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/modB/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/modB/src/main/resources/META-INF/resources/index.html
@@ -171,7 +171,7 @@
             <h3>More reading</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/gradle-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io/guides/" target="_blank">All guides</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -142,7 +142,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>

--- a/integration-tests/maven/src/test/resources/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -143,7 +143,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started">Getting started</a></li>
                 <li><a href="https://quarkus.io">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -140,7 +140,7 @@
             <h3>Next steps</h3>
             <ul>
                 <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
-                <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
+                <li><a href="https://quarkus.io/guides/getting-started" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>
         </div>

--- a/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -139,7 +139,7 @@
         <div class="right-section">
             <h3>Next steps</h3>
             <ul>
-                <li><a href="https://quarkus.io/guides/maven-tooling.html" target="_blank">Setup your IDE</a></li>
+                <li><a href="https://quarkus.io/guides/maven-tooling" target="_blank">Setup your IDE</a></li>
                 <li><a href="https://quarkus.io/guides/getting-started.html" target="_blank">Getting started</a></li>
                 <li><a href="https://quarkus.io" target="_blank">Quarkus Web Site</a></li>
             </ul>


### PR DESCRIPTION
This removes the .html from the https://quarkus.io/guides/maven-tooling and the https://quarkus.io/guides/getting-started URLs