### PR TITLE
Update OIDC web-app guide to use the client secret

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -161,6 +161,7 @@ The OpenID Connect extension allows you to define the configuration using the `a
 ----
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=frontend
+quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
@@ -168,7 +169,7 @@ quarkus.http.auth.permission.authenticated.policy=authenticated
 
 This is the simplest configuration you can have when enabling authentication to your application. 
 
-The `quarkus.oidc.client-id` property references the `client_id` issued by the OpenID Connect Provider and, in this case, the application is a public client (no client secret is defined).
+The `quarkus.oidc.client-id` property references the `client_id` issued by the OpenID Connect Provider and the `quarkus.oidc.credentials.secret` property sets the client secret.
 
 The `quarkus.oidc.application-type` property is set to `web-app` in order to tell Quarkus that you want to enable the OpenID Connect Authorization Code Flow, so that your users are redirected to the OpenID Connect Provider to authenticate.
 


### PR DESCRIPTION
Fixes #21500

This PR aligns with https://github.com/quarkusio/quarkus-quickstarts/pull/994.

#21500 is not exactly about using the client secret - but about not logging 401 error details at a debug level - which I hopefully convinced the user in [this comment](https://github.com/quarkusio/quarkus/issues/21500#issuecomment-970742094) that from a security point of view 401 only is correct and we don't log the security errors at a higher level.

However, the original issue was really about the web-app guide showing the public client without a secret - which the user tried to address but mistyped the property name - so this PR (alongside https://github.com/quarkusio/quarkus-quickstarts/pull/994) updates the guide to use a secret which will also minimize typos in the future. It also will show the best practice - since in case of OIDC `web-app` the endpoint acts as a confidential OIDC client which really must use a secret