### PR TITLE
Fix RestClientFallbackConfigSourceInterceptor#iterateNames()

### DIFF
--- a/extensions/resteasy-classic/rest-client/config/src/main/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptor.java
+++ b/extensions/resteasy-classic/rest-client/config/src/main/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptor.java
@@ -71,6 +71,13 @@ public class RestClientFallbackConfigSourceInterceptor extends FallbackConfigSou
             final String name = namesIterator.next();
             names.add(name);
 
+            if (name.startsWith("%")) {
+                // Don't do any conversions on properties that belong to inactive profiles.
+                // The active profile property names are normalized by the ProfileConfigSourceInterceptor, so they do not have
+                // the "%profile." prefix at this point.
+                continue;
+            }
+
             String[] prefixAndProperty = extractMPClientPrefixAndProperty(name);
             if (prefixAndProperty != null) { // effectively if name.contains("/mp-rest/")
                 String clientPrefix = prefixAndProperty[0];

--- a/extensions/resteasy-classic/rest-client/config/src/test/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptorTest.java
+++ b/extensions/resteasy-classic/rest-client/config/src/test/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptorTest.java
@@ -87,7 +87,7 @@ public class RestClientFallbackConfigSourceInterceptorTest {
     }
 
     @Test
-    public void testInterceptorGetValue() {
+    public void testGetValue() {
         RestClientFallbackConfigSourceInterceptor interceptor = new RestClientFallbackConfigSourceInterceptor();
         ConfigSourceInterceptorContext interceptorContext = new TestContext();
         ConfigValue value;
@@ -112,7 +112,7 @@ public class RestClientFallbackConfigSourceInterceptorTest {
     }
 
     @Test
-    public void testInterceptorIterateNames() {
+    public void testIterateNames() {
         RestClientFallbackConfigSourceInterceptor interceptor = new RestClientFallbackConfigSourceInterceptor();
         Iterator<String> iterator;
 
@@ -135,6 +135,33 @@ public class RestClientFallbackConfigSourceInterceptorTest {
 
                 "quarkus.rest-client-reactive.disable-smart-produces",
                 "quarkus.rest-client.disable-smart-produces");
+    }
+
+    @Test
+    public void testIterateNamesExcludeInactiveProfiles() {
+        RestClientFallbackConfigSourceInterceptor interceptor = new RestClientFallbackConfigSourceInterceptor();
+        Iterator<String> iterator;
+
+        // client properties
+        iterator = interceptor.iterateNames(new TestContext(Arrays.asList(
+                "%prod.key/mp-rest/url",
+                "%dev.key/mp-rest/url",
+                "key/mp-rest/url",
+                "%prod.quarkus.rest-client.key2.url",
+                "%dev.quarkus.rest-client.key2.url",
+                "quarkus.rest-client.key2.url")));
+
+        assertThat(iteratorToCollection(iterator)).containsOnly(
+                // all the original property names should be included
+                "%prod.key/mp-rest/url",
+                "%dev.key/mp-rest/url",
+                "key/mp-rest/url",
+                "%prod.quarkus.rest-client.key2.url",
+                "%dev.quarkus.rest-client.key2.url",
+                "quarkus.rest-client.key2.url",
+
+                // only the conversion of "key/mp-rest/url" should be added
+                "quarkus.rest-client.key.url");
     }
 
     private static Collection<String> iteratorToCollection(Iterator<String> iterator) {

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientProfilesConfigTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientProfilesConfigTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.restclient.configuration;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RestClientProfilesConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(EchoResource.class,
+                            EchoClient.class, EchoClientWithConfigKey.class))
+            .withConfigurationResource("profiles-application.properties");
+
+    @RestClient
+    EchoClient echoClient;
+
+    @RestClient
+    EchoClientWithConfigKey shortNameClient;
+
+    @Test
+    public void shouldRespond() {
+        Assertions.assertEquals("Hello", echoClient.echo("Hello"));
+        Assertions.assertEquals("Hello", shortNameClient.echo("Hello"));
+    }
+
+}

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/resources/profiles-application.properties
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/resources/profiles-application.properties
@@ -1,0 +1,5 @@
+%prod.echo-client/mp-rest/url=${UNKNOWN_VAR}
+%test.echo-client/mp-rest/url=http://localhost:${quarkus.http.test-port:8081}
+
+%prod.quarkus.rest-client.EchoClient.url=${UNKNOWN_VAR}
+%test.quarkus.rest-client.EchoClient.url=http://localhost:${quarkus.http.test-port:8081}


### PR DESCRIPTION
The fallback interceptor shouldn't do any conversions on properties that are
prefixed with the "%profile." prefixes. The fact that the profile prefix
is present means the property belongs to an inactive profile. The active
profile property names should be already normalized by the
ProfileConfigSourceInterceptor interceptor.

This fixes https://github.com/quarkusio/quarkus/issues/21533