### PR TITLE
Cover `@QuarkusTestResource` & `@QuarkusMainTest` in `QuarkusTestProfileAwareClassOrderer`, skip `@Nested`, activate globally

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
+import org.junit.jupiter.api.Nested;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -38,6 +39,7 @@ import io.quarkus.test.junit.main.QuarkusMainTest;
  * Limitations:
  * <ul>
  * <li>Only JUnit5 test classes are subject to ordering, e.g. ArchUnit test classes are not passed to this orderer.</li>
+ * <li>This orderer does not handle {@link Nested} test classes.</li>
  * </ul>
  */
 public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
@@ -54,7 +56,8 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     @Override
     public void orderClasses(ClassOrdererContext context) {
-        if (context.getClassDescriptors().size() <= 1) {
+        // don't do anything if there is just one test class or the current order request is for @Nested tests
+        if (context.getClassDescriptors().size() <= 1 || context.getClassDescriptors().get(0).isAnnotated(Nested.class)) {
             return;
         }
         var prefixQuarkusTest = context

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrderer.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.junit.util;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
 
@@ -7,16 +8,22 @@ import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
 
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 /**
- * A {@link ClassOrderer} that orders {@link QuarkusTest} and {@link QuarkusIntegrationTest} classes for minimum Quarkus
- * restarts by grouping them by their {@link TestProfile}.
+ * A {@link ClassOrderer} that orders {@link QuarkusTest}, {@link QuarkusIntegrationTest} and {@link QuarkusMainTest} classes
+ * for minimum Quarkus
+ * restarts by grouping them by their {@link TestProfile} and {@link QuarkusTestResource} annotation(s).
  * <p/>
  * By default, Quarkus*Tests not using any profile come first, then classes using a profile (in groups) and then all other
- * non-Quarkus tests (e.g. plain unit tests).
+ * non-Quarkus tests (e.g. plain unit tests).<br/>
+ * Quarkus*Tests with {@linkplain QuarkusTestResource#restrictToAnnotatedClass() restricted} {@code QuarkusTestResource} come
+ * after tests with profiles and Quarkus*Tests with only unrestricted resources are handled like tests without a profile (come
+ * first).
  * <p/>
  * Internally, ordering is based on three prefixes that are prepended to the fully qualified name of the respective class, with
  * the fully qualified class name of the {@link io.quarkus.test.junit.QuarkusTestProfile QuarkusTestProfile} as an infix (if
@@ -30,8 +37,6 @@ import io.quarkus.test.junit.TestProfile;
  * <p/>
  * Limitations:
  * <ul>
- * <li>This orderer does not (yet) consider {@linkplain io.quarkus.test.common.QuarkusTestResource#restrictToAnnotatedClass()
- * test resources that are restricted to the annotated class}.</li>
  * <li>Only JUnit5 test classes are subject to ordering, e.g. ArchUnit test classes are not passed to this orderer.</li>
  * </ul>
  */
@@ -39,10 +44,12 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
 
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST = "20_";
     protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "40_";
+    protected static final String DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "45_";
     protected static final String DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST = "60_";
 
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST = "quarkus.test.orderer.prefix.quarkus-test";
     static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE = "quarkus.test.orderer.prefix.quarkus-test-with-profile";
+    static final String CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES = "quarkus.test.orderer.prefix.quarkus-test-with-restricted-resource";
     static final String CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST = "quarkus.test.orderer.prefix.non-quarkus-test";
 
     @Override
@@ -50,11 +57,17 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
         if (context.getClassDescriptors().size() <= 1) {
             return;
         }
-        var prefixQuarkusTest = context.getConfigurationParameter(CFGKEY_ORDER_PREFIX_QUARKUS_TEST)
+        var prefixQuarkusTest = context
+                .getConfigurationParameter(CFGKEY_ORDER_PREFIX_QUARKUS_TEST)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST);
-        var prefixQuarkusTestWithProfile = context.getConfigurationParameter(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE)
+        var prefixQuarkusTestWithProfile = context
+                .getConfigurationParameter(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE)
                 .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_PROFILE);
-        var prefixNonQuarkusTest = context.getConfigurationParameter(CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST)
+        var prefixQuarkusTestWithRestrictedResource = context
+                .getConfigurationParameter(CFGKEY_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES)
+                .orElse(DEFAULT_ORDER_PREFIX_QUARKUS_TEST_WITH_RESTRICTED_RES);
+        var prefixNonQuarkusTest = context
+                .getConfigurationParameter(CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST)
                 .orElse(DEFAULT_ORDER_PREFIX_NON_QUARKUS_TEST);
 
         context.getClassDescriptors().sort(Comparator.comparing(classDescriptor -> {
@@ -64,14 +77,31 @@ public class QuarkusTestProfileAwareClassOrderer implements ClassOrderer {
             }
             var testClassName = classDescriptor.getTestClass().getName();
             if (classDescriptor.isAnnotated(QuarkusTest.class)
-                    || classDescriptor.isAnnotated(QuarkusIntegrationTest.class)) {
+                    || classDescriptor.isAnnotated(QuarkusIntegrationTest.class)
+                    || classDescriptor.isAnnotated(QuarkusMainTest.class)) {
                 return classDescriptor.findAnnotation(TestProfile.class)
                         .map(TestProfile::value)
                         .map(profileClass -> prefixQuarkusTestWithProfile + profileClass.getName() + "@" + testClassName)
-                        .orElseGet(() -> prefixQuarkusTest + testClassName);
+                        .orElseGet(() -> {
+                            var prefix = hasRestrictedResource(classDescriptor)
+                                    ? prefixQuarkusTestWithRestrictedResource
+                                    : prefixQuarkusTest;
+                            return prefix + testClassName;
+                        });
             }
             return prefixNonQuarkusTest + testClassName;
         }));
+    }
+
+    private boolean hasRestrictedResource(ClassDescriptor classDescriptor) {
+        return classDescriptor.findRepeatableAnnotations(QuarkusTestResource.class).stream()
+                .anyMatch(res -> res.restrictToAnnotatedClass() || isMetaTestResource(res, classDescriptor));
+    }
+
+    private boolean isMetaTestResource(QuarkusTestResource resource, ClassDescriptor classDescriptor) {
+        return Arrays.stream(classDescriptor.getTestClass().getAnnotationsByType(QuarkusTestResource.class))
+                .map(QuarkusTestResource::value)
+                .noneMatch(resource.value()::equals);
     }
 
     /**

--- a/test-framework/junit5/src/main/resources/junit-platform.properties
+++ b/test-framework/junit5/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer


### PR DESCRIPTION
Resolves #20420 and also makes sure that everyone working on this repo has the same test order (which has also a small con, but mostly pros).

This will also activate the orderer in user projects, but you can opt out of that via a custom `junit-platform.properties` (just tested this via a quickstart).
For most users this should be just fine and is actually an improvement.

If we merge this, I'll add something to the migration guide.