### PR TITLE
Resteasy Reactive: Use `uri.getRawQuery` instead of `uri.getQuery`

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/BasicRestClientTest.java
@@ -2,6 +2,7 @@ package io.quarkus.rest.client.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -58,5 +59,17 @@ public class BasicRestClientTest {
     @Test
     void shouldHelloInts() {
         assertThat(testBean.helloNonSimpleSyncInts()).isEqualTo(new Integer[] { 1, 2, 3 });
+    }
+
+    @Test
+    void shouldMapQueryParamsWithSpecialCharacters() {
+        Map<String, String> map = testBean.helloQueryParamsToMap();
+        assertThat(map).size().isEqualTo(6);
+        assertThat(map.get("p1")).isEqualTo("1");
+        assertThat(map.get("p2")).isEqualTo("2");
+        assertThat(map.get("p3")).isEqualTo("3");
+        assertThat(map.get("p4")).isEqualTo("4");
+        assertThat(map.get("p5")).isEqualTo("5");
+        assertThat(map.get("p6")).isEqualTo("6");
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloNonSimpleClient.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloNonSimpleClient.java
@@ -1,9 +1,13 @@
 package io.quarkus.rest.client.reactive;
 
+import java.util.Map;
+
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -38,4 +42,10 @@ public interface HelloNonSimpleClient {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/ints")
     Uni<Integer[]> echoAsyncInts(Integer[] value);
+
+    @GET
+    @Path("/query-params-to-map")
+    Map<String, String> echoQueryAsMap(@QueryParam("p1") String p1, @QueryParam("p2(") String p2,
+            @QueryParam("p3[") String p3, @QueryParam("p4?") String p4, @QueryParam("p5=") String p5,
+            @QueryParam("p6-") String p6);
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloResource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/HelloResource.java
@@ -1,12 +1,15 @@
 package io.quarkus.rest.client.reactive;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
@@ -37,6 +40,23 @@ public class HelloResource {
     @Path("/ints")
     public int[] bytes(int[] value) {
         return value;
+    }
+
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/query-params-to-map")
+    public Map<String, String> queryParamsToMap(@QueryParam("p1") String p1, @QueryParam("p2(") String p2,
+            @QueryParam("p3[") String p3, @QueryParam("p4?") String p4, @QueryParam("p5=") String p5,
+            @QueryParam("p6-") String p6) {
+        Map<String, String> map = new HashMap<>();
+        map.put("p1", p1);
+        map.put("p2", p2);
+        map.put("p3", p3);
+        map.put("p4", p4);
+        map.put("p5", p5);
+        map.put("p6", p6);
+        return map;
     }
 
     @RestClient

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/TestBean.java
@@ -1,6 +1,7 @@
 package io.quarkus.rest.client.reactive;
 
 import java.net.URL;
+import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -41,5 +42,9 @@ public class TestBean {
 
     Integer[] helloNonSimpleSyncInts() {
         return clientNonSimple.echoSyncInts(new Integer[] { 1, 2, 3 });
+    }
+
+    Map<String, String> helloQueryParamsToMap() {
+        return clientNonSimple.echoQueryAsMap("1", "2", "3", "4", "5", "6");
     }
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -251,7 +251,7 @@ public class ClientSendRequestHandler implements ClientRestHandler {
 
         return requestOptions.onItem()
                 .transform(r -> r.setMethod(HttpMethod.valueOf(state.getHttpMethod()))
-                        .setURI(uri.getPath() + (uri.getQuery() == null ? "" : "?" + uri.getQuery()))
+                        .setURI(uri.getPath() + (uri.getRawQuery() == null ? "" : "?" + uri.getRawQuery()))
                         .setFollowRedirects(followRedirects))
                 .onItem().invoke(r -> {
                     if (readTimeout instanceof Long) {


### PR DESCRIPTION
When getting the URI, using `uri.getQuery()`, the query is automatically decoded, so it's losing some special characters. For example, having the following url:

```
http://localhost:8081/ps?p1=1&p2%28=2&p3%5B=3&p4?=4&p5%3D=5&p6-=6
```

When using `uri.getQuery()`, it's decoded to:

```
http://localhost:8081/ps?p1=1&p2(=2&p3[=3&p4?=4&p5==5&p6-=6
```

Hence we're losing the ability to manage special characters like `=` (see `p5` value which we cannot know if the `=` belongs to the key or to the value). 

Using `uri.getRawQuery` returns the encoded uri and the existing functionality already deals with the later decoding.

Fixes https://github.com/quarkusio/quarkus/issues/21234