### PR TITLE
Pass on compiler release flag value in Maven dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilationProvider.java
@@ -39,6 +39,7 @@ public interface CompilationProvider extends Closeable {
         private final File outputDirectory;
         private final Charset sourceEncoding;
         private final List<String> compilerOptions;
+        private final String releaseJavaVersion;
         private final String sourceJavaVersion;
         private final String targetJvmVersion;
         private final List<String> compilePluginArtifacts;
@@ -52,6 +53,7 @@ public interface CompilationProvider extends Closeable {
                 File outputDirectory,
                 String sourceEncoding,
                 List<String> compilerOptions,
+                String releaseJavaVersion,
                 String sourceJavaVersion,
                 String targetJvmVersion,
                 List<String> compilePluginArtifacts,
@@ -64,6 +66,7 @@ public interface CompilationProvider extends Closeable {
             this.outputDirectory = outputDirectory;
             this.sourceEncoding = sourceEncoding == null ? StandardCharsets.UTF_8 : Charset.forName(sourceEncoding);
             this.compilerOptions = compilerOptions == null ? new ArrayList<String>() : compilerOptions;
+            this.releaseJavaVersion = releaseJavaVersion;
             this.sourceJavaVersion = sourceJavaVersion;
             this.targetJvmVersion = targetJvmVersion;
             this.compilePluginArtifacts = compilePluginArtifacts;
@@ -96,6 +99,10 @@ public interface CompilationProvider extends Closeable {
 
         public List<String> getCompilerOptions() {
             return compilerOptions;
+        }
+
+        public String getReleaseJavaVersion() {
+            return releaseJavaVersion;
         }
 
         public String getSourceJavaVersion() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
@@ -6,29 +6,30 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.quarkus.runtime.util.StringUtil;
-
 /**
  * A set of compiler flags for javac.
  *
- * Can combine system-provided default flags with user-supplied flags and <code>-source</code>
- * and <code>-target</code> settings.
+ * Can combine system-provided default flags with user-supplied flags and <code>--release</code>
+ * and <code>-source</code> and <code>-target</code> settings.
  */
 public class CompilerFlags {
 
     private final Set<String> defaultFlags;
     private final List<String> userFlags;
+    private final String releaseJavaVersion; //can be null
     private final String sourceJavaVersion; //can be null
     private final String targetJavaVersion; //can be null
 
     public CompilerFlags(
             Set<String> defaultFlags,
             Collection<String> userFlags,
+            String releaseJavaVersion,
             String sourceJavaVersion,
             String targetJavaVersion) {
 
         this.defaultFlags = defaultFlags == null ? new LinkedHashSet<>() : new LinkedHashSet<>(defaultFlags);
         this.userFlags = userFlags == null ? new ArrayList<>() : new ArrayList<>(userFlags);
+        this.releaseJavaVersion = releaseJavaVersion;
         this.sourceJavaVersion = sourceJavaVersion;
         this.targetJavaVersion = targetJavaVersion;
     }
@@ -43,7 +44,11 @@ public class CompilerFlags {
 
         flagList.addAll(effectiveDefaultFlags);
 
-        // Add -source and -target flags.
+        // Add --release and -source and -target flags.
+        if (releaseJavaVersion != null) {
+            flagList.add("--release");
+            flagList.add(releaseJavaVersion);
+        }
         if (sourceJavaVersion != null) {
             flagList.add("-source");
             flagList.add(sourceJavaVersion);
@@ -70,6 +75,6 @@ public class CompilerFlags {
 
     @Override
     public String toString() {
-        return "CompilerFlags@{" + StringUtil.join(", ", toList().iterator()) + "}";
+        return "CompilerFlags@{" + String.join(", ", toList()) + "}";
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -49,6 +49,7 @@ public class DevModeContext implements Serializable {
     private String[] args;
 
     private List<String> compilerOptions;
+    private String releaseJavaVersion;
     private String sourceJavaVersion;
     private String targetJvmVersion;
 
@@ -141,6 +142,14 @@ public class DevModeContext implements Serializable {
 
     public void setCompilerOptions(List<String> compilerOptions) {
         this.compilerOptions = compilerOptions;
+    }
+
+    public String getReleaseJavaVersion() {
+        return releaseJavaVersion;
+    }
+
+    public void setReleaseJavaVersion(String releaseJavaVersion) {
+        this.releaseJavaVersion = releaseJavaVersion;
     }
 
     public String getSourceJavaVersion() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -65,7 +65,7 @@ public class JavaCompilationProvider implements CompilationProvider {
             fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singleton(context.getOutputDirectory()));
 
             CompilerFlags compilerFlags = new CompilerFlags(COMPILER_OPTIONS, context.getCompilerOptions(),
-                    context.getSourceJavaVersion(), context.getTargetJvmVersion());
+                    context.getReleaseJavaVersion(), context.getSourceJavaVersion(), context.getTargetJvmVersion());
 
             Iterable<? extends JavaFileObject> sources = fileManager.getJavaFileObjectsFromFiles(filesToCompile);
             JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics,

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusCompiler.java
@@ -171,6 +171,7 @@ public class QuarkusCompiler implements Closeable {
                                 new File(compilationUnit.getClassesPath()),
                                 context.getSourceEncoding(),
                                 context.getCompilerOptions(),
+                                context.getReleaseJavaVersion(),
                                 context.getSourceJavaVersion(),
                                 context.getTargetJvmVersion(),
                                 context.getCompilerPluginArtifacts(),

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -172,6 +172,12 @@ public abstract class QuarkusDevModeLauncher {
         }
 
         @SuppressWarnings("unchecked")
+        public B releaseJavaVersion(String releaseJavaVersion) {
+            QuarkusDevModeLauncher.this.releaseJavaVersion = releaseJavaVersion;
+            return (B) this;
+        }
+
+        @SuppressWarnings("unchecked")
         public B sourceJavaVersion(String sourceJavaVersion) {
             QuarkusDevModeLauncher.this.sourceJavaVersion = sourceJavaVersion;
             return (B) this;
@@ -283,6 +289,7 @@ public abstract class QuarkusDevModeLauncher {
     private List<String> compilerOptions = new ArrayList<>(0);
     private List<String> compilerPluginArtifacts;
     private List<String> compilerPluginOptions;
+    private String releaseJavaVersion;
     private String sourceJavaVersion;
     private String targetJavaVersion;
     private Set<Path> buildFiles = new HashSet<>(0);
@@ -393,6 +400,7 @@ public abstract class QuarkusDevModeLauncher {
             devModeContext.setCompilerPluginsOptions(compilerPluginOptions);
         }
 
+        devModeContext.setReleaseJavaVersion(releaseJavaVersion);
         devModeContext.setSourceJavaVersion(sourceJavaVersion);
         devModeContext.setTargetJvmVersion(targetJavaVersion);
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/CompilerFlagsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/CompilerFlagsTest.java
@@ -16,67 +16,71 @@ public class CompilerFlagsTest {
     void nullHandling() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(null, null, null, null),
-                        new CompilerFlags(setOf(), listOf(), null, null)));
+                        new CompilerFlags(null, null, null, null, null),
+                        new CompilerFlags(setOf(), listOf(), null, null, null)));
     }
 
     @Test
     void defaulting() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null),
-                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null)),
+                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf("-a", "-b"), listOf("-c", "-d"), null, null),
-                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null)));
+                        new CompilerFlags(setOf("-a", "-b"), listOf("-c", "-d"), null, null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null, null)));
     }
 
     @Test
     void redundancyReduction() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null),
-                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null)),
+                        new CompilerFlags(setOf("-a", "-b"), listOf(), null, null, null),
+                        new CompilerFlags(setOf(), listOf("-a", "-b"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf("-a", "-b", "-c"), listOf("-a", "-b"), null, null),
-                        new CompilerFlags(setOf("-c"), listOf("-a", "-b"), null, null)));
+                        new CompilerFlags(setOf("-a", "-b", "-c"), listOf("-a", "-b"), null, null, null),
+                        new CompilerFlags(setOf("-c"), listOf("-a", "-b"), null, null, null)));
     }
 
     @Test
     void sourceAndTarget() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf(), "1", null),
-                        new CompilerFlags(setOf(), listOf("-source", "1"), null, null)),
+                        new CompilerFlags(setOf(), listOf(), "1", null, null),
+                        new CompilerFlags(setOf(), listOf("--release", "1"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf(), null, "2"),
-                        new CompilerFlags(setOf(), listOf("-target", "2"), null, null)),
+                        new CompilerFlags(setOf(), listOf(), null, "2", null),
+                        new CompilerFlags(setOf(), listOf("-source", "2"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf(), "1", "2"),
-                        new CompilerFlags(setOf(), listOf("-source", "1", "-target", "2"), null, null)),
+                        new CompilerFlags(setOf(), listOf(), null, null, "3"),
+                        new CompilerFlags(setOf(), listOf("-target", "3"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf("-source", "3", "-target", "4"), "1", "2"),
-                        new CompilerFlags(setOf(), listOf("-source", "1", "-target", "2", "-source", "3", "-target", "4"), null,
-                                null)));
+                        new CompilerFlags(setOf(), listOf(), "1", "2", "3"),
+                        new CompilerFlags(setOf(), listOf("--release", "1", "-source", "2", "-target", "3"), null, null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf("--release", "4", "-source", "5", "-target", "6"), "1", "2", "3"),
+                        new CompilerFlags(setOf(), listOf("--release", "1", "-source", "2", "-target", "3", "--release", "4",
+                                "-source", "5", "-target", "6"), null, null, null)));
     }
 
     @Test
     void allFeatures() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(setOf("-b", "-c", "-d"), listOf("-a", "-b", "-c"), "1", "2"),
-                        new CompilerFlags(setOf(), listOf("-d", "-source", "1", "-target", "2", "-a", "-b", "-c"), null,
-                                null)));
+                        new CompilerFlags(setOf("-b", "-c", "-d"), listOf("-a", "-b", "-c"), "1", "2", "3"),
+                        new CompilerFlags(setOf(),
+                                listOf("-d", "--release", "1", "-source", "2", "-target", "3", "-a", "-b", "-c"),
+                                null, null, null)));
     }
 
     @Test
     void listConversion() {
         assertAll(
                 () -> assertEquals(
-                        new CompilerFlags(null, null, null, null).toList(),
+                        new CompilerFlags(null, null, null, null, null).toList(),
                         listOf()),
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null).toList(),
+                        new CompilerFlags(setOf(), listOf("-a", "-b", "-c", "-d"), null, null, null).toList(),
                         listOf("-a", "-b", "-c", "-d")));
     }
 


### PR DESCRIPTION
Found while looking at #19952

Without this there could be inconsistencies when a project is _not_ using `source` or `target` but just `release` (which is actually the recommended way nowadays, as far as I'm concerned).

Btw, I thought about adding a test (that tries to provoke such an inconsistency) but that would require Java > 11 and our Maven tests only run with 11, ATM.