### PR TITLE
Close delayed handler 2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -40,7 +40,7 @@ import io.quarkus.bootstrap.app.RunningQuarkusApplication;
 import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildContext;
@@ -110,7 +110,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                 }
                                 //this sucks, but when we get here logging is gone
                                 //so we just setup basic console logging
-                                InitialConfigurator.DELAYED_HANDLER.addHandler(new ConsoleHandler(
+                                QuarkusDelayedHandler.INSTANCE.addHandler(new ConsoleHandler(
                                         ConsoleHandler.Target.SYSTEM_OUT,
                                         new ColorPatternFormatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n")));
                                 consoleContext.reset(new ConsoleCommand(' ', "Restarts the application", "to restart", 0, null,
@@ -161,7 +161,7 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                         if (RuntimeUpdatesProcessor.INSTANCE != null) {
                             Thread.currentThread().setContextClassLoader(curatedApplication.getBaseRuntimeClassLoader());
                             try {
-                                if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
+                                if (!QuarkusDelayedHandler.INSTANCE.isActivated()) {
                                     Class<?> cl = Thread.currentThread().getContextClassLoader()
                                             .loadClass(LoggingSetupRecorder.class.getName());
                                     cl.getMethod("handleFailedStart").invoke(null);

--- a/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/logging/LoggingResourceProcessor.java
@@ -23,7 +23,7 @@ import org.jboss.logmanager.EmbeddedConfigurator;
 import org.objectweb.asm.Opcodes;
 
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.IsDevelopment;
@@ -63,6 +63,7 @@ import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.logging.InitialConfigurator;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.configuration.ConfigInstantiator;
 import io.quarkus.runtime.console.ConsoleRuntimeConfig;
@@ -198,7 +199,7 @@ public final class LoggingResourceProcessor {
             ((QuarkusClassLoader) Thread.currentThread().getContextClassLoader()).addCloseTask(new Runnable() {
                 @Override
                 public void run() {
-                    InitialConfigurator.DELAYED_HANDLER.buildTimeComplete();
+                    QuarkusDelayedHandler.INSTANCE.buildTimeComplete();
                 }
             });
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -24,7 +24,6 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.builder.Version;
@@ -64,6 +63,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.TryBlock;
+import io.quarkus.logging.InitialConfigurator;
 import io.quarkus.runtime.Application;
 import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.LaunchMode;

--- a/core/runtime/src/main/java/io/quarkus/logging/InitialConfigurator.java
+++ b/core/runtime/src/main/java/io/quarkus/logging/InitialConfigurator.java
@@ -1,18 +1,19 @@
-package io.quarkus.bootstrap.logging;
+package io.quarkus.logging;
 
-import io.quarkus.bootstrap.graal.ImageInfo;
 import java.util.logging.Handler;
 import java.util.logging.Level;
+
 import org.jboss.logmanager.EmbeddedConfigurator;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
+
+import io.quarkus.bootstrap.graal.ImageInfo;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 
 /**
  *
  */
 public final class InitialConfigurator implements EmbeddedConfigurator {
-
-    public static final QuarkusDelayedHandler DELAYED_HANDLER = new QuarkusDelayedHandler();
 
     @Override
     public Level getMinimumLevelOf(final String loggerName) {
@@ -33,7 +34,7 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
                         createDefaultHandler()
                 };
             } else {
-                return new Handler[] { DELAYED_HANDLER };
+                return new Handler[] { QuarkusDelayedHandler.INSTANCE };
             }
         } else {
             return EmbeddedConfigurator.NO_HANDLERS;

--- a/core/runtime/src/main/java/io/quarkus/logging/InitialConfigurator.java
+++ b/core/runtime/src/main/java/io/quarkus/logging/InitialConfigurator.java
@@ -9,11 +9,21 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
 
 import io.quarkus.bootstrap.graal.ImageInfo;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.runtime.logging.LoggingSetupRecorder;
 
-/**
- *
- */
 public final class InitialConfigurator implements EmbeddedConfigurator {
+
+    public InitialConfigurator() {
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                if (!QuarkusDelayedHandler.INSTANCE.isActivated()) {
+                    LoggingSetupRecorder.handleFailedStart();
+                }
+            }
+        }));
+    }
 
     @Override
     public Level getMinimumLevelOf(final String loggerName) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java
@@ -24,7 +24,7 @@ import org.jboss.logging.Logger;
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.wildfly.common.lock.Locks;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.configuration.ProfileManager;
@@ -240,7 +240,7 @@ public class ApplicationLifecycleManager {
     // this is needed only when async console logging is enabled
     private static void ensureConsoleLogsDrained() {
         AsyncHandler asyncHandler = null;
-        for (Handler handler : InitialConfigurator.DELAYED_HANDLER.getHandlers()) {
+        for (Handler handler : QuarkusDelayedHandler.INSTANCE.getHandlers()) {
             if (handler instanceof AsyncHandler) {
                 asyncHandler = (AsyncHandler) handler;
                 Handler[] nestedHandlers = asyncHandler.getHandlers();

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/LoggingSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/LoggingSubstitutions.java
@@ -12,8 +12,8 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.logging.InitialConfigurator;
 
 /**
  */

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -38,7 +38,7 @@ import org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler;
 import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.jboss.logmanager.handlers.SyslogHandler;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.dev.console.CurrentAppExceptionHighlighter;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
@@ -206,8 +206,8 @@ public class LoggingSetupRecorder {
             }
         }
 
-        InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
-        InitialConfigurator.DELAYED_HANDLER.setHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
+        QuarkusDelayedHandler.INSTANCE.setAutoFlush(false);
+        QuarkusDelayedHandler.INSTANCE.setHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
     }
 
     public static void initializeBuildTimeLogging(LogConfig config, LogBuildTimeConfig buildConfig,
@@ -268,8 +268,8 @@ public class LoggingSetupRecorder {
                 addNamedHandlersToCategory(categoryConfig, namedHandlers, categoryLogger, errorManager);
             }
         }
-        InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
-        InitialConfigurator.DELAYED_HANDLER.setBuildTimeHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
+        QuarkusDelayedHandler.INSTANCE.setAutoFlush(false);
+        QuarkusDelayedHandler.INSTANCE.setBuildTimeHandlers(handlers.toArray(EmbeddedConfigurator.NO_HANDLERS));
     }
 
     private static Level getLogLevel(String categoryName, CategoryConfig categoryConfig, Map<String, CategoryConfig> categories,
@@ -338,7 +338,7 @@ public class LoggingSetupRecorder {
                     handlerName));
         }
         namedHandlers.put(handlerName, handler);
-        InitialConfigurator.DELAYED_HANDLER.addLoggingCloseTask(new Runnable() {
+        QuarkusDelayedHandler.INSTANCE.addLoggingCloseTask(new Runnable() {
             @Override
             public void run() {
                 handler.close();
@@ -353,7 +353,7 @@ public class LoggingSetupRecorder {
             Handler handler = namedHandlers.get(categoryNamedHandler);
             if (handler != null) {
                 categoryLogger.addHandler(handler);
-                InitialConfigurator.DELAYED_HANDLER.addLoggingCloseTask(new Runnable() {
+                QuarkusDelayedHandler.INSTANCE.addLoggingCloseTask(new Runnable() {
                     @Override
                     public void run() {
                         categoryLogger.removeHandler(handler);
@@ -371,8 +371,8 @@ public class LoggingSetupRecorder {
             final ConsoleHandler handler = new ConsoleHandler(new PatternFormatter(
                     "%d{HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n"));
             handler.setLevel(Level.INFO);
-            InitialConfigurator.DELAYED_HANDLER.setAutoFlush(false);
-            InitialConfigurator.DELAYED_HANDLER.setHandlers(new Handler[] { handler });
+            QuarkusDelayedHandler.INSTANCE.setAutoFlush(false);
+            QuarkusDelayedHandler.INSTANCE.setHandlers(new Handler[] { handler });
         }
     }
 

--- a/core/runtime/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
+++ b/core/runtime/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
@@ -1,0 +1,1 @@
+io.quarkus.logging.InitialConfigurator

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
@@ -3,7 +3,11 @@ package io.quarkus.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
-import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
@@ -11,7 +15,6 @@ import org.jboss.logmanager.handlers.FileHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -28,7 +31,7 @@ public class CategoryConfiguredHandlerTest {
         LogManager logManager = LogManager.getLogManager();
         assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
 
-        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        QuarkusDelayedHandler delayedHandler = QuarkusDelayedHandler.INSTANCE;
         assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
 
         Handler handler = Arrays.stream(delayedHandler.getHandlers()).filter(h -> (h instanceof ConsoleHandler))

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/LoggingTestsHelper.java
@@ -11,7 +11,6 @@ import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Assertions;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 
 public class LoggingTestsHelper {
@@ -20,7 +19,7 @@ public class LoggingTestsHelper {
         LogManager logManager = LogManager.getLogManager();
         assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
 
-        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        QuarkusDelayedHandler delayedHandler = QuarkusDelayedHandler.INSTANCE;
         assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
         assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
 

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
@@ -17,7 +17,6 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -43,7 +42,7 @@ public class JsonFormatterDefaultConfigTest {
         LogManager logManager = LogManager.getLogManager();
         assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
 
-        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        QuarkusDelayedHandler delayedHandler = QuarkusDelayedHandler.INSTANCE;
         assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
         assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
 

--- a/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerTest.java
+++ b/extensions/logging-sentry/deployment/src/test/java/io/quarkus/logging/sentry/SentryLoggerTest.java
@@ -11,7 +11,6 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.test.QuarkusUnitTest;
 import io.sentry.HubAdapter;
@@ -41,7 +40,7 @@ public class SentryLoggerTest {
         LogManager logManager = LogManager.getLogManager();
         assertThat(logManager).isInstanceOf(org.jboss.logmanager.LogManager.class);
 
-        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        QuarkusDelayedHandler delayedHandler = QuarkusDelayedHandler.INSTANCE;
         assertThat(Logger.getLogger("").getHandlers()).contains(delayedHandler);
         assertThat(delayedHandler.getLevel()).isEqualTo(Level.ALL);
 

--- a/extensions/neo4j/runtime/src/test/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorderTest.java
+++ b/extensions/neo4j/runtime/src/test/java/io/quarkus/neo4j/runtime/Neo4jDriverRecorderTest.java
@@ -9,7 +9,7 @@ import java.util.logging.LogRecord;
 import org.graalvm.nativeimage.ImageInfo;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.runtime.ssl.SslContextConfiguration;
 import io.quarkus.test.InMemoryLogHandler;
@@ -94,7 +94,7 @@ class Neo4jDriverRecorderTest {
     @Test
     void shouldWarnWhenEncryptionIsNotPossible() {
         var capturingHandler = new InMemoryLogHandler(r -> r.getLoggerName().contains("Neo4jDriverRecorder"));
-        InitialConfigurator.DELAYED_HANDLER.addHandler(capturingHandler);
+        QuarkusDelayedHandler.INSTANCE.addHandler(capturingHandler);
         try {
             runTestPretendingToBeInNativeImageWithoutSSL(() -> {
                 var recorder = new Neo4jDriverRecorder();
@@ -113,7 +113,7 @@ class Neo4jDriverRecorderTest {
                                 "Native SSL is disabled, communication between this client and the Neo4j server cannot be encrypted."));
             });
         } finally {
-            InitialConfigurator.DELAYED_HANDLER.removeHandler(capturingHandler);
+            QuarkusDelayedHandler.INSTANCE.removeHandler(capturingHandler);
         }
     }
 }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
@@ -45,6 +45,8 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 @SuppressWarnings({ "unused", "WeakerAccess" })
 public class QuarkusDelayedHandler extends ExtHandler {
 
+    public static final QuarkusDelayedHandler INSTANCE = new QuarkusDelayedHandler();
+
     /**
      * This is a system property that can be used to help debug startup issues if TRACE and DEBUG logs are being
      * dropped due to the queue limit being exceeded.

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/Timing.java
@@ -1,7 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
 import io.quarkus.bootstrap.graal.ImageInfo;
-import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.logging.Handler;
@@ -123,7 +123,7 @@ public class Timing {
             /**
              * We can safely close log handlers after stop time has been printed.
              */
-            Handler[] handlers = InitialConfigurator.DELAYED_HANDLER.clearHandlers();
+            Handler[] handlers = QuarkusDelayedHandler.INSTANCE.clearHandlers();
             for (Handler handler : handlers) {
                 try {
                     handler.close();

--- a/independent-projects/bootstrap/runner/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
+++ b/independent-projects/bootstrap/runner/src/main/resources/META-INF/services/org.jboss.logmanager.EmbeddedConfigurator
@@ -1,1 +1,0 @@
-io.quarkus.bootstrap.logging.InitialConfigurator


### PR DESCRIPTION
@stuartwdouglas so this is an alternative approach to https://github.com/quarkusio/quarkus/pull/20797 based on your comments.

There is one issue though: when building the project, I end up with:
```
Exception in thread "Thread-24" java.lang.NoClassDefFoundError: io/quarkus/runtime/logging/LoggingSetupRecorder
	at io.quarkus.logging.InitialConfigurator$1.run(InitialConfigurator.java:22)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: io.quarkus.runtime.logging.LoggingSetupRecorder
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:271)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:247)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:239)
	... 2 more
```
at the end of the build - which is normal given how things are implemented. I don't think we can use the Quarkus application shutdown hooks as the whole point of this is to be able to catch issues when the application is not started.

Except if you have a better idea, I'm leaning towards polishing https://github.com/quarkusio/quarkus/pull/20797 and get it in.
