### PR TITLE
Add commons-logging exclusion to keycloak-admin extension

### DIFF
--- a/extensions/keycloak-admin-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-client/runtime/pom.xml
@@ -38,6 +38,10 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jackson2-provider</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Commons-logging was still appearing in classpath with a gradle setup.

Although it wouldnt show in maven tree (`mvnw dependency:tree`), it would show in gradle tree otherwise (`gradlew dependencies`).

I am not sure what is the real cause of that, but guided by this another PR https://github.com/quarkusio/quarkus/pull/21148 and this commentary https://github.com/quarkusio/quarkus/issues/20896#issuecomment-973915104 I repeated the same kind of solution and it solved the problem.

The solution it self consists in adding another exclusion of commons-logging in keycloak-admin-client dependency of the extension.

After building the extension again I could test it against a real app with native binaries and it worked pretty well.