### PR TITLE
Fix named datasource handling for dev-services

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
+++ b/extensions/hibernate-orm/deployment/src/test/resources/application-multiple-persistence-units-annotations.properties
@@ -1,11 +1,10 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default
+quarkus.datasource.jdbc.max-size=1
 
 quarkus.datasource.users.db-kind=h2
-quarkus.datasource.users.jdbc.url=jdbc:h2:mem:users
+quarkus.datasource.users.jdbc.min-size=2
 
 quarkus.datasource.inventory.db-kind=h2
-quarkus.datasource.inventory.jdbc.url=jdbc:h2:mem:inventory
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create


### PR DESCRIPTION
Because of how the Quarkus Runtime Config objects are populated
for map fields (like the named datasources), it so happened
that when a user configured a jdbc property for a named datasource,
the DevServices provided URL for that datasource was not ending
up in `DataSourceJdbcRuntimeConfig`.

Fixes: #21387