### PR TITLE
Add support for service registry service binding 

### DIFF
--- a/extensions/apicurio-registry-avro/deployment/pom.xml
+++ b/extensions/apicurio-registry-avro/deployment/pom.xml
@@ -23,6 +23,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
+        
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-avro-deployment</artifactId>

--- a/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/binding/ServiceRegistryBindingExtensionProcessor.java
+++ b/extensions/apicurio-registry-avro/deployment/src/main/java/io/quarkus/apicurio/registry/binding/ServiceRegistryBindingExtensionProcessor.java
@@ -1,0 +1,21 @@
+package io.quarkus.apicurio.registry.avro.binding;
+
+import io.quarkus.apicurio.registry.binding.ServiceRegistryBindingConverter;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+
+class ServiceRegistryBindingExtensionProcessor {
+
+    @BuildStep
+    void registerServiceBinding(Capabilities capabilities,
+            BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        if (capabilities.isPresent(Capability.KUBERNETES_SERVICE_BINDING)) {
+            serviceProvider.produce(
+                    new ServiceProviderBuildItem("io.quarkus.apicurio.registry.binding.ServiceRegistryBindingConverter",
+                            ServiceRegistryBindingConverter.class.getName()));
+        }
+    }
+}

--- a/extensions/apicurio-registry-avro/runtime/pom.xml
+++ b/extensions/apicurio-registry-avro/runtime/pom.xml
@@ -28,7 +28,12 @@
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-common-rest-client-vertx</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-service-binding</artifactId>
+            <optional>true</optional>
+        </dependency>
+        
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
@@ -41,6 +46,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
+    
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+      </dependency>
     </dependencies>
 
     <build>

--- a/extensions/apicurio-registry-avro/runtime/src/main/java/io/quarkus/apicurio/registry/binding/ServiceRegistryBindingConverter.java
+++ b/extensions/apicurio-registry-avro/runtime/src/main/java/io/quarkus/apicurio/registry/binding/ServiceRegistryBindingConverter.java
@@ -1,0 +1,103 @@
+package io.quarkus.apicurio.registry.binding;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.kubernetes.service.binding.runtime.ServiceBinding;
+import io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConfigSource;
+import io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter;
+
+public class ServiceRegistryBindingConverter implements ServiceBindingConverter {
+
+    private static Logger LOG = Logger.getLogger(ServiceRegistryBindingConverter.class.getName());
+
+    private static final String INCOMING_PREFIX = "mp.messaging.incoming.";
+    private static final String OUTGOING_PREFIX = "mp.messaging.outgoing.";
+
+    @Override
+    public Optional<ServiceBindingConfigSource> convert(List<ServiceBinding> serviceBindings) {
+        var matchingByType = ServiceBinding.singleMatchingByType("serviceregistry", serviceBindings);
+        Config config = ConfigProvider.getConfig();
+        if (matchingByType.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var binding = matchingByType.get();
+
+        List<String> channels = extractChannels(config);
+
+        Map<String, String> properties = new HashMap<>();
+
+        String registryUrl = binding.getProperties().get("registryUrl");
+        if (registryUrl == null) {
+            registryUrl = binding.getProperties().get("registryurl");
+        }
+        if (registryUrl != null) {
+            properties.put("kafka.apicurio.registry.url", registryUrl);
+        }
+
+        for (String channel : channels) {
+
+            String prefix = channel;
+
+            String oauthTokenUrl = binding.getProperties().get("oauthTokenUrl");
+            if (oauthTokenUrl == null) {
+                oauthTokenUrl = binding.getProperties().get("oauthtokenurl");
+            }
+            if (oauthTokenUrl != null) {
+                properties.put(prefix + "apicurio.auth.service.token.endpoint", oauthTokenUrl);
+            }
+
+            String clientId = binding.getProperties().get("clientId");
+            if (clientId == null) {
+                clientId = binding.getProperties().get("clientid");
+            }
+            if (clientId != null) {
+                properties.put(prefix + "apicurio.auth.client.id", clientId);
+            }
+
+            String clientSecret = binding.getProperties().get("clientSecret");
+            if (clientSecret == null) {
+                clientSecret = binding.getProperties().get("clientsecret");
+            }
+            if (clientSecret != null) {
+                properties.put(prefix + "apicurio.auth.client.secret", clientSecret);
+            }
+            if (registryUrl != null) {
+                properties.put(prefix + "apicurio.registry.url", registryUrl);
+            }
+        }
+
+        return Optional.of(new ServiceBindingConfigSource("serviceregistry-k8s-service-binding-source", properties));
+    }
+
+    private List<String> extractChannels(Config configIn) {
+
+        var list = new ArrayList<String>();
+
+        for (String propertyName : configIn.getPropertyNames()) {
+            if (propertyName.startsWith(INCOMING_PREFIX)) {
+                var channelAndProp = StringUtils.substringAfter(propertyName, INCOMING_PREFIX);
+                //remove property
+                var channelName = StringUtils.substringBefore(channelAndProp, ".");
+                if (!StringUtils.isBlank(channelName))
+                    list.add(INCOMING_PREFIX + channelName + ".");
+            } else if (propertyName.startsWith(OUTGOING_PREFIX)) {
+                var channelAndProp = StringUtils.substringAfter(propertyName, OUTGOING_PREFIX);
+                //remove property
+                var channelName = StringUtils.substringBefore(channelAndProp, ".");
+                if (!StringUtils.isBlank(channelName))
+                    list.add(OUTGOING_PREFIX + channelName + ".");
+            }
+        }
+        return list;
+    }
+}

--- a/extensions/apicurio-registry-avro/runtime/src/main/resources/META-INF/services/io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter
+++ b/extensions/apicurio-registry-avro/runtime/src/main/resources/META-INF/services/io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter
@@ -1,0 +1,1 @@
+io.quarkus.apicurio.registry.binding.ServiceRegistryBindingConverter


### PR DESCRIPTION
This pull request adds to the apicurio registry avro extension the ability to consume service bindings injected by the service binding operator. This work is being done as part of adding service registry binding to the rhoas operator and cli.

The SBO provides the following bindings
+ *oauthTokenUrl* binds to channels' `apicurio.auth.token.endpoint` property +
+ *clientId* binds to channels' `apicurio.auth.client.id`  property+
+ *oauthRealm* binds to channels' `apicurio.auth.realm`  property+
+ *registry* binds to channels' `apicurio.registry.url` and `mp.messaging.connector.smallrye-kafka.apicurio.registry.url`  properties+

== How to Test

=== Prerequisites

 * OpenShift 4.9 cluster with rhoas-operator and service binding operator installed
 * `rhoas` Cli
 * `oc` cli
 * console.redhat.com account
 
=== Cluster and Services Setup

  Ensure that you have logged into your cluster with oc, and have logged into your Application Services account with `rhoas login`. Create a kafka instance with `rhoas kafka create`, and a service registry instance with `rhoas service-registry create`. Once your kafka and service registry entries are ready, create a kafka topic called movies. You can use `hroas kafka topic create`. You will then execute `rhoas cluster connect` twice - connecting the kafka instance and your service registry instance separately with each run. When you connect the kafka instance, you will be prompted to update your kafka ACLs and provided a command to do so using a service account that was created. It is important you do this.

We have provided a sample application(https://github.com/secondsun/kafka-avro-schema-quickstart/). This application is deployed to OpenShift as a container. One you have deployed the container, use `rhoas cluster bind` to first bind the kafka connection, then execute the command again to bind the service registry. Once the pod has restartted, use the route provided by openshift to navigate to `/movies.html`. You should see a screen showing a random movie title.

There is a version of the application already containerized with the extension here : quuay.io/secondsun/kafka-avro-schema-quickstart:latest

A video of the process is here : 

https://www.youtube.com/watch?v=ul9JDjXLquw