### PR TITLE
Use Hibernate Reactive's persistAll in Panache

### DIFF
--- a/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-reactive-panache-common/runtime/src/main/java/io/quarkus/hibernate/reactive/panache/common/runtime/AbstractJpaOperations.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.reactive.panache.common.runtime;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -10,9 +11,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.persistence.LockModeType;
@@ -33,6 +32,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     // FIXME: make it configurable?
     static final long TIMEOUT_MS = 5000;
+    private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
     private static void executeInVertxEventLoop(Runnable runnable) {
         Vertx vertx = Arc.container().instance(Vertx.class).get();
@@ -80,27 +80,28 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
         });
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Uni<Void> persist(Iterable<?> entities) {
-        return persist(StreamSupport.stream(entities.spliterator(), false));
+        List list = new ArrayList();
+        for (Object entity : entities) {
+            list.add(entity);
+        }
+        return persist(list.toArray(EMPTY_OBJECT_ARRAY));
     }
 
     public Uni<Void> persist(Object firstEntity, Object... entities) {
-        List<Object> array = new ArrayList<>(entities.length + 1);
-        array.add(firstEntity);
-        for (Object entity : entities) {
-            array.add(entity);
-        }
-        return persist(array.stream());
+        List<Object> list = new ArrayList<>(entities.length + 1);
+        list.add(firstEntity);
+        Collections.addAll(list, entities);
+        return persist(list.toArray(EMPTY_OBJECT_ARRAY));
     }
 
     public Uni<Void> persist(Stream<?> entities) {
-        Uni<Mutiny.Session> session = getSession();
-        List<Uni<Void>> uniList = entities.map(entity -> persist(session, entity)).collect(Collectors.toList());
-        return Uni.combine().all().unis(uniList).discardItems();
-        // this should work, but doesn't
-        //        return Multi.createFrom().items(entities)
-        //                .map(entity -> persist(session, entity))
-        //                .onItem().ignoreAsUni();
+        return persist(entities.toArray());
+    }
+
+    public Uni<Void> persist(Object... entities) {
+        return getSession().chain(session -> session.persistAll(entities));
     }
 
     public Uni<Void> delete(Object entity) {


### PR DESCRIPTION
The one thing I am not sure of is that when using this, we are not checking if the session contains each entity as the simple `persist` method does (and as the previous - erroneous - implementation implicitly did)

Fixes: #21772