### PR TITLE
Spring Data: Fix interface projection using Page and Slice

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/AbstractMethodsAdder.java
@@ -143,7 +143,8 @@ public abstract class AbstractMethodsAdder {
                     MethodDescriptor.ofMethod(Optional.class, "empty", Optional.class));
             catchBlock.returnValue(emptyOptional);
         } else if (DotNames.LIST.equals(returnType) || DotNames.COLLECTION.equals(returnType)
-                || DotNames.SET.equals(returnType) || DotNames.ITERATOR.equals(returnType)) {
+                || DotNames.SET.equals(returnType) || DotNames.ITERATOR.equals(returnType)
+                || DotNames.SPRING_DATA_PAGE.equals(returnType) || DotNames.SPRING_DATA_SLICE.equals(returnType)) {
             ResultHandle list;
 
             if (customResultType == null) {
@@ -188,6 +189,34 @@ public abstract class AbstractMethodsAdder {
                 ResultHandle set = methodCreator.newInstance(
                         MethodDescriptor.ofConstructor(LinkedHashSet.class, Collection.class), list);
                 methodCreator.returnValue(set);
+            } else if (DotNames.SPRING_DATA_PAGE.equals(returnType)) {
+                ResultHandle pageResult;
+                if (pageableParameterIndex != null) {
+                    ResultHandle count = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(PanacheQuery.class, "count", long.class),
+                            panacheQuery);
+                    pageResult = methodCreator.newInstance(
+                            MethodDescriptor.ofConstructor(PageImpl.class, List.class, Pageable.class, long.class),
+                            list, methodCreator.getMethodParam(pageableParameterIndex), count);
+                } else {
+                    pageResult = methodCreator.newInstance(MethodDescriptor.ofConstructor(PageImpl.class, List.class), list);
+                }
+
+                methodCreator.returnValue(pageResult);
+            } else if (DotNames.SPRING_DATA_SLICE.equals(returnType)) {
+                ResultHandle sliceResult;
+                if (pageableParameterIndex != null) {
+                    ResultHandle hasNextPage = methodCreator.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(PanacheQuery.class, "hasNextPage", boolean.class),
+                            panacheQuery);
+                    sliceResult = methodCreator.newInstance(
+                            MethodDescriptor.ofConstructor(SliceImpl.class, List.class, Pageable.class, boolean.class),
+                            list, methodCreator.getMethodParam(pageableParameterIndex), hasNextPage);
+                } else {
+                    sliceResult = methodCreator.newInstance(MethodDescriptor.ofConstructor(SliceImpl.class, List.class), list);
+                }
+
+                methodCreator.returnValue(sliceResult);
             }
             methodCreator.returnValue(list);
 
@@ -197,41 +226,6 @@ public abstract class AbstractMethodsAdder {
                     panacheQuery);
             methodCreator.returnValue(stream);
 
-        } else if (DotNames.SPRING_DATA_PAGE.equals(returnType)) {
-            ResultHandle list = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(PanacheQuery.class, "list", List.class),
-                    panacheQuery);
-            ResultHandle pageResult;
-            if (pageableParameterIndex != null) {
-                ResultHandle count = methodCreator.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(PanacheQuery.class, "count", long.class),
-                        panacheQuery);
-                pageResult = methodCreator.newInstance(
-                        MethodDescriptor.ofConstructor(PageImpl.class, List.class, Pageable.class, long.class),
-                        list, methodCreator.getMethodParam(pageableParameterIndex), count);
-            } else {
-                pageResult = methodCreator.newInstance(MethodDescriptor.ofConstructor(PageImpl.class, List.class), list);
-            }
-
-            methodCreator.returnValue(pageResult);
-
-        } else if (DotNames.SPRING_DATA_SLICE.equals(returnType)) {
-            ResultHandle list = methodCreator.invokeInterfaceMethod(
-                    MethodDescriptor.ofMethod(PanacheQuery.class, "list", List.class),
-                    panacheQuery);
-            ResultHandle sliceResult;
-            if (pageableParameterIndex != null) {
-                ResultHandle hasNextPage = methodCreator.invokeInterfaceMethod(
-                        MethodDescriptor.ofMethod(PanacheQuery.class, "hasNextPage", boolean.class),
-                        panacheQuery);
-                sliceResult = methodCreator.newInstance(
-                        MethodDescriptor.ofConstructor(SliceImpl.class, List.class, Pageable.class, boolean.class),
-                        list, methodCreator.getMethodParam(pageableParameterIndex), hasNextPage);
-            } else {
-                sliceResult = methodCreator.newInstance(MethodDescriptor.ofConstructor(SliceImpl.class, List.class), list);
-            }
-
-            methodCreator.returnValue(sliceResult);
         } else if (isHibernateSupportedReturnType(returnType)) {
             ResultHandle singleResult = methodCreator.invokeInterfaceMethod(
                     MethodDescriptor.ofMethod(PanacheQuery.class, "singleResult", Object.class),

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/BasicTypeDataRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/BasicTypeDataRepository.java
@@ -2,11 +2,15 @@ package io.quarkus.spring.data.deployment;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -22,4 +26,13 @@ public interface BasicTypeDataRepository extends JpaRepository<BasicTypeData, In
 
     @Query("select timeZone from BasicTypeData where locale = ?1")
     Set<TimeZone> timeZonesByLocale(Locale locale);
+
+    @Query(value = "select id, doubleValue from BasicTypeData")
+    List<WithDoubleValue> findAllDoubleValuesToList();
+
+    @Query(value = "select id, doubleValue from BasicTypeData", countQuery = "select count(*) from BasicTypeData")
+    Page<WithDoubleValue> findAllDoubleValuesToPage(Pageable pageable);
+
+    @Query(value = "select id, doubleValue from BasicTypeData", countQuery = "select count(*) from BasicTypeData")
+    Slice<WithDoubleValue> findAllDoubleValuesToSlice(Pageable pageable);
 }

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/WithDoubleValue.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/WithDoubleValue.java
@@ -1,0 +1,7 @@
+package io.quarkus.spring.data.deployment;
+
+public interface WithDoubleValue {
+    Integer getId();
+
+    Double getDoubleValue();
+}


### PR DESCRIPTION
The interface project worked fine using Lists, but not using Page and Slice. Example:

```java
@Repository
public interface BasicTypeDataRepository extends CrudRepository<BasicTypeData, Integer> {

    // works
    @Query(value = "select id, doubleValue from BasicTypeData")
    List<WithDoubleValue> findAllDoubleValuesToList();

   // it does not work (1)
    @Query(value = "select id, doubleValue from BasicTypeData")
    Page<WithDoubleValue> findAllDoubleValuesToPage();
}
```

This PR fixes the interface projection when returning a Page object (1).

Fixes https://github.com/quarkusio/quarkus/issues/21616