### PR TITLE
Support `@EmbeddedId` in spring-data-jpa repositories & allow ids to be returned from `@Query` methods

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
@@ -86,6 +87,7 @@ public final class DotNames {
             .createSimple(Persistable.class.getName());
 
     public static final DotName JPA_ID = DotName.createSimple(Id.class.getName());
+    public static final DotName JPA_EMBEDDED_ID = DotName.createSimple(EmbeddedId.class.getName());
     public static final DotName VERSION = DotName.createSimple(Version.class.getName());
     public static final DotName JPA_INHERITANCE = DotName.createSimple(Inheritance.class.getName());
     public static final DotName JPA_MAPPED_SUPERCLASS = DotName.createSimple(MappedSuperclass.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/CustomQueryMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/CustomQueryMethodsAdder.java
@@ -66,7 +66,7 @@ public class CustomQueryMethodsAdder extends AbstractMethodsAdder {
     }
 
     public void add(ClassCreator classCreator, FieldDescriptor entityClassFieldDescriptor, ClassInfo repositoryClassInfo,
-            ClassInfo entityClassInfo) {
+            ClassInfo entityClassInfo, String idTypeStr) {
 
         // Remember custom return types: {resultType:{methodName:[fieldNames]}}
         Map<DotName, Map<String, List<String>>> customResultTypes = new HashMap<>(3);
@@ -279,6 +279,7 @@ public class CustomQueryMethodsAdder extends AbstractMethodsAdder {
                     DotName customResultTypeName = resultType.name();
 
                     if (customResultTypeName.equals(entityClassInfo.name())
+                            || customResultTypeName.toString().equals(idTypeStr)
                             || isHibernateSupportedReturnType(customResultTypeName)) {
                         // no special handling needed
                         customResultTypeName = null;
@@ -291,7 +292,7 @@ public class CustomQueryMethodsAdder extends AbstractMethodsAdder {
                         if (Modifier.isInterface(resultClassInfo.flags())) {
                             // Find the implementation name, and use that for subsequent query result generation
                             customResultTypeName = customResultTypeNames.computeIfAbsent(customResultTypeName,
-                                    k -> createSimpleInterfaceImpl(resultType.name()));
+                                    this::createSimpleInterfaceImpl);
 
                             // Remember the parameters for this usage of the custom type, we'll deal with it later
                             customResultTypes.computeIfAbsent(customResultTypeName,

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/SpringDataRepositoryCreator.java
@@ -116,7 +116,7 @@ public class SpringDataRepositoryCreator {
             derivedMethodsAdder.add(classCreator, entityClassFieldCreator.getFieldDescriptor(), generatedClassName,
                     repositoryToImplement, entityClassInfo);
             customQueryMethodsAdder.add(classCreator, entityClassFieldCreator.getFieldDescriptor(),
-                    repositoryToImplement, entityClassInfo);
+                    repositoryToImplement, entityClassInfo, idTypeStr);
         }
     }
 

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCall.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCall.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "phone_call")
+public class PhoneCall {
+
+    @EmbeddedId
+    private PhoneNumberId id;
+
+    private int duration;
+
+    PhoneCall() {
+    }
+
+    public PhoneCall(PhoneNumberId id) {
+        this.id = id;
+    }
+
+    public PhoneNumberId getId() {
+        return id;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallRepository.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhoneCallRepository extends JpaRepository<PhoneCall, PhoneNumberId> {
+
+    PhoneCall findByIdAreaCode(String areaCode);
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallRepository.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallRepository.java
@@ -1,8 +1,14 @@
 package io.quarkus.it.spring.data.jpa;
 
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PhoneCallRepository extends JpaRepository<PhoneCall, PhoneNumberId> {
 
     PhoneCall findByIdAreaCode(String areaCode);
+
+    @Query("select p.id from PhoneCall p")
+    Set<PhoneNumberId> findAllIds();
 }

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.spring.data.jpa;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -24,5 +26,12 @@ public class PhoneCallResource {
     @Produces("application/json")
     public PhoneCall phoneCallByAreaCode(@PathParam("areaCode") String areaCode) {
         return repository.findByIdAreaCode(areaCode);
+    }
+
+    @Path("ids")
+    @GET
+    @Produces("application/json")
+    public Set<PhoneNumberId> allIds() {
+        return repository.findAllIds();
     }
 }

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallResource.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneCallResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.spring.data.jpa;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+@Path("/phonecall")
+public class PhoneCallResource {
+
+    @Inject
+    PhoneCallRepository repository;
+
+    @Path("{areaCode}/{number}")
+    @GET
+    @Produces("application/json")
+    public PhoneCall phoneCallById(@PathParam("areaCode") String areaCode, @PathParam("number") String number) {
+        return repository.findById(new PhoneNumberId(areaCode, number)).orElse(null);
+    }
+
+    @Path("{areaCode}")
+    @GET
+    @Produces("application/json")
+    public PhoneCall phoneCallByAreaCode(@PathParam("areaCode") String areaCode) {
+        return repository.findByIdAreaCode(areaCode);
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneNumberId.java
+++ b/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/PhoneNumberId.java
@@ -1,0 +1,31 @@
+package io.quarkus.it.spring.data.jpa;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class PhoneNumberId implements Serializable {
+
+    @Column(name = "area_code")
+    private String areaCode;
+
+    private String number;
+
+    PhoneNumberId() {
+    }
+
+    public PhoneNumberId(String areaCode, String number) {
+        this.areaCode = areaCode;
+        this.number = number;
+    }
+
+    public String getAreaCode() {
+        return areaCode;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+}

--- a/integration-tests/spring-data-jpa/src/main/resources/import.sql
+++ b/integration-tests/spring-data-jpa/src/main/resources/import.sql
@@ -34,6 +34,9 @@ INSERT INTO person(id, name, age, joined, active, address_id) VALUES (4, 'DeMar'
 INSERT INTO person(id, name, age, joined, active, address_id) VALUES (5, 'DeMar', 20, '2019-05-05', true, NULL);
 INSERT INTO person(id, name, age, joined, active, address_id) VALUES (6, null , 22, '2019-06-06', true, NULL);
 
+INSERT INTO phone_call(area_code, number, duration) VALUES ('1234', '56789', 25);
+INSERT INTO phone_call(area_code, number, duration) VALUES ('1010', '11111', 13);
+
 INSERT INTO post(id, title, bypass, posted, organization) VALUES (1, 'Quarkus first public release!', false, '2019-03-01 12:00:00.000', 'RH');
 INSERT INTO post(id, title, bypass, posted, organization) VALUES (2, 'Quarkus 0.12.0 released', false, '2019-04-01 12:00:00.000', 'RH');
 INSERT INTO post(id, title, bypass, posted, organization) VALUES (3, 'Quarkus 0.20 released', false, '2019-06-01 12:00:00.000', 'RH');

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceIT.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.spring.data.jpa;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class PhoneCallResourceIT extends PhoneCallResourceTest {
+
+}

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceTest.java
@@ -24,4 +24,12 @@ public class PhoneCallResourceTest {
                 .body(containsString("11111"))
                 .body(containsString("13"));
     }
+
+    @Test
+    public void testFindAllIds() {
+        when().get("/phonecall/ids").then()
+                .statusCode(200)
+                .body(containsString("11111"))
+                .body(containsString("56789"));
+    }
 }

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PhoneCallResourceTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.spring.data.jpa;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class PhoneCallResourceTest {
+
+    @Test
+    public void testFindById() {
+        when().get("/phonecall/1234/56789").then()
+                .statusCode(200)
+                .body(containsString("25"));
+    }
+
+    @Test
+    public void testFindByAreaCode() {
+        when().get("/phonecall/1010").then()
+                .statusCode(200)
+                .body(containsString("11111"))
+                .body(containsString("13"));
+    }
+}


### PR DESCRIPTION
Resolves #10870

The second commit prevents exceptions like:
```
Caused by: java.lang.IllegalArgumentException: Query annotations may only use interfaces to map results to non-entity types. Offending query string is "select p.id from PhoneCall p" on method findAllIds of Repository io.quarkus.it.spring.data.jpa.PhoneCallRepository
        at io.quarkus.spring.data.deployment.generate.CustomQueryMethodsAdder.add(CustomQueryMethodsAdder.java:300)
```
The second commit could also be a separate PR, but the change is tiny and is also about ids (in general, not only embedded ones), so ...

Please let me know if you prefer a separation.

It would be great if that could end up in 2.5!