### PR TITLE
Fix GraalVM version pattern matching and add test for isJava17

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 final class GraalVM {
     static final class Version implements Comparable<Version> {
         private static final Pattern PATTERN = Pattern.compile(
-                "(GraalVM|native-image)( Version)? (?<version>[1-9][0-9]*(\\.[0-9]+)+(-dev\\p{XDigit}*)?)(?<distro>[^\n$]*)(Java Version (?<javaVersion>[^)]+))?\\s*");
+                "(GraalVM|native-image)( Version)? (?<version>[1-9][0-9]*(\\.[0-9]+)+(-dev\\p{XDigit}*)?)(?<distro>.*?)?(\\(Java Version (?<javaVersion>[^)]+)\\))?$");
 
         static final Version UNVERSIONED = new Version("Undefined", "snapshot", Distribution.ORACLE);
         static final Version VERSION_21_2 = new Version("GraalVM 21.2", "21.2", Distribution.ORACLE);
@@ -100,6 +100,7 @@ final class GraalVM {
         public String toString() {
             return "Version{" +
                     "version=" + version +
+                    ", fullVersion=" + fullVersion +
                     ", distribution=" + distribution +
                     ", javaVersion=" + javaVersion +
                     '}';

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/GraalVMTest.java
@@ -116,4 +116,17 @@ public class GraalVMTest {
         assertThat(Version.of(Stream.of(version)).isNewerThan(Version.of(Stream.of(other)))).isTrue();
     }
 
+    @Test
+    public void testGraalVMVersionIsJava17() {
+        Version graalVM21_3_11 = Version.of(Stream.of("GraalVM 21.3.0 Java 11 CE (Java Version 11.0.13+7-jvmci-21.3-b05)"));
+        assertThat(graalVM21_3_11.isJava17()).isFalse();
+        Version graalVM21_3_17 = Version.of(Stream.of("GraalVM 21.3.0 Java 17 CE (Java Version 17.0.1+12-jvmci-21.3-b05)"));
+        assertThat(graalVM21_3_17.isJava17()).isTrue();
+        Version mandrel21_3_11 = Version
+                .of(Stream.of("native-image 21.3.0.0-Final Mandrel Distribution (Java Version 11.0.13+8)"));
+        assertThat(mandrel21_3_11.isJava17()).isFalse();
+        Version mandrel21_3_17 = Version
+                .of(Stream.of("native-image 21.3.0.0-Final Mandrel Distribution (Java Version 17.0.1+12)"));
+        assertThat(mandrel21_3_17.isJava17()).isTrue();
+    }
 }


### PR DESCRIPTION
The regexp group "distro" was greedy and was capturing the java version as well.