### PR TITLE
Enforce Maven 3.8.4 to build Quarkus

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -441,7 +441,7 @@
                                         <version>[${maven.compiler.release},)</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
-                                        <version>${supported-maven-versions}</version>
+                                        <version>[${proposed-maven-version},)</version>
                                     </requireMavenVersion>
                                     <!-- Disabled due to https://issues.apache.org/jira/browse/MENFORCER-359 (3.0.0-M3)
                                          3.0.0 suffers from https://issues.apache.org/jira/browse/MENFORCER-394, so we need to wait for a fixed release.


### PR DESCRIPTION
Before it was effectively `[3.6.2,)`.

Reasoning: CI is running with 3.8.4 and only 3.8.4, so we have no (continuous) feedback for other versions.
So better avoid nasty surprises by being more strict.

Btw, has anyone checked lately whether anything below 3.8.1 is still working?