### PR TITLE
Revert "Lazily initialize (Reactive)MongoClient"

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
+++ b/extensions/mongodb-client/deployment/src/test/java/io/quarkus/mongodb/MongoMetricsTest.java
@@ -44,9 +44,9 @@ public class MongoMetricsTest extends MongoTestBase {
 
     @Test
     void testMetricsInitialization() {
-        // Clients are created lazily, this metric should not be present yet
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.size", getTags())).isNull();
-        assertThat(getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags())).isNull();
+        // Clients are created eagerly, this metric should always be initialized to zero once connected
+        assertEquals(0L, getGaugeValueOrNull("mongodb.connection-pool.size", getTags()));
+        assertEquals(0L, getGaugeValueOrNull("mongodb.connection-pool.checked-out-count", getTags()));
 
         // Just need to execute something so that an connection is opened
         String name = client.listDatabaseNames().first();

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongoClientRecorder.java
@@ -2,7 +2,6 @@ package io.quarkus.mongodb.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.enterprise.inject.Default;
@@ -40,32 +39,27 @@ public class MongoClientRecorder {
         };
     }
 
-    /** Helper to lazily create Mongo clients. */
-    static final class MongoClientSupplier<T> implements Supplier<T> {
-        private final Function<MongoClients, T> producer;
-
-        MongoClientSupplier(Function<MongoClients, T> producer) {
-            this.producer = producer;
-        }
-
-        @Override
-        public T get() {
-            // The beans defined in io.quarkus.mongodb.deployment.MongoClientProcessor.createBlockingSyntheticBean and
-            // io.quarkus.mongodb.deployment.MongoClientProcessor.createReactiveSyntheticBean are ApplicationScoped,
-            // so no need to cache the result here.
-            MongoClients mongoClients = Arc.container().instance(MongoClients.class).get();
-            return producer.apply(mongoClients);
-        }
-    }
-
     public Supplier<MongoClient> mongoClientSupplier(String clientName,
             @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
-        return new MongoClientSupplier<>(mongoClients -> mongoClients.createMongoClient(clientName));
+        MongoClient mongoClient = Arc.container().instance(MongoClients.class).get().createMongoClient(clientName);
+        return new Supplier<MongoClient>() {
+            @Override
+            public MongoClient get() {
+                return mongoClient;
+            }
+        };
     }
 
     public Supplier<ReactiveMongoClient> reactiveMongoClientSupplier(String clientName,
             @SuppressWarnings("unused") MongodbConfig mongodbConfig) {
-        return new MongoClientSupplier<>(mongoClients -> mongoClients.createReactiveMongoClient(clientName));
+        ReactiveMongoClient reactiveMongoClient = Arc.container().instance(MongoClients.class).get()
+                .createReactiveMongoClient(clientName);
+        return new Supplier<ReactiveMongoClient>() {
+            @Override
+            public ReactiveMongoClient get() {
+                return reactiveMongoClient;
+            }
+        };
     }
 
     public RuntimeValue<MongoClient> getClient(String name) {


### PR DESCRIPTION
This reverts commit 1a8be69dc2132bee61302b998ffbdfe90eee1680. (#20935)
to fix (dependening on test execution order):
```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.901 s <<< FAILURE! - in io.quarkus.it.mongodb.BookResourceTest
[ERROR] io.quarkus.it.mongodb.BookResourceTest.health  Time elapsed: 1.693 s  <<< FAILURE!
java.lang.AssertionError:
2 expectations failed.
JSON path checks.data doesn't match.
Expected: iterable with items [map containing ["<default>"->ANYTHING]] in any order
  Actual: <[null]>

JSON path checks.data doesn't match.
Expected: iterable with items [map containing ["<default-reactive>"->ANYTHING]] in any order
  Actual: <[null]>
```

As suggested here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/main.20is.20broken/near/261911812

/cc @cescoffier @loicmathieu 