### PR TITLE
Make uncategorized work for extensions without categories

### DIFF
--- a/extensions/panache/rest-data-panache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/panache/rest-data-panache/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "REST data with Panache"
+metadata:
+  unlisted: true

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -172,6 +172,21 @@
       "origins": [
         "io.quarkus:quarkus-fake-bom:999-FAKE:json:999-FAKE"
       ]
+    },
+    {
+      "name": "Uncategorized extension",
+      "description": "Some uncategorized extension",
+      "metadata": {
+        "keywords": [
+          "uncategorized"
+        ],
+        "status": "preview",
+        "built-with-quarkus-core": "999-FAKE"
+      },
+      "artifact": "io.quarkus:quarkus-uncategorized-extension::jar:999-FAKE",
+      "origins": [
+        "io.quarkus:quarkus-fake-bom:999-FAKE:json:999-FAKE"
+      ]
     }
   ],
   "categories": [

--- a/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/CatalogProcessorTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/CatalogProcessorTest.java
@@ -1,7 +1,11 @@
 package io.quarkus.platform.catalog;
 
+import static io.quarkus.devtools.testing.FakeExtensionCatalog.newFakeExtensionCatalog;
 import static io.quarkus.platform.catalog.processor.CatalogProcessor.getProcessedCategoriesInOrder;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +25,7 @@ public class CatalogProcessorTest extends PlatformAwareTestBase {
                 .map(ProcessedCategory::getCategory)
                 .map(Category::getId)
                 .startsWith("web", "data", "messaging", "core", "reactive", "cloud", "observability", "security",
-                        "serialization", "miscellaneous", "compatibility", "alt-languages", "uncategorized");
+                        "serialization", "miscellaneous", "compatibility", "alt-languages");
     }
 
     @Test
@@ -31,9 +35,21 @@ public class CatalogProcessorTest extends PlatformAwareTestBase {
                 .map(Extension::getArtifact)
                 .map(ArtifactCoords::getArtifactId)
                 .startsWith("quarkus-resteasy", "quarkus-resteasy-jackson",
-                        "quarkus-resteasy-jsonb", "quarkus-apache-httpclient",
-                        "quarkus-vertx-http", "quarkus-vertx-graphql",
-                        "quarkus-grpc", "quarkus-grpc-common",
-                        "quarkus-hibernate-validator");
+                        "quarkus-resteasy-jsonb", "quarkus-vertx-graphql",
+                        "quarkus-grpc", "quarkus-hibernate-validator",
+                        "quarkus-jaxrs-client-reactive",
+                        "quarkus-rest-client-mutiny");
+    }
+
+    @Test
+    void testUncategorizedExtensions() {
+        final ExtensionCatalog catalog = newFakeExtensionCatalog();
+        final Optional<ProcessedCategory> uncategorized = getProcessedCategoriesInOrder(catalog).stream()
+                .filter(c -> Objects.equals(c.getCategory().getId(), "uncategorized")).findFirst();
+        assertThat(uncategorized).isPresent();
+        assertThat(uncategorized.get().getSortedExtensions())
+                .map(Extension::getArtifact)
+                .map(ArtifactCoords::getArtifactId)
+                .contains("quarkus-uncategorized-extension");
     }
 }


### PR DESCRIPTION
Fixes:
- a bug added by #21510 (See https://github.com/quarkusio/quarkus/pull/21510#pullrequestreview-808689208)
- add tests for uncategorized
- add `rest-data-panache` descriptor as unlisted (until we decide if it should be listed)
- don't add unlisted extensions to processed categories (it was done in code.quarkus.io before) but better do it here


