### PR TITLE
Fix codestart regression with dependency override

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartData.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/CodestartData.java
@@ -59,18 +59,18 @@ public final class CodestartData {
         final Set<CodestartDep> boms = new LinkedHashSet<>();
         final Set<CodestartDep> dependencies = new LinkedHashSet<>();
         final Set<CodestartDep> testDependencies = new LinkedHashSet<>();
-        codestartsStream
-                .flatMap(s -> Stream.of(s.getBaseLanguageSpec(), s.getLanguageSpec(languageName)))
-                .forEach(d -> {
-                    dependencies.addAll(d.getDependencies());
-                    testDependencies.addAll(d.getTestDependencies());
-                });
         platforms.stream()
                 .map(CodestartDep::new)
                 .forEach(boms::add);
         extensions.stream()
                 .map(CodestartDep::new)
                 .forEach(dependencies::add);
+        codestartsStream
+                .flatMap(s -> Stream.of(s.getBaseLanguageSpec(), s.getLanguageSpec(languageName)))
+                .forEach(d -> {
+                    dependencies.addAll(d.getDependencies());
+                    testDependencies.addAll(d.getTestDependencies());
+                });
         depsData.put("dependencies", dependencies);
         depsData.put("boms", boms);
         depsData.put("test-dependencies", testDependencies);

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/CodestartProjectGenerationTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/CodestartProjectGenerationTest.java
@@ -12,10 +12,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CodestartProjectGenerationTest {
+public class CodestartProjectGenerationTest {
 
+    private static final TestCodestartResourceLoader RESOURCE_LOADER = new TestCodestartResourceLoader();
     private final Path projectPath = Paths.get("target/codestarts-test");
-    private TestCodestartResourceLoader resourceLoader = new TestCodestartResourceLoader();
 
     @BeforeEach
     void setUp() {
@@ -119,12 +119,12 @@ class CodestartProjectGenerationTest {
                 .hasSameTextualContentAs(getResource("expected-pom-maven-merge.xml"));
     }
 
-    private CodestartCatalog<CodestartProjectInput> load() throws IOException {
-        return CodestartCatalogLoader.loadDefaultCatalog(resourceLoader, "codestarts/core", "codestarts/examples");
+    public static CodestartCatalog<CodestartProjectInput> load() throws IOException {
+        return CodestartCatalogLoader.loadDefaultCatalog(RESOURCE_LOADER, "codestarts/core", "codestarts/examples");
     }
 
-    private CodestartCatalog<CodestartProjectInput> loadSpecific(String s) throws IOException {
-        return CodestartCatalogLoader.loadDefaultCatalog(resourceLoader, "codestarts/core", "codestarts/examples",
+    public static CodestartCatalog<CodestartProjectInput> loadSpecific(String s) throws IOException {
+        return CodestartCatalogLoader.loadDefaultCatalog(RESOURCE_LOADER, "codestarts/core", "codestarts/examples",
                 "codestarts/" + s);
     }
 

--- a/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/CodestartDataTest.java
+++ b/independent-projects/tools/codestarts/src/test/java/io/quarkus/devtools/codestarts/core/CodestartDataTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.devtools.codestarts.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.quarkus.devtools.codestarts.CodestartCatalog;
+import io.quarkus.devtools.codestarts.CodestartProjectGenerationTest;
+import io.quarkus.devtools.codestarts.CodestartProjectInput;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.Test;
+
+class CodestartDataTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDependenciesOverrideWithVersion() throws IOException {
+        final CodestartCatalog<CodestartProjectInput> catalog = CodestartProjectGenerationTest.loadSpecific("deps");
+        final Map<String, Object> dependenciesData = CodestartData.buildDependenciesData(catalog.getCodestarts().stream()
+                .filter(c -> c.isSelected(Sets.newLinkedHashSet("codestart-dep1", "codestart-dep2"))),
+                "a",
+                Lists.list("input.group:some-dep:1.2", "my.group:base-dep1", "my.group:a-dep1:1.1"),
+                Lists.list("input.group:some-bom"));
+        assertThat((Set<Map<String, String>>) dependenciesData.get("dependencies"))
+                .isNotNull()
+                .map(m -> m.get("formatted-gav"))
+                .containsExactlyInAnyOrder(
+                        "input.group:some-dep:1.2",
+                        "my.group:base-dep1",
+                        "my.group:a-dep1:1.1",
+                        "my.group:base-depversion:1.10",
+                        "my.group:base-dep2",
+                        "my.group:a-dep2");
+        assertThat((Set<Map<String, String>>) dependenciesData.get("test-dependencies"))
+                .isNotNull()
+                .map(m -> m.get("formatted-gav"))
+                .containsExactlyInAnyOrder(
+                        "my.group:base-test-dep1",
+                        "my.group:a-test-dep1",
+                        "my.group:base-test-dep2");
+        assertThat((Set<Map<String, String>>) dependenciesData.get("boms"))
+                .isNotNull()
+                .map(m -> m.get("formatted-gav"))
+                .containsExactly("input.group:some-bom");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDependenciesOverrideNoVersion() throws IOException {
+        final CodestartCatalog<CodestartProjectInput> catalog = CodestartProjectGenerationTest.loadSpecific("deps");
+        final Map<String, Object> dependenciesData = CodestartData.buildDependenciesData(catalog.getCodestarts().stream()
+                .filter(c -> c.isSelected(Sets.newLinkedHashSet("codestart-dep1"))),
+                "a",
+                Lists.list("my.group:base-depversion"),
+                Lists.newArrayList());
+        assertThat((Set<Map<String, String>>) dependenciesData.get("dependencies"))
+                .isNotNull()
+                .map(m -> m.get("formatted-gav"))
+                .containsExactlyInAnyOrder(
+                        "my.group:base-dep1",
+                        "my.group:a-dep1",
+                        "my.group:base-depversion");
+    }
+}

--- a/independent-projects/tools/codestarts/src/test/resources/codestarts/deps/dep1/codestart.yml
+++ b/independent-projects/tools/codestarts/src/test/resources/codestarts/deps/dep1/codestart.yml
@@ -1,0 +1,17 @@
+---
+name: codestart-dep1
+ref: codestart-dep1
+language:
+  base:
+    dependencies:
+    - my.group:base-dep1
+    - my.group:base-depversion:1.10
+    test-dependencies:
+    - my.group:base-test-dep1
+  a:
+    data:
+      foo: bar
+    dependencies:
+      - my.group:a-dep1
+    test-dependencies:
+      - my.group:a-test-dep1

--- a/independent-projects/tools/codestarts/src/test/resources/codestarts/deps/dep2/codestart.yml
+++ b/independent-projects/tools/codestarts/src/test/resources/codestarts/deps/dep2/codestart.yml
@@ -1,0 +1,14 @@
+---
+name: codestart-dep2
+ref: codestart-dep2
+language:
+  base:
+    dependencies:
+    - my.group:base-dep2
+    test-dependencies:
+    - my.group:base-test-dep2
+  a:
+    data:
+      foo: bar2
+    dependencies:
+      - my.group:a-dep2

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartGenerationTest.java
@@ -85,7 +85,7 @@ class QuarkusCodestartGenerationTest {
         final QuarkusCodestartProjectInput input = QuarkusCodestartProjectInput.builder()
                 .addData(getGenerationTestInputData())
                 .addBoms(QuarkusCodestartTesting.getPlatformBoms())
-                .addExtension(ArtifactKey.fromString("io.quarkus:quarkus-resteasy"))
+                .addExtension(ArtifactCoords.fromString("io.quarkus:quarkus-resteasy:1.8"))
                 .addExtension(ArtifactCoords.fromString("commons-io:commons-io:2.5"))
 
                 .build();
@@ -102,6 +102,7 @@ class QuarkusCodestartGenerationTest {
                 .satisfies(checkContains("<dependency>\n" +
                         "      <groupId>io.quarkus</groupId>\n" +
                         "      <artifactId>quarkus-resteasy</artifactId>\n" +
+                        "      <version>1.8</version>\n" +
                         "    </dependency>\n"));
     }
 

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -31,16 +31,17 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-arc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
- https://github.com/quarkusio/quarkus/pull/20892 introduced a regression, overriding is not working anymore due to a mistake (Set.add is not overriding but quite the opposite 😬)
- Added unit and integration test to make sure it works as expected

This regression was found in Kogito https://github.com/quarkusio/quarkus/pull/20892 during the bump to Quarkus 2.5.0.Final, **we have a clean workaround, so no rush for a new release**. 

**AFAIK this regression shouldn't have any other impact as this feature is not used yet anywhere else.**



