### PR TITLE
Code cleanup with small performance improvements

### DIFF
--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaIdentityProvider.java
@@ -2,8 +2,6 @@ package io.quarkus.amazon.lambda.http;
 
 import java.util.Optional;
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
-
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanArchiveProcessor.java
@@ -109,9 +109,7 @@ public class BeanArchiveProcessor {
                 .initBeanDefiningAnnotations(additionalBeanDefiningAnnotations.stream()
                         .map(bda -> new BeanDefiningAnnotation(bda.getName(), bda.getDefaultScope()))
                         .collect(Collectors.toList()), stereotypes);
-        for (DotName customScopeAnnotationName : customScopes.getCustomScopeNames()) {
-            beanDefiningAnnotations.add(customScopeAnnotationName);
-        }
+        beanDefiningAnnotations.addAll(customScopes.getCustomScopeNames());
         // Also include archives that are not bean archives but contain qualifiers or interceptor bindings
         beanDefiningAnnotations.add(DotNames.QUALIFIER);
         beanDefiningAnnotations.add(DotNames.INTERCEPTOR_BINDING);

--- a/extensions/elasticsearch-rest-client-common/runtime/src/main/java/io/quarkus/elasticsearch/restclient/common/runtime/graal/Substitute_RestClient.java
+++ b/extensions/elasticsearch-rest-client-common/runtime/src/main/java/io/quarkus/elasticsearch/restclient/common/runtime/graal/Substitute_RestClient.java
@@ -1,8 +1,6 @@
 package io.quarkus.elasticsearch.restclient.common.runtime.graal;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/extensions/elasticsearch-rest-client-common/runtime/src/main/java/io/quarkus/elasticsearch/restclient/common/runtime/graal/Substitute_RestClient.java
+++ b/extensions/elasticsearch-rest-client-common/runtime/src/main/java/io/quarkus/elasticsearch/restclient/common/runtime/graal/Substitute_RestClient.java
@@ -57,8 +57,7 @@ final class Substitute_RestClient {
             nodesByHost.put(node.getHost(), node);
             authCache.put(node.getHost(), new BasicScheme());
         }
-        this.nodeTuple = new NodeTuple<>(Collections.unmodifiableList(new ArrayList<>(nodesByHost.values())),
-                authCache);
+        this.nodeTuple = new NodeTuple<>(List.copyOf(nodesByHost.values()), authCache);
         this.blacklist.clear();
     }
 

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -350,9 +350,7 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                                 responseEvent.put(dsName, outputCloudEvent.dataSchema());
                             }
 
-                            outputCloudEvent.extensions()
-                                    .entrySet()
-                                    .forEach(e -> responseEvent.put(e.getKey(), e.getValue()));
+                            responseEvent.putAll(outputCloudEvent.extensions());
 
                             String dataContentType = outputCloudEvent.dataContentType();
                             if (dataContentType != null) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/recording/PrevalidatedQuarkusMetadata.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import org.hibernate.MappingException;
 import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.internal.MetadataImpl;
 import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.infinispan.client.deployment.devservices;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/Utils_socketHandler.java
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/java/io/quarkus/jdbc/mariadb/runtime/graal/Utils_socketHandler.java
@@ -1,7 +1,6 @@
 package io.quarkus.jdbc.mariadb.runtime.graal;
 
 import org.mariadb.jdbc.internal.io.socket.SocketHandlerFunction;
-import org.mariadb.jdbc.internal.util.Utils;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;

--- a/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
+++ b/extensions/kubernetes-config/deployment/src/main/java/io/quarkus/kubernetes/config/deployment/KubernetesConfigProcessor.java
@@ -1,7 +1,7 @@
 package io.quarkus.kubernetes.config.deployment;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.jboss.logmanager.Level;
 
@@ -43,7 +43,7 @@ public class KubernetesConfigProcessor {
                     new KubernetesRoleBuildItem.PolicyRule(
                             Collections.singletonList(""),
                             Collections.singletonList("secrets"),
-                            Arrays.asList("get")))));
+                            List.of("get")))));
             roleBindingProducer.produce(new KubernetesRoleBindingBuildItem("view-secrets", false));
         }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MinikubeManifestGenerator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/MinikubeManifestGenerator.java
@@ -1,7 +1,5 @@
 package io.quarkus.kubernetes.deployment;
 
-import static io.quarkus.kubernetes.deployment.Constants.MINIKUBE;
-
 import java.util.Optional;
 
 import io.dekorate.AbstractKubernetesManifestGenerator;

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/HttpBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/HttpBinderProcessor.java
@@ -22,7 +22,6 @@ import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 import io.quarkus.micrometer.runtime.config.runtime.HttpClientConfig;
 import io.quarkus.micrometer.runtime.config.runtime.HttpServerConfig;
 import io.quarkus.micrometer.runtime.config.runtime.VertxConfig;
-import io.quarkus.vertx.http.deployment.FilterBuildItem;
 
 /**
  * Avoid directly referencing optional dependencies

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MetricDescriptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MetricDescriptor.java
@@ -1,7 +1,6 @@
 package io.quarkus.micrometer.runtime.binder.mpmetrics;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -68,7 +67,7 @@ class MetricDescriptor {
     }
 
     public String toString() {
-        return name + Arrays.asList(tags);
+        return name + List.of(tags);
     }
 
     // Deal with ubiquitous MetricID containing nefarious TreeSet and arbitrary

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MpMetricsRegistryProducer.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MpMetricsRegistryProducer.java
@@ -1,7 +1,5 @@
 package io.quarkus.micrometer.runtime.binder.mpmetrics;
 
-import java.util.*;
-
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 

--- a/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
+++ b/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/NarayanaJtaRecorder.java
@@ -2,7 +2,6 @@ package io.quarkus.narayana.jta.runtime;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.logging.Logger;
@@ -38,9 +37,7 @@ public class NarayanaJtaRecorder {
     public void setDefaultProperties(Properties properties) {
         //TODO: this is a huge hack to avoid loading XML parsers
         //this needs a proper SPI
-        for (Map.Entry<Object, Object> i : System.getProperties().entrySet()) {
-            properties.put(i.getKey(), i.getValue());
-        }
+        properties.putAll(System.getProperties());
 
         try {
             Field field = PropertiesFactory.class.getDeclaredField("delegatePropertiesFactory");

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -586,15 +585,15 @@ public class KeycloakDevServicesProcessor {
         ClientRepresentation client = new ClientRepresentation();
 
         client.setClientId(clientId);
-        client.setRedirectUris(Arrays.asList("*"));
+        client.setRedirectUris(List.of("*"));
         client.setPublicClient(false);
         client.setSecret(oidcClientSecret);
         client.setDirectAccessGrantsEnabled(true);
         client.setServiceAccountsEnabled(true);
         client.setImplicitFlowEnabled(true);
         client.setEnabled(true);
-        client.setRedirectUris(Arrays.asList("*"));
-        client.setDefaultClientScopes(Arrays.asList("microprofile-jwt"));
+        client.setRedirectUris(List.of("*"));
+        client.setDefaultClientScopes(List.of("microprofile-jwt"));
 
         return client;
     }
@@ -605,7 +604,7 @@ public class KeycloakDevServicesProcessor {
         user.setUsername(username);
         user.setEnabled(true);
         user.setCredentials(new ArrayList<>());
-        user.setRealmRoles(Arrays.asList(realmRoles));
+        user.setRealmRoles(List.of(realmRoles));
 
         CredentialRepresentation credential = new CredentialRepresentation();
 

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TestSpanExporter.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TestSpanExporter.java
@@ -2,7 +2,6 @@ package io.quarkus.opentelemetry.deployment;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -20,7 +19,7 @@ public class TestSpanExporter implements SpanExporter {
 
     public List<SpanData> getFinishedSpanItems() {
         synchronized (this) {
-            return Collections.unmodifiableList(new ArrayList<>(finishedSpanItems));
+            return List.copyOf(finishedSpanItems);
         }
     }
 

--- a/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache/runtime/src/main/java/io/quarkus/hibernate/orm/panache/runtime/AdditionalJpaOperations.java
@@ -88,9 +88,8 @@ public class AdditionalJpaOperations {
         boolean doCascade = Arrays.stream(propertyCascadeStyles)
                 .anyMatch(cascadeStyle -> cascadeStyle.doCascade(CascadingActions.DELETE));
         boolean hasElementCollection = declaredAttributes.stream()
-                .filter(attribute -> attribute.getPersistentAttributeType()
-                        .equals(Attribute.PersistentAttributeType.ELEMENT_COLLECTION))
-                .count() > 0;
+                .anyMatch(attribute -> attribute.getPersistentAttributeType()
+                        .equals(Attribute.PersistentAttributeType.ELEMENT_COLLECTION));
         return doCascade || hasElementCollection;
 
     }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/GetHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/GetHalMethodImplementor.java
@@ -14,7 +14,6 @@ import io.quarkus.rest.data.panache.RestDataResource;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
 import io.quarkus.rest.data.panache.deployment.properties.ResourceProperties;
 import io.quarkus.rest.data.panache.deployment.utils.ResponseImplementor;
-import io.quarkus.rest.data.panache.runtime.hal.HalEntityWrapper;
 
 public final class GetHalMethodImplementor extends HalMethodImplementor {
 

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/devmode/ResourceNotFoundHandler.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/devmode/ResourceNotFoundHandler.java
@@ -1,7 +1,5 @@
 package io.quarkus.vertx.web.runtime.devmode;
 
-import static io.quarkus.runtime.TemplateHtmlBuilder.adjustRoot;
-
 import java.util.List;
 
 import io.quarkus.runtime.TemplateHtmlBuilder;

--- a/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
+++ b/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
@@ -1,6 +1,5 @@
 package io.quarkus.resteasy.common.spi;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -99,7 +98,7 @@ public final class ResteasyDotNames {
     }
 
     // Types ignored for reflection used by the RESTEasy and SmallRye REST client extensions.
-    private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(Arrays.asList(
+    private static final Set<DotName> TYPES_IGNORED_FOR_REFLECTION = new HashSet<>(List.of(
     // Consider adding packages below instead if it makes more sense
     ));
 

--- a/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
+++ b/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
@@ -1,7 +1,6 @@
 package io.quarkus.resteasy.common.spi;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
+++ b/extensions/resteasy-classic/resteasy-common/spi/src/main/java/io/quarkus/resteasy/common/spi/ResteasyDotNames.java
@@ -55,8 +55,7 @@ public final class ResteasyDotNames {
     public static final DotName JSONB_TRANSIENT = DotName.createSimple("javax.json.bind.annotation.JsonbTransient");
     public static final DotName XML_TRANSIENT = DotName.createSimple("javax.xml.bind.annotation.XmlTransient");
 
-    public static final List<DotName> JAXRS_METHOD_ANNOTATIONS = Collections
-            .unmodifiableList(Arrays.asList(GET, POST, HEAD, DELETE, PUT, PATCH, OPTIONS));
+    public static final List<DotName> JAXRS_METHOD_ANNOTATIONS = List.of(GET, POST, HEAD, DELETE, PUT, PATCH, OPTIONS);
 
     public static final IgnoreTypeForReflectionPredicate IGNORE_TYPE_FOR_REFLECTION_PREDICATE = new IgnoreTypeForReflectionPredicate();
     public static final IgnoreFieldForReflectionPredicate IGNORE_FIELD_FOR_REFLECTION_PREDICATE = new IgnoreFieldForReflectionPredicate();

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -1,6 +1,5 @@
 package io.quarkus.resteasy.reactive.common.runtime;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomResourceProducersGenerator.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CustomResourceProducersGenerator.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -37,7 +36,6 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.runtime.util.HashUtil;
-import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 
 final class CustomResourceProducersGenerator {
 

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/DenyingUnannotatedTransformer.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/DenyingUnannotatedTransformer.java
@@ -1,7 +1,6 @@
 package io.quarkus.security.deployment;
 
 import static io.quarkus.security.deployment.SecurityTransformerUtils.DENY_ALL;
-import static io.quarkus.security.deployment.SecurityTransformerUtils.hasStandardSecurityAnnotation;
 
 import java.util.List;
 

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devconsole/DevReactiveMessagingInfos.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devconsole/DevReactiveMessagingInfos.java
@@ -40,9 +40,7 @@ public class DevReactiveMessagingInfos {
 
                 // Unfortunately, there is no easy way to obtain the connectors metadata
                 Connectors connectors = container.instance(Connectors.class).get();
-                for (Entry<String, Component> entry : connectors.outgoingConnectors.entrySet()) {
-                    publishers.put(entry.getKey(), entry.getValue());
-                }
+                publishers.putAll(connectors.outgoingConnectors);
                 for (Entry<String, Component> entry : connectors.incomingConnectors.entrySet()) {
                     consumers.computeIfAbsent(entry.getKey(), fun)
                             .add(entry.getValue());

--- a/extensions/spring-cache/deployment/src/main/java/io/quarkus/spring/cache/SpringCacheProcessor.java
+++ b/extensions/spring-cache/deployment/src/main/java/io/quarkus/spring/cache/SpringCacheProcessor.java
@@ -33,8 +33,7 @@ public class SpringCacheProcessor {
     static final DotName CACHE_PUT = DotName.createSimple(CachePut.class.getName());
     static final DotName CACHE_EVICT = DotName.createSimple(CacheEvict.class.getName());
 
-    private static final List<DotName> CACHE_ANNOTATIONS = Collections
-            .unmodifiableList(Arrays.asList(CACHEABLE, CACHE_PUT, CACHE_EVICT));
+    private static final List<DotName> CACHE_ANNOTATIONS = List.of(CACHEABLE, CACHE_PUT, CACHE_EVICT);
 
     // some of these restrictions can probably be lifted by us doing additional work on caching after https://github.com/quarkusio/quarkus/pull/8631 lands
     private static final Set<String> CURRENTLY_UNSUPPORTED_ANNOTATION_VALUES = Collections

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -2,9 +2,6 @@ package io.quarkus.spring.data.deployment;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.URL;
-import java.sql.Blob;
-import java.sql.NClob;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;

--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/FilterBuildItem.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/FilterBuildItem.java
@@ -27,7 +27,7 @@ public final class FilterBuildItem extends MultiBuildItem {
         this.filterClass = builder.filterClass;
         this.loadOnStartup = builder.loadOnStartup;
         this.asyncSupported = builder.asyncSupported;
-        this.mappings = Collections.unmodifiableList(new ArrayList<>(builder.mappings));
+        this.mappings = List.copyOf(builder.mappings);
         this.instanceFactory = builder.instanceFactory;
         this.initParams = Collections.unmodifiableMap(new HashMap<>(builder.initParams));
     }

--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/ServletBuildItem.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/ServletBuildItem.java
@@ -28,7 +28,7 @@ public final class ServletBuildItem extends MultiBuildItem {
         this.servletClass = builder.servletClass;
         this.loadOnStartup = builder.loadOnStartup;
         this.asyncSupported = builder.asyncSupported;
-        this.mappings = Collections.unmodifiableList(new ArrayList<>(builder.mappings));
+        this.mappings = List.copyOf(builder.mappings);
         this.instanceFactory = builder.instanceFactory;
         this.initParams = Collections.unmodifiableMap(new HashMap<>(builder.initParams));
         this.multipartConfig = builder.multipartConfig;

--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSourceProvider.java
@@ -1,6 +1,6 @@
 package io.quarkus.vault.runtime.config;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
@@ -18,6 +18,6 @@ public class VaultConfigSourceProvider implements ConfigSourceProvider {
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
-        return Arrays.asList(new VaultConfigSource(vaultBootstrapConfig));
+        return List.of(new VaultConfigSource(vaultBootstrapConfig));
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapModelResolver.java
@@ -83,7 +83,7 @@ public class BootstrapModelResolver implements ModelResolver {
         this.versionRangeResolver = versionRangeResolver;
         this.remoteRepositoryManager = remoteRepositoryManager;
         this.repositories = repositories;
-        this.externalRepositories = Collections.unmodifiableList(new ArrayList<>(repositories));
+        this.externalRepositories = List.copyOf(repositories);
         this.repositoryIds = new HashSet<>();
     }
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/CodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/CodestartFileReader.java
@@ -3,8 +3,6 @@ package io.quarkus.devtools.codestarts.core.reader;
 import io.quarkus.devtools.codestarts.CodestartResource;
 import io.quarkus.devtools.codestarts.CodestartResource.Source;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,10 +11,10 @@ public interface CodestartFileReader {
 
     CodestartFileReader DEFAULT = new DefaultCodestartFileReader();
 
-    List<CodestartFileReader> ALL = Collections.unmodifiableList(Arrays.asList(
+    List<CodestartFileReader> ALL = List.of(
             DEFAULT,
             new QuteCodestartFileReader(),
-            new IgnoreCodestartFileReader()));
+            new IgnoreCodestartFileReader());
 
     boolean matches(String fileName);
 


### PR DESCRIPTION
Misc code cleanup:

* f53197e0ac - stream().anyMatch should be faster than .filter().count()
* 9f8c2e7fc5 - Use .putAll instead of for loop or .forEach
* 41ff661375 - Use optimized List.of instead of Arrays.asList
* e39103a563 - Unused imports removal
* e61209433f - Use List.copyOf and List.of instead of Collections.unmodifiableList