### PR TITLE
Fix native-image arguments generation for native-sources package type

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -90,7 +90,8 @@ public class NativeImageBuildStep {
             List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
             List<ExcludeConfigBuildItem> excludeConfigs,
             NativeImageAllowIncompleteClasspathAggregateBuildItem incompleteClassPathAllowed,
-            List<JPMSExportBuildItem> jpmsExportBuildItems) {
+            List<JPMSExportBuildItem> jpmsExportBuildItems,
+            List<NativeImageSecurityProviderBuildItem> nativeImageSecurityProviders) {
 
         Path outputDir;
         try {
@@ -109,13 +110,15 @@ public class NativeImageBuildStep {
                 .setNativeConfig(nativeConfig)
                 .setOutputTargetBuildItem(outputTargetBuildItem)
                 .setNativeImageProperties(nativeImageProperties)
-                .setBrokenClasspath(incompleteClassPathAllowed.isAllow())
                 .setExcludeConfigs(excludeConfigs)
                 .setJPMSExportBuildItems(jpmsExportBuildItems)
+                .setBrokenClasspath(incompleteClassPathAllowed.isAllow())
+                .setNativeImageSecurityProviders(nativeImageSecurityProviders)
                 .setOutputDir(outputDir)
                 .setRunnerJarName(runnerJar.getFileName().toString())
                 // the path to native-image is not known now, it is only known at the time the native-sources will be consumed
                 .setNativeImageName(nativeImageName)
+                .setGraalVMVersion(GraalVM.Version.CURRENT)
                 .build();
         List<String> command = nativeImageArgs.getArgs();
         try (FileOutputStream commandFOS = new FileOutputStream(outputDir.resolve("native-image.args").toFile())) {


### PR DESCRIPTION
* Ensures the `NativeImageSecurityProvidersBuildItem` (introduced in https://github.com/quarkusio/quarkus/pull/17774) is taken into account when using `-Dquarkus.package.type=native-sources`
* Gets the GraalVM version so that it can be taken in account when generating the arguments (e.g. to avoid adding parameters that are not present in some older version)