### PR TITLE
Support OIDC cookie name suffixes

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -505,6 +505,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public boolean cookieForceSecure;
 
         /**
+         * Cookie name suffix.
+         * For example, a session cookie name for the default OIDC tenant is 'q_session' but can be changed to 'q_session_test'
+         * if this property is set to 'test'.
+         */
+        @ConfigItem
+        public Optional<String> cookieSuffix = Optional.empty();
+
+        /**
          * Cookie path parameter value which, if set, will be used to set a path parameter for the session, state and post
          * logout cookies.
          * The `cookie-path-header` property, if set, will be checked first.
@@ -680,6 +688,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setIdTokenRequired(boolean idTokenRequired) {
             this.idTokenRequired = idTokenRequired;
+        }
+
+        public Optional<String> getCookieSuffix() {
+            return cookieSuffix;
+        }
+
+        public void setCookieSuffix(String cookieSuffix) {
+            this.cookieSuffix = Optional.of(cookieSuffix);
         }
 
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -670,21 +670,23 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private static String getStateCookieName(TenantConfigContext configContext) {
-        String cookieSuffix = getCookieSuffix(configContext.oidcConfig.tenantId.get());
-        return STATE_COOKIE_NAME + cookieSuffix;
+        return STATE_COOKIE_NAME + getCookieSuffix(configContext.oidcConfig);
     }
 
     private static String getPostLogoutCookieName(TenantConfigContext configContext) {
-        String cookieSuffix = getCookieSuffix(configContext.oidcConfig.tenantId.get());
-        return POST_LOGOUT_COOKIE_NAME + cookieSuffix;
+        return POST_LOGOUT_COOKIE_NAME + getCookieSuffix(configContext.oidcConfig);
     }
 
     private static String getSessionCookieName(OidcTenantConfig oidcConfig) {
-        String cookieSuffix = getCookieSuffix(oidcConfig.tenantId.get());
-        return SESSION_COOKIE_NAME + cookieSuffix;
+        return SESSION_COOKIE_NAME + getCookieSuffix(oidcConfig);
     }
 
-    static String getCookieSuffix(String tenantId) {
-        return !"Default".equals(tenantId) ? "_" + tenantId : "";
+    static String getCookieSuffix(OidcTenantConfig oidcConfig) {
+        String tenantId = oidcConfig.tenantId.get();
+        String tenantIdSuffix = !"Default".equals(tenantId) ? "_" + tenantId : "";
+
+        return oidcConfig.authentication.cookieSuffix.isPresent()
+                ? (tenantIdSuffix + "_" + oidcConfig.authentication.cookieSuffix.get())
+                : tenantIdSuffix;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -31,13 +31,13 @@ public class DefaultTokenStateManager implements TokenStateManager {
             } else {
                 CodeAuthenticationMechanism.createCookie(routingContext,
                         oidcConfig,
-                        getAccessTokenCookieName(oidcConfig.getTenantId().get()),
+                        getAccessTokenCookieName(oidcConfig),
                         tokens.getAccessToken(),
                         routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
                 if (tokens.getRefreshToken() != null) {
                     CodeAuthenticationMechanism.createCookie(routingContext,
                             oidcConfig,
-                            getRefreshTokenCookieName(oidcConfig.getTenantId().get()),
+                            getRefreshTokenCookieName(oidcConfig),
                             tokens.getRefreshToken(),
                             routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
                 }
@@ -52,7 +52,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
                 if (tokens.getRefreshToken() != null) {
                     CodeAuthenticationMechanism.createCookie(routingContext,
                             oidcConfig,
-                            getRefreshTokenCookieName(oidcConfig.getTenantId().get()),
+                            getRefreshTokenCookieName(oidcConfig),
                             tokens.getRefreshToken(),
                             routingContext.get(CodeAuthenticationMechanism.SESSION_MAX_AGE_PARAM));
                 }
@@ -110,20 +110,20 @@ public class DefaultTokenStateManager implements TokenStateManager {
     }
 
     private static ServerCookie getAccessTokenCookie(RoutingContext routingContext, OidcTenantConfig oidcConfig) {
-        return (ServerCookie) routingContext.request().getCookie(getAccessTokenCookieName(oidcConfig.getTenantId().get()));
+        return (ServerCookie) routingContext.request().getCookie(getAccessTokenCookieName(oidcConfig));
     }
 
     private static ServerCookie getRefreshTokenCookie(RoutingContext routingContext, OidcTenantConfig oidcConfig) {
-        return (ServerCookie) routingContext.request().getCookie(getRefreshTokenCookieName(oidcConfig.getTenantId().get()));
+        return (ServerCookie) routingContext.request().getCookie(getRefreshTokenCookieName(oidcConfig));
     }
 
-    private static String getAccessTokenCookieName(String tenantId) {
-        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(tenantId);
+    private static String getAccessTokenCookieName(OidcTenantConfig oidcConfig) {
+        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(oidcConfig);
         return SESSION_AT_COOKIE_NAME + cookieSuffix;
     }
 
-    private static String getRefreshTokenCookieName(String tenantId) {
-        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(tenantId);
+    private static String getRefreshTokenCookieName(OidcTenantConfig oidcConfig) {
+        String cookieSuffix = CodeAuthenticationMechanism.getCookieSuffix(oidcConfig);
         return SESSION_RT_COOKIE_NAME + cookieSuffix;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -101,6 +101,7 @@ quarkus.oidc.tenant-https.authentication.scopes=profile,email,phone
 quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
 quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
+quarkus.oidc.tenant-https.authentication.cookie-suffix=test
 
 quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-javascript.client-id=quarkus-app

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -93,7 +93,7 @@ public class CodeFlowTest {
                     .loadWebResponse(
                             new WebRequest(URI.create("http://localhost:8081/tenant-https").toURL()));
             String keycloakUrl = webResponse.getResponseHeaderValue("location");
-            verifyLocationHeader(webClient, keycloakUrl, "tenant-https", "xforwarded%2Ftenant-https",
+            verifyLocationHeader(webClient, keycloakUrl, "tenant-https_test", "xforwarded%2Ftenant-https",
                     true);
 
             HtmlPage page = webClient.getPage(keycloakUrl);
@@ -131,6 +131,8 @@ public class CodeFlowTest {
 
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
             assertEquals("tenant-https", page.getBody().asText());
+            Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
+            assertNotNull(sessionCookie);
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -144,7 +146,7 @@ public class CodeFlowTest {
                     .loadWebResponse(
                             new WebRequest(URI.create("http://localhost:8081/tenant-https/query?a=b").toURL()));
             String keycloakUrl = webResponse.getResponseHeaderValue("location");
-            verifyLocationHeader(webClient, keycloakUrl, "tenant-https", "tenant-https",
+            verifyLocationHeader(webClient, keycloakUrl, "tenant-https_test", "tenant-https",
                     true);
 
             HtmlPage page = webClient.getPage(keycloakUrl);
@@ -177,6 +179,8 @@ public class CodeFlowTest {
 
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
             assertEquals("tenant-https?a=b", page.getBody().asText());
+            Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
+            assertNotNull(sessionCookie);
             webClient.getCookieManager().clearCookies();
         }
     }


### PR DESCRIPTION
Fixes #21641

This PR introduces an OIDC `cookie-suffix` property for users to avoid seeing the cookie conflicts in complex OIDC deployments with multiple Quarkus profiles - originally I thought of using the value of `quarkus.profile` by default but then I thought I could have the side-effects. A simple property is all what is needed.

Nothing changes by default, for example, a session cookie will be named `q_session` for a default tenant or for example `q_session_keycloak` for a `keycloak` tenant.

If this property is set, for example, to `test` then it is changed to `q_session_test` for a default tenant and `q_session_keycloak_test` for a `keycloak` tenant.