### PR TITLE
Qute - fix ChildResolutionContext.getExtendingBlock()

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
@@ -108,9 +108,9 @@ class ResolutionContextImpl implements ResolutionContext {
                 if (block != null) {
                     return block;
                 }
-                if (parent != null) {
-                    return parent.getExtendingBlock(name);
-                }
+            }
+            if (parent != null) {
+                return parent.getExtendingBlock(name);
             }
             return null;
         }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IncludeTest.java
@@ -156,4 +156,11 @@ public class IncludeTest {
         }
     }
 
+    @Test
+    public void testInsertInLoop() {
+        Engine engine = Engine.builder().addDefaults().build();
+        engine.putTemplate("super", engine.parse("{#for i in 5}{#insert row}No row{/}{/for}"));
+        assertEquals("1:2:3:4:5:", engine.parse("{#include super}{#row}{i}:{/row}{/}").render());
+    }
+
 }


### PR DESCRIPTION
- it should always try the parent context as a fallback
- resolves #21584