### PR TITLE
More flexible support for OIDC logout endpoints

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -53,6 +53,7 @@ image::dev-ui-oidc-keycloak-card.png[alt=Dev UI OpenId Connect Card,role="center
 
 Click on the `Provider: Keycloak` link and you will see a Keycloak page which will be presented slightly differently depending on how `Dev Services for Keycloak` feature has been configured.
 
+[[develop-service-applications]]
 === Developing Service Applications
 
 By default the Keycloak page can be used to support the development of a link:security-openid-connect[Quarkus OIDC service application].
@@ -146,6 +147,7 @@ image::dev-ui-keycloak-client-credentials-grant.png[alt=Dev UI OpenId Connect Ke
 
 You can test the service the same way as with the `Password` grant.
 
+[[develop-web-app-applications]]
 === Developing OpenId Connect Web App Applications
 
 If you develop a link:security-openid-connect-web-authentication[Quarkus OIDC web-app application] then you should set `quarkus.oidc.application-type=web-app` in `application.properties` before starting the application.
@@ -155,6 +157,20 @@ You will see a screen like this one:
 image::dev-ui-keycloak-sign-in-to-service.png[alt=Dev UI OpenId Connect Keycloak Sign In,role="center"]
 
 Set a relative service endpoint path, click on `Sign In To Service` and you will be redirected to Keycloak to enter a username and password in a new browser tab and get a response from the Quarkus application.
+
+Note that in this case Dev UI does not really enrich a dev experience since it is a Quarkus OIDC `web-app` application which controls the authorization code flow and acquires the tokens.
+
+To make Dev UI more useful for supporting the development of OIDC `web-app` applications you may want to consider setting profile specific values for `quarkus.oidc.application-type`:
+
+[source,properties]
+----
+%prod.quarkus.oidc.application-type=web-app
+%test.quarkus.oidc.application-type=web-app
+%dev.quarkus.oidc.application-type=service
+----
+
+It will ensure that all Dev UI options described in <<develop-service-applications, Developing OpenId Connect Service Applications>> will be available when your `web-app` application is run in dev mode. The limitation of this approach is that both access and ID tokens returned with the code flow and acquired with Dev UI will be sent to the endpoint as HTTP `Bearer` tokens - which will not work well if your endpoint requires the injection of `IdToken`.
+However it will work as expected if your `web-app` application only uses the access token, for example, as a source of roles or to get `UserInfo`, even if it is assumed to be a `service` application in devmode.
 
 === Running the tests
 
@@ -233,9 +249,15 @@ If you work with other providers then a Dev UI experience described in the <<key
 The current access token is used by default to test the service with `Swagger UI` or `GrapghQL UI`. If the provider (other than Keycloak) returns a binary access token then it will be used with `Swagger UI` or `GrapghQL UI` only if this provider has a token introspection endpoint otherwise an `IdToken` which is always in a JWT format will be passed to `Swagger UI` or `GrapghQL UI`. In such cases you can verify with the manual Dev UI test that `401` will always be returned for the current binary access token. Also note that using `IdToken` as a fallback with either of these UIs is only possible with the authorization code flow.
 ====
 
-Some providers such as `Auth0` do not support a standard RP initiated logout so a logout option will also be hidden.
+Some providers such as `Auth0` do not support a standard RP initiated logout so the provider specific logout properties will have to be confogured for a logout option be visible, please see link:security-openid-connect-web-authentication#user-initiated-logout[OpenId Connect User-Initiated Logout] for more information.
 
-At the moment `Dev UI for all OpenId Connect Providers` only supports an authorization code grant. More grants may be supported in the future, similarly to how it is done with `Dev Services for Keycloak`.
+Similarly, if you'd like to use a `password` or `client_credentials` grant for Dev UI to acquire the tokens then you may have to configure some extra provider specific properties, for example:
+
+[source,properties]
+----
+quarkus.oidc.devui.grant.type=password
+quarkus.oidc.devui.grant-options.password.audience=http://localhost:8080
+----
 
 == Dev Services and UI Support for other OpenId Connect Providers
 

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -410,6 +410,7 @@ By default the logout is based on the expiration time of the ID Token issued by 
 
 The current user session may be automatically extended by enabling a `quarkus.oidc.token.refresh-expired` property. If it is set to `true` then when the current ID Token expires a Refresh Token Grant will be used to refresh ID Token as well as Access and Refresh Tokens.
 
+[[user-initiated-logout]]
 ==== User-Initiated Logout
 
 Users can request a logout by sending a request to the Quarkus endpoint logout path set with a `quarkus.oidc.logout.path` property.
@@ -429,10 +430,11 @@ Here is an example of how to configure an RP initiated logout flow:
 ----
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus
 quarkus.oidc.client-id=frontend
+quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=web-app
 
-quarkus.oidc.tenant-logout.logout.path=/logout
-quarkus.oidc.tenant-logout.logout.post-logout-path=/postlogout
+quarkus.oidc.logout.path=/logout
+quarkus.oidc.logout.post-logout-path=/welcome.html
 
 # Only the authenticated users can initiate a logout:
 quarkus.http.auth.permission.authenticated.paths=/logout
@@ -445,6 +447,32 @@ quarkus.http.auth.permission.authenticated.policy=permit
 
 You may also need to set `quarkus.oidc.authentication.cookie-path` to a path value common to all of the application resources which is `/` in this example.
 See <<oidc-cookies, Dealing with Cookies>> for more information.
+
+Note that some OpenId Connect providers do not support https://openid.net/specs/openid-connect-session-1_0.html#RPLogout[RP-Initiated Logout] specification (possibly because it is still technically a draft) and do not return an OpenId Connect well-known `end_session_endpoint` metadata property. However it should not be a problem since these providers' specific logout mechanisms may only differ in how the logout URL query parameters are named.
+
+According to the https://openid.net/specs/openid-connect-session-1_0.html#RPLogout[RP-Initiated Logout] specification, the `quarkus.oidc.logout.post-logout-path` property is represented as a `post_logout_redirect_uri` query parameter which will not be recognized by the providers which do not support this specification.
+
+You can use `quarkus.oidc.logout.post-logout-url-param` to work around this issue. You can also request more logout query parameters added with `quarkus.oidc.logout.extra-params`. For example, here is how you can support a logout with `Auth0`:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=https://dev-xxx.us.auth0.com
+quarkus.oidc.client-id=redacted
+quarkus.oidc.credentials.secret=redacted
+quarkus.oidc.application-type=web-app
+
+quarkus.oidc.tenant-logout.logout.path=/logout
+quarkus.oidc.tenant-logout.logout.post-logout-path=/welcome.html
+
+# Auth0 does not return the `end_session_endpoint` metadata property, configire it instead
+quarkus.oidc.end-session-path=v2/logout
+# Auth0 will not recognize the 'post_logout_redirect_uri' query parameter so make sure it is named as 'returnTo'
+quarkus.oidc.logout.post-logout-uri-param=returnTo
+
+# Set more properties if needed.
+# For example, if 'client_id' is provided then a valid logout URI should be set as Auth0 Application property, without it - as Auth0 Tenant property.
+quarkus.oidc.logout.extra-params.client_id=${quarkus.oidc.client-id}
+----
 
 [[session-management]]
 === Session Management

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -163,7 +163,7 @@ public class OidcCommonUtils {
     }
 
     public static String getOidcEndpointUrl(String authServerUrl, Optional<String> endpointPath) {
-        if (endpointPath.isPresent()) {
+        if (endpointPath != null && endpointPath.isPresent()) {
             return isAbsoluteUrl(endpointPath) ? endpointPath.get() : authServerUrl + prependSlash(endpointPath.get());
         } else {
             return null;

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -16,6 +16,10 @@ public final class OidcConstants {
     public static final String ACCESS_TOKEN_VALUE = "access_token";
     public static final String ID_TOKEN_VALUE = "id_token";
 
+    public static final String LOGOUT_ID_TOKEN_HINT = "id_token_hint";
+    public static final String LOGOUT_STATE = "state";
+    public static final String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
+
     public static final String INTROSPECTION_TOKEN_TYPE_HINT = "token_type_hint";
     public static final String INTROSPECTION_TOKEN = "token";
     public static final String INTROSPECTION_TOKEN_ACTIVE = "active";

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
@@ -5,11 +5,22 @@ import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
+import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
+import io.quarkus.oidc.runtime.OidcConfigPropertySupplier;
 
 public abstract class AbstractDevConsoleProcessor {
+    protected static final String CONFIG_PREFIX = "quarkus.oidc.";
+    protected static final String CLIENT_ID_CONFIG_KEY = CONFIG_PREFIX + "client-id";
+    protected static final String CLIENT_SECRET_CONFIG_KEY = CONFIG_PREFIX + "credentials.secret";
+    protected static final String AUTHORIZATION_PATH_CONFIG_KEY = CONFIG_PREFIX + "authorization-path";
+    protected static final String TOKEN_PATH_CONFIG_KEY = CONFIG_PREFIX + "token-path";
+    protected static final String END_SESSION_PATH_CONFIG_KEY = CONFIG_PREFIX + "end-session-path";
+    protected static final String POST_LOGOUT_URI_PARAM_CONFIG_KEY = CONFIG_PREFIX + "logout.post-logout-uri-param";
+
     protected void produceDevConsoleTemplateItems(Capabilities capabilities,
             BuildProducer<DevConsoleTemplateInfoBuildItem> devConsoleTemplate,
+            BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeInfo,
             String oidcProviderName,
             String oidcApplicationType,
             String oidcGrantType,
@@ -23,11 +34,6 @@ public abstract class AbstractDevConsoleProcessor {
         devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("oidcApplicationType", oidcApplicationType));
         devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("oidcGrantType", oidcGrantType));
 
-        devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("authorizationUrl", authorizationUrl));
-        devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("tokenUrl", tokenUrl));
-        if (logoutUrl != null) {
-            devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("logoutUrl", logoutUrl));
-        }
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("swaggerIsAvailable", true));
         }
@@ -35,6 +41,26 @@ public abstract class AbstractDevConsoleProcessor {
             devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("graphqlIsAvailable", true));
         }
         devConsoleTemplate.produce(new DevConsoleTemplateInfoBuildItem("introspectionIsAvailable", introspectionIsAvailable));
+
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("clientId",
+                        new OidcConfigPropertySupplier(CLIENT_ID_CONFIG_KEY)));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("clientSecret",
+                        new OidcConfigPropertySupplier(CLIENT_SECRET_CONFIG_KEY, "")));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("authorizationUrl",
+                        new OidcConfigPropertySupplier(AUTHORIZATION_PATH_CONFIG_KEY, authorizationUrl, true)));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("tokenUrl",
+                        new OidcConfigPropertySupplier(TOKEN_PATH_CONFIG_KEY, tokenUrl, true)));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("logoutUrl",
+                        new OidcConfigPropertySupplier(END_SESSION_PATH_CONFIG_KEY, logoutUrl, true)));
+        devConsoleRuntimeInfo.produce(
+                new DevConsoleRuntimeTemplateInfoBuildItem("postLogoutUriParam",
+                        new OidcConfigPropertySupplier(POST_LOGOUT_URI_PARAM_CONFIG_KEY)));
+
     }
 
     protected void produceDevConsoleRouteItems(BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -18,13 +18,8 @@ import io.quarkus.oidc.deployment.devservices.AbstractDevConsoleProcessor;
 import io.quarkus.oidc.deployment.devservices.OidcAuthorizationCodePostHandler;
 import io.quarkus.oidc.deployment.devservices.OidcPasswordClientCredHandler;
 import io.quarkus.oidc.deployment.devservices.OidcTestServiceHandler;
-import io.quarkus.oidc.runtime.OidcConfigPropertySupplier;
 
 public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
-
-    private static final String CONFIG_PREFIX = "quarkus.oidc.";
-    private static final String CLIENT_ID_CONFIG_KEY = CONFIG_PREFIX + "client-id";
-    private static final String CLIENT_SECRET_CONFIG_KEY = CONFIG_PREFIX + "credentials.secret";
 
     KeycloakBuildTimeConfig keycloakConfig;
     OidcBuildTimeConfig oidcConfig;
@@ -45,6 +40,7 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
 
             produceDevConsoleTemplateItems(capabilities,
                     devConsoleInfo,
+                    devConsoleRuntimeInfo,
                     "Keycloak",
                     (String) configProps.get().getProperties().get("quarkus.oidc.application-type"),
                     oidcConfig.devui.grant.type.isPresent() ? oidcConfig.devui.grant.type.get().getGrantType()
@@ -53,12 +49,6 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     realmUrl + "/protocol/openid-connect/token",
                     realmUrl + "/protocol/openid-connect/logout",
                     true);
-            devConsoleRuntimeInfo.produce(
-                    new DevConsoleRuntimeTemplateInfoBuildItem("clientId",
-                            new OidcConfigPropertySupplier(CLIENT_ID_CONFIG_KEY)));
-            devConsoleRuntimeInfo.produce(
-                    new DevConsoleRuntimeTemplateInfoBuildItem("clientSecret",
-                            new OidcConfigPropertySupplier(CLIENT_SECRET_CONFIG_KEY, "")));
 
         }
     }

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -187,7 +187,7 @@ var port = {config:property('quarkus.http.port')};
         localStorage.removeItem('authorized');
     
         window.location.assign('{info:logoutUrl??}'
-          + "?post_logout_redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider");
+          + "?" + '{info:postLogoutUriParam??}' + "=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider");
     }
         
     function exchangeCodeForTokens(code){

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -149,6 +150,18 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<String> postLogoutPath = Optional.empty();
 
+        /**
+         * Name of the post logout URI parameter which will be added as a query parameter to the logout redirect URI.
+         */
+        @ConfigItem(defaultValue = OidcConstants.POST_LOGOUT_REDIRECT_URI)
+        public String postLogoutUriParam;
+
+        /**
+         * Additional properties which will be added as the query parameters to the logout redirect URI.
+         */
+        @ConfigItem
+        public Map<String, String> extraParams;
+
         public void setPath(Optional<String> path) {
             this.path = path;
         }
@@ -163,6 +176,22 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public Optional<String> getPostLogoutPath() {
             return postLogoutPath;
+        }
+
+        public Map<String, String> getExtraParams() {
+            return extraParams;
+        }
+
+        public void setExtraParams(Map<String, String> extraParams) {
+            this.extraParams = extraParams;
+        }
+
+        public String getPostLogoutUriParam() {
+            return postLogoutUriParam;
+        }
+
+        public void setPostLogoutUriParam(String postLogoutUriParam) {
+            this.postLogoutUriParam = postLogoutUriParam;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
@@ -1,13 +1,18 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
-public class OidcConfigPropertySupplier implements Supplier<String> {
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 
+public class OidcConfigPropertySupplier implements Supplier<String> {
+    private static final String AUTH_SERVER_URL_CONFIG_KEY = "quarkus.oidc.auth-server-url";
+    private static final String END_SESSION_PATH_KEY = "quarkus.oidc.end-session-path";
     private String oidcConfigProperty;
     private String defaultValue;
+    private boolean urlProperty;
 
     public OidcConfigPropertySupplier() {
 
@@ -18,16 +23,34 @@ public class OidcConfigPropertySupplier implements Supplier<String> {
     }
 
     public OidcConfigPropertySupplier(String oidcConfigProperty, String defaultValue) {
+        this(oidcConfigProperty, defaultValue, false);
+    }
+
+    public OidcConfigPropertySupplier(String oidcConfigProperty, String defaultValue, boolean urlProperty) {
         this.oidcConfigProperty = oidcConfigProperty;
         this.defaultValue = defaultValue;
+        this.urlProperty = urlProperty;
     }
 
     @Override
     public String get() {
-        if (defaultValue != null) {
-            return ConfigProvider.getConfig().getOptionalValue(oidcConfigProperty, String.class).orElse(defaultValue);
+        if (defaultValue != null || END_SESSION_PATH_KEY.equals(oidcConfigProperty)) {
+            Optional<String> value = ConfigProvider.getConfig().getOptionalValue(oidcConfigProperty, String.class);
+            if (value.isPresent()) {
+                return checkUrlProperty(value.get());
+            }
+            return defaultValue;
         } else {
-            return ConfigProvider.getConfig().getValue(oidcConfigProperty, String.class);
+            return checkUrlProperty(ConfigProvider.getConfig().getValue(oidcConfigProperty, String.class));
+        }
+    }
+
+    private String checkUrlProperty(String value) {
+        if (urlProperty && !value.startsWith("http:")) {
+            String authServerUrl = ConfigProvider.getConfig().getValue(AUTH_SERVER_URL_CONFIG_KEY, String.class);
+            return OidcCommonUtils.getOidcEndpointUrl(authServerUrl, Optional.of(value));
+        } else {
+            return value;
         }
     }
 
@@ -45,6 +68,14 @@ public class OidcConfigPropertySupplier implements Supplier<String> {
 
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public boolean isUrlProperty() {
+        return urlProperty;
+    }
+
+    public void setUrlProperty(boolean urlProperty) {
+        this.urlProperty = urlProperty;
     }
 
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowResource.java
@@ -3,19 +3,26 @@ package io.quarkus.it.keycloak;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/code-flow")
-@Authenticated
 public class CodeFlowResource {
 
     @Inject
     SecurityIdentity identity;
 
     @GET
+    @Authenticated
     public String access() {
         return identity.getPrincipal().getName();
+    }
+
+    @GET
+    @Path("/post-logout")
+    public String postLogout(@QueryParam("clientId") String clientId) {
+        return "Welcome, clientId: " + clientId;
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -14,7 +14,7 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.contains("recovered-no-discovery")) {
             return "no-discovery";
         }
-        if (path.endsWith("code-flow")) {
+        if (path.endsWith("code-flow") || path.endsWith("code-flow/logout")) {
             return "code-flow";
         }
         if (path.endsWith("code-flow-user-info")) {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -13,6 +13,10 @@ quarkus.oidc.no-discovery.authentication.scopes=profile,email,phone
 
 quarkus.oidc.code-flow.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow.client-id=quarkus-web-app
+quarkus.oidc.code-flow.logout.path=/code-flow/logout
+quarkus.oidc.code-flow.logout.post-logout-path=/code-flow/post-logout
+quarkus.oidc.code-flow.logout.post-logout-uri-param=returnTo
+quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.client-id}
 quarkus.oidc.code-flow.credentials.secret=secret
 quarkus.oidc.code-flow.application-type=web-app
 
@@ -49,3 +53,6 @@ quarkus.oidc.bearer-wrong-role-path.roles.role-claim-path=path
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+
+quarkus.http.auth.permission.logout.paths=/code-flow/logout
+quarkus.http.auth.permission.logout.policy=authenticated

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -2,6 +2,8 @@ package io.quarkus.it.keycloak;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.Set;
@@ -12,6 +14,7 @@ import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
@@ -40,6 +43,13 @@ public class CodeFlowAuthorizationTest {
             page = form.getInputByValue("login").click();
 
             assertEquals("alice", page.getBody().asText());
+            assertNotNull(getSessionCookie(webClient, "code-flow"));
+
+            page = webClient.getPage("http://localhost:8081/code-flow/logout");
+            assertEquals("Welcome, clientId: quarkus-web-app", page.getBody().asText());
+            assertNull(getSessionCookie(webClient, "code-flow"));
+            // Clear the post logout cookie
+            webClient.getCookieManager().clearCookies();
         }
     }
 
@@ -57,6 +67,8 @@ public class CodeFlowAuthorizationTest {
             page = form.getInputByValue("login").click();
 
             assertEquals("alice:alice", page.getBody().asText());
+            assertNotNull(getSessionCookie(webClient, "code-flow-user-info-only"));
+            webClient.getCookieManager().clearCookies();
         }
     }
 
@@ -75,5 +87,9 @@ public class CodeFlowAuthorizationTest {
                                 "  \"access_token\": \""
                                 + OidcWiremockTestResource.getAccessToken("alice", Set.of()) + "\""
                                 + "}")));
+    }
+
+    private Cookie getSessionCookie(WebClient webClient, String tenantId) {
+        return webClient.getCookieManager().getCookie("q_session" + (tenantId == null ? "" : "_" + tenantId));
     }
 }

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -70,7 +70,9 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                         "    \"token_endpoint\": \"" + server.baseUrl() + "/auth/realms/quarkus/token\"," +
                                         "    \"issuer\" : \"" + TOKEN_ISSUER + "\"," +
                                         "    \"introspection_endpoint\": \"" + server.baseUrl()
-                                        + "/auth/realms/quarkus/protocol/openid-connect/token/introspect\""
+                                        + "/auth/realms/quarkus/protocol/openid-connect/token/introspect\","
+                                        + "    \"end_session_endpoint\": \"" + server.baseUrl()
+                                        + "/auth/realms/quarkus/protocol/openid-connect/end-session\""
                                         +
                                         "}")));
 
@@ -147,6 +149,15 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                         .willReturn(aResponse()
                                 .withHeader("Location",
                                         "{{request.query.redirect_uri}}?state={{request.query.state}}&code=58af24f2-9093-4674-a431-4a9d66be719c.50437113-cd78-48a2-838e-b936fe458c5d.0ac5df91-e044-4051-bd03-106a3a5fb9cc")
+                                .withStatus(302)
+                                .withTransformers("response-template")));
+
+        // Logout Request
+        server.stubFor(
+                get(urlPathMatching("/auth/realms/quarkus/protocol/openid-connect/end-session"))
+                        .willReturn(aResponse()
+                                .withHeader("Location",
+                                        "{{request.query.returnTo}}?clientId={{request.query.client_id}}")
                                 .withStatus(302)
                                 .withTransformers("response-template")));
 


### PR DESCRIPTION
Fixes #21581

This PR attempts to make it easier to support logging out of OIDC providers (Auth0, Google, etc) which may be OIDC compliant but do not support RP-initiated Logout (since it is a draft, thought it is only a technicality, Keycloak, Azure support it). The following is done:
- `OidcTenantConfig` is updated to make it possible to use a custom parameter to represent a standard `post_logout_redirect_uri`: this is where a user should be returned back to the application after the logout. For example, it can be now set to `returnTo` in case of `Auth0`; an option to add some extra logout parameters is also provided - this is the only OIDC specific update which does not change any flow, only makes it easier to support the logout with more providers 
- Updated `OidcWireMockResource` to support testing the logout and updated the `integration-tests/oidc-wiremock` test to test the new properties (`integration-tests/oidc-code-flow` continues testing the logout directly against Keycloak)
- Updated OIDC Dev UI to pick up the custom logout parameter, with a better support for the case where the discovery has to be disabled, verified the logout option is now visible and effective in DevUI with `Auth0`
- Updated the docs