### PR TITLE
Fix Avro substitutions for Java 17

### DIFF
--- a/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/graal/AvroSubstitutions.java
+++ b/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/graal/AvroSubstitutions.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -15,6 +16,7 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK17OrLater;
 
 @TargetClass(className = "org.apache.avro.generic.GenericDatumReader")
 final class Target_org_apache_avro_generic_GenericDatumReader {
@@ -54,6 +56,31 @@ final class Target_org_apache_avro_generic_GenericDatumReader {
         this.creator = Thread.currentThread();
     }
 
+}
+
+@TargetClass(className = "org.apache.avro.reflect.ReflectionUtil", onlyWith = JDK17OrLater.class)
+final class Target_org_apache_avro_reflect_ReflectionUtil {
+
+    @Substitute
+    public static <V, R> Function<V, R> getConstructorAsFunction(Class<V> parameterClass, Class<R> clazz) {
+        // Cannot use the method handle approach as it uses ProtectionDomain which got removed.
+        try {
+            Constructor<R> constructor = clazz.getConstructor(parameterClass);
+            return new Function<V, R>() {
+                @Override
+                public R apply(V v) {
+                    try {
+                        return constructor.newInstance(v);
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Unable to create new instance for " + clazz, e);
+                    }
+                }
+            };
+        } catch (Throwable t) {
+            // if something goes wrong, do not provide a Function instance
+            return null;
+        }
+    }
 }
 
 class AvroSubstitutions {


### PR DESCRIPTION
The upstream code uses MethodHandle, which with Java 17, touches the ProtectionDomain class. That class is not accessible in GraalVM.
This commit changes the method using the MethodHandle to use regular reflection. It only applies to Java 17+.

This PR fixes https://github.com/quarkusio/quarkus-quickstarts/issues/990
