### PR TITLE
Support an absolute OidcClient token-path

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -54,6 +54,15 @@ quarkus.oidc-client.discovery-enabled=false
 quarkus.oidc-client.token-path=/protocol/openid-connect/tokens
 ----
 
+A more compact way to configure the token endpoint URL without the discovery is to set `quarkus.oidc-client.token-path` to an absolute URL:
+
+[source, properties]
+----
+quarkus.oidc-client.token-path=http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
+----
+
+Setting 'quarkus.oidc-client.auth-server-url' and 'quarkus.oidc-client.discovery-enabled' is not required in this case.
+
 === Supported Token Grants
 
 The main token grants which `OidcClient` can use to acquire the tokens are the `client_credentials` (default) and `password` grants.

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -105,6 +105,11 @@ public class OidcClientRecorder {
         }
 
         try {
+            if (oidcConfig.authServerUrl.isEmpty() && !OidcCommonUtils.isAbsoluteUrl(oidcConfig.tokenPath)) {
+                throw new ConfigurationException(
+                        "Either 'quarkus.oidc-client.auth-server-url' or absolute 'quarkus.oidc-client.token-path' URL must be set");
+            }
+            OidcCommonUtils.verifyEndpointUrl(getEndpointUrl(oidcConfig));
             OidcCommonUtils.verifyCommonConfiguration(oidcConfig, false, false);
         } catch (Throwable t) {
             LOG.debug(t.getMessage());
@@ -112,7 +117,6 @@ public class OidcClientRecorder {
             return Uni.createFrom().item(new DisabledOidcClient(message));
         }
 
-        String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
         WebClientOptions options = new WebClientOptions();
 
         OidcCommonUtils.setHttpClientOptions(oidcConfig, tlsConfig, options);
@@ -120,11 +124,16 @@ public class OidcClientRecorder {
         WebClient client = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx.get()), options);
 
         Uni<String> tokenRequestUriUni = null;
-        if (!oidcConfig.discoveryEnabled) {
-            tokenRequestUriUni = Uni.createFrom()
-                    .item(OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.tokenPath));
+        if (OidcCommonUtils.isAbsoluteUrl(oidcConfig.tokenPath)) {
+            tokenRequestUriUni = Uni.createFrom().item(oidcConfig.tokenPath.get());
         } else {
-            tokenRequestUriUni = discoverTokenRequestUri(client, authServerUriString.toString(), oidcConfig);
+            String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
+            if (!oidcConfig.discoveryEnabled) {
+                tokenRequestUriUni = Uni.createFrom()
+                        .item(OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.tokenPath));
+            } else {
+                tokenRequestUriUni = discoverTokenRequestUri(client, authServerUriString.toString(), oidcConfig);
+            }
         }
         return tokenRequestUriUni.onItemOrFailure()
                 .transform(new BiFunction<String, Throwable, OidcClient>() {
@@ -132,7 +141,7 @@ public class OidcClientRecorder {
                     @Override
                     public OidcClient apply(String tokenRequestUri, Throwable t) {
                         if (t != null) {
-                            throw toOidcClientException(authServerUriString, t);
+                            throw toOidcClientException(getEndpointUrl(oidcConfig), t);
                         }
 
                         if (tokenRequestUri == null) {
@@ -179,7 +188,12 @@ public class OidcClientRecorder {
                                 commonRefreshGrantParams,
                                 oidcConfig);
                     }
+
                 });
+    }
+
+    private static String getEndpointUrl(OidcClientConfig oidcConfig) {
+        return oidcConfig.authServerUrl.isPresent() ? oidcConfig.authServerUrl.get() : oidcConfig.tokenPath.get();
     }
 
     private static void setGrantClientParams(OidcClientConfig oidcConfig, MultiMap grantParams, String grantType) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -21,14 +21,13 @@ public class OidcCommonConfig {
 
     /**
      * Enables OIDC discovery.
-     * If the discovery is disabled then the 'token-path' property must be configured.
+     * If the discovery is disabled then the OIDC endpoint URLs must be configured individually.
      */
     @ConfigItem(defaultValue = "true")
     public boolean discoveryEnabled = true;
 
     /**
-     * Relative path of the OIDC token endpoint which issues access and refresh tokens
-     * using either 'client_credentials' or 'password' grants
+     * Relative path or absolute URL of the OIDC token endpoint which issues access and refresh tokens.
      */
     @ConfigItem
     public Optional<String> tokenPath = Optional.empty();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -34,7 +34,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public ApplicationType applicationType = ApplicationType.SERVICE;
 
     /**
-     * Relative path of the OIDC authorization endpoint which authenticates the users.
+     * Relative path or absolute URL of the OIDC authorization endpoint which authenticates the users.
      * This property must be set for the 'web-app' applications if OIDC discovery is disabled.
      * This property will be ignored if the discovery is enabled.
      */
@@ -42,7 +42,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Optional<String> authorizationPath = Optional.empty();
 
     /**
-     * Relative path of the OIDC userinfo endpoint.
+     * Relative path or absolute URL of the OIDC userinfo endpoint.
      * This property must only be set for the 'web-app' applications if OIDC discovery is disabled
      * and 'authentication.user-info-required' property is enabled.
      * This property will be ignored if the discovery is enabled.
@@ -51,7 +51,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Optional<String> userInfoPath = Optional.empty();
 
     /**
-     * Relative path of the OIDC RFC7662 introspection endpoint which can introspect both opaque and JWT tokens.
+     * Relative path or absolute URL of the OIDC RFC7662 introspection endpoint which can introspect both opaque and JWT tokens.
      * This property must be set if OIDC discovery is disabled and 1) the opaque bearer access tokens have to be verified
      * or 2) JWT tokens have to be verified while the cached JWK verification set with no matching JWK is being refreshed.
      * This property will be ignored if the discovery is enabled.
@@ -60,7 +60,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Optional<String> introspectionPath = Optional.empty();
 
     /**
-     * Relative path of the OIDC JWKS endpoint which returns a JSON Web Key Verification Set.
+     * Relative path or absolute URL of the OIDC JWKS endpoint which returns a JSON Web Key Verification Set.
      * This property should be set if OIDC discovery is disabled and the local JWT verification is required.
      * This property will be ignored if the discovery is enabled.
      */
@@ -68,7 +68,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Optional<String> jwksPath = Optional.empty();
 
     /**
-     * Relative path of the OIDC end_session_endpoint.
+     * Relative path or absolute URL of the OIDC end_session_endpoint.
      * This property must be set if OIDC discovery is disabled and RP Initiated Logout support for the 'web-app' applications is
      * required.
      * This property will be ignored if the discovery is enabled.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -142,6 +142,7 @@ public class OidcRecorder {
         }
 
         try {
+            verifyAuthServerUrl(oidcConfig);
             OidcCommonUtils.verifyCommonConfiguration(oidcConfig, isServiceApp(oidcConfig), true);
         } catch (ConfigurationException t) {
             return Uni.createFrom().failure(t);
@@ -316,6 +317,13 @@ public class OidcRecorder {
 
     private static boolean isServiceApp(OidcTenantConfig oidcConfig) {
         return ApplicationType.SERVICE.equals(oidcConfig.applicationType);
+    }
+
+    private static void verifyAuthServerUrl(OidcCommonConfig oidcConfig) {
+        if (!oidcConfig.getAuthServerUrl().isPresent()) {
+            throw new ConfigurationException("'quarkus.oidc.auth-server-url' property must be configured");
+        }
+        OidcCommonUtils.verifyEndpointUrl(oidcConfig.getAuthServerUrl().get());
     }
 
 }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -7,9 +7,7 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
-quarkus.oidc-client.non-standard-response.auth-server-url=${keycloak.url}
-quarkus.oidc-client.non-standard-response.discovery-enabled=false
-quarkus.oidc-client.non-standard-response.token-path=/non-standard-tokens
+quarkus.oidc-client.non-standard-response.token-path=${keycloak.url}/non-standard-tokens
 quarkus.oidc-client.non-standard-response.client-id=quarkus-app
 quarkus.oidc-client.non-standard-response.credentials.secret=secret
 quarkus.oidc-client.non-standard-response.grant.type=password


### PR DESCRIPTION
Fixes #21506

This PR is quite simple, it allows to use the absolute token path without having to set 2 more properties - but I just had to change the way the checks are done as the same checks were shared between `oidc-client` and `oidc`