### PR TITLE
Fix native compatibility with Confluent kafka-avro-serializer version 7.0.0

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -345,6 +345,10 @@ public class KafkaProcessor {
                             "io.confluent.kafka.serializers.KafkaAvroSerializer"));
 
             reflectiveClass
+                    .produce(new ReflectiveClassBuildItem(true, false, false,
+                            "io.confluent.kafka.serializers.context.NullContextNameStrategy"));
+
+            reflectiveClass
                     .produce(new ReflectiveClassBuildItem(true, true, false,
                             "io.confluent.kafka.serializers.subject.TopicNameStrategy",
                             "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy",

--- a/integration-tests/kafka-avro-apicurio2/pom.xml
+++ b/integration-tests/kafka-avro-apicurio2/pom.xml
@@ -65,11 +65,15 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>6.1.1</version>
+            <version>7.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.ws.rs</groupId>
                     <artifactId>jakarta.ws.rs-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Register NullContextNameStrategy for reflection. 

Fixes #21412