### PR TITLE
FAI-681: Integrate TrustyService with Quarkus DevServices services

### DIFF
--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -13,7 +13,8 @@ public interface DevServicesDatasourceProvider {
     RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
             Optional<String> datasourceName,
             Optional<String> imageName, Map<String, String> additionalProperties,
-            OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout);
+            OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout,
+            boolean useTestContainersSharedNetwork);
 
     default boolean isDockerRequired() {
         return true;

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -267,7 +267,8 @@ public class DevServicesDatasourceProcessor {
                             ConfigProvider.getConfig().getOptionalValue(prefix + "password", String.class),
                             Optional.ofNullable(dbName), dataSourceBuildTimeConfig.devservices.imageName,
                             dataSourceBuildTimeConfig.devservices.properties,
-                            dataSourceBuildTimeConfig.devservices.port, launchMode, globalDevServicesConfig.timeout);
+                            dataSourceBuildTimeConfig.devservices.port, launchMode, globalDevServicesConfig.timeout,
+                            dataSourceBuildTimeConfig.devservices.useTestContainersSharedNetwork);
             closeableList.add(datasource.getCloseTask());
 
             propertiesMap.put(prefix + "db-kind", dataSourceBuildTimeConfig.dbKind.orElse(null));

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -54,4 +54,13 @@ public class DevServicesBuildTimeConfig {
      */
     @ConfigItem
     public OptionalInt port;
+
+    /**
+     * Whether this particular data source's container should join TestContainers Shared Network.
+     * <p>
+     * By default, the data source container will join Docker's default network.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean useTestContainersSharedNetwork;
+
 }

--- a/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
+++ b/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
@@ -31,7 +31,8 @@ public class DerbyDevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
+                    boolean useTestContainersSharedNetwork) {
                 try {
                     int port = fixedExposedPort.isPresent() ? fixedExposedPort.getAsInt()
                             : 1527 + (launchMode == LaunchMode.TEST ? 0 : 1);

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -30,7 +30,8 @@ public class H2DevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout,
+                    boolean useTestContainersSharedNetwork) {
                 try {
                     final Server tcpServer = Server.createTcpServer("-tcpPort",
                             port.isPresent() ? String.valueOf(port.getAsInt()) : "0");

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -9,6 +9,7 @@ import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -33,9 +34,10 @@ public class MariaDBDevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
+                    boolean useTestContainersSharedNetwork) {
                 QuarkusMariaDBContainer container = new QuarkusMariaDBContainer(imageName, fixedExposedPort,
-                        devServicesSharedNetworkBuildItem.isPresent());
+                        devServicesSharedNetworkBuildItem.isPresent(), useTestContainersSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
                 container.withPassword(password.orElse("quarkus"))
                         .withUsername(username.orElse("quarkus"))
@@ -65,11 +67,15 @@ public class MariaDBDevServicesProcessor {
 
         private String hostName = null;
 
-        public QuarkusMariaDBContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
+        public QuarkusMariaDBContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
+                boolean useTestContainersSharedNetwork) {
             super(DockerImageName.parse(imageName.orElse(MariaDBContainer.IMAGE + ":" + MariaDBDevServicesProcessor.TAG))
                     .asCompatibleSubstituteFor(DockerImageName.parse(MariaDBContainer.IMAGE)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            if (useTestContainersSharedNetwork) {
+                withNetwork(Network.SHARED);
+            }
         }
 
         @Override

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -9,6 +9,7 @@ import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -32,9 +33,10 @@ public class MySQLDevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
+                    boolean useTestContainersSharedNetwork) {
                 QuarkusMySQLContainer container = new QuarkusMySQLContainer(imageName, fixedExposedPort,
-                        devServicesSharedNetworkBuildItem.isPresent());
+                        devServicesSharedNetworkBuildItem.isPresent(), useTestContainersSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
                 container.withPassword(password.orElse("quarkus"))
                         .withUsername(username.orElse("quarkus"))
@@ -64,11 +66,15 @@ public class MySQLDevServicesProcessor {
 
         private String hostName = null;
 
-        public QuarkusMySQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
+        public QuarkusMySQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
+                boolean useTestContainersSharedNetwork) {
             super(DockerImageName.parse(imageName.orElse(MySQLContainer.IMAGE + ":" + MySQLDevServicesProcessor.TAG))
                     .asCompatibleSubstituteFor(DockerImageName.parse(MySQLContainer.IMAGE)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            if (useTestContainersSharedNetwork) {
+                withNetwork(Network.SHARED);
+            }
         }
 
         @Override

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -37,9 +38,10 @@ public class OracleDevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
+                    boolean useTestContainersSharedNetwork) {
                 QuarkusOracleServerContainer container = new QuarkusOracleServerContainer(imageName, fixedExposedPort,
-                        devServicesSharedNetworkBuildItem.isPresent());
+                        devServicesSharedNetworkBuildItem.isPresent(), useTestContainersSharedNetwork);
                 startupTimeout.ifPresent(container::withStartupTimeout);
                 container.withUsername(username.orElse(DEFAULT_DATABASE_USER))
                         .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
@@ -70,12 +72,15 @@ public class OracleDevServicesProcessor {
         private String hostName = null;
 
         public QuarkusOracleServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
-                boolean useSharedNetwork) {
+                boolean useSharedNetwork, boolean useTestContainersSharedNetwork) {
             super(DockerImageName
                     .parse(imageName.orElse(OracleDevServicesProcessor.IMAGE + ":" + OracleDevServicesProcessor.TAG))
                     .asCompatibleSubstituteFor(OracleDevServicesProcessor.IMAGE));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+            if (useTestContainersSharedNetwork) {
+                withNetwork(Network.SHARED);
+            }
         }
 
         @Override


### PR DESCRIPTION
This contains the changes I've had to implement to have the following running:-

- A `kogito` application running on `localhost:8080`
- This `kogito` application starting a Docker container for a service it needs `TrustyService`.
- This `kogito` application connecting with and using Quarkus' DevServices Redpanda (Kafka) instance.
- `TrustyService` connecting with and using Quarkus' DevServices Redpanda (Kafka) instance.
- `TrustyService` connecting with and using Quarkus' DevServices PostgreSQL instance.

So, by simply running `mvn compile quarkus:dev` I get a fully operational environment. Great.

It is not using what Quarkus defines as a "shared network" that is used for Integration Testing. 