### PR TITLE
Fix duplicate quarkus-bootstrap-core test-jar in build-parent

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -276,13 +276,6 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-core</artifactId>
-                <version>${project.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-integration-test-class-transformer</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Fixes:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus:quarkus-junit5:jar:999-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.quarkus:quarkus-bootstrap-core:test-jar -> duplicate declaration of version ${project.version} @ io.quarkus:quarkus-build-parent:999-SNAPSHOT, /home/moldowan/proj/quarkus/build-parent/pom.xml, line 277, column 25
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```