### PR TITLE
Introduce quarkusGoOffline task to download app dependencies for off-line use

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -43,6 +43,7 @@ import io.quarkus.gradle.tasks.QuarkusAddExtension;
 import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusDev;
 import io.quarkus.gradle.tasks.QuarkusGenerateCode;
+import io.quarkus.gradle.tasks.QuarkusGoOffline;
 import io.quarkus.gradle.tasks.QuarkusListCategories;
 import io.quarkus.gradle.tasks.QuarkusListExtensions;
 import io.quarkus.gradle.tasks.QuarkusListPlatforms;
@@ -72,6 +73,7 @@ public class QuarkusPlugin implements Plugin<Project> {
     public static final String QUARKUS_REMOTE_DEV_TASK_NAME = "quarkusRemoteDev";
     public static final String QUARKUS_TEST_TASK_NAME = "quarkusTest";
     public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
+    public static final String QUARKUS_GO_OFFLINE_TASK_NAME = "quarkusGoOffline";
 
     @Deprecated
     public static final String BUILD_NATIVE_TASK_NAME = "buildNative";
@@ -110,6 +112,12 @@ public class QuarkusPlugin implements Plugin<Project> {
         tasks.register(LIST_PLATFORMS_TASK_NAME, QuarkusListPlatforms.class);
         tasks.register(ADD_EXTENSION_TASK_NAME, QuarkusAddExtension.class);
         tasks.register(REMOVE_EXTENSION_TASK_NAME, QuarkusRemoveExtension.class);
+        tasks.register(QUARKUS_GO_OFFLINE_TASK_NAME, QuarkusGoOffline.class, task -> {
+            task.setCompileClasspath(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+            task.setTestCompileClasspath(
+                    project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME));
+            task.setQuarkusDevClasspath(project.getConfigurations().getByName(DEV_MODE_CONFIGURATION_NAME));
+        });
 
         TaskProvider<QuarkusGenerateCode> quarkusGenerateCode = tasks.register(QUARKUS_GENERATE_CODE_TASK_NAME,
                 QuarkusGenerateCode.class);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGoOffline.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGoOffline.java
@@ -1,0 +1,56 @@
+package io.quarkus.gradle.tasks;
+
+import javax.inject.Inject;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.TaskAction;
+
+import io.quarkus.runtime.LaunchMode;
+
+public class QuarkusGoOffline extends QuarkusTask {
+
+    private Configuration compileClasspath;
+    private Configuration testCompileClasspath;
+    private Configuration quarkusDevClasspath;
+
+    @Inject
+    public QuarkusGoOffline() {
+        super("Resolve all dependencies for offline usage");
+    }
+
+    @CompileClasspath
+    public Configuration getCompileClasspath() {
+        return compileClasspath;
+    }
+
+    public void setCompileClasspath(Configuration compileClasspath) {
+        this.compileClasspath = compileClasspath;
+    }
+
+    @CompileClasspath
+    public Configuration getTestCompileClasspath() {
+        return testCompileClasspath;
+    }
+
+    public void setTestCompileClasspath(Configuration testCompileClasspath) {
+        this.testCompileClasspath = testCompileClasspath;
+    }
+
+    @CompileClasspath
+    public Configuration getQuarkusDevClasspath() {
+        return quarkusDevClasspath;
+    }
+
+    public void setQuarkusDevClasspath(Configuration quarkusDevClasspath) {
+        this.quarkusDevClasspath = quarkusDevClasspath;
+    }
+
+    @TaskAction
+    public void resolveAllModels() {
+        extension().getApplicationModel(LaunchMode.NORMAL);
+        extension().getApplicationModel(LaunchMode.DEVELOPMENT);
+        extension().getApplicationModel(LaunchMode.TEST);
+    }
+
+}

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -346,6 +346,22 @@ In a separated terminal or the embedded terminal, go to the project root and run
 
 Open the project directory in VS Code. If you have installed the Java Extension Pack (grouping a set of Java extensions), the project is loaded as a Gradle project.
 
+== Downloading dependencies for offline development and testing
+
+Quarkus extension dependencies are divided into the runtime extension dependencies that end up on the application runtime
+classpath and the deployment (or build time) extension dependencies that are resolved by Quarkus only at application build time to create
+the build classpath. Application developers are expected to express dependencies only on the runtime artifacts of Quarkus extensions.
+
+To enable the use-case of building and testing a Quarkus application offline, the plugin includes the `quarkusGoOffline` task that could be called from the command line like this:
+
+[source,bash]
+----
+./gradlew quarkusGoOffline
+----
+
+This task will resolve all the runtime, build time, test and dev mode dependencies of the application to the Gradle cache.
+Once executed, you will be able to safely run quarkus task with `--offline` flag.
+
 == Building a native executable
 
 Native executables make Quarkus applications ideal for containers and serverless workloads.


### PR DESCRIPTION
This introduce the `quarkusPrepareOffline` task that resolves all application dependencies. 