### PR TITLE
Unbind some useless Maven plugin executions from integration-test modules

### DIFF
--- a/integration-tests/class-transformer/deployment/disable-unbind-executions
+++ b/integration-tests/class-transformer/deployment/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/class-transformer/disable-unbind-executions
+++ b/integration-tests/class-transformer/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/class-transformer/runtime/disable-unbind-executions
+++ b/integration-tests/class-transformer/runtime/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/common-jpa-entities/disable-unbind-executions
+++ b/integration-tests/common-jpa-entities/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/disable-unbind-executions
+++ b/integration-tests/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/legacy-app/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/legacy-app/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/legacy-library-a/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/legacy-library-a/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/legacy-library-b/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/legacy-library-b/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/modern-app/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/modern-app/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/modern-library-a/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/modern-library-a/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/jpa-mapping-xml/modern-library-b/disable-unbind-executions
+++ b/integration-tests/jpa-mapping-xml/modern-library-b/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -354,5 +354,49 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- "unbind" all default executions that make no sense for (most) integration-tests -->
+        <profile>
+            <id>unbind-executions</id>
+            <activation>
+                <file>
+                    <missing>${basedir}/disable-unbind-executions</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-jar</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-install</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/shared-library/disable-unbind-executions
+++ b/integration-tests/shared-library/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.


### PR DESCRIPTION
Should also lower the memory pressure in CI.

The main motivation to do that are the Java heap space issues we've been seeing lately.
Most of the time those were happening in the `docs` module which isn't part of the JVM Test runs anymore (since #21498),
but I've also seen those errors in other jar packaging executions.

This opt out via flagfile istn't pretty, but the same approach is used to configure the native build.
I could alternatively pull out those phase values into properties ("none" by default) and let the respective modules reset them to the proper values, but that seems a bit brittle.