### PR TITLE
Fix mongodb-client health test after client creation was made lazy

### DIFF
--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.mongodb;
 
+import static io.restassured.RestAssured.get;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -46,6 +47,8 @@ public class BookResourceTest {
 
     @Test
     public void health() throws Exception {
+        // trigger (lazy) creation of the client, otherwise the health check would fail
+        get("/books");
         RestAssured.when().get("/q/health/ready").then()
                 .body("status", is("UP"),
                         "checks.data", containsInAnyOrder(hasKey(MongoHealthCheck.CLIENT_DEFAULT)),


### PR DESCRIPTION
Better alternative to #21539. Relates to #20935.

See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/main.20is.20broken/near/261926866