### PR TITLE
Upgrade to the flatten-platform-bom plugin 0.0.40

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -218,6 +218,13 @@
             <!-- Miscellaneous -->
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-core</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-war-launcher-runner</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/independent-projects/bootstrap/bom-test/pom.xml
+++ b/independent-projects/bootstrap/bom-test/pom.xml
@@ -14,6 +14,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-core</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -29,13 +29,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-core</artifactId>
-                <version>${project.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-app-model</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <gitflow-incremental-builder.version>3.14.4</gitflow-incremental-builder.version>
-        <quarkus-platform-bom-plugin.version>0.0.31</quarkus-platform-bom-plugin.version>
+        <quarkus-platform-bom-plugin.version>0.0.40</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>


### PR DESCRIPTION
Also move the bootstrap core tests JAR from the quarkus-bom to the build parent.

The 0.0.40 version includes `filterInvalidConstraints` option that filters out non-resolvable constraints from the BOM. However, it's not enabled and should be used with care, because artifacts may be spread across multiple repos. Whether an artifact can be resolved or not depends on what Maven repos are enabled in the build.