### PR TITLE
Remove the deprecated OIDC code

### DIFF
--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -2,15 +2,17 @@ package io.quarkus.oidc.test;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import io.quarkus.oidc.OidcRequestContext;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.TenantConfigResolver;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 
 @ApplicationScoped
 public class CustomTenantConfigResolver implements TenantConfigResolver {
     @Override
-    public OidcTenantConfig resolve(RoutingContext context) {
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
         if (context.request().path().endsWith("/tenant-config-resolver")) {
             OidcTenantConfig config = new OidcTenantConfig();
             config.setTenantId("tenant-config-resolver");
@@ -18,9 +20,9 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setClientId("quarkus-web-app");
             config.getCredentials().setSecret("secret");
             config.applicationType = ApplicationType.WEB_APP;
-            return config;
+            return Uni.createFrom().item(config);
         }
-        return null;
+        return Uni.createFrom().nullItem();
     }
 
     private String getIssuerUrl() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
+import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -726,20 +727,6 @@ public class OidcTenantConfig extends OidcCommonConfig {
          */
         @ConfigItem
         public boolean refreshExpired;
-
-        /**
-         * Token auto-refresh interval in seconds during the user re-authentication.
-         * If this option is set then the valid ID token will be refreshed if it will expire in less than a number of seconds
-         * set by this option. The user will still be authenticated if the ID token can no longer be refreshed but is still
-         * valid.
-         * This option will be ignored if the 'refresh-expired' property is not enabled.
-         *
-         * Note this property is deprecated and will be removed in one of the next releases.
-         * Please use 'quarkus.oidc.token.refresh-token-time-skew'
-         */
-        @ConfigItem
-        @Deprecated
-        public Optional<Duration> autoRefreshInterval = Optional.empty();
 
         /**
          * Refresh token time skew in seconds.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TenantConfigResolver.java
@@ -17,24 +17,9 @@ public interface TenantConfigResolver {
     /**
      * Returns a {@link OidcTenantConfig} given a {@code RoutingContext}.
      *
-     * @param context the routing context
-     * @return the tenant configuration. If {@code null}, indicates that the default configuration/tenant should be chosen
-     *
-     * @deprecated Use {@link #resolve(RoutingContext, OidcRequestContext<OidcTenantConfig>))} instead.
-     */
-    @Deprecated
-    default OidcTenantConfig resolve(RoutingContext context) {
-        throw new UnsupportedOperationException("resolve is not implemented");
-    }
-
-    /**
-     * Returns a {@link OidcTenantConfig} given a {@code RoutingContext}.
-     *
      * @param requestContext the routing context
      * @return the tenant configuration. If the uni resolves to {@code null}, indicates that the default configuration/tenant
      *         should be chosen
      */
-    default Uni<OidcTenantConfig> resolve(RoutingContext routingContext, OidcRequestContext<OidcTenantConfig> requestContext) {
-        return Uni.createFrom().item(resolve(routingContext));
-    }
+    Uni<OidcTenantConfig> resolve(RoutingContext routingContext, OidcRequestContext<OidcTenantConfig> requestContext);
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/TokenStateManager.java
@@ -20,49 +20,12 @@ public interface TokenStateManager {
      * @param routingContext the request context
      * @param oidcConfig the tenant configuration
      * @param tokens the authorization code flow tokens
-     *
-     * @return the token state
-     *
-     * @deprecated Use
-     *             {@link #createTokenState(RoutingContext, OidcTenantConfig, AuthorizationCodeTokens, OidcRequestContext)}
-     *
-     */
-    @Deprecated
-    default String createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            AuthorizationCodeTokens tokens) {
-        throw new UnsupportedOperationException("createTokenState is not implemented");
-    }
-
-    /**
-     * Convert the authorization code flow tokens into a token state.
-     *
-     * @param routingContext the request context
-     * @param oidcConfig the tenant configuration
-     * @param tokens the authorization code flow tokens
      * @param requestContext the request context
      *
      * @return the token state
      */
-    default Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext) {
-        return Uni.createFrom().item(createTokenState(routingContext, oidcConfig, tokens));
-    }
-
-    /**
-     * Convert the token state into the authorization code flow tokens.
-     *
-     * @param routingContext the request context
-     * @param oidcConfig the tenant configuration
-     * @param tokenState the token state
-     *
-     * @return the authorization code flow tokens
-     *
-     * @deprecated Use {@link #getTokens(RoutingContext, OidcTenantConfig, String, OidcRequestContext)} instead.
-     */
-    @Deprecated
-    default AuthorizationCodeTokens getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
-        throw new UnsupportedOperationException("getTokens is not implemented");
-    }
+    Uni<String> createTokenState(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            AuthorizationCodeTokens tokens, OidcRequestContext<String> requestContext);
 
     /**
      * Convert the token state into the authorization code flow tokens.
@@ -74,24 +37,8 @@ public interface TokenStateManager {
      *
      * @return the authorization code flow tokens
      */
-    default Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
-            String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext) {
-        return Uni.createFrom().item(getTokens(routingContext, oidcConfig, tokenState));
-    }
-
-    /**
-     * Delete the token state.
-     *
-     * @param routingContext the request context
-     * @param oidcConfig the tenant configuration
-     * @param tokenState the token state
-     *
-     * @deprecated Use {@link #deleteTokens(RoutingContext, OidcTenantConfig, String, OidcRequestContext)} instead
-     */
-    @Deprecated
-    default void deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState) {
-        throw new UnsupportedOperationException("deleteTokens is not implemented");
-    }
+    Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig,
+            String tokenState, OidcRequestContext<AuthorizationCodeTokens> requestContext);
 
     /**
      * Delete the token state.
@@ -100,10 +47,7 @@ public interface TokenStateManager {
      * @param oidcConfig the tenant configuration
      * @param tokenState the token state
      */
-    default Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
-            OidcRequestContext<Void> requestContext) {
-        deleteTokens(routingContext, oidcConfig, tokenState);
-        return Uni.createFrom().voidItem();
-    }
+    Uni<Void> deleteTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
+            OidcRequestContext<Void> requestContext);
 
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -215,16 +215,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 });
     }
 
-    @Deprecated
     private static boolean tokenAutoRefreshPrepared(JsonObject tokenJson, RoutingContext vertxContext,
             OidcTenantConfig oidcConfig) {
         if (tokenJson != null
                 && oidcConfig.token.refreshExpired
-                && (oidcConfig.token.getRefreshTokenTimeSkew().isPresent() || oidcConfig.token.autoRefreshInterval.isPresent())
+                && oidcConfig.token.getRefreshTokenTimeSkew().isPresent()
                 && vertxContext.get(REFRESH_TOKEN_GRANT_RESPONSE) != Boolean.TRUE
                 && vertxContext.get(NEW_AUTHENTICATION) != Boolean.TRUE) {
-            final long refreshTokenTimeSkew = (oidcConfig.token.getRefreshTokenTimeSkew()
-                    .orElseGet(() -> oidcConfig.token.autoRefreshInterval.get())).getSeconds();
+            final long refreshTokenTimeSkew = oidcConfig.token.getRefreshTokenTimeSkew().get().getSeconds();
             final long expiry = tokenJson.getLong("exp");
             final long now = System.currentTimeMillis() / 1000;
             return now + refreshTokenTimeSkew > expiry;


### PR DESCRIPTION
This PR just removes some deprecated code - the `autoRefreshTimeout` property has been deprecated a long time ago, and `TenantConfigResolver` and `TokenStateManager` had non-Uni aware methods also deprecated for a few releases now. I think it is OK to clean up a bit for `2.6.0.CR1` (have one more update in mind). I'll update the `2.6 Migration Guide` too - when the removed code was deprecated the related migration guides were updated as far as I recall... 