### PR TITLE
Update OIDC Dev UI to support extra grant options

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.deployment;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -58,6 +59,12 @@ public class DevUiConfig {
         @ConfigItem
         public Optional<Type> type;
     }
+
+    /**
+     * Grant options
+     */
+    @ConfigItem
+    public Map<String, Map<String, String>> grantOptions;
 
     /**
      * The WebClient timeout.

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcAuthorizationCodePostHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcAuthorizationCodePostHandler.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.deployment.devservices;
 
 import java.time.Duration;
+import java.util.Map;
 
 import org.jboss.logging.Logger;
 
@@ -20,10 +21,13 @@ public class OidcAuthorizationCodePostHandler extends DevConsolePostHandler {
 
     Vertx vertxInstance;
     Duration timeout;
+    Map<String, String> grantOptions;
 
-    public OidcAuthorizationCodePostHandler(Vertx vertxInstance, Duration timeout) {
+    public OidcAuthorizationCodePostHandler(Vertx vertxInstance, Duration timeout,
+            Map<String, Map<String, String>> grantOptions) {
         this.vertxInstance = vertxInstance;
         this.timeout = timeout;
+        this.grantOptions = grantOptions.get("code");
     }
 
     @Override
@@ -46,6 +50,9 @@ public class OidcAuthorizationCodePostHandler extends DevConsolePostHandler {
             props.add("grant_type", "authorization_code");
             props.add("code", form.get("authorizationCode"));
             props.add("redirect_uri", form.get("redirectUri"));
+            if (grantOptions != null) {
+                props.addAll(grantOptions);
+            }
 
             String tokens = request.sendBuffer(OidcCommonUtils.encodeForm(props)).onItem()
                     .transform(resp -> getBodyAsString(resp))

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -106,8 +106,8 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     : Duration.ofSeconds(4);
             produceDevConsoleRouteItems(devConsoleRoute,
                     new OidcTestServiceHandler(vertxInstance, webClientTimeout),
-                    new OidcAuthorizationCodePostHandler(vertxInstance, webClientTimeout),
-                    new OidcPasswordClientCredHandler(vertxInstance, webClientTimeout));
+                    new OidcAuthorizationCodePostHandler(vertxInstance, webClientTimeout, oidcConfig.devui.grantOptions),
+                    new OidcPasswordClientCredHandler(vertxInstance, webClientTimeout, oidcConfig.devui.grantOptions));
         }
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevServicesUtils.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevServicesUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.deployment.devservices;
 
 import java.time.Duration;
+import java.util.Map;
 
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.vertx.core.MultiMap;
@@ -27,6 +28,7 @@ public final class OidcDevServicesUtils {
             String clientSecret,
             String userName,
             String userPassword,
+            Map<String, String> passwordGrantOptions,
             Duration timeout) throws Exception {
         HttpRequest<Buffer> request = client.postAbs(tokenUrl);
         request.putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
@@ -40,6 +42,9 @@ public final class OidcDevServicesUtils {
         props.add("username", userName);
         props.add("password", userPassword);
         props.add("grant_type", "password");
+        if (passwordGrantOptions != null) {
+            props.addAll(passwordGrantOptions);
+        }
 
         return request.sendBuffer(OidcCommonUtils.encodeForm(props)).onItem()
                 .transform(resp -> getAccessTokenFromJson(resp)).await().atMost(timeout);
@@ -49,6 +54,7 @@ public final class OidcDevServicesUtils {
             String tokenUrl,
             String clientId,
             String clientSecret,
+            Map<String, String> clientCredGrantOptions,
             Duration timeout) throws Exception {
         HttpRequest<Buffer> request = client.postAbs(tokenUrl);
         request.putHeader(HttpHeaders.CONTENT_TYPE.toString(), HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
@@ -60,6 +66,9 @@ public final class OidcDevServicesUtils {
         }
 
         props.add("grant_type", "client_credentials");
+        if (clientCredGrantOptions != null) {
+            props.addAll(clientCredGrantOptions);
+        }
 
         return request.sendBuffer(OidcCommonUtils.encodeForm(props)).onItem()
                 .transform(resp -> getAccessTokenFromJson(resp)).await().atMost(timeout);

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcPasswordClientCredHandler.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcPasswordClientCredHandler.java
@@ -18,15 +18,20 @@ public class OidcPasswordClientCredHandler extends DevConsolePostHandler {
 
     Vertx vertxInstance;
     Duration timeout;
+    Map<String, String> passwordGrantOptions;
+    Map<String, String> clientCredGrantOptions;
 
-    public OidcPasswordClientCredHandler(Vertx vertxInstance, Duration timeout) {
-        this(vertxInstance, timeout, Map.of());
+    public OidcPasswordClientCredHandler(Vertx vertxInstance, Duration timeout, Map<String, Map<String, String>> grantOptions) {
+        this(vertxInstance, timeout, Map.of(), grantOptions);
     }
 
-    public OidcPasswordClientCredHandler(Vertx vertxInstance, Duration timeout, Map<String, String> users) {
+    public OidcPasswordClientCredHandler(Vertx vertxInstance, Duration timeout, Map<String, String> users,
+            Map<String, Map<String, String>> grantOptions) {
         this.vertxInstance = vertxInstance;
         this.timeout = timeout;
         this.users = users;
+        this.passwordGrantOptions = grantOptions.get("password");
+        this.clientCredGrantOptions = grantOptions.get("client");
     }
 
     @Override
@@ -49,6 +54,7 @@ public class OidcPasswordClientCredHandler extends DevConsolePostHandler {
                         form.get("client"), form.get("clientSecret"),
                         userName,
                         password,
+                        passwordGrantOptions,
                         timeout);
             } else {
                 LOG.infof("Using a client_credentials grant to get a token token from '%s' with client id '%s'",
@@ -57,6 +63,7 @@ public class OidcPasswordClientCredHandler extends DevConsolePostHandler {
                 token = OidcDevServicesUtils.getClientCredAccessToken(client, tokenUrl,
                         form.get("client"),
                         form.get("clientSecret"),
+                        clientCredGrantOptions,
                         timeout);
             }
             LOG.infof("Test token: %s", token);

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -73,8 +73,10 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     : KeycloakDevServicesProcessor.capturedDevServicesConfiguration.webClienTimeout;
             produceDevConsoleRouteItems(devConsoleRoute,
                     new OidcTestServiceHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout),
-                    new OidcAuthorizationCodePostHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout),
-                    new OidcPasswordClientCredHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout, users));
+                    new OidcAuthorizationCodePostHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout,
+                            oidcConfig.devui.grantOptions),
+                    new OidcPasswordClientCredHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout, users,
+                            oidcConfig.devui.grantOptions));
         }
     }
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -519,7 +519,7 @@ public class KeycloakDevServicesProcessor {
         try {
             String token = OidcDevServicesUtils.getPasswordAccessToken(client,
                     keycloakUrl + "/realms/master/protocol/openid-connect/token",
-                    "admin-cli", null, "admin", "admin", capturedDevServicesConfiguration.webClienTimeout);
+                    "admin-cli", null, "admin", "admin", null, capturedDevServicesConfiguration.webClienTimeout);
 
             HttpResponse<Buffer> response = client.postAbs(keycloakUrl + "/admin/realms")
                     .putHeader(HttpHeaders.CONTENT_TYPE.toString(), "application/json")


### PR DESCRIPTION
`OidcClient` issue was resolved recently were a password grant request had to have an extra option added and indeed, when testing `OIDC DevUI` against `Auth0` I recall having to set the global properties in the test application settings in the `Auth0` console to have both `password` and `client_credentials` (`audience` param) working.

So this PR is just about a simple replication of what is done for `OidcClient` to make sure `OIDC Dev UI` can be more useful for testing non-code flow grants with non-Keycloak providers - adds an option to set the grant specific properties.

Keeping it as `Draft` as I yet to confirm it helps when testing against `Auth0`