### PR TITLE
Move findbugs constraint to the quarkus-bom as a runtime dependency of quarkus-grpc-common

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -17,6 +17,7 @@
         <bouncycastle.version>1.69</bouncycastle.version>
         <bouncycastle.fips.version>1.0.2.1</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>1.0.12.2</bouncycastle.tls.fips.version>
+        <findbugs.version>3.0.2</findbugs.version>
         <jandex.version>2.4.1.Final</jandex.version>
         <resteasy.version>4.7.3.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
@@ -188,11 +189,6 @@
         <jib-core.version>0.20.0</jib-core.version>
         <google-http-client.version>1.38.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
-        <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.42.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
-        <grpc-jprotoc.version>1.2.0</grpc-jprotoc.version>
-        <protobuf-java.version>3.19.1</protobuf-java.version>
-        <protoc.version>${protobuf-java.version}</protoc.version>
         <picocli.version>4.6.2</picocli.version>
         <google-cloud-functions.version>1.0.1</google-cloud-functions.version>
         <commons-compress.version>1.21</commons-compress.version>
@@ -2782,6 +2778,13 @@
             </dependency>
 
             <!-- External dependencies -->
+
+            <!-- GRPC dependency -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${findbugs.version}</version>
+            </dependency>
 
             <!-- Bouncy Castle -->
             <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -91,7 +91,6 @@
         <elasticsearch.protocol>http</elasticsearch.protocol>
 
         <!-- Align various dependencies that are not really part of the bom-->
-        <findbugs.version>3.0.2</findbugs.version>
         <junit4.version>4.13.2</junit4.version>
 
         <!-- The image to use for tests that run Keycloak -->
@@ -116,10 +115,6 @@
         <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-
-        <!--TODO: remove when switched back to quarkus-maven-plugin for grpc stubs-->
-        <protoc.version>3.19.1</protoc.version> <!--keep in sync with the BOM-->
-        <grpc.version>1.42.1</grpc.version> <!--keep in sync with the BOM -->
 
         <!-- Webjars -->
         <webjar.bootstrap.version>4.6.0</webjar.bootstrap.version>
@@ -232,11 +227,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-legacy-launcher</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${findbugs.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.unboundid</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -40,7 +40,6 @@
         <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- changed from the original version due to https://snyk.io/vuln/maven:org.apache.maven.shared:maven-shared-utils@3.2.1 -->
         <maven-wagon.version>3.4.3</maven-wagon.version>
         <httpcore.version>4.4.14</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson.version>2.12.5</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -54,7 +53,6 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <graal-sdk.version>21.3.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <smallrye-common.version>1.8.0</smallrye-common.version>
         <gradle-tooling.version>7.3</gradle-tooling.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,14 @@
         <skipDocs>false</skipDocs>
         <skip.gradle.tests>false</skip.gradle.tests>
 
+        <!-- Dependency versions -->
+
+        <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
+        <grpc.version>1.42.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc-jprotoc.version>1.2.0</grpc-jprotoc.version>
+        <protoc.version>3.19.1</protoc.version>
+        <protobuf-java.version>${protoc.version}</protobuf-java.version>
+
     </properties>
 
     <modules>


### PR DESCRIPTION
This also moves `grpc`-related version properties that are referenced from other module POMs to the root POM to have them defined once.