### PR TITLE
Make sure quarkus-extension.yaml can be parsed using CatalogMapperHelper

### DIFF
--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTestBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTestBuilder.java
@@ -209,15 +209,13 @@ public class QuarkusCodestartTestBuilder {
             Objects.requireNonNull(buildWithQuarkusCoreVersion, "quarkus version not found in extensions");
             String quarkusVersion = quarkusBomVersion != null ? quarkusBomVersion : buildWithQuarkusCoreVersion;
             enableRegistryClientTestConfig(quarkusBomGroupId != null ? quarkusBomGroupId : "io.quarkus", quarkusVersion);
-            final ExtensionCatalog extensionCatalog = QuarkusProjectHelper
-                    .getExtensionCatalog(quarkusVersion);
+            final ExtensionCatalog extensionCatalog = QuarkusProjectHelper.getExtensionCatalog(quarkusVersion);
             disableRegistryClientTestConfig();
-            if (!(extensionCatalog instanceof ExtensionCatalog.Mutable)) {
-                throw new IllegalStateException("Problem with the given ExtensionCatalog type");
-            }
-            extensions.addAll(extensionCatalog.getExtensions());
-            ((ExtensionCatalog.Mutable) extensionCatalog).setExtensions(extensions);
-            this.extensionCatalog = extensionCatalog;
+            final ExtensionCatalog.Mutable mutableCatalog = extensionCatalog instanceof ExtensionCatalog.Mutable
+                    ? (ExtensionCatalog.Mutable) extensionCatalog
+                    : extensionCatalog.mutable();
+            extensions.forEach(mutableCatalog::addExtension);
+            this.extensionCatalog = mutableCatalog.build();
         } catch (IOException e) {
             throw new IllegalStateException("Error while reading standalone extension catalog", e);
         }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CatalogMapperHelper.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/CatalogMapperHelper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.json.JsonArtifactCoordsMixin;
 import java.io.BufferedReader;
@@ -19,9 +20,18 @@ import java.nio.file.Path;
 public class CatalogMapperHelper {
 
     private static ObjectMapper mapper;
+    private static ObjectMapper yamlMapper;
 
     public static ObjectMapper mapper() {
         return mapper == null ? mapper = initMapper(new ObjectMapper()) : mapper;
+    }
+
+    private static ObjectMapper yamlMapper() {
+        return yamlMapper == null ? yamlMapper = initMapper(new ObjectMapper(new YAMLFactory())) : yamlMapper;
+    }
+
+    private static ObjectMapper mapperForPath(Path p) {
+        return p.getFileName().toString().endsWith("json") ? mapper() : yamlMapper();
     }
 
     public static ObjectMapper initMapper(ObjectMapper mapper) {
@@ -35,7 +45,7 @@ public class CatalogMapperHelper {
     }
 
     public static void serialize(Object catalog, Path p) throws IOException {
-        serialize(mapper(), catalog, p);
+        serialize(mapperForPath(p), catalog, p);
     }
 
     public static void serialize(ObjectMapper mapper, Object catalog, Path p) throws IOException {
@@ -56,7 +66,7 @@ public class CatalogMapperHelper {
     }
 
     public static <T> T deserialize(Path p, Class<T> t) throws IOException {
-        return deserialize(mapper(), p, t);
+        return deserialize(mapperForPath(p), p, t);
     }
 
     public static <T> T deserialize(ObjectMapper mapper, Path p, Class<T> t) throws IOException {

--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/catalog/ExtensionTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/catalog/ExtensionTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.registry.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.maven.ArtifactCoords;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionTest {
+
+    static Path baseDir = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("src/test/resources/extension");
+
+    @Test
+    void deserializeYamlFile() throws Exception {
+
+        final Path extYaml = baseDir.resolve("quarkus-extension.yaml");
+        assertThat(extYaml).exists();
+
+        final Extension e = Extension.fromFile(extYaml);
+        assertThat(e.getArtifact()).isEqualTo(new ArtifactCoords("io.quarkus", "quarkus-resteasy-reactive", "999-PLACEHOLDER"));
+        final Map<String, Object> metadata = e.getMetadata();
+        assertThat(metadata.get("short-name")).isEqualTo("resteasy-reactive");
+    }
+}

--- a/independent-projects/tools/registry-client/src/test/resources/extension/quarkus-extension.yaml
+++ b/independent-projects/tools/registry-client/src/test/resources/extension/quarkus-extension.yaml
@@ -1,0 +1,41 @@
+---
+name: "RESTEasy Reactive"
+artifact: "io.quarkus:quarkus-resteasy-reactive:999-PLACEHOLDER"
+metadata:
+  short-name: "resteasy-reactive"
+  keywords:
+  - "jaxrs"
+  - "web"
+  - "rest"
+  categories:
+  - "web"
+  - "reactive"
+  status: "stable"
+  guide: "https://quarkus.io/guides/resteasy-reactive"
+  codestart:
+    name: "resteasy-reactive"
+    languages:
+    - "java"
+    - "kotlin"
+    - "scala"
+    artifact: "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-SNAPSHOT"
+  config:
+  - "quarkus.resteasy-reactive."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.rest"
+    - "io.quarkus.resteasy.reactive"
+  extension-dependencies:
+  - "io.quarkus:quarkus-resteasy-reactive-common"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+  - "io.quarkus:quarkus-vertx"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-netty"
+  - "io.quarkus:quarkus-vertx-http"
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-jsonp"
+description: "Reactive implementation of JAX-RS with additional features. This extension\
+  \ is not compatible with the quarkus-resteasy extension, or any of the extensions\
+  \ that depend on it."


### PR DESCRIPTION
This fixes a regression in codestart testing when `quarkus-extension.yaml` are parsed after the extension catalog API and JSON binding refactoring change.