### PR TITLE
Don't include version in the Swagger UI header

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationConfig.java
@@ -24,8 +24,8 @@ public class ApplicationConfig {
     public Optional<String> version;
 
     /**
-     * The header to use for UI Screen (Swagger UI, GraphQL UI etc)
+     * The header to use for UI Screen (Swagger UI, GraphQL UI etc).
      */
-    @ConfigItem(defaultValue = "{applicationName} {applicationVersion} (powered by Quarkus {quarkusVersion})")
+    @ConfigItem(defaultValue = "{applicationName} (powered by Quarkus)")
     public Optional<String> uiHeader;
 }


### PR DESCRIPTION
Nothing good comes from exposing this information by default.