### PR TITLE
Load protobuf-java parent-first

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -199,6 +199,7 @@
                         <parentFirstArtifact>au.com.dius.pact.consumer:junit5</parentFirstArtifact>
                         <parentFirstArtifact>au.com.dius.pact:consumer</parentFirstArtifact>
 
+                        <parentFirstArtifact>com.google.protobuf:protobuf-java</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>org.graalvm.sdk:graal-sdk</runnerParentFirstArtifact>


### PR DESCRIPTION
Fixes current test failures in `integration-tests/devmode`:
```
[ERROR] Tests run: 5, Failures: 0, Errors: 5, Skipped: 0, Time elapsed: 6.322 s <<< FAILURE! - in io.quarkus.test.reload.AdditionalWatchedResourcesDevModeTest
[ERROR] io.quarkus.test.reload.AdditionalWatchedResourcesDevModeTest.watchedInSubPath  Time elapsed: 4.59 s  <<< ERROR!
java.lang.RuntimeException:
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
        [error]: Build step io.quarkus.grpc.deployment.devmode.GrpcDevConsoleProcessor#collectMessagePrototypes threw an exception: java.lang.LinkageError: loader constraint violation: loader 'app' wants to load interface com.google.protobuf.MessageOrBuilder. A different interface with the same name was previously loaded by io.quarkus.bootstrap.classloading.QuarkusClassLoader @2aac87ab. (com.google.protobuf.MessageOrBuilder is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @2aac87ab, parent loader 'app')
```
that were caused by #21482. (It's unclear to me ATM why PR-CI was green for that PR.)

See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/main.20is.20broken/near/262252418

Take all that with a grain of salt as I'm neither a gRPC user nor a classloading ninja.