### PR TITLE
Fix CME in MicrometerRecorder shutdown hook

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerRecorder.java
@@ -139,7 +139,8 @@ public class MicrometerRecorder {
                         Metrics.globalRegistry.remove(meter);
                     }
                 }
-                for (MeterRegistry meterRegistry : Metrics.globalRegistry.getRegistries()) {
+                // iterate over defensive copy to avoid ConcurrentModificationException
+                for (MeterRegistry meterRegistry : new ArrayList<>(Metrics.globalRegistry.getRegistries())) {
                     meterRegistry.close();
                     Metrics.removeRegistry(meterRegistry);
                 }


### PR DESCRIPTION
The collection returned by `Metrics.globalRegistry.getRegistries()` is not a copy, so later calls to `Metrics.removeRegistry()` end up modifying the same underlying collection and thus results in `ConcurrentModificationException`s in the for loop of the shutdown hook registered by `MicrometerRecorder#configureRegistries()`.

Fixes #21604