### PR TITLE
Fix `upx` mode selection (system vs. in-container)

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -40,17 +40,20 @@ public class UpxCompressionBuildStep {
         }
 
         Optional<File> upxPathFromSystem = getUpxFromSystem();
-        boolean inContainerUpx = upxPathFromSystem.isEmpty() || nativeConfig.isContainerBuild();
-        if (inContainerUpx) {
+        if (upxPathFromSystem.isPresent()) {
+            log.debug("Running UPX from system path");
+            if (!runUpxFromHost(upxPathFromSystem.get(), image.getPath().toFile(), nativeConfig)) {
+                throw new IllegalStateException("Unable to compress the native executable");
+            }
+        } else if (nativeConfig.isContainerBuild()) {
             log.infof("Running UPX from a container using the builder image: " + nativeConfig.builderImage);
             if (!runUpxInContainer(image, nativeConfig)) {
                 throw new IllegalStateException("Unable to compress the native executable");
             }
         } else {
-            log.debug("Running UPX from system path");
-            if (!runUpxFromHost(upxPathFromSystem.get(), image.getPath().toFile(), nativeConfig)) {
-                throw new IllegalStateException("Unable to compress the native executable");
-            }
+            log.errorf("Unable to compress the native executable. Either install `upx` from https://upx.github.io/" +
+                    " on your machine, or enable in-container build using `-Dquarkus.native.container-build=true`.");
+            throw new IllegalStateException("Unable to compress the native executable: `upx` not available");
         }
         log.infof("Native executable compressed: %s", image.getPath().toFile().getAbsolutePath());
     }

--- a/docs/src/main/asciidoc/upx.adoc
+++ b/docs/src/main/asciidoc/upx.adoc
@@ -28,10 +28,15 @@ The UPX compression requires:
 * or to have built the native executable using an in-container build.
 
 If you have the `upx` command available on your path, Quarkus uses it.
-
 Otherwise, if you built the native image using an in-container build (using `quarkus.native.container-build=true`) and if the builder image provides the `upx` command, Quarkus compresses the executable from inside the container.
 
 If you are not in one of these cases, the compression fails.
+
+[IMPORTANT]
+.upx is cross-platform.
+====
+`upx` can compress executables using a different architecture and OS than your host machine. For example, `upx` on a MacOS X machine can compress a Linux 64bits executables.
+====
 
 == Configuring the UPX compression
 


### PR DESCRIPTION
`upx` is cross-platform, and so, for performance reasons, we should always privilege system `upx` if available. That was described in the doc and not implemented correctly. 