### PR TITLE
Avoid duplicate calls to getParameterTypes and getGenericParameterTypes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveMethodBuildItem.java
@@ -25,11 +25,13 @@ public final class ReflectiveMethodBuildItem extends MultiBuildItem {
     }
 
     public ReflectiveMethodBuildItem(Method method) {
-        String[] params = new String[method.getParameterCount()];
-        for (int i = 0; i < params.length; ++i) {
-            params[i] = method.getParameterTypes()[i].getName();
+        this.params = new String[method.getParameterCount()];
+        if (method.getParameterCount() > 0) {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            for (int i = 0; i < params.length; ++i) {
+                params[i] = parameterTypes[i].getName();
+            }
         }
-        this.params = params;
         this.name = method.getName();
         this.declaringClass = method.getDeclaringClass().getName();
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/proxy/ProxyFactory.java
@@ -190,9 +190,10 @@ public class ProxyFactory<T> {
                 ctor.returnValue(null);
             }
 
+            Class<?>[] parameterTypes = injectConstructor.getParameterTypes();
             List<Class<?>> args = new ArrayList<>();
             args.add(InvocationHandler.class);
-            args.addAll(Arrays.asList(injectConstructor.getParameterTypes()));
+            args.addAll(Arrays.asList(parameterTypes));
             try (MethodCreator ctor = cc
                     .getMethodCreator(MethodDescriptor.ofConstructor(proxyName, args.toArray(Class[]::new)))) {
                 List<ResultHandle> params = new ArrayList<>();
@@ -201,7 +202,7 @@ public class ProxyFactory<T> {
                 }
                 ctor.invokeSpecialMethod(
                         MethodDescriptor.ofConstructor(injectConstructor.getDeclaringClass(),
-                                injectConstructor.getParameterTypes()),
+                                parameterTypes),
                         ctor.getThis(),
                         params.toArray(ResultHandle[]::new));
                 ctor.writeInstanceField(invocationHandlerField, ctor.getThis(), ctor.getMethodParam(0));
@@ -268,8 +269,9 @@ public class ProxyFactory<T> {
                 defineClass();
                 Object[] args = new Object[constructor.getParameterCount()];
                 args[0] = handler;
+                Class<?>[] parameterTypes = this.constructor.getParameterTypes();
                 for (int i = 1; i < constructor.getParameterCount(); ++i) {
-                    Constructor<?> ctor = this.constructor.getParameterTypes()[i].getConstructor();
+                    Constructor<?> ctor = parameterTypes[i].getConstructor();
                     ctor.setAccessible(true);
                     args[i] = ctor.newInstance();
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -4,6 +4,7 @@ import static io.quarkus.gizmo.MethodDescriptor.ofConstructor;
 import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
 
 import java.io.Closeable;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -497,9 +498,11 @@ public class BytecodeRecorderImpl implements RecorderContext {
                     //for every parameter that was passed into the method we create a deferred value
                     //this will allocate a space in the array, so the value can be deserialized correctly
                     //even if the code for an invocation is split over several methods
+                    Class<?>[] parameterTypes = call.method.getParameterTypes();
+                    Annotation[][] parameterAnnotations = call.method.getParameterAnnotations();
                     for (int i = 0; i < call.parameters.length; ++i) {
                         call.deferredParameters[i] = loadObjectInstance(call.parameters[i], parameterMap,
-                                call.method.getParameterTypes()[i], Arrays.stream(call.method.getParameterAnnotations()[i])
+                                parameterTypes[i], Arrays.stream(parameterAnnotations[i])
                                         .anyMatch(s -> s.annotationType() == RelaxedValidation.class));
                     }
                 } catch (Exception e) {
@@ -1148,10 +1151,11 @@ public class BytecodeRecorderImpl implements RecorderContext {
             }
             int count = 0;
             nonDefaultConstructorHandles = new DeferredParameter[params.size()];
+            Class<?>[] parameterTypes = nonDefaultConstructorHolder.constructor.getParameterTypes();
             for (int i = 0; i < params.size(); i++) {
                 Object obj = params.get(i);
                 nonDefaultConstructorHandles[i] = loadObjectInstance(obj, existing,
-                        nonDefaultConstructorHolder.constructor.getParameterTypes()[count++], relaxedValidation);
+                        parameterTypes[count++], relaxedValidation);
             }
         } else if (classesToUseRecorableConstructor.contains(param.getClass())) {
             Constructor<?> current = null;
@@ -1181,9 +1185,13 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 if (ctor.isAnnotationPresent(RecordableConstructor.class)) {
                     nonDefaultConstructorHolder = new NonDefaultConstructorHolder(ctor, null);
                     nonDefaultConstructorHandles = new DeferredParameter[ctor.getParameterCount()];
-                    for (int i = 0; i < ctor.getParameterCount(); ++i) {
-                        String name = ctor.getParameters()[i].getName();
-                        constructorParamNameMap.put(name, i);
+
+                    if (ctor.getParameterCount() > 0) {
+                        Parameter[] ctorParameters = ctor.getParameters();
+                        for (int i = 0; i < ctor.getParameterCount(); ++i) {
+                            String name = ctorParameters[i].getName();
+                            constructorParamNameMap.put(name, i);
+                        }
                     }
                     break;
                 }
@@ -1323,10 +1331,12 @@ public class BytecodeRecorderImpl implements RecorderContext {
 
                                 for (Method m : param.getClass().getMethods()) {
                                     if (m.getName().equals(i.getWriteMethod().getName())) {
-                                        if (m.getParameterCount() > 0
-                                                && m.getParameterTypes()[0].isAssignableFrom(param.getClass())) {
-                                            propertyType = m.getParameterTypes()[0];
-                                            break;
+                                        if (m.getParameterCount() > 0) {
+                                            Class<?>[] parameterTypes = m.getParameterTypes();
+                                            if (parameterTypes[0].isAssignableFrom(param.getClass())) {
+                                                propertyType = parameterTypes[0];
+                                                break;
+                                            }
                                         }
                                     }
 

--- a/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
+++ b/extensions/amazon-lambda/deployment/src/main/java/io/quarkus/amazon/lambda/deployment/AmazonLambdaProcessor.java
@@ -162,15 +162,17 @@ public final class AmazonLambdaProcessor {
         // for reflection.  Shouldn't have to do this.
         for (Method method : handlerClass.getMethods()) {
             if (method.getName().equals("handleRequest")
-                    && method.getParameterCount() == 2
-                    && !method.getParameterTypes()[0].equals(Object.class)) {
-                reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, true, true, method.getParameterTypes()[0].getName()));
-                reflectiveClassBuildItemBuildProducer
-                        .produce(new ReflectiveClassBuildItem(true, true, true, method.getReturnType().getName()));
-                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, true, true,
-                        DateTime.class));
-                break;
+                    && method.getParameterCount() == 2) {
+                Class<?>[] parameterTypes = method.getParameterTypes();
+                if (!parameterTypes[0].equals(Object.class)) {
+                    reflectiveClassBuildItemBuildProducer
+                            .produce(new ReflectiveClassBuildItem(true, true, true, parameterTypes[0].getName()));
+                    reflectiveClassBuildItemBuildProducer
+                            .produce(new ReflectiveClassBuildItem(true, true, true, method.getReturnType().getName()));
+                    reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(true, true, true,
+                            DateTime.class));
+                    break;
+                }
             }
         }
     }

--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -52,10 +52,11 @@ public class AmazonLambdaRecorder {
         beanContainer = container;
         ObjectMapper objectMapper = AmazonLambdaMapperRecorder.objectMapper;
         Method handlerMethod = discoverHandlerMethod(handlerClass);
-        if (handlerMethod.getParameterTypes()[0].equals(S3Event.class)) {
+        Class<?> parameterType = handlerMethod.getParameterTypes()[0];
+        if (parameterType.equals(S3Event.class)) {
             objectReader = new S3EventInputReader(objectMapper);
         } else {
-            objectReader = new JacksonInputReader(objectMapper.readerFor(handlerMethod.getParameterTypes()[0]));
+            objectReader = new JacksonInputReader(objectMapper.readerFor(parameterType));
         }
         objectWriter = new JacksonOutputWriter(objectMapper.writerFor(handlerMethod.getReturnType()));
     }
@@ -85,9 +86,11 @@ public class AmazonLambdaRecorder {
         Method method = null;
         for (int i = 0; i < methods.length && method == null; i++) {
             if (methods[i].getName().equals("handleRequest")) {
-                final Class<?>[] types = methods[i].getParameterTypes();
-                if (types.length == 2 && !types[0].equals(Object.class)) {
-                    method = methods[i];
+                if (methods[i].getParameterCount() == 2) {
+                    final Class<?>[] types = methods[i].getParameterTypes();
+                    if (!types[0].equals(Object.class)) {
+                        method = methods[i];
+                    }
                 }
             }
         }

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionInvoker.java
@@ -26,10 +26,13 @@ public class FunctionInvoker {
         this.method = method;
         if (method.getParameterCount() > 0) {
             parameterInjectors = new ArrayList<>(method.getParameterCount());
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            Type[] genericParameterTypes = method.getGenericParameterTypes();
+            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
             for (int i = 0; i < method.getParameterCount(); i++) {
-                Type type = method.getGenericParameterTypes()[i];
-                Class clz = method.getParameterTypes()[i];
-                Annotation[] annotations = method.getParameterAnnotations()[i];
+                Type type = genericParameterTypes[i];
+                Class<?> clz = parameterTypes[i];
+                Annotation[] annotations = parameterAnnotations[i];
                 ValueInjector injector = ParameterInjector.createInjector(type, clz, annotations);
                 if (injector instanceof InputValueInjector) {
                     inputType = type;

--- a/extensions/google-cloud-functions/runtime/src/main/java/io/quarkus/gcp/functions/QuarkusBackgroundFunction.java
+++ b/extensions/google-cloud-functions/runtime/src/main/java/io/quarkus/gcp/functions/QuarkusBackgroundFunction.java
@@ -60,8 +60,9 @@ public final class QuarkusBackgroundFunction implements RawBackgroundFunction {
                     if (method.getName().equals("accept")) {
                         // the first parameter of the accept method is the event, we need to register it's type to
                         // be able to deserialize to it to mimic what a BackgroundFunction does
-                        if (method.getParameterTypes()[0] != Object.class) {// FIXME we have two accept methods !!!
-                            parameterType = method.getParameterTypes()[0];
+                        Class<?>[] parameterTypes = method.getParameterTypes();
+                        if (parameterTypes[0] != Object.class) {// FIXME we have two accept methods !!!
+                            parameterType = parameterTypes[0];
                         }
                     }
                 }

--- a/extensions/narayana-lra/runtime/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipant.java
+++ b/extensions/narayana-lra/runtime/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipant.java
@@ -117,13 +117,12 @@ public class LRAParticipant {
 
         verifyReturnType(method);
 
-        Class<?>[] parameterTypes = method.getParameterTypes();
-
-        if (parameterTypes.length > 2) {
+        if (method.getParameterCount() > 2) {
             throw new IllegalStateException(String.format("%s: %s",
                     method.toGenericString(), "Participant method cannot have more than 2 arguments"));
         }
 
+        Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length > 0 && !parameterTypes[0].equals(URI.class)) {
             throw new IllegalStateException(String.format("%s: %s",
                     method.toGenericString(), "Invalid argument type in LRA participant method: " + parameterTypes[0]));
@@ -146,12 +145,12 @@ public class LRAParticipant {
                     method.toGenericString(), "Invalid return type for @AfterLRA method: " + method.getReturnType()));
         }
 
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length > 2) {
+        if (method.getParameterCount() > 2) {
             throw new IllegalStateException(String.format("%s: %s",
                     method.toGenericString(), "@AfterLRA method cannot have more than 2 arguments"));
         }
 
+        Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length > 0 && !parameterTypes[0].equals(URI.class)) {
             throw new IllegalStateException(String.format("%s: %s",
                     method.toGenericString(), "Invalid first argument of @AfterLRA method: " + parameterTypes[0]));

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/MethodsCandidate.java
@@ -31,10 +31,11 @@ final class MethodsCandidate implements AccessorCandidate {
                         for (Method method : methods) {
                             try {
                                 if (params.parameterTypesMatch(method.isVarArgs(), method.getParameterTypes())) {
+                                    Class<?>[] parameterTypes = method.getParameterTypes();
                                     Object[] args = new Object[method.getParameterCount()];
                                     for (int i = 0; i < args.length; i++) {
                                         if (method.isVarArgs() && (i == args.length - 1)) {
-                                            Class<?> lastParam = method.getParameterTypes()[i];
+                                            Class<?> lastParam = parameterTypes[i];
                                             args[i] = params.getVarargsResults(method.getParameterCount(),
                                                     lastParam.getComponentType());
                                         } else {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -290,14 +290,15 @@ public class RuntimeResourceDeployment {
                     Method javaMethod = lazyMethod.getMethod();
                     // Workaround our lack of support for generic params by not doing this init if there are not runtime
                     // param converter providers
-                    converter.init(paramConverterProviders, javaMethod.getParameterTypes()[i],
-                            javaMethod.getGenericParameterTypes()[i],
-                            javaMethod.getParameterAnnotations()[i]);
+                    Class<?>[] parameterTypes = javaMethod.getParameterTypes();
+                    Type[] genericParameterTypes = javaMethod.getGenericParameterTypes();
+                    Annotation[][] parameterAnnotations = javaMethod.getParameterAnnotations();
+                    converter.init(paramConverterProviders, parameterTypes[i], genericParameterTypes[i],
+                            parameterAnnotations[i]);
                     // make sure we give the user provided resolvers the chance to convert
                     converter = new RuntimeResolvedConverter(converter);
-                    converter.init(paramConverterProviders, javaMethod.getParameterTypes()[i],
-                            javaMethod.getGenericParameterTypes()[i],
-                            javaMethod.getParameterAnnotations()[i]);
+                    converter.init(paramConverterProviders, parameterTypes[i], genericParameterTypes[i],
+                            parameterAnnotations[i]);
                 }
             }
 

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/InjectionEnricher.java
@@ -156,15 +156,15 @@ public class InjectionEnricher implements TestEnricher {
             if (beanManager == null) {
                 return values;
             }
+            Class<?>[] parameterTypes = method.getParameterTypes();
             try {
                 // obtain the same method definition but from the TCCL
                 method = getClass().getClassLoader()
                         .loadClass(method.getDeclaringClass().getName())
-                        .getMethod(method.getName(), convertToCL(method.getParameterTypes(), getClass().getClassLoader()));
+                        .getMethod(method.getName(), convertToCL(parameterTypes, getClass().getClassLoader()));
             } catch (Throwable t) {
                 throw new RuntimeException(t);
             }
-            Class<?>[] parameterTypes = method.getParameterTypes();
             for (int i = 0; i < parameterTypes.length; i++) {
                 try {
                     values[i] = getInstanceByType(beanManager, i, method, (CreationalContext<?>) creationalContext);

--- a/test-framework/arquillian/src/main/java/io/quarkus/arquillian/MethodParameterInjectionPoint.java
+++ b/test-framework/arquillian/src/main/java/io/quarkus/arquillian/MethodParameterInjectionPoint.java
@@ -63,8 +63,9 @@ public class MethodParameterInjectionPoint<T> implements InjectionPoint {
     }
 
     private Type findTypeOrGenericType() {
-        if (method.getGenericParameterTypes().length > 0) {
-            return method.getGenericParameterTypes()[position];
+        Type[] genericParameterTypes = method.getGenericParameterTypes();
+        if (genericParameterTypes.length > 0) {
+            return genericParameterTypes[position];
         }
         return method.getParameterTypes()[position];
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -9,6 +9,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -869,11 +870,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             //TODO: make this more pluggable
             List<Object> originalArguments = invocationContext.getArguments();
             List<Object> argumentsFromTccl = new ArrayList<>();
+            Parameter[] parameters = invocationContext.getExecutable().getParameters();
             for (int i = 0; i < originalArguments.size(); i++) {
                 Object arg = originalArguments.get(i);
                 boolean cloneRequired = false;
                 Object replacement = null;
-                Class<?> argClass = invocationContext.getExecutable().getParameters()[i].getType();
+                Class<?> argClass = parameters[i].getType();
                 if (arg != null) {
                     Class<?> theclass = argClass;
                     while (theclass.isArray()) {


### PR DESCRIPTION
Calling getParameterTypes or getGenericParameterTypes creates clones of the underlying arrays.
Doing so during iterations is costly, so lets better not do that.

This again saves saves a few ms. I saw both of these calls at "0,8% of all" according to the flamegraphs.

Related to #21552