### PR TITLE
Add import to docs

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -97,6 +97,8 @@ To make the test pass, we also need to update `GreetingResourceTest.kt` like so:
 
 [source,kotlin]
 ----
+import org.hamcrest.Matchers.equalTo
+
 @QuarkusTest
 class GreetingResourceTest {
 


### PR DESCRIPTION
This makes it clear where the 'equalTo' method is coming from.

Fixes #21755