### PR TITLE
Get OIDC recover from the connection failure if the discovery is disabled

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -151,8 +152,10 @@ public class OidcRecorder {
         if (!oidcConfig.discoveryEnabled) {
             if (!isServiceApp(oidcConfig)) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
-                    throw new OIDCException("'web-app' applications must have 'authorization-path' and 'token-path' properties "
-                            + "set when the discovery is disabled.");
+                    throw new ConfigurationException(
+                            "'web-app' applications must have 'authorization-path' and 'token-path' properties "
+                                    + "set when the discovery is disabled.",
+                            Set.of("quarkus.oidc.authorization-path", "quarkus.oidc.token-path"));
                 }
             }
             // JWK and introspection endpoints have to be set for both 'web-app' and 'service' applications  
@@ -160,8 +163,9 @@ public class OidcRecorder {
                 if (!oidcConfig.authentication.isIdTokenRequired() && oidcConfig.authentication.isUserInfoRequired()) {
                     LOG.debugf("tenant %s supports only UserInfo", oidcConfig.tenantId.get());
                 } else {
-                    throw new OIDCException(
-                            "Either 'jwks-path' or 'introspection-path' properties must be set when the discovery is disabled.");
+                    throw new ConfigurationException(
+                            "Either 'jwks-path' or 'introspection-path' properties must be set when the discovery is disabled.",
+                            Set.of("quarkus.oidc.jwks-path", "quarkus.oidc.introspection-path"));
                 }
             }
         }
@@ -254,6 +258,7 @@ public class OidcRecorder {
                     .withBackOff(OidcCommonUtils.CONNECTION_BACKOFF_DURATION, OidcCommonUtils.CONNECTION_BACKOFF_DURATION)
                     .expireIn(connectionDelayInMillisecs)
                     .onFailure()
+                    .transform(t -> toOidcException(t, oidcConfig.authServerUrl.get()))
                     .invoke(client::close);
         } else {
             return client.getJsonWebKeySet();

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -11,6 +11,9 @@ public class CustomTenantResolver implements TenantResolver {
     @Override
     public String resolve(RoutingContext context) {
         String path = context.normalizedPath();
+        if (path.contains("recovered-no-discovery")) {
+            return "no-discovery";
+        }
         if (path.endsWith("code-flow")) {
             return "code-flow";
         }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResourceOidcRecoveredNoDiscovery.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/UsersResourceOidcRecoveredNoDiscovery.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.it.keycloak.model.User;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/recovered-no-discovery/api/users")
+public class UsersResourceOidcRecoveredNoDiscovery {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Path("/preferredUserName")
+    @RolesAllowed("user")
+    @Produces(MediaType.APPLICATION_JSON)
+    public User preferredUserName() {
+        return new User(((JsonWebToken) identity.getPrincipal()).getClaim("preferred_username"));
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -4,6 +4,13 @@ quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.authentication.scopes=profile,email,phone
 
+quarkus.oidc.no-discovery.auth-server-url=http://localhost:8180/auth/realms/quarkus2/
+quarkus.oidc.no-discovery.discovery-enabled=false
+quarkus.oidc.no-discovery.jwks-path=protocol/openid-connect/certs
+quarkus.oidc.no-discovery.client-id=quarkus-app
+quarkus.oidc.no-discovery.credentials.secret=secret
+quarkus.oidc.no-discovery.authentication.scopes=profile,email,phone
+
 quarkus.oidc.code-flow.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow.client-id=quarkus-web-app
 quarkus.oidc.code-flow.credentials.secret=secret


### PR DESCRIPTION
Fixes #21706 

It already works and tested when OIDC fails to discover OIDC metadata at the start up but if the discovery is disabled then it fails to recover. 

So this PR does a very simple fix (wraps the connection exception into `OIDCException` which is checked when the recovery is activated), updated the existing test and added a new test confirming it is now properly recovered.
Also replaces 2 `OIDCException`s with `ConfigurationException` - the latter is used everywhere in the OIDC code when the config issue is detected - the use of `OIDCException` in such cases is the old code...

No OIDC logic itself has been affected....