### PR TITLE
Check the alternate POM argument in BootstrapWorkspaceProvider before loading the workspace

### DIFF
--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BootstrapWorkspaceProvider.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/BootstrapWorkspaceProvider.java
@@ -1,36 +1,56 @@
 package io.quarkus.maven;
 
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.codehaus.plexus.component.annotations.Component;
+import org.jboss.logging.Logger;
 
 @Component(role = BootstrapWorkspaceProvider.class, instantiationStrategy = "singleton")
 public class BootstrapWorkspaceProvider {
 
     private final Path base;
-    private boolean loaded;
+    private boolean initialized;
     private LocalProject origin;
 
     public BootstrapWorkspaceProvider() {
-        // load the workspace lazily on request, in case the component is injected but the logic using it is skipped 
+        // load the workspace lazily on request, in case the component is injected but the logic using it is skipped
         base = Paths.get("").normalize().toAbsolutePath();
     }
 
     public LocalProject origin() {
-        if (!loaded) {
-            try {
-                origin = LocalProject.loadWorkspace(base);
-            } catch (BootstrapMavenException e) {
+        if (!initialized) {
+            Path modulePath = base;
+            final String alternatePomParam = BootstrapMavenOptions.newInstance()
+                    .getOptionValue(BootstrapMavenOptions.ALTERNATE_POM_FILE);
+            if (alternatePomParam != null) {
+                final Path path = Paths.get(alternatePomParam);
+                if (path.isAbsolute()) {
+                    modulePath = path;
+                } else {
+                    modulePath = base.resolve(path);
+                }
             }
-            loaded = true;
+            try {
+                origin = LocalProject.loadWorkspace(modulePath);
+            } catch (BootstrapMavenException e) {
+                Logger.getLogger(BootstrapWorkspaceProvider.class).warn("Failed to load workspace for " + modulePath);
+            }
+            initialized = true;
         }
         return origin;
     }
 
     public LocalWorkspace workspace() {
-        return origin().getWorkspace();
+        final LocalProject origin = origin();
+        return origin == null ? null : origin.getWorkspace();
+    }
+
+    public LocalProject getProject(String groupId, String artifactId) {
+        final LocalWorkspace workspace = workspace();
+        return workspace == null ? null : workspace.getProject(groupId, artifactId);
     }
 }

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -445,7 +445,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         codestartObject.put("artifact", codestartArtifactCoords.toString());
         if (!skipCodestartValidation) {
             // first we look for it in the workspace, if it's in there we don't need to actually resolve the artifact, because it might not have been built yet
-            if (workspaceProvider.workspace().getProject(codestartArtifactCoords.getGroupId(),
+            if (workspaceProvider.getProject(codestartArtifactCoords.getGroupId(),
                     codestartArtifactCoords.getArtifactId()) == null) {
                 try {
                     resolve(new DefaultArtifact(codestartArtifact));


### PR DESCRIPTION
This change allows to build extension projects with commands specifying alternate POMs with `-f`.