### PR TITLE
Remove single `.` from log message and fix one test

### DIFF
--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
@@ -85,8 +85,8 @@ class Neo4jDevServicesProcessor {
                 devServicePropertiesProducer.produce(new DevServicesConfigResultBuildItem(NEO4J_PASSWORD_PROP,
                         neo4jContainer.getAdminPassword()));
 
-                log.infof("Dev Services started a Neo4j container reachable at %s.", neo4jContainer.getBoltUrl());
-                log.infof("Neo4j Browser is reachable at %s.", neo4jContainer.getBrowserUrl());
+                log.infof("Dev Services started a Neo4j container reachable at %s", neo4jContainer.getBoltUrl());
+                log.infof("Neo4j Browser is reachable at %s", neo4jContainer.getBrowserUrl());
                 log.infof("The username for both endpoints is `%s`, authenticated by `%s`", "neo4j",
                         neo4jContainer.getAdminPassword());
                 log.infof("Connect via Cypher-Shell: cypher-shell -u %s -p %s -a %s", "neo4j",

--- a/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
+++ b/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
@@ -32,7 +32,7 @@ public class Neo4jDevModeTests {
                 .withConfigurationResource("application.properties")
                 .setLogRecordPredicate(record -> true)
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
-                        .contains("Dev Services started a Neo4j container reachable at %s."));
+                        .contains("Dev Services started a Neo4j container reachable at %s"));
 
         @Inject
         Driver driver;
@@ -60,14 +60,14 @@ public class Neo4jDevModeTests {
         static QuarkusUnitTest test = new QuarkusUnitTest()
                 .withEmptyApplication()
                 .withConfigurationResource("application.properties")
-                .overrideConfigKey("quarkus.neo4j.devservices.fixed-bolt-port", FIXED_BOLD_PORT)
-                .overrideConfigKey("quarkus.neo4j.devservices.fixed-http-port", FIXED_HTTP_PORT)
+                .overrideConfigKey("quarkus.neo4j.devservices.bolt-port", FIXED_BOLD_PORT)
+                .overrideConfigKey("quarkus.neo4j.devservices.http-port", FIXED_HTTP_PORT)
                 .setAllowTestClassOutsideDeployment(true) // Needed to use the PortUtils above.
                 .setLogRecordPredicate(record -> true)
                 .assertLogRecords(records -> assertThat(records)
                         .isNotEmpty()
-                        .anyMatch(recordMatches("Dev Services started a Neo4j container reachable at %s.", FIXED_BOLD_PORT))
-                        .anyMatch(recordMatches("Neo4j Browser is reachable at %s.", FIXED_HTTP_PORT)));
+                        .anyMatch(recordMatches("Dev Services started a Neo4j container reachable at %s", FIXED_BOLD_PORT))
+                        .anyMatch(recordMatches("Neo4j Browser is reachable at %s", FIXED_HTTP_PORT)));
 
         @Inject
         Driver driver;
@@ -117,7 +117,7 @@ public class Neo4jDevModeTests {
                 .setLogRecordPredicate(record -> true)
                 .assertLogRecords(records -> assertThat(records)
                         .isNotEmpty()
-                        .noneMatch(recordMatches("Neo4j Browser is reachable at %s.", "7474")));
+                        .noneMatch(recordMatches("Neo4j Browser is reachable at %s", "7474")));
 
         @Inject
         Driver driver;
@@ -140,7 +140,7 @@ public class Neo4jDevModeTests {
                 .overrideConfigKey("quarkus.neo4j.devservices.image-name", "neo4j:4.3-enterprise")
                 .overrideConfigKey("quarkus.neo4j.devservices.additional-env.NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
-                        .contains("Dev Services started a Neo4j container reachable at %s."));
+                        .contains("Dev Services started a Neo4j container reachable at %s"));
 
         @Inject
         Driver driver;


### PR DESCRIPTION
Most tooling (several IDEs and the macOS console) treat those dots as clickable part of the URL, which they are not. The commit changes that.

The commit also fixes a failing test (`io.quarkus.neo4j.deployment.Neo4jDevModeTests.DevServicesShouldBeAbleToUseFixedPorts`) that failed as the configuration for the properties under test had been renamed.

The latter should be investigated I think (the fact, that those tests doesn't seem to run)