### PR TITLE
Ignore configuration errors due to classloader mismatch in the quarkusBuild task

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusAugmentor.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.ServiceConfigurationError;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -172,6 +173,8 @@ public class QuarkusAugmentor {
                 ConfigProviderResolver.instance()
                         .releaseConfig(ConfigProviderResolver.instance().getConfig(deploymentClassLoader));
             } catch (Exception ignore) {
+
+            } catch (ServiceConfigurationError ignore) {
 
             }
             if (deploymentClassLoader instanceof Closeable) {


### PR DESCRIPTION
If the classloader is different, then we end up with a `ServiceConfigurationError` instead of an exception. I am not sure if this was done intentionally or just that we don't have a sample application. I noticed this problem when I upgraded dependency from 2.2 to 2.3 / 2.4. The application in question is a Gradle based multi-module project.