### PR TITLE
Make quarkus-jdbc-mysql work properly in native mode for Java 17

### DIFF
--- a/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/graal/com/mysql/cj/jdbc/MySQLJDBCSubstitutions.java
+++ b/extensions/jdbc/jdbc-mysql/runtime/src/main/java/io/quarkus/jdbc/mysql/runtime/graal/com/mysql/cj/jdbc/MySQLJDBCSubstitutions.java
@@ -1,0 +1,49 @@
+package io.quarkus.jdbc.mysql.runtime.graal.com.mysql.cj.jdbc;
+
+import java.sql.SQLException;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "com.mysql.cj.jdbc.ConnectionGroupManager")
+final class ConnectionGroupManager {
+
+    @Substitute
+    public static void registerJmx() throws SQLException {
+        throw new IllegalStateException("Not Implemented in native mode");
+    }
+
+}
+
+@TargetClass(className = "com.mysql.cj.jdbc.jmx.LoadBalanceConnectionGroupManager")
+final class LoadBalanceConnectionGroupManager {
+
+    @Substitute
+    public synchronized void registerJmx() throws java.sql.SQLException {
+        throw new IllegalStateException("Not Implemented in native mode");
+    }
+
+}
+
+@TargetClass(className = "com.mysql.cj.jdbc.jmx.ReplicationGroupManager")
+final class ReplicationGroupManager {
+
+    @Substitute
+    public synchronized void registerJmx() throws SQLException {
+        throw new IllegalStateException("Not Implemented in native mode");
+    }
+
+}
+
+@TargetClass(className = "com.mysql.cj.jdbc.ha.ReplicationConnectionGroupManager")
+final class ReplicationConnectionGroupManager {
+
+    @Substitute
+    public static void registerJmx() throws SQLException {
+        throw new IllegalStateException("Not Implemented in native mode");
+    }
+
+}
+
+class MySQLJDBCSubstitutions {
+}


### PR DESCRIPTION
Fixes: #21366

I tested this with the `jpa-mysql` integration test being run with Java 17 and GraalVM 17 (which we don't run in our CI)