### PR TITLE
JUnit 4 is needed to start the Infinispan container

### DIFF
--- a/test-framework/infinispan-client/pom.xml
+++ b/test-framework/infinispan-client/pom.xml
@@ -71,7 +71,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit4.version}</version>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes the issue we have in the quickstarts.