### PR TITLE
Optimize ArtifactInfoUtil to more often use the CurateOutcomeBuildItem

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
@@ -33,6 +33,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
 
@@ -40,16 +41,17 @@ public class ArcDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     @Record(ExecutionTime.STATIC_INIT)
-    public DevConsoleRuntimeTemplateInfoBuildItem exposeArcContainer(ArcRecorder recorder) {
+    public DevConsoleRuntimeTemplateInfoBuildItem exposeArcContainer(ArcRecorder recorder,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
         return new DevConsoleRuntimeTemplateInfoBuildItem("arcContainer",
-                new ArcContainerSupplier());
+                new ArcContainerSupplier(), this.getClass(), curateOutcomeBuildItem);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
     void monitor(ArcConfig config, BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> runtimeInfos,
             BuildProducer<AdditionalBeanBuildItem> beans, BuildProducer<AnnotationsTransformerBuildItem> annotationTransformers,
             CustomScopeAnnotationsBuildItem customScopes,
-            List<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations) {
+            List<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations, CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (!config.devMode.monitoringEnabled) {
             return;
         }
@@ -60,7 +62,7 @@ public class ArcDevConsoleProcessor {
         // Events
         runtimeInfos.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("eventsMonitor",
-                        new BeanLookupSupplier(EventsMonitor.class)));
+                        new BeanLookupSupplier(EventsMonitor.class), this.getClass(), curateOutcomeBuildItem));
         beans.produce(AdditionalBeanBuildItem.unremovableOf(EventsMonitor.class));
         // Invocations
         beans.produce(AdditionalBeanBuildItem.builder().setUnremovable()
@@ -85,7 +87,7 @@ public class ArcDevConsoleProcessor {
             }
         }));
         runtimeInfos.produce(new DevConsoleRuntimeTemplateInfoBuildItem("invocationsMonitor",
-                new BeanLookupSupplier(InvocationsMonitor.class)));
+                new BeanLookupSupplier(InvocationsMonitor.class), this.getClass(), curateOutcomeBuildItem));
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devconsole/CacheDevConsoleProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/devconsole/CacheDevConsoleProcessor.java
@@ -7,14 +7,16 @@ import io.quarkus.cache.runtime.devconsole.CacheDevConsoleRecorder;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 
 public class CacheDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("cacheInfos", new CaffeineCacheSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("cacheInfos", new CaffeineCacheSupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 
     @BuildStep

--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayDevConsoleProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayDevConsoleProcessor.java
@@ -31,8 +31,9 @@ public class FlywayDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(
-            FlywayProcessor.MigrationStateBuildItem migrationStateBuildItem) {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("containers", new FlywayContainersSupplier());
+            FlywayProcessor.MigrationStateBuildItem migrationStateBuildItem, CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("containers", new FlywayContainersSupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 
     @BuildStep

--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/devmode/GrpcDevConsoleProcessor.java
@@ -46,6 +46,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.dev.testing.GrpcWebSocketProxy;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
@@ -64,10 +65,11 @@ import io.quarkus.grpc.runtime.devmode.StreamCollectorInterceptor;
 public class GrpcDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public void devConsoleInfo(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> infos) {
+    public void devConsoleInfo(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> infos,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
         infos.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("grpcServices",
-                        new BeanLookupSupplier(GrpcServices.class)));
+                        new BeanLookupSupplier(GrpcServices.class), this.getClass(), curateOutcomeBuildItem));
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/devconsole/HibernateDevConsoleProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/devconsole/HibernateDevConsoleProcessor.java
@@ -2,14 +2,17 @@ package io.quarkus.hibernate.orm.deployment.devconsole;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleInfoSupplier;
 
 public class HibernateDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectDeploymentUnits() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("persistence", new HibernateOrmDevConsoleInfoSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectDeploymentUnits(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("persistence", new HibernateOrmDevConsoleInfoSupplier(),
+                this.getClass(),
+                curateOutcomeBuildItem);
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole.HibernateSearchDevConsoleRecorder;
@@ -13,8 +14,9 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole.Hibernat
 public class HibernateSearchElasticsearchDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("indexedEntityTypes", new HibernateSearchSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("indexedEntityTypes", new HibernateSearchSupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 
     @BuildStep

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devconsole/InfinispanDevConsoleProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devconsole/InfinispanDevConsoleProcessor.java
@@ -2,13 +2,15 @@ package io.quarkus.infinispan.client.deployment.devconsole;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.infinispan.client.runtime.InfinispanServerUrlSupplier;
 
 public class InfinispanDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem infinispanServer() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("serverUrl", new InfinispanServerUrlSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem infinispanServer(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("serverUrl", new InfinispanServerUrlSupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 }

--- a/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devconsole/DevConsoleProcessor.java
+++ b/extensions/kafka-streams/deployment/src/main/java/io/quarkus/kafka/streams/deployment/devconsole/DevConsoleProcessor.java
@@ -2,14 +2,16 @@ package io.quarkus.kafka.streams.deployment.devconsole;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.kafka.streams.runtime.TopologySupplier;
 
 public class DevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectInfos() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("topology", new TopologySupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectInfos(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("topology", new TopologySupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 
 }

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devconsole/LiquibaseDevConsoleProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/devconsole/LiquibaseDevConsoleProcessor.java
@@ -5,6 +5,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.liquibase.runtime.devconsole.LiquibaseDevConsoleRecorder;
@@ -13,8 +14,10 @@ import io.quarkus.liquibase.runtime.devconsole.LiquibaseFactoriesSupplier;
 public class LiquibaseDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("liquibaseFactories", new LiquibaseFactoriesSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("liquibaseFactories", new LiquibaseFactoriesSupplier(),
+                this.getClass(),
+                curateOutcomeBuildItem);
     }
 
     @BuildStep

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/AbstractDevConsoleProcessor.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.deployment.devservices;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
@@ -21,6 +22,7 @@ public abstract class AbstractDevConsoleProcessor {
     protected void produceDevConsoleTemplateItems(Capabilities capabilities,
             BuildProducer<DevConsoleTemplateInfoBuildItem> devConsoleTemplate,
             BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeInfo,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
             String oidcProviderName,
             String oidcApplicationType,
             String oidcGrantType,
@@ -44,22 +46,26 @@ public abstract class AbstractDevConsoleProcessor {
 
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("clientId",
-                        new OidcConfigPropertySupplier(CLIENT_ID_CONFIG_KEY)));
+                        new OidcConfigPropertySupplier(CLIENT_ID_CONFIG_KEY), this.getClass(), curateOutcomeBuildItem));
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("clientSecret",
-                        new OidcConfigPropertySupplier(CLIENT_SECRET_CONFIG_KEY, "")));
+                        new OidcConfigPropertySupplier(CLIENT_SECRET_CONFIG_KEY, ""), this.getClass(), curateOutcomeBuildItem));
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("authorizationUrl",
-                        new OidcConfigPropertySupplier(AUTHORIZATION_PATH_CONFIG_KEY, authorizationUrl, true)));
+                        new OidcConfigPropertySupplier(AUTHORIZATION_PATH_CONFIG_KEY, authorizationUrl, true), this.getClass(),
+                        curateOutcomeBuildItem));
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("tokenUrl",
-                        new OidcConfigPropertySupplier(TOKEN_PATH_CONFIG_KEY, tokenUrl, true)));
+                        new OidcConfigPropertySupplier(TOKEN_PATH_CONFIG_KEY, tokenUrl, true), this.getClass(),
+                        curateOutcomeBuildItem));
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("logoutUrl",
-                        new OidcConfigPropertySupplier(END_SESSION_PATH_CONFIG_KEY, logoutUrl, true)));
+                        new OidcConfigPropertySupplier(END_SESSION_PATH_CONFIG_KEY, logoutUrl, true), this.getClass(),
+                        curateOutcomeBuildItem));
         devConsoleRuntimeInfo.produce(
                 new DevConsoleRuntimeTemplateInfoBuildItem("postLogoutUriParam",
-                        new OidcConfigPropertySupplier(POST_LOGOUT_URI_PARAM_CONFIG_KEY)));
+                        new OidcConfigPropertySupplier(POST_LOGOUT_URI_PARAM_CONFIG_KEY), this.getClass(),
+                        curateOutcomeBuildItem));
 
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -13,6 +13,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
@@ -50,7 +51,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
             BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeInfo,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,
-            Capabilities capabilities) {
+            Capabilities capabilities, CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (isOidcTenantEnabled() && isAuthServerUrlSet() && isClientIdSet()) {
 
             if (vertxInstance == null) {
@@ -88,6 +89,7 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
             produceDevConsoleTemplateItems(capabilities,
                     devConsoleInfo,
                     devConsoleRuntimeInfo,
+                    curateOutcomeBuildItem,
                     providerName,
                     getApplicationType(),
                     oidcConfig.devui.grant.type.isPresent() ? oidcConfig.devui.grant.type.get().getGrantType() : "code",

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -10,6 +10,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
@@ -29,7 +30,7 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
     public void setConfigProperties(BuildProducer<DevConsoleTemplateInfoBuildItem> devConsoleInfo,
             BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeInfo,
             Optional<KeycloakDevServicesConfigBuildItem> configProps,
-            Capabilities capabilities) {
+            Capabilities capabilities, CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (configProps.isPresent() && configProps.get().getProperties().containsKey("keycloak.url")) {
             String keycloakUrl = (String) configProps.get().getProperties().get("keycloak.url");
             String realmUrl = keycloakUrl + "/realms/" + configProps.get().getProperties().get("keycloak.realm");
@@ -41,6 +42,7 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
             produceDevConsoleTemplateItems(capabilities,
                     devConsoleInfo,
                     devConsoleRuntimeInfo,
+                    curateOutcomeBuildItem,
                     "Keycloak",
                     (String) configProps.get().getProperties().get("quarkus.oidc.application-type"),
                     oidcConfig.devui.grant.type.isPresent() ? oidcConfig.devui.grant.type.get().getGrantType()
@@ -49,7 +51,6 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     realmUrl + "/protocol/openid-connect/token",
                     realmUrl + "/protocol/openid-connect/logout",
                     true);
-
         }
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devconsole/ResteasyReactiveDevConsoleProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/devconsole/ResteasyReactiveDevConsoleProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
 import io.quarkus.resteasy.reactive.server.runtime.EndpointScoresSupplier;
@@ -24,8 +25,9 @@ import io.quarkus.vertx.http.runtime.StaticResourcesRecorder;
 public class ResteasyReactiveDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectScores() {
-        return new DevConsoleRuntimeTemplateInfoBuildItem("endpointScores", new EndpointScoresSupplier());
+    public DevConsoleRuntimeTemplateInfoBuildItem collectScores(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("endpointScores", new EndpointScoresSupplier(), this.getClass(),
+                curateOutcomeBuildItem);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devconsole/RestClientReactiveDevConsoleProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/devconsole/RestClientReactiveDevConsoleProcessor.java
@@ -4,15 +4,16 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.runtime.BeanLookupSupplier;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.rest.client.reactive.runtime.devconsole.RestClientsContainer;
 
 public class RestClientReactiveDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem devConsoleInfo() {
+    public DevConsoleRuntimeTemplateInfoBuildItem devConsoleInfo(CurateOutcomeBuildItem curateOutcomeBuildItem) {
         return new DevConsoleRuntimeTemplateInfoBuildItem("devRestClients",
-                new BeanLookupSupplier(RestClientsContainer.class));
+                new BeanLookupSupplier(RestClientsContainer.class), this.getClass(), curateOutcomeBuildItem);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -65,6 +65,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.gizmo.ClassCreator;
@@ -263,13 +264,13 @@ public class SchedulerProcessor {
     @BuildStep
     @Record(value = STATIC_INIT, optional = true)
     public DevConsoleRouteBuildItem devConsole(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> infos,
-            SchedulerDevConsoleRecorder recorder) {
+            SchedulerDevConsoleRecorder recorder, CurateOutcomeBuildItem curateOutcomeBuildItem) {
         infos.produce(new DevConsoleRuntimeTemplateInfoBuildItem("schedulerContext",
-                new BeanLookupSupplier(SchedulerContext.class)));
+                new BeanLookupSupplier(SchedulerContext.class), this.getClass(), curateOutcomeBuildItem));
         infos.produce(new DevConsoleRuntimeTemplateInfoBuildItem("scheduler",
-                new BeanLookupSupplier(Scheduler.class)));
+                new BeanLookupSupplier(Scheduler.class), this.getClass(), curateOutcomeBuildItem));
         infos.produce(new DevConsoleRuntimeTemplateInfoBuildItem("configLookup",
-                recorder.getConfigLookup()));
+                recorder.getConfigLookup(), this.getClass(), curateOutcomeBuildItem));
         return new DevConsoleRouteBuildItem("schedules", "POST", recorder.invokeHandler());
     }
 

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devconsole/ReactiveMessagingDevConsoleProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/devconsole/ReactiveMessagingDevConsoleProcessor.java
@@ -13,6 +13,7 @@ import io.quarkus.arc.processor.InjectionPointInfo;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.smallrye.reactivemessaging.deployment.ReactiveMessagingDotNames;
 import io.quarkus.smallrye.reactivemessaging.runtime.devconsole.Connectors;
@@ -22,9 +23,9 @@ import io.quarkus.smallrye.reactivemessaging.runtime.devconsole.DevReactiveMessa
 public class ReactiveMessagingDevConsoleProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    public DevConsoleRuntimeTemplateInfoBuildItem collectInfos() {
+    public DevConsoleRuntimeTemplateInfoBuildItem collectInfos(CurateOutcomeBuildItem curateOutcomeBuildItem) {
         return new DevConsoleRuntimeTemplateInfoBuildItem("reactiveMessagingInfos",
-                new DevReactiveMessagingInfosSupplier());
+                new DevReactiveMessagingInfosSupplier(), this.getClass(), curateOutcomeBuildItem);
     }
 
     @Record(STATIC_INIT)

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ConfigDescriptionBuildItem;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.dev.config.CurrentConfig;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
@@ -38,7 +39,8 @@ public class ConfigEditorProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     public void config(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeTemplateProducer,
             List<ConfigDescriptionBuildItem> configDescriptionBuildItems,
-            Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig) {
+            Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
         List<ConfigDescription> configDescriptions = new ArrayList<>();
         for (ConfigDescriptionBuildItem item : configDescriptionBuildItems) {
             configDescriptions.add(
@@ -52,12 +54,14 @@ public class ConfigEditorProcessor {
         }
 
         devConsoleRuntimeTemplateProducer.produce(new DevConsoleRuntimeTemplateInfoBuildItem("config",
-                new ConfigDescriptionsSupplier(configDescriptions)));
+                new ConfigDescriptionsSupplier(configDescriptions), this.getClass(), curateOutcomeBuildItem));
 
         devConsoleRuntimeTemplateProducer.produce(new DevConsoleRuntimeTemplateInfoBuildItem("hasDevServices",
                 new HasDevServicesSupplier(devServicesLauncherConfig.isPresent()
                         && devServicesLauncherConfig.get().getConfig() != null
-                        && !devServicesLauncherConfig.get().getConfig().isEmpty())));
+                        && !devServicesLauncherConfig.get().getConfig().isEmpty()),
+                this.getClass(),
+                curateOutcomeBuildItem));
     }
 
     @BuildStep

--- a/extensions/vertx-http/dev-console-spi/src/main/java/io/quarkus/devconsole/spi/DevConsoleRuntimeTemplateInfoBuildItem.java
+++ b/extensions/vertx-http/dev-console-spi/src/main/java/io/quarkus/devconsole/spi/DevConsoleRuntimeTemplateInfoBuildItem.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.ArtifactInfoUtil;
 
 /**
@@ -28,6 +29,13 @@ public final class DevConsoleRuntimeTemplateInfoBuildItem extends MultiBuildItem
         this.object = object;
     }
 
+    /**
+     *
+     * @param name
+     * @param object
+     * @deprecated use {@link #DevConsoleRuntimeTemplateInfoBuildItem(String, Supplier, Class, CurateOutcomeBuildItem)}
+     */
+    @Deprecated
     public DevConsoleRuntimeTemplateInfoBuildItem(String name, Supplier<? extends Object> object) {
         String callerClassName = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass()
                 .getCanonicalName();
@@ -38,6 +46,15 @@ public final class DevConsoleRuntimeTemplateInfoBuildItem extends MultiBuildItem
             throw new RuntimeException(e);
         }
         Map.Entry<String, String> info = ArtifactInfoUtil.groupIdAndArtifactId(callerClass);
+        this.groupId = info.getKey();
+        this.artifactId = info.getValue();
+        this.name = name;
+        this.object = object;
+    }
+
+    public DevConsoleRuntimeTemplateInfoBuildItem(String name, Supplier<? extends Object> object, Class<?> callerClass,
+            CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        Map.Entry<String, String> info = ArtifactInfoUtil.groupIdAndArtifactId(callerClass, curateOutcomeBuildItem);
         this.groupId = info.getKey();
         this.artifactId = info.getValue();
         this.name = name;


### PR DESCRIPTION
This prevents multiple filesystems to be opened, just to retrieve the groupid + artifactid.
The CurateOutcomeBuildItem knows the root paths of all jars and directories, which can simply be searched against.

In the current state, this pr saves about 20ms. The ArtifactInfoUtil does not appear anymore in my flamegraphs.

Relates to #21552, but not a complete fix.