### PR TITLE
Rest client config - avoid warnings about unrecognized config keys

### DIFF
--- a/extensions/resteasy-classic/rest-client/config/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client/config/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -20,7 +20,12 @@ public class RestClientsConfig {
      * a class bearing that annotation, in which case it is possible to use the short name, as well as fully qualified
      * name.
      */
-    private final Map<String, RestClientConfig> configs = new HashMap<>();
+    // This variable is only here to avoid warnings about unrecognized configuration keys. The map is otherwise ignored,
+    // and the RestClientConfig instances are loaded via `RestClientConfig#load()` methods instead.
+    @ConfigItem(name = ConfigItem.PARENT)
+    Map<String, RestClientConfig> preloadedConfigs;
+
+    final Map<String, RestClientConfig> configs = new HashMap<>();
 
     /**
      * By default, REST Client Reactive uses text/plain content type for String values

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/UnknownConfigTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/UnknownConfigTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.restclient.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.restclient.config.RestClientConfig;
+import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnknownConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("restclient-config-test-application.properties", "application.properties"))
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                Set<String> properties = logRecords.stream().flatMap(
+                        logRecord -> Stream.of(logRecord.getParameters())).map(Object::toString).collect(Collectors.toSet());
+                assertEquals(0, properties.size(), "Expected 0 warnings");
+            });
+
+    @Inject
+    RestClientsConfig restClientsConfig;
+
+    @Test
+    void testClientConfigsArePresent() {
+        verifyClientConfig(restClientsConfig.getClientConfig("echo-client"));
+        verifyClientConfig(restClientsConfig.getClientConfig("io.quarkus.restclient.configuration.EchoClient"));
+        verifyClientConfig(restClientsConfig.getClientConfig("EchoClient"));
+        verifyClientConfig(restClientsConfig.getClientConfig("a.b.c.Client"));
+    }
+
+    private void verifyClientConfig(RestClientConfig config) {
+        assertTrue(config.url.isPresent());
+        assertEquals("http://localhost:8081", config.url.get());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/21698