### PR TITLE
Fix OpenTelemetry native compilation issue

### DIFF
--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/pom.xml
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/pom.xml
@@ -49,6 +49,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/graal/OtlpExporterSubstitutions.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/runtime/src/main/java/io/quarkus/opentelemetry/exporter/otlp/runtime/graal/OtlpExporterSubstitutions.java
@@ -3,9 +3,8 @@ package io.quarkus.opentelemetry.exporter.otlp.runtime.graal;
 import static java.util.Objects.requireNonNull;
 
 import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
-import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
@@ -27,25 +26,18 @@ final class Target_io_opentelemetry_exporter_otlp_internal_grpc_ManagedChannelUt
         requireNonNull(managedChannelBuilder, "managedChannelBuilder");
         requireNonNull(trustedCertificatesPem, "trustedCertificatesPem");
 
-        TrustManagerFactory tmf = trustManagerFactory(trustedCertificatesPem);
+        X509TrustManager tm = io.opentelemetry.exporter.otlp.internal.TlsUtil.trustManager(trustedCertificatesPem);
 
         // gRPC does not abstract TLS configuration so we need to check the implementation and act
         // accordingly.
         if (managedChannelBuilder.getClass().getName().equals("io.grpc.netty.NettyChannelBuilder")) {
             NettyChannelBuilder nettyBuilder = (NettyChannelBuilder) managedChannelBuilder;
-            nettyBuilder.sslContext(GrpcSslContexts.forClient().trustManager(tmf).build());
+            nettyBuilder.sslContext(GrpcSslContexts.forClient().trustManager(tm).build());
         } else {
             throw new SSLException(
                     "TLS certificate configuration not supported for unrecognized ManagedChannelBuilder "
                             + managedChannelBuilder.getClass().getName());
         }
-    }
-
-    // Just provide access to "trustManagerFactory"
-    @Alias
-    private static TrustManagerFactory trustManagerFactory(byte[] trustedCertificatesPem)
-            throws SSLException {
-        return null;
     }
 }
 


### PR DESCRIPTION
We need to use the TlsUtils class to get the TrustManager.
This fixes https://github.com/quarkusio/quarkus-quickstarts/issues/992
