### PR TITLE
Publish gradle model artifact with correct coordinate

### DIFF
--- a/devtools/gradle/gradle-application-plugin/pom.xml
+++ b/devtools/gradle/gradle-application-plugin/pom.xml
@@ -53,6 +53,15 @@
 
     <build>
         <plugins>
+            <!-- Do not deploy this project-->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/devtools/gradle/gradle-extension-plugin/pom.xml
+++ b/devtools/gradle/gradle-extension-plugin/pom.xml
@@ -26,6 +26,15 @@
 
     <build>
         <plugins>
+            <!-- Do not deploy this project-->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/devtools/gradle/gradle-model/build.gradle
+++ b/devtools/gradle/gradle-model/build.gradle
@@ -13,7 +13,18 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+group = 'io.quarkus'
+
 artifacts {
     archives sourcesJar
     archives javadocJar
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId = 'quarkus-gradle-model'
+            from components.java
+        }
+    }
 }

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -39,19 +39,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <plugins>
-            <!-- Do not deploy this project-->
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-maven-plugin.version}</version>
-                <configuration>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>windows</id>


### PR DESCRIPTION
This fix `gradle-model` artifact coordinate publication from gradle command. 

It matches coordinate used by maven. 