### PR TITLE
Log Agroal 'Connection acquired without transaction.' warning with stack trace right away

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalEventLoggingListener.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/AgroalEventLoggingListener.java
@@ -10,10 +10,14 @@ final class AgroalEventLoggingListener implements AgroalDataSourceListener {
 
     private static final Logger log = Logger.getLogger("io.agroal.pool");
 
-    private final String datasourceName;
+    private static final String CONN_WITHOUT_TX = "Connection acquired without transaction.";
 
-    public AgroalEventLoggingListener(String name) {
+    private final String datasourceName;
+    private final boolean transactionRequirementWarningActive;
+
+    public AgroalEventLoggingListener(String name, boolean transactionRequirementWarningActive) {
         this.datasourceName = "Datasource '" + name + "'";
+        this.transactionRequirementWarningActive = transactionRequirementWarningActive;
     }
 
     @Override
@@ -73,7 +77,11 @@ final class AgroalEventLoggingListener implements AgroalDataSourceListener {
 
     @Override
     public void onWarning(Throwable throwable) {
-        log.warnv("{0}: {1}", datasourceName, throwable.getMessage());
-        log.debug("Cause: ", throwable);
+        if (transactionRequirementWarningActive && CONN_WITHOUT_TX.equals(throwable.getMessage())) {
+            log.warnv(throwable, "{0}", datasourceName);
+        } else {
+            log.warnv("{0}: {1}", datasourceName, throwable.getMessage());
+            log.debug("Cause: ", throwable);
+        }
     }
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.ConnectionValidator;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.TransactionRequirement;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration.DataSourceImplementation;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
@@ -186,7 +187,9 @@ public class DataSources {
         // Explicit reference to bypass reflection need of the ServiceLoader used by AgroalDataSource#from
         AgroalDataSourceConfiguration agroalConfiguration = dataSourceConfiguration.get();
         AgroalDataSource dataSource = new io.agroal.pool.DataSource(agroalConfiguration,
-                new AgroalEventLoggingListener(dataSourceName));
+                new AgroalEventLoggingListener(dataSourceName,
+                        agroalConfiguration.connectionPoolConfiguration()
+                                .transactionRequirement() == TransactionRequirement.WARN));
         log.debugv("Started datasource {0} connected to {1}", dataSourceName,
                 agroalConfiguration.connectionPoolConfiguration().connectionFactoryConfiguration().jdbcUrl());
 


### PR DESCRIPTION
Rationale: https://github.com/quarkusio/quarkus/pull/18946#issuecomment-983043432

Before:
```
2021-11-30 22:36:36,985 WARN  [io.agr.pool] (main) Datasource '<default>': Connection acquired without transaction.
2021-11-30 22:36:36,985 DEBUG [io.agr.pool] (main) Cause: : java.sql.SQLException: Connection acquired without transaction.
        at io.agroal.pool.ConnectionPool.afterAcquire(ConnectionPool.java:351)
        at io.agroal.pool.ConnectionPool.getConnection(ConnectionPool.java:245)
        at io.agroal.pool.DataSource.getConnection(DataSource.java:86)
        [...]
```

After:
```
2021-12-01 00:36:30,688 WARN  [io.agr.pool] (main) Datasource '<default>': java.sql.SQLException: Connection acquired without transaction.
        at io.agroal.pool.ConnectionPool.afterAcquire(ConnectionPool.java:351)
        at io.agroal.pool.ConnectionPool.getConnection(ConnectionPool.java:245)
        at io.agroal.pool.DataSource.getConnection(DataSource.java:86)
        [...]
```

The exception message check is far from pretty, but I don't see another way due to the lack of a dedicated listener method.
It would be nice if such a method could be added to a future Agroral release, /cc @barreiro.