### PR TITLE
Remove wildcard exclusion from `quarkus-grpc-protoc-plugin` for now to fix devmode ITs

### DIFF
--- a/extensions/grpc/codegen/pom.xml
+++ b/extensions/grpc/codegen/pom.xml
@@ -111,12 +111,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-protoc-plugin</artifactId>
             <classifier>shaded</classifier>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Short-term alternative to #21593 (which is incomplete).

Passed on my machine:
```
mvn clean install -pl extensions/grpc/codegen -amd -pl '!integration-tests/gradle/' -pl '!integration-tests/maven/'
```