### PR TITLE
Support extra params for OidcClient password grant

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -159,6 +159,12 @@ public class OidcClientRecorder {
                                                 grantOptions.get(OidcConstants.PASSWORD_GRANT_USERNAME));
                                         tokenGrantParams.add(OidcConstants.PASSWORD_GRANT_PASSWORD,
                                                 grantOptions.get(OidcConstants.PASSWORD_GRANT_PASSWORD));
+                                        for (Map.Entry<String, String> entry : grantOptions.entrySet()) {
+                                            if (!OidcConstants.PASSWORD_GRANT_USERNAME.equals(entry.getKey())
+                                                    && !OidcConstants.PASSWORD_GRANT_PASSWORD.equals(entry.getKey())) {
+                                                tokenGrantParams.add(entry.getKey(), entry.getValue());
+                                            }
+                                        }
                                     } else {
                                         tokenGrantParams.addAll(grantOptions);
                                     }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -18,6 +18,7 @@ quarkus.oidc-client.non-standard-response.grant.refresh-token-property=refreshTo
 quarkus.oidc-client.non-standard-response.grant.expires-in-property=expiresIn
 quarkus.oidc-client.non-standard-response.grant-options.password.username=alice
 quarkus.oidc-client.non-standard-response.grant-options.password.password=alice
+quarkus.oidc-client.non-standard-response.grant-options.password.extra_param=extra_param_value
 quarkus.oidc-client.non-standard-response.headers.X-Custom=XCustomHeaderValue
 
 quarkus.oidc-client.non-standard-response-without-header.auth-server-url=${keycloak.url}

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -37,7 +37,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                                 "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
         server.stubFor(WireMock.post("/non-standard-tokens")
                 .withHeader("X-Custom", matching("XCustomHeaderValue"))
-                .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
+                .withRequestBody(matching("grant_type=password&username=alice&password=alice&extra_param=extra_param_value"))
                 .willReturn(WireMock
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Fixes #21415.

The username and password properties must go first as some endpoints require a specific order - so other parameters if any are added afterwards