### PR TITLE
Fix Reactive Route stream serialization without relying on the Multi sub-type

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -399,18 +399,16 @@ The previous snippet produces:
 
 You can return a `Multi` to produce a JSON Array, where every item is an item from this array.
 The response is written item by item to the client.
-The `content-type` is set to `application/json` if not set already.
-
-To use this feature, you need to wrap the returned `Multi` using `io.quarkus.vertx.web.ReactiveRoutes.asJsonArray`:
+To do that set the `produces` attribute to `"application/json"` (or `ReactiveRoutes.APPLICATION_JSON`).
 
 [source, java]
 ----
-@Route(path = "/people")
+@Route(path = "/people", produces = ReactiveRoutes.APPLICATION_JSON)
 Multi<Person> people(RoutingContext context) {
-    return ReactiveRoutes.asJsonArray(Multi.createFrom().items(
+    return Multi.createFrom().items(
             new Person("superman", 1),
             new Person("batman", 2),
-            new Person("spiderman", 3)));
+            new Person("spiderman", 3));
 }
 ----
 
@@ -425,24 +423,34 @@ The previous snippet produces:
 ]
 ----
 
+TIP: The `produces` attribute is an array.
+When you pass a single value you can omit the "{" and "}".
+Note that `"application/json"` must be the first value in the array.
+
 Only `Multi<String>`, `Multi<Object>` and `Multi<Void>` can be written into the JSON Array.
 Using a `Multi<Void>` produces an empty array.
 You cannot use `Multi<Buffer>`.
 If you need to use `Buffer`, transform the content into a JSON or String representation first.
 
+[NOTE]
+.Deprecation of `asJsonArray`
+====
+The `ReactiveRoutes.asJsonArray` has been deprecated as it is not compatible with the security layer of Quarkus.
+====
+
 === Event Stream and Server-Sent Event support
 
 You can return a `Multi` to produce an event source (stream of server sent events).
-To enable this feature, you need to wrap the returned `Multi` using `io.quarkus.vertx.web.ReactiveRoutes.asEventStream`:
+To enable this feature, set the `produces` attribute to `"text/event-stream"` (or `ReactiveRoutes.EVENT_STREAM`), such as in:
 
 [source, java]
 ----
-@Route(path = "/people")
+@Route(path = "/people", produces = ReactiveRoutes.EVENT_STREAM)
 Multi<Person> people(RoutingContext context) {
-    return ReactiveRoutes.asEventStream(Multi.createFrom().items(
+    return Multi.createFrom().items(
             new Person("superman", 1),
             new Person("batman", 2),
-            new Person("spiderman", 3)));
+            new Person("spiderman", 3));
 }
 ----
 
@@ -460,6 +468,10 @@ data: {"name":"spiderman", "id": 3}
 id: 2
 
 ----
+
+TIP: The `produces` attribute is an array.
+When you pass a single value you can omit the "{" and "}".
+Note that `"text/event-stream"` must be the first value in the array.
 
 You can also implement the `io.quarkus.vertx.web.ReactiveRoutes.ServerSentEvent` interface to customize the `event` and `id` section of the server sent event:
 
@@ -491,7 +503,7 @@ class PersonEvent implements ReactiveRoutes.ServerSentEvent<Person> {
 }
 ----
 
-Using a `Multi<PersonEvent>` (wrapped using `io.quarkus.vertx.web.ReactiveRoutes.asEventStream`) would produce:
+Using a `Multi<PersonEvent>` would produce:
 
 [source, text]
 ----
@@ -509,14 +521,20 @@ id: 3
 
 ----
 
+[NOTE]
+.Deprecation of `asEventStream`
+====
+The `ReactiveRoutes.asEventStream` has been deprecated as it is not compatible with the security layer of Quarkus.
+====
+
 === Json Stream in NDJSON format
 
 You can return a `Multi` to produce a newline delimited stream of JSON values.
-To enable this feature, you need to wrap the returned `Multi` using `io.quarkus.vertx.web.ReactiveRoutes.asJsonStream`:
+To enable this feature, set the `produces` attribute of the `@Route` annotation to `"application/x-ndjson"` (or `ReactiveRoutes.ND_JSON`):
 
 [source, java]
 ----
-@Route(path = "/people")
+@Route(path = "/people", produces = ReactiveRoutes.ND_JSON)
 Multi<Person> people(RoutingContext context) {
     return ReactiveRoutes.asJsonStream(Multi.createFrom().items(
             new Person("superman", 1),
@@ -536,11 +554,14 @@ This method would produce:
 
 ----
 
+TIP: The `produces` attribute is an array. When you pass a single value you can omit the "{" and "}".
+Note that `"application/x-ndjson"` must be the first value in the array.
+
 You can also provide strings instead of Objects, in that case the strings will be wrapped in quotes to become valid JSON values:
 
 [source, java]
 ----
-@Route(path = "/people")
+@Route(path = "/people", produces = ReactiveRoutes.ND_JSON)
 Multi<Person> people(RoutingContext context) {
     return ReactiveRoutes.asJsonStream(Multi.createFrom().items(
             "superman",
@@ -557,6 +578,12 @@ Multi<Person> people(RoutingContext context) {
 "spiderman"
 
 ----
+
+[NOTE]
+.Deprecation of `asJsonStream`
+====
+The `ReactiveRoutes.asJsonStream` has been deprecated as it is not compatible with the security layer of Quarkus.
+====
 
 === Using Bean Validation
 

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/HandlerDescriptor.java
@@ -16,31 +16,30 @@ class HandlerDescriptor {
     private final MethodInfo method;
     private final BeanValidationAnnotationsBuildItem validationAnnotations;
     private final HandlerType handlerType;
-    private final Type contentType;
+    private final Type payloadType;
+    private final String[] contentTypes;
 
-    HandlerDescriptor(MethodInfo method, BeanValidationAnnotationsBuildItem bvAnnotations, HandlerType handlerType) {
+    HandlerDescriptor(MethodInfo method, BeanValidationAnnotationsBuildItem bvAnnotations, HandlerType handlerType,
+            String[] producedTypes) {
         this.method = method;
         this.validationAnnotations = bvAnnotations;
         this.handlerType = handlerType;
         Type returnType = method.returnType();
         if (returnType.kind() == Kind.VOID) {
-            contentType = null;
+            payloadType = null;
         } else {
             if (returnType.name().equals(DotNames.UNI) || returnType.name().equals(DotNames.MULTI)
                     || returnType.name().equals(DotNames.COMPLETION_STAGE)) {
-                contentType = returnType.asParameterizedType().arguments().get(0);
+                payloadType = returnType.asParameterizedType().arguments().get(0);
             } else {
-                contentType = returnType;
+                payloadType = returnType;
             }
         }
+        this.contentTypes = producedTypes;
     }
 
     Type getReturnType() {
         return method.returnType();
-    }
-
-    boolean isReturningVoid() {
-        return method.returnType().kind().equals(Type.Kind.VOID);
     }
 
     boolean isReturningUni() {
@@ -53,6 +52,13 @@ class HandlerDescriptor {
 
     boolean isReturningCompletionStage() {
         return method.returnType().name().equals(DotNames.COMPLETION_STAGE);
+    }
+
+    public String getFirstContentType() {
+        if (contentTypes == null || contentTypes.length == 0) {
+            return null;
+        }
+        return contentTypes[0];
     }
 
     /**
@@ -86,28 +92,28 @@ class HandlerDescriptor {
         return false;
     }
 
-    Type getContentType() {
-        return contentType;
+    Type getPayloadType() {
+        return payloadType;
     }
 
-    boolean isContentTypeString() {
-        Type type = getContentType();
+    boolean isPayloadString() {
+        Type type = getPayloadType();
         if (type == null) {
             return false;
         }
         return type.name().equals(io.quarkus.arc.processor.DotNames.STRING);
     }
 
-    boolean isContentTypeBuffer() {
-        Type type = getContentType();
+    boolean isPayloadTypeBuffer() {
+        Type type = getPayloadType();
         if (type == null) {
             return false;
         }
         return type.name().equals(DotNames.BUFFER);
     }
 
-    boolean isContentTypeMutinyBuffer() {
-        Type type = getContentType();
+    boolean isPayloadMutinyBuffer() {
+        Type type = getPayloadType();
         if (type == null) {
             return false;
         }

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/Methods.java
@@ -238,7 +238,7 @@ class Methods {
     }
 
     static boolean isNoContent(HandlerDescriptor descriptor) {
-        return descriptor.getContentType().name()
+        return descriptor.getPayloadType().name()
                 .equals(DotName.createSimple(Void.class.getName()));
     }
 
@@ -249,7 +249,7 @@ class Methods {
     }
 
     static MethodDescriptor getEndMethodForContentType(HandlerDescriptor descriptor) {
-        if (descriptor.isContentTypeBuffer() || descriptor.isContentTypeMutinyBuffer()) {
+        if (descriptor.isPayloadTypeBuffer() || descriptor.isPayloadMutinyBuffer()) {
             return END_WITH_BUFFER;
         }
         return END_WITH_STRING;

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/JsonMultiRouteWithAsJsonArrayTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/JsonMultiRouteWithAsJsonArrayTest.java
@@ -1,0 +1,145 @@
+package io.quarkus.vertx.web.mutiny;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.ReactiveRoutes;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+
+public class JsonMultiRouteWithAsJsonArrayTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SimpleBean.class));
+
+    @Test
+    public void testMultiRoute() {
+        when().get("/hello").then().statusCode(200)
+                .body(is("[\"Hello world!\"]"))
+                .header("content-type", "application/json");
+        when().get("/hellos").then().statusCode(200)
+                .body(is("[\"hello\",\"world\",\"!\"]"))
+                .header("content-type", "application/json");
+        when().get("/no-hello").then().statusCode(200).body(is("[]"))
+                .header("content-type", "application/json");
+        // status already sent, but not the end of the array
+        when().get("/hello-and-fail").then().statusCode(200)
+                .body(containsString("[\"Hello\""))
+                .body(not(containsString("]")));
+
+        when().get("/buffers").then().statusCode(500);
+
+        when().get("/void").then().statusCode(200).body(is("[]"));
+
+        when().get("/people").then().statusCode(200)
+                .body("size()", is(3))
+                .body("[0].name", is("superman"))
+                .body("[1].name", is("batman"))
+                .body("[2].name", is("spiderman"))
+                .header("content-type", "application/json");
+
+        when().get("/people-content-type").then().statusCode(200)
+                .body("size()", is(3))
+                .body("[0].name", is("superman"))
+                .body("[1].name", is("batman"))
+                .body("[2].name", is("spiderman"))
+                .header("content-type", "application/json;charset=utf-8");
+
+        when().get("/failure").then().statusCode(500).body(containsString("boom"));
+        when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
+        when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
+
+    }
+
+    static class SimpleBean {
+
+        @Route(path = "hello")
+        Multi<String> hello(RoutingContext context) {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().item("Hello world!"));
+        }
+
+        @Route(path = "hellos")
+        Multi<String> hellos(RoutingContext context) {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().items("hello", "world", "!"));
+        }
+
+        @Route(path = "no-hello")
+        Multi<String> noHello(RoutingContext context) {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().empty());
+        }
+
+        @Route(path = "hello-and-fail")
+        Multi<String> helloAndFail() {
+            return ReactiveRoutes.asJsonArray(Multi.createBy().concatenating().streams(
+                    Multi.createFrom().item("Hello"),
+                    Multi.createFrom().failure(new IOException("boom"))));
+        }
+
+        @Route(path = "buffers")
+        Multi<Buffer> buffers(RoutingContext context) {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom()
+                    .items(Buffer.buffer("Buffer"), Buffer.buffer(" Buffer"), Buffer.buffer(" Buffer.")));
+        }
+
+        @Route(path = "void")
+        Multi<Void> multiVoid(RoutingContext context) {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().range(0, 200)
+                    .onItem().ignore());
+        }
+
+        @Route(path = "/people")
+        Multi<Person> people() {
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/people-content-type")
+        Multi<Person> peopleWithContentType(RoutingContext context) {
+            context.response().putHeader("content-type", "application/json;charset=utf-8");
+            return ReactiveRoutes.asJsonArray(Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/failure")
+        Multi<Person> fail(RoutingContext context) {
+            return Multi.createFrom().failure(new IOException("boom"));
+        }
+
+        @Route(path = "/sync-failure")
+        Multi<Person> failSync(RoutingContext context) {
+            throw new IllegalStateException("boom");
+        }
+
+        @Route(path = "/null")
+        Multi<String> uniNull(RoutingContext context) {
+            return null;
+        }
+
+    }
+
+    static class Person {
+        public String name;
+        public int id;
+
+        public Person(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+    }
+
+}

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/JsonMultiRouteWithContentTypeTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/JsonMultiRouteWithContentTypeTest.java
@@ -17,7 +17,7 @@ import io.smallrye.mutiny.Multi;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 
-public class JsonMultiRouteTest {
+public class JsonMultiRouteWithContentTypeTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
@@ -64,69 +64,69 @@ public class JsonMultiRouteTest {
 
     static class SimpleBean {
 
-        @Route(path = "hello")
-        Multi<String> hello(RoutingContext context) {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().item("Hello world!"));
+        @Route(path = "hello", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<String> hello() {
+            return Multi.createFrom().item("Hello world!");
         }
 
-        @Route(path = "hellos")
-        Multi<String> hellos(RoutingContext context) {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().items("hello", "world", "!"));
+        @Route(path = "hellos", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<String> hellos() {
+            return Multi.createFrom().items("hello", "world", "!");
         }
 
-        @Route(path = "no-hello")
-        Multi<String> noHello(RoutingContext context) {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().empty());
+        @Route(path = "no-hello", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<String> noHello() {
+            return Multi.createFrom().empty();
         }
 
-        @Route(path = "hello-and-fail")
+        @Route(path = "hello-and-fail", produces = ReactiveRoutes.APPLICATION_JSON)
         Multi<String> helloAndFail() {
-            return ReactiveRoutes.asJsonArray(Multi.createBy().concatenating().streams(
+            return Multi.createBy().concatenating().streams(
                     Multi.createFrom().item("Hello"),
-                    Multi.createFrom().failure(new IOException("boom"))));
+                    Multi.createFrom().failure(new IOException("boom")));
         }
 
-        @Route(path = "buffers")
-        Multi<Buffer> buffers(RoutingContext context) {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom()
-                    .items(Buffer.buffer("Buffer"), Buffer.buffer(" Buffer"), Buffer.buffer(" Buffer.")));
+        @Route(path = "buffers", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<Buffer> buffers() {
+            return Multi.createFrom()
+                    .items(Buffer.buffer("Buffer"), Buffer.buffer(" Buffer"), Buffer.buffer(" Buffer."));
         }
 
-        @Route(path = "void")
-        Multi<Void> multiVoid(RoutingContext context) {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().range(0, 200)
-                    .onItem().ignore());
+        @Route(path = "void", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<Void> multiVoid() {
+            return Multi.createFrom().range(0, 200)
+                    .onItem().ignore();
         }
 
-        @Route(path = "/people")
+        @Route(path = "/people", produces = ReactiveRoutes.APPLICATION_JSON)
         Multi<Person> people() {
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().items(
+            return Multi.createFrom().items(
                     new Person("superman", 1),
                     new Person("batman", 2),
-                    new Person("spiderman", 3)));
+                    new Person("spiderman", 3));
         }
 
-        @Route(path = "/people-content-type")
+        @Route(path = "/people-content-type", produces = ReactiveRoutes.APPLICATION_JSON)
         Multi<Person> peopleWithContentType(RoutingContext context) {
             context.response().putHeader("content-type", "application/json;charset=utf-8");
-            return ReactiveRoutes.asJsonArray(Multi.createFrom().items(
+            return Multi.createFrom().items(
                     new Person("superman", 1),
                     new Person("batman", 2),
-                    new Person("spiderman", 3)));
+                    new Person("spiderman", 3));
         }
 
-        @Route(path = "/failure")
-        Multi<Person> fail(RoutingContext context) {
+        @Route(path = "/failure", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<Person> fail() {
             return Multi.createFrom().failure(new IOException("boom"));
         }
 
-        @Route(path = "/sync-failure")
-        Multi<Person> failSync(RoutingContext context) {
+        @Route(path = "/sync-failure", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<Person> failSync() {
             throw new IllegalStateException("boom");
         }
 
-        @Route(path = "/null")
-        Multi<String> uniNull(RoutingContext context) {
+        @Route(path = "/null", produces = ReactiveRoutes.APPLICATION_JSON)
+        Multi<String> uniNull() {
             return null;
         }
 

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithAsJsonStreamTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithAsJsonStreamTest.java
@@ -1,0 +1,166 @@
+package io.quarkus.vertx.web.mutiny;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.ReactiveRoutes;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+public class NdjsonMultiRouteWithAsJsonStreamTest {
+
+    public static final String CONTENT_TYPE_NDJSON = "application/x-ndjson";
+    public static final String CONTENT_TYPE_STREAM_JSON = "application/stream+json";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SimpleBean.class));
+
+    @Test
+    public void testNdjsonMultiRoute() {
+        when().get("/hello").then().statusCode(200)
+                .body(is("\"Hello world!\"\n"))
+                .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_NDJSON);
+
+        when().get("/hellos").then().statusCode(200)
+                .body(containsString(
+                // @formatter:off
+                        "\"hello\"\n"
+                            + "\"world\"\n"
+                            + "\"!\"\n"))
+                        // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_NDJSON);
+
+        when().get("/no-hello").then().statusCode(200).body(hasLength(0))
+                .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_NDJSON);
+
+        // We get the item followed by the exception
+        when().get("/hello-and-fail").then().statusCode(200)
+                .body(containsString("\"Hello\""))
+                .body(not(containsString("boom")));
+
+        when().get("/void").then().statusCode(204).body(hasLength(0));
+
+        when().get("/people").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                                "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"
+                ))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_NDJSON);
+
+        when().get("/people-content-type").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                                "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), is(CONTENT_TYPE_NDJSON + ";charset=utf-8"));
+
+        when().get("/people-content-type-stream-json").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), CONTENT_TYPE_STREAM_JSON);
+
+        when().get("/failure").then().statusCode(500).body(containsString("boom"));
+        when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
+        when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
+    }
+
+    static class SimpleBean {
+
+        @Route(path = "hello")
+        Multi<String> hello(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().item("Hello world!"));
+        }
+
+        @Route(path = "hellos")
+        Multi<String> hellos(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().items("hello", "world", "!"));
+        }
+
+        @Route(path = "no-hello")
+        Multi<String> noHello(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().empty());
+        }
+
+        @Route(path = "hello-and-fail")
+        Multi<String> helloAndFail(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createBy().concatenating().streams(
+                    Multi.createFrom().item("Hello"),
+                    Multi.createFrom().failure(() -> new IOException("boom"))));
+        }
+
+        @Route(path = "void")
+        Multi<Void> multiVoid(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().range(0, 200)
+                    .onItem().ignore());
+        }
+
+        @Route(path = "/people")
+        Multi<Person> people(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/people-content-type")
+        Multi<Person> peopleWithContentType(RoutingContext context) {
+            context.response().putHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_NDJSON + ";charset=utf-8");
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/people-content-type-stream-json", produces = { CONTENT_TYPE_STREAM_JSON })
+        Multi<Person> peopleWithContentTypeStreamJson(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3)));
+        }
+
+        @Route(path = "/failure")
+        Multi<Person> fail(RoutingContext context) {
+            return ReactiveRoutes.asJsonStream(Multi.createFrom().failure(new IOException("boom")));
+        }
+
+        @Route(path = "/sync-failure")
+        Multi<Person> failSync(RoutingContext context) {
+            throw new IllegalStateException("boom");
+        }
+
+        @Route(path = "/null")
+        Multi<String> uniNull(RoutingContext context) {
+            return null;
+        }
+    }
+
+    static class Person {
+        public String name;
+        public int id;
+
+        public Person(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+    }
+
+}

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithContentTypeTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/NdjsonMultiRouteWithContentTypeTest.java
@@ -1,0 +1,167 @@
+package io.quarkus.vertx.web.mutiny;
+
+import static io.quarkus.vertx.web.ReactiveRoutes.JSON_STREAM;
+import static io.quarkus.vertx.web.ReactiveRoutes.ND_JSON;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+public class NdjsonMultiRouteWithContentTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SimpleBean.class));
+
+    @Test
+    public void testNdjsonMultiRoute() {
+        when().get("/hello").then().statusCode(200)
+                .body(is("\"Hello world!\"\n"))
+                .header(HttpHeaders.CONTENT_TYPE.toString(), ND_JSON);
+
+        when().get("/hellos").then().statusCode(200)
+                .body(containsString(
+                // @formatter:off
+                        "\"hello\"\n"
+                            + "\"world\"\n"
+                            + "\"!\"\n"))
+                        // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), ND_JSON);
+
+        when().get("/no-hello").then().statusCode(200).body(hasLength(0))
+                .header(HttpHeaders.CONTENT_TYPE.toString(), ND_JSON);
+
+        // We get the item followed by the exception
+        when().get("/hello-and-fail").then().statusCode(200)
+                .body(containsString("\"Hello\""))
+                .body(not(containsString("boom")));
+
+        when().get("/void").then().statusCode(204).body(hasLength(0));
+
+        when().get("/people").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                                "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"
+                ))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), ND_JSON);
+
+        when().get("/people-content-type").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                                "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), is(ND_JSON + ";charset=utf-8"));
+
+        when().get("/people-content-type-stream-json").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "{\"name\":\"superman\",\"id\":1}\n" +
+                                "{\"name\":\"batman\",\"id\":2}\n" +
+                                "{\"name\":\"spiderman\",\"id\":3}\n"))
+                // @formatter:on
+                .header(HttpHeaders.CONTENT_TYPE.toString(), JSON_STREAM);
+
+        when().get("/failure").then().statusCode(500).body(containsString("boom"));
+        when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
+        when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
+    }
+
+    static class SimpleBean {
+
+        @Route(path = "hello", produces = ND_JSON)
+        Multi<String> hello() {
+            return Multi.createFrom().item("Hello world!");
+        }
+
+        @Route(path = "hellos", produces = ND_JSON)
+        Multi<String> hellos() {
+            return Multi.createFrom().items("hello", "world", "!");
+        }
+
+        @Route(path = "no-hello", produces = ND_JSON)
+        Multi<String> noHello() {
+            return Multi.createFrom().empty();
+        }
+
+        @Route(path = "hello-and-fail", produces = ND_JSON)
+        Multi<String> helloAndFail() {
+            return Multi.createBy().concatenating().streams(
+                    Multi.createFrom().item("Hello"),
+                    Multi.createFrom().failure(() -> new IOException("boom")));
+        }
+
+        @Route(path = "void", produces = ND_JSON)
+        Multi<Void> multiVoid() {
+            return Multi.createFrom().range(0, 200)
+                    .onItem().ignore();
+        }
+
+        @Route(path = "/people", produces = ND_JSON)
+        Multi<Person> people() {
+            return Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3));
+        }
+
+        @Route(path = "/people-content-type", produces = ND_JSON)
+        Multi<Person> peopleWithContentType(RoutingContext context) {
+            context.response().putHeader(HttpHeaders.CONTENT_TYPE, ND_JSON + ";charset=utf-8");
+            return Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3));
+        }
+
+        @Route(path = "/people-content-type-stream-json", produces = { JSON_STREAM })
+        Multi<Person> peopleWithContentTypeStreamJson() {
+            return Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3));
+        }
+
+        @Route(path = "/failure", produces = ND_JSON)
+        Multi<Person> fail() {
+            return Multi.createFrom().failure(new IOException("boom"));
+        }
+
+        @Route(path = "/sync-failure", produces = ND_JSON)
+        Multi<Person> failSync() {
+            throw new IllegalStateException("boom");
+        }
+
+        @Route(path = "/null", produces = ND_JSON)
+        Multi<String> uniNull() {
+            return null;
+        }
+    }
+
+    static class Person {
+        public String name;
+        public int id;
+
+        public Person(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+    }
+
+}

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithAsEventStreamTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithAsEventStreamTest.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Multi;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
 
-public class SSEMultiRouteTest {
+public class SSEMultiRouteWithAsEventStreamTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithContentTypeTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/mutiny/SSEMultiRouteWithContentTypeTest.java
@@ -1,0 +1,295 @@
+package io.quarkus.vertx.web.mutiny;
+
+import static io.quarkus.vertx.web.ReactiveRoutes.EVENT_STREAM;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.ReactiveRoutes;
+import io.quarkus.vertx.web.Route;
+import io.smallrye.mutiny.Multi;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.RoutingContext;
+
+public class SSEMultiRouteWithContentTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(SimpleBean.class));
+
+    @Test
+    public void testSSEMultiRoute() {
+        when().get("/hello").then().statusCode(200)
+                .body(is("data: Hello world!\nid: 0\n\n"))
+                .header("content-type", "text/event-stream");
+
+        when().get("/hellos").then().statusCode(200)
+                .body(containsString(
+                // @formatter:off
+                        "data: hello\nid: 0\n\n"
+                            + "data: world\nid: 1\n\n"
+                            + "data: !\nid: 2\n\n"))
+                        // @formatter:on
+                .header("content-type", "text/event-stream");
+
+        when().get("/no-hello").then().statusCode(200).body(hasLength(0))
+                .header("content-type", "text/event-stream");
+
+        // We get the item followed by the exception
+        when().get("/hello-and-fail").then().statusCode(200)
+                .body(containsString("id: 0"))
+                .body(not(containsString("boom")));
+
+        when().get("/buffer").then().statusCode(200)
+                .body(is("data: Buffer\nid: 0\n\n"))
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/buffers").then().statusCode(200)
+                .body(is("data: Buffer\nid: 0\n\ndata: Buffer\nid: 1\n\ndata: Buffer.\nid: 2\n\n"))
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/mutiny-buffer").then().statusCode(200)
+                .body(is("data: Buffer\nid: 0\n\ndata: Mutiny\nid: 1\n\n"))
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/void").then().statusCode(204).body(hasLength(0));
+
+        when().get("/people").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                                "data: {\"name\":\"superman\",\"id\":1}\nid: 0\n\n" +
+                                "data: {\"name\":\"batman\",\"id\":2}\nid: 1\n\n" +
+                                "data: {\"name\":\"spiderman\",\"id\":3}\nid: 2\n\n"))
+                        // @formatter:on
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/people-content-type").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "data: {\"name\":\"superman\",\"id\":1}\nid: 0\n\n" +
+                                "data: {\"name\":\"batman\",\"id\":2}\nid: 1\n\n" +
+                                "data: {\"name\":\"spiderman\",\"id\":3}\nid: 2\n\n"))
+                // @formatter:on
+                .header("content-type", is("text/event-stream;charset=utf-8"));
+
+        when().get("/people-as-event").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "event: person\ndata: {\"name\":\"superman\",\"id\":1}\nid: 1\n\n" +
+                                "event: person\ndata: {\"name\":\"batman\",\"id\":2}\nid: 2\n\n" +
+                                "event: person\ndata: {\"name\":\"spiderman\",\"id\":3}\nid: 3\n\n"))
+                // @formatter:on
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/people-as-event-without-id").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "event: person\ndata: {\"name\":\"superman\",\"id\":1}\nid: 0\n\n" +
+                                "event: person\ndata: {\"name\":\"batman\",\"id\":2}\nid: 1\n\n" +
+                                "event: person\ndata: {\"name\":\"spiderman\",\"id\":3}\nid: 2\n\n"))
+                // @formatter:on
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/people-as-event-without-event").then().statusCode(200)
+                .body(is(
+                // @formatter:off
+                        "data: {\"name\":\"superman\",\"id\":1}\nid: 1\n\n" +
+                                "data: {\"name\":\"batman\",\"id\":2}\nid: 2\n\n" +
+                                "data: {\"name\":\"spiderman\",\"id\":3}\nid: 3\n\n"))
+                // @formatter:on
+                .header("content-type", is("text/event-stream"));
+
+        when().get("/failure").then().statusCode(500).body(containsString("boom"));
+        when().get("/null").then().statusCode(500).body(containsString(NullPointerException.class.getName()));
+        when().get("/sync-failure").then().statusCode(500).body(containsString("boom"));
+
+    }
+
+    static class SimpleBean {
+
+        @Route(path = "hello", produces = EVENT_STREAM)
+        Multi<String> hello() {
+            return Multi.createFrom().item("Hello world!");
+        }
+
+        @Route(path = "hellos", produces = EVENT_STREAM)
+        Multi<String> hellos() {
+            return Multi.createFrom().items("hello", "world", "!");
+        }
+
+        @Route(path = "no-hello", produces = EVENT_STREAM)
+        Multi<String> noHello() {
+            return Multi.createFrom().empty();
+        }
+
+        @Route(path = "hello-and-fail", produces = EVENT_STREAM)
+        Multi<String> helloAndFail() {
+            return Multi.createBy().concatenating().streams(
+                    Multi.createFrom().item("Hello"),
+                    Multi.createFrom().failure(() -> new IOException("boom")));
+        }
+
+        @Route(path = "buffer", produces = EVENT_STREAM)
+        Multi<Buffer> buffer() {
+            return Multi.createFrom().item(Buffer.buffer("Buffer"));
+        }
+
+        @Route(path = "buffers", produces = EVENT_STREAM)
+        Multi<Buffer> buffers() {
+            return Multi.createFrom()
+                    .items(Buffer.buffer("Buffer"), Buffer.buffer("Buffer"), Buffer.buffer("Buffer."));
+        }
+
+        @Route(path = "mutiny-buffer", produces = EVENT_STREAM)
+        Multi<io.vertx.mutiny.core.buffer.Buffer> bufferMutiny() {
+            return Multi.createFrom().items(io.vertx.mutiny.core.buffer.Buffer.buffer("Buffer"),
+                    io.vertx.mutiny.core.buffer.Buffer.buffer("Mutiny"));
+        }
+
+        @Route(path = "void", produces = EVENT_STREAM)
+        Multi<Void> multiVoid() {
+            return Multi.createFrom().range(0, 200).onItem().ignore();
+        }
+
+        @Route(path = "/people", produces = EVENT_STREAM)
+        Multi<Person> people() {
+            return Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3));
+        }
+
+        @Route(path = "/people-as-event", produces = EVENT_STREAM)
+        Multi<PersonAsEvent> peopleAsEvent() {
+            return Multi.createFrom().items(
+                    new PersonAsEvent("superman", 1),
+                    new PersonAsEvent("batman", 2),
+                    new PersonAsEvent("spiderman", 3));
+        }
+
+        @Route(path = "/people-as-event-without-id", produces = EVENT_STREAM)
+        Multi<PersonAsEventWithoutId> peopleAsEventWithoutId() {
+            return Multi.createFrom().items(
+                    new PersonAsEventWithoutId("superman", 1),
+                    new PersonAsEventWithoutId("batman", 2),
+                    new PersonAsEventWithoutId("spiderman", 3));
+        }
+
+        @Route(path = "/people-as-event-without-event", produces = EVENT_STREAM)
+        Multi<PersonAsEventWithoutEvent> peopleAsEventWithoutEvent() {
+            return Multi.createFrom().items(
+                    new PersonAsEventWithoutEvent("superman", 1),
+                    new PersonAsEventWithoutEvent("batman", 2),
+                    new PersonAsEventWithoutEvent("spiderman", 3));
+        }
+
+        @Route(path = "/people-content-type", produces = EVENT_STREAM)
+        Multi<Person> peopleWithContentType(RoutingContext context) {
+            context.response().putHeader("content-type", "text/event-stream;charset=utf-8");
+            return Multi.createFrom().items(
+                    new Person("superman", 1),
+                    new Person("batman", 2),
+                    new Person("spiderman", 3));
+        }
+
+        @Route(path = "/failure", produces = EVENT_STREAM)
+        Multi<Person> fail() {
+            return Multi.createFrom().failure(new IOException("boom"));
+        }
+
+        @Route(path = "/sync-failure", produces = EVENT_STREAM)
+        Multi<Person> failSync() {
+            throw new IllegalStateException("boom");
+        }
+
+        @Route(path = "/null", produces = EVENT_STREAM)
+        Multi<String> uniNull() {
+            return null;
+        }
+
+    }
+
+    static class Person {
+        public String name;
+        public int id;
+
+        public Person(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+    }
+
+    static class PersonAsEvent implements ReactiveRoutes.ServerSentEvent<Person> {
+        public String name;
+        public int id;
+
+        public PersonAsEvent(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        @Override
+        public Person data() {
+            return new Person(name, id);
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+
+        @Override
+        public String event() {
+            return "person";
+        }
+    }
+
+    static class PersonAsEventWithoutId implements ReactiveRoutes.ServerSentEvent<Person> {
+        public String name;
+        public int id;
+
+        public PersonAsEventWithoutId(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        @Override
+        public Person data() {
+            return new Person(name, id);
+        }
+
+        @Override
+        public String event() {
+            return "person";
+        }
+    }
+
+    static class PersonAsEventWithoutEvent implements ReactiveRoutes.ServerSentEvent<Person> {
+        public String name;
+        public int id;
+
+        public PersonAsEventWithoutEvent(String name, int id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        @Override
+        public Person data() {
+            return new Person(name, id);
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+    }
+
+}

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/ReactiveRoutes.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/ReactiveRoutes.java
@@ -12,6 +12,74 @@ import io.smallrye.mutiny.Multi;
  */
 public class ReactiveRoutes {
 
+    /**
+     * The content-type to use to indicate you want to produce an JSON Array response, such as in:
+     * 
+     * <pre>
+     * {@code
+     * &#64;Route(path = "/heroes", produces = ReactiveRoutes.APPLICATION_JSON_CONTENT_TYPE)
+     * Multi<Person> heroes() {
+     *     return Multi.createFrom().items(
+     *             new Person("superman", 1),
+     *             new Person("batman", 2),
+     *             new Person("spiderman", 3));
+     * }
+     * }
+     * </pre>
+     *
+     * Note that the array is streamed object per object.
+     * Each object is written individually in the response, until the last one.
+     */
+    public static final String APPLICATION_JSON = "application/json";
+
+    /**
+     * The content-type to use to indicate you want to produce a server-sent-event (SSE) stream response, such as in:
+     * 
+     * <pre>
+     * {@code
+     * &#64;Route(path = "/heroes", produces = ReactiveRoutes.EVENT_STREAM_CONTENT_TYPE)
+     * Multi<Person> heroes() {
+     *     return Multi.createFrom().items(
+     *             new Person("superman", 1),
+     *             new Person("batman", 2),
+     *             new Person("spiderman", 3));
+     * }
+     * }
+     * </pre>
+     *
+     */
+    public static final String EVENT_STREAM = "text/event-stream";
+
+    /**
+     * The content-type to use to indicate you want to produce <a href="http://ndjson.org/">NDJSON stream</a> response,
+     * such as in:
+     * 
+     * <pre>
+     * {@code
+     * &#64;Route(path = "/heroes", produces = ReactiveRoutes.ND_JSON_CONTENT_TYPE)
+     * Multi<Person> heroes() {
+     *     return Multi.createFrom().items(
+     *             new Person("superman", 1),
+     *             new Person("batman", 2),
+     *             new Person("spiderman", 3));
+     * }
+     * }
+     * </pre>
+     *
+     * NDJSON stands for <em>Newline Delimited JSON</em>.
+     * NDJSON is a convenient format for storing or streaming structured data that may be processed one record at a time:
+     * <ol>
+     * <li>Line Separator is '\n',</li>
+     * <li>Each Line is a valid JSON value.</li>
+     * </ol>
+     */
+    public static final String ND_JSON = "application/x-ndjson";
+
+    /**
+     * A content-type providing the same output as {@link #ND_JSON}.
+     */
+    public static final String JSON_STREAM = "application/stream+json";
+
     private ReactiveRoutes() {
         // Avoid direct instantiation.
     }
@@ -48,7 +116,10 @@ public class ReactiveRoutes {
      * @param multi the multi to be written
      * @param <T> the type of item, can be string, buffer, object or io.quarkus.vertx.web.ReactiveRoutes.ServerSentEvent
      * @return the wrapped multi
+     * @deprecated Instead, set the `produces` attribute of the {@link Route} annotation to
+     *             {@link ReactiveRoutes#EVENT_STREAM} and return a <em>plain</em> Multi.
      */
+    @Deprecated
     public static <T> Multi<T> asEventStream(Multi<T> multi) {
         return new SSEMulti<>(Objects.requireNonNull(multi, "The passed multi must not be `null`"));
     }
@@ -85,7 +156,10 @@ public class ReactiveRoutes {
      * @param multi the multi to be written
      * @param <T> the type of item, can be string, object
      * @return the wrapped multi
+     * @deprecated Instead, set the `produces` attribute of the {@link Route} annotation to
+     *             {@link ReactiveRoutes#ND_JSON} and return a <em>plain</em> Multi.
      */
+    @Deprecated
     public static <T> Multi<T> asJsonStream(Multi<T> multi) {
         return new NdjsonMulti<>(Objects.requireNonNull(multi, "The passed multi must not be `null`"));
     }
@@ -118,7 +192,10 @@ public class ReactiveRoutes {
      * @param multi the multi to be written
      * @param <T> the type of item, can be string or object
      * @return the wrapped multi
+     * @deprecated Instead, set the `produces` attribute of the {@link Route} annotation to
+     *             {@link ReactiveRoutes#APPLICATION_JSON} and return a <em>plain</em> Multi.
      */
+    @Deprecated
     public static <T> Multi<T> asJsonArray(Multi<T> multi) {
         return new JsonArrayMulti<>(Objects.requireNonNull(multi, "The passed multi must not be `null`"));
     }

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/Route.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/Route.java
@@ -131,12 +131,26 @@ public @interface Route {
     int order() default 0;
 
     /**
-     * Used for content-based routing.
+     * Used for content-based routing and stream serialization.
      * <p>
-     * If no {@code Content-Type} header is set then try to use the most acceptable content type.
+     * If no {@code Content-Type} header is set then try to use the most acceptable content-type.
      *
      * If the request does not contain an 'Accept' header and no content type is explicitly set in the
      * handler then the content type will be set to the first content type in the array.
+     *
+     * When a route returns a {@link io.smallrye.mutiny.Multi}, this attribute is used to define how that stream is
+     * serialized. In this case, accepted values are:
+     * <ul>
+     * <li>{@link ReactiveRoutes#APPLICATION_JSON} - Encode the response into a JSON Array, where each item is sent one by
+     * one,</li>
+     * <li>{@link ReactiveRoutes#EVENT_STREAM} - Encode the response as a stream of server-sent-events,</li>
+     * <li>{@link ReactiveRoutes#ND_JSON} or {@link ReactiveRoutes#JSON_STREAM} - Encode the response as JSON stream,
+     * when each item is sent one by one with a `\n` as delimiter between them</li>
+     * </ul>
+     *
+     * When this attribute is not set, and the route returns a {@link io.smallrye.mutiny.Multi}, no special serialization is
+     * applied.
+     * The items are sent one-by-one without delimiters.
      * 
      * @see io.vertx.ext.web.Route#produces(String)
      * @see RoutingContext#getAcceptableContentType()


### PR DESCRIPTION
Provide another way to generate streams from Reactive Routes that do not require a specific Multi sub-type.

Sub-typing Multi does not work when the route is protected using @RolesAllowed as the security interceptor changes the returned Multi actual type.

The previous approach is still supported but is deprecated. The documentation mentions the new approach and explains why the previous approach should be avoided.

CC @michalszynkiewicz 

Fix #21044 