### PR TITLE
Provide contextual error message for incorrect use of @BeanParam

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/FailWithAnnotationsInAMethodOfBeanParamTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/FailWithAnnotationsInAMethodOfBeanParamTest.java
@@ -1,0 +1,54 @@
+package io.quarkus.resteasy.reactive.server.test.beanparam;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FailWithAnnotationsInAMethodOfBeanParamTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(DeploymentException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GreetingResource.class, NoQueryParamsInFieldsNameData.class));
+
+    @Test
+    void shouldBeanParamWorkWithoutFieldsAnnotatedWithQueryParam() {
+        Assertions.fail("The test case should not be invoked as it should fail with a deployment exception.");
+    }
+
+    @Path("/greeting")
+    public static class GreetingResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@BeanParam NoQueryParamsInFieldsNameData request) {
+            return "Hello, " + request.getName();
+        }
+    }
+
+    public static class NoQueryParamsInFieldsNameData {
+        private String name;
+
+        @QueryParam("name")
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/FailWithNoAnnotationsInBeanParamTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/beanparam/FailWithNoAnnotationsInBeanParamTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.server.test.beanparam;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FailWithNoAnnotationsInBeanParamTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setExpectedException(DeploymentException.class)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(GreetingResource.class, NoQueryParamsInFieldsNameData.class));
+
+    @Test
+    void shouldBeanParamWorkWithoutFieldsAnnotatedWithQueryParam() {
+        Assertions.fail("The test case should not be invoked as it should fail with a deployment exception.");
+    }
+
+    @Path("/greeting")
+    public static class GreetingResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@BeanParam NoQueryParamsInFieldsNameData request) {
+            return "Hello, " + request.getName();
+        }
+    }
+
+    public static class NoQueryParamsInFieldsNameData {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -231,6 +231,11 @@ public final class ResteasyReactiveDotNames {
     public static final Set<DotName> RESOURCE_CTOR_PARAMS_THAT_NEED_HANDLING = new HashSet<>(
             Arrays.asList(QUERY_PARAM, HEADER_PARAM, PATH_PARAM, MATRIX_PARAM, COOKIE_PARAM));
 
+    public static final Set<DotName> JAX_RS_ANNOTATIONS_FOR_FIELDS = new HashSet<>(
+            Arrays.asList(BEAN_PARAM, MULTI_PART_FORM_PARAM, PATH_PARAM, QUERY_PARAM, HEADER_PARAM, FORM_PARAM, MATRIX_PARAM,
+                    COOKIE_PARAM, REST_PATH_PARAM, REST_QUERY_PARAM, REST_HEADER_PARAM, REST_FORM_PARAM, REST_MATRIX_PARAM,
+                    REST_COOKIE_PARAM, CONTEXT, DEFAULT_VALUE, SUSPENDED));
+
     public static final DotName ENCODED = DotName.createSimple(Encoded.class.getName());
 
     public static final DotName QUARKUS_REST_CONTAINER_RESPONSE_FILTER = DotName

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/BeanParamInfo.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/BeanParamInfo.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.common.model;
 public class BeanParamInfo implements InjectableBean {
     private boolean isFormParamRequired;
     private boolean isInjectionRequired;
+    private int fieldExtractorsCount;
 
     @Override
     public boolean isFormParamRequired() {
@@ -24,5 +25,15 @@ public class BeanParamInfo implements InjectableBean {
     public InjectableBean setInjectionRequired(boolean isInjectionRequired) {
         this.isInjectionRequired = isInjectionRequired;
         return this;
+    }
+
+    @Override
+    public int getFieldExtractorsCount() {
+        return fieldExtractorsCount;
+    }
+
+    @Override
+    public void setFieldExtractorsCount(int fieldExtractorsCount) {
+        this.fieldExtractorsCount = fieldExtractorsCount;
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/InjectableBean.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/InjectableBean.java
@@ -8,14 +8,21 @@ public interface InjectableBean {
     /**
      * @return true if we have a FORM injectable field, either directly or in supertypes
      */
-    public boolean isFormParamRequired();
+    boolean isFormParamRequired();
 
-    public InjectableBean setFormParamRequired(boolean isFormParamRequired);
+    InjectableBean setFormParamRequired(boolean isFormParamRequired);
 
     /**
      * @return true if we have injectable fields, either directly or in supertypes
      */
-    public boolean isInjectionRequired();
+    boolean isInjectionRequired();
 
-    public InjectableBean setInjectionRequired(boolean isInjectionRequired);
+    InjectableBean setInjectionRequired(boolean isInjectionRequired);
+
+    /**
+     * @return the number of field extractors.
+     */
+    int getFieldExtractorsCount();
+
+    void setFieldExtractorsCount(int fieldExtractorsCount);
 }


### PR DESCRIPTION
The @QueryParam annotation is only allowed to be use in fields, no methods. 
This PR will detect when users wrongly use the JAX-RS annotations meant to be used in fields, in methods. It will also throw a deployment exception when a `BeanParam` does not have fields annotated with `QueryParam`.

Fix https://github.com/quarkusio/quarkus/issues/21789