### PR TITLE
Fix InfinispanTestResource Junit dependency

### DIFF
--- a/test-framework/infinispan-client/pom.xml
+++ b/test-framework/infinispan-client/pom.xml
@@ -66,12 +66,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- needed to make the junit version converge -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit4.version}</version>
-            <optional>true</optional>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit4-mock</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Replace junit dependency with the quarkus-junit4-mocks.
The dependency cannot be removed, as the classes are loaded, but not used.

Fixes https://github.com/quarkusio/quarkus-quickstarts/issues/985
