### PR TITLE
End Vert.x response before propagating mapped exception in VertxBlockingoutput

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxBlockingOutput.java
@@ -79,6 +79,7 @@ public class VertxBlockingOutput implements VertxOutput {
             if (data != null && data.refCnt() > 0) {
                 data.release();
             }
+            request.response().end();
             throw new IOException(throwable);
         }
         try {


### PR DESCRIPTION
Relates to: https://github.com/quarkusio/quarkus/issues/21841