### PR TITLE
Prevent creation of multiple java.lang.reflect.Parameter array clones

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -216,9 +216,12 @@ public class ProxyFactory<T> {
 
                     ResultHandle getDeclaredMethodParamsArray = mc.newArray(Class.class,
                             methodInfo.getParameterCount());
-                    for (int i = 0; i < methodInfo.getParameterCount(); i++) {
-                        ResultHandle paramClass = mc.loadClass(methodInfo.getParameters()[i].getType());
-                        mc.writeArrayValue(getDeclaredMethodParamsArray, i, paramClass);
+                    if (methodInfo.getParameterCount() > 0) {
+                        Parameter[] methodInfoParameters = methodInfo.getParameters();
+                        for (int i = 0; i < methodInfo.getParameterCount(); i++) {
+                            ResultHandle paramClass = mc.loadClass(methodInfoParameters[i].getType());
+                            mc.writeArrayValue(getDeclaredMethodParamsArray, i, paramClass);
+                        }
                     }
                     ResultHandle method = mc.invokeVirtualMethod(
                             MethodDescriptor.ofMethod(Class.class, "getDeclaredMethod", Method.class, String.class,

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -1168,9 +1169,12 @@ public class BytecodeRecorderImpl implements RecorderContext {
             }
             nonDefaultConstructorHolder = new NonDefaultConstructorHolder(current, null);
             nonDefaultConstructorHandles = new DeferredParameter[current.getParameterCount()];
-            for (int i = 0; i < current.getParameterCount(); ++i) {
-                String name = current.getParameters()[i].getName();
-                constructorParamNameMap.put(name, i);
+            if (current.getParameterCount() > 0) {
+                Parameter[] parameters = current.getParameters();
+                for (int i = 0; i < current.getParameterCount(); ++i) {
+                    String name = parameters[i].getName();
+                    constructorParamNameMap.put(name, i);
+                }
             }
         } else {
             for (Constructor<?> ctor : param.getClass().getConstructors()) {


### PR DESCRIPTION
Calling getParameters() for a java.lang.reflect.Method results in a clone of the parameter array being created.
This clone was recreated on each array iteration.

Simply declaring a local variable with the parameters avoids this cost.

Related to #21552