### PR TITLE
Replace `newSingleThreadExecutor()` with `newFixedThreadPool(1)`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -58,7 +58,7 @@ public abstract class NativeImageBuildRunner {
             log.info(String.join(" ", buildCommand).replace("$", "\\$"));
             final Process process = ProcessUtil.launchProcessStreamStdOut(processBuilder, processInheritIODisabled);
             addShutdownHook(process);
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(new ErrorReplacingProcessReader(process.getErrorStream(), outputDir.resolve("reports").toFile(),
                     errorReportLatch));
             executor.shutdown();

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -173,7 +173,7 @@ public class PriceConsumer implements Runnable {
     @Inject
     ConnectionFactory connectionFactory;
 
-    private final ExecutorService scheduler = Executors.newSingleThreadExecutor();
+    private final ExecutorService scheduler = Executors.newFixedThreadPool(1);
 
     private volatile String lastPrice;
 

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -527,7 +527,7 @@ public class MovieResourceTest {
     }
 
     private ExecutorService startSendingMovies() {
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
         executorService.execute(() -> {
             while (true) {
                 given()

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -356,7 +356,7 @@ public class S2iProcessor {
     }
 
     private static void waitForBuildComplete(OpenShiftClient client, S2iConfig s2iConfig, String buildName, Closeable watch) {
-        Executor executor = Executors.newSingleThreadExecutor();
+        Executor executor = Executors.newFixedThreadPool(1);
         executor.execute(() -> {
             try {
                 client.builds().withName(buildName).waitUntilCondition(b -> !RUNNING.equalsIgnoreCase(b.getStatus().getPhase()),

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/KafkaStreamsProducer.java
@@ -101,7 +101,7 @@ public class KafkaStreamsProducer {
                 runtimeConfig);
         this.kafkaAdminClient = Admin.create(getAdminClientConfig(kafkaStreamsProperties));
 
-        this.executorService = Executors.newSingleThreadExecutor();
+        this.executorService = Executors.newFixedThreadPool(1);
 
         this.kafkaStreams = initializeKafkaStreams(kafkaStreamsProperties, runtimeConfig, kafkaAdminClient, topology.get(),
                 kafkaClientSupplier, stateListener, globalStateRestoreListener, uncaughtExceptionHandlerListener,

--- a/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/devmode/KafkaStreamsHotReplacementSetup.java
+++ b/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/devmode/KafkaStreamsHotReplacementSetup.java
@@ -13,7 +13,7 @@ public class KafkaStreamsHotReplacementSetup implements HotReplacementSetup {
 
     private HotReplacementContext context;
     private volatile long nextUpdate;
-    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor executor = Executors.newFixedThreadPool(1);
 
     @Override
     public void setupHotDeployment(HotReplacementContext context) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilter.java
@@ -36,14 +36,14 @@ public abstract class AsyncRequestFilter implements ResteasyReactiveContainerReq
             ctx.abortWith(Response.ok(name).build());
         } else if ("async-pass".equals(action)) {
             ctx.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> ctx.resume());
         } else if ("async-pass-instant".equals(action)) {
             ctx.suspend();
             ctx.resume();
         } else if ("async-fail".equals(action)) {
             ctx.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> ctx.abortWith(Response.ok(name).build()));
         } else if ("async-fail-instant".equals(action)) {
             ctx.suspend();
@@ -51,7 +51,7 @@ public abstract class AsyncRequestFilter implements ResteasyReactiveContainerReq
         } else if ("async-throw-late".equals(action)) {
             ctx.suspend();
             ServerRequestContext resteasyReactiveCallbackContext = ctx.getServerRequestContext();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(2000);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilterResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncRequestFilterResource.java
@@ -62,7 +62,7 @@ public class AsyncRequestFilterResource {
     @Path("async")
     @GET
     public CompletionStage<Response> async() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         CompletableFuture<Response> resp = new CompletableFuture<>();
         executor.submit(() -> {
             try {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resteasy/async/filters/AsyncResponseFilter.java
@@ -43,21 +43,21 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
             ctx.setEntity(name);
         } else if ("async-pass".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> requestContext.resume());
         } else if ("async-pass-instant".equals(action)) {
             requestContext.suspend();
             requestContext.resume();
         } else if ("async-fail".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 ctx.setEntity(name);
                 requestContext.resume();
             });
         } else if ("async-fail-late".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(300);
@@ -76,7 +76,7 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
         } else if ("async-throw-late".equals(action)) {
             requestContext.suspend();
             ServerRequestContext resteasyReactiveCallbackContext = requestContext.getServerRequestContext();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(2000);

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/ProcessorSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/ProcessorSignatureTest.java
@@ -419,7 +419,7 @@ public class ProcessorSignatureTest {
 
     public abstract static class Spy {
         List<String> items = new CopyOnWriteArrayList<>();
-        static ExecutorService executor = Executors.newSingleThreadExecutor();
+        static ExecutorService executor = Executors.newFixedThreadPool(1);
 
         public List<String> getItems() {
             return items;

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/PublisherSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/PublisherSignatureTest.java
@@ -295,7 +295,7 @@ public class PublisherSignatureTest {
 
     public static class Spy {
         List<Integer> items = new CopyOnWriteArrayList<>();
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
 
         public List<Integer> getItems() {
             return items;

--- a/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/TransformerSignatureTest.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/signatures/TransformerSignatureTest.java
@@ -179,7 +179,7 @@ public class TransformerSignatureTest {
 
     public abstract static class Spy {
         List<String> items = new CopyOnWriteArrayList<>();
-        static ExecutorService executor = Executors.newSingleThreadExecutor();
+        static ExecutorService executor = Executors.newFixedThreadPool(1);
 
         public List<String> items() {
             return items;

--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devmode/ReactiveMessagingHotReplacementSetup.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/devmode/ReactiveMessagingHotReplacementSetup.java
@@ -17,7 +17,7 @@ public class ReactiveMessagingHotReplacementSetup implements HotReplacementSetup
 
     private HotReplacementContext context;
     private volatile long nextUpdate;
-    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor executor = Executors.newFixedThreadPool(1);
 
     @Override
     public void setupHotDeployment(HotReplacementContext context) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncRequestFilter.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncRequestFilter.java
@@ -33,14 +33,14 @@ public abstract class AsyncRequestFilter implements ResteasyReactiveContainerReq
             ctx.abortWith(Response.ok(name).build());
         } else if ("async-pass".equals(action)) {
             ctx.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> ctx.resume());
         } else if ("async-pass-instant".equals(action)) {
             ctx.suspend();
             ctx.resume();
         } else if ("async-fail".equals(action)) {
             ctx.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> ctx.abortWith(Response.ok(name).build()));
         } else if ("async-fail-instant".equals(action)) {
             ctx.suspend();
@@ -48,7 +48,7 @@ public abstract class AsyncRequestFilter implements ResteasyReactiveContainerReq
         } else if ("async-throw-late".equals(action)) {
             ctx.suspend();
             ServerRequestContext resteasyReactiveCallbackContext = ctx.getServerRequestContext();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(2000);

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncRequestFilterResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncRequestFilterResource.java
@@ -60,7 +60,7 @@ public class AsyncRequestFilterResource {
     @Path("async")
     @GET
     public CompletionStage<Response> async() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         CompletableFuture<Response> resp = new CompletableFuture<>();
         executor.submit(() -> {
             try {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncResponseFilter.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resteasy/async/filters/AsyncResponseFilter.java
@@ -40,21 +40,21 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
             ctx.setEntity(name);
         } else if ("async-pass".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> requestContext.resume());
         } else if ("async-pass-instant".equals(action)) {
             requestContext.suspend();
             requestContext.resume();
         } else if ("async-fail".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 ctx.setEntity(name);
                 requestContext.resume();
             });
         } else if ("async-fail-late".equals(action)) {
             requestContext.suspend();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(300);
@@ -73,7 +73,7 @@ public abstract class AsyncResponseFilter implements ResteasyReactiveContainerRe
         } else if ("async-throw-late".equals(action)) {
             requestContext.suspend();
             ServerRequestContext resteasyReactiveCallbackContext = requestContext.getServerRequestContext();
-            ExecutorService executor = Executors.newSingleThreadExecutor();
+            ExecutorService executor = Executors.newFixedThreadPool(1);
             executor.submit(() -> {
                 try {
                     Thread.sleep(2000);

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/QuarkusDevGradleTestBase.java
@@ -34,7 +34,7 @@ public abstract class QuarkusDevGradleTestBase extends QuarkusGradleWrapperTestB
         ExecutorService executor = null;
         final BuildResult[] buildResult = new BuildResult[1];
         try {
-            executor = Executors.newSingleThreadExecutor();
+            executor = Executors.newFixedThreadPool(1);
             quarkusDev = executor.submit(new Runnable() {
                 @Override
                 public void run() {

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
@@ -60,7 +60,7 @@ public class ContextEndpoint {
     @GET
     @Path("/resteasy-tc")
     public CompletionStage<String> resteasyThreadContextTest(@Context UriInfo uriInfo) {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
         return ret.thenApplyAsync(text -> {
             uriInfo.getAbsolutePath();
@@ -81,7 +81,7 @@ public class ContextEndpoint {
     @GET
     @Path("/servlet-tc")
     public CompletionStage<String> servletThreadContextTest(@Context UriInfo uriInfo) {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
         return ret.thenApplyAsync(text -> {
             servletRequest.getContentType();
@@ -106,7 +106,7 @@ public class ContextEndpoint {
     @GET
     @Path("/arc-tc")
     public CompletionStage<String> arcThreadContextTest() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
 
         Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
         RequestBean instance = Arc.container().instance(RequestBean.class).get();
@@ -137,7 +137,7 @@ public class ContextEndpoint {
     @GET
     @Path("/noarc-tc")
     public CompletionStage<String> noarcThreadContextTest() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         ThreadContext tc = ThreadContext.builder().cleared(ThreadContext.CDI).build();
         Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
         RequestBean instance = Arc.container().instance(RequestBean.class).get();
@@ -182,7 +182,7 @@ public class ContextEndpoint {
     @GET
     @Path("/transaction-tc")
     public CompletionStage<String> transactionThreadContextTest() throws SystemException {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
 
         ContextEntity entity = new ContextEntity();

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/customContext/CustomContextTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/customContext/CustomContextTest.java
@@ -31,7 +31,7 @@ public class CustomContextTest {
 
     @Test
     public void testCustomContextPropagation() throws Exception {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
 
         // set something to custom context
         CustomContext.set("foo");

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
@@ -49,7 +49,7 @@ public class MutinyContextEndpoint {
     @Inject
     HttpServletRequest servletRequest;
 
-    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ExecutorService executor = Executors.newFixedThreadPool(1);
 
     @PreDestroy
     public void shutdown() {
@@ -173,7 +173,7 @@ public class MutinyContextEndpoint {
     @GET
     @Path("/arc-tc-uni")
     public Uni<String> arcContextPropagationWithThreadContext() {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newFixedThreadPool(1);
 
         Assert.assertTrue(Arc.container().instance(RequestBean.class).isAvailable());
         RequestBean instance = Arc.container().instance(RequestBean.class).get();


### PR DESCRIPTION
According to @jponge: 
> `Executors.newSingleThreadExecutor()` wraps a fixed thread executor in a class with a finalizer. That finalizer calls `shutdown()`.