### PR TITLE
Move quarkus-devtools-testing to the quarkus-bom as it's used for extension dev

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5610,6 +5610,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devtools-testing</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devtools-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-apache-httpclient</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -169,23 +169,12 @@
             <!-- Dev tools -->
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-devtools-testing</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devmode-test-utils</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-devtools-utilities</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-devtools-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/integration-tests/gradle/pom.xml
+++ b/integration-tests/gradle/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- The following dependencies are generated in a way that is consistent with other normal IT modules,
              that is "runtime" deps are defined with scope compile and "minimal extension deployment dependencies"

--- a/test-framework/maven/pom.xml
+++ b/test-framework/maven/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Specifically codestart dev and testing.