### PR TITLE
Make docker executable configurable when using Jib

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -162,4 +162,11 @@ public class JibConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean offlineMode;
+
+    /**
+     * Name of binary used to execute the docker commands. This is only used by Jib
+     * when the container image is being built locally.
+     */
+    @ConfigItem
+    public Optional<String> dockerExecutableName;
 }


### PR DESCRIPTION
When Jib builds a container locally (as opposed to pushing to a registry),
it needs a docker executable to perform the build.
With this change, the name of that executable is now configurable
using either `quarkus.jib.docker-executable-name` or
`quarkus.docker.executable-name`

Resolves: #21677