### PR TITLE
Copy default methods of a RestClient Reactive interface to the generated class

### DIFF
--- a/integration-tests/rest-client-reactive/pom.xml
+++ b/integration-tests/rest-client-reactive/pom.xml
@@ -12,7 +12,6 @@
     <name>Quarkus - Integration Tests - REST Client Reactive</name>
 
     <!--todo add ssl tests-->
-    <!--todo test fault tolerance integration-->
 
     <dependencies>
         <!-- Client dependencies -->
@@ -24,6 +23,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
 
         <!-- Tracing dependency -->
@@ -68,6 +72,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
@@ -38,6 +38,9 @@ public class ClientCallingResource {
     @RestClient
     ClientWithExceptionMapper clientWithExceptionMapper;
 
+    @RestClient
+    FaultToleranceClient faultToleranceClient;
+
     @Inject
     InMemorySpanExporter inMemorySpanExporter;
 
@@ -131,6 +134,10 @@ public class ClientCallingResource {
                     .end(Json.encodePrettily(inMemorySpanExporter.getFinishedSpanItems()
                             .stream().filter(sd -> !sd.getName().contains("export"))
                             .collect(Collectors.toList())));
+        });
+
+        router.route("/call-with-fault-tolerance").blockingHandler(rc -> {
+            rc.end(faultToleranceClient.helloWithFallback());
         });
     }
 

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/FaultToleranceClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/FaultToleranceClient.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.rest.client.main;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/unprocessable")
+@RegisterRestClient(configKey = "w-fault-tolerance")
+public interface FaultToleranceClient {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    String hello();
+
+    @Fallback(fallbackMethod = "fallback")
+    default String helloWithFallback() {
+        return hello();
+    }
+
+    default String fallback() {
+        return "Hello fallback!";
+    }
+}

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 w-exception-mapper/mp-rest/url=${test.url}
+w-fault-tolerance/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.multipart.MultipartClient/mp-rest/url=${test.url}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -85,6 +85,14 @@ public class BasicTest {
     }
 
     @Test
+    void shouldInterceptDefaultMethod() {
+        RestAssured.with().body(baseUrl).post("/call-with-fault-tolerance")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello fallback!"));
+    }
+
+    @Test
     void shouldCreateClientSpans() {
         // Reset captured traces
         RestAssured.given().when().get("/export-clear").then().statusCode(200);


### PR DESCRIPTION
RestClient Reactive generates a `...$$CDIWrapper` class for each
RestClient interface, and creates an implementation of each
RestClient method. This leaves non-RestClient methods (`default`
methods) on the interface, which means that if they are annotated
with an interceptor binding, the interceptor is not invoked.
This is because interceptor bindings are not inherited from
superinterfaces, only from superclasses (and while ArC has some
support for intercepting `default` methods from superinterfaces,
it doesn't extends that far).

This PR doesn't attempt to support intercepting `default` methods
in general, because that's a gray area. Instead, it fixes how
RestClient Reactive generates the class for a RestClient interface
(because RestClient interfaces are special in that they may define
class-based beans if annotated `@RegisterRestClient`). In addition
to RestClient methods, `default` methods from the RestClient
interface are also copied to the generated class. (The "copy"
delegates to the `default` method inherited from the superinterface,
which had to be added to Gizmo, hence the Gizmo update.) That itself
is enough for interceptors to start working.

Fixes #21674