### PR TITLE
Initialize dependency validation for gradle extensions

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -6,6 +6,7 @@ import org.gradle.api.Project;
 
 public class QuarkusExtensionConfiguration {
 
+    private boolean disableValidation;
     private String deploymentArtifact;
     private String deploymentModule;
     private List<String> excludedArtifacts;
@@ -19,6 +20,14 @@ public class QuarkusExtensionConfiguration {
 
     public QuarkusExtensionConfiguration(Project project) {
         this.project = project;
+    }
+
+    public void setDisableValidation(boolean disableValidation) {
+        this.disableValidation = disableValidation;
+    }
+
+    public boolean isValidationDisabled() {
+        return disableValidation;
     }
 
     public String getDeploymentArtifact() {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTask.java
@@ -1,0 +1,130 @@
+package io.quarkus.extension.gradle.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.extension.gradle.QuarkusExtensionConfiguration;
+import io.quarkus.gradle.tooling.dependency.DependencyUtils;
+import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
+
+public class ValidateExtensionTask extends DefaultTask {
+
+    private QuarkusExtensionConfiguration extensionConfiguration;
+    private Configuration runtimeModuleClasspath;
+    private Configuration deploymentModuleClasspath;
+
+    public ValidateExtensionTask() {
+        setDescription("Validate extension dependencies");
+        setGroup("quarkus");
+    }
+
+    public void setQuarkusExtensionConfiguration(QuarkusExtensionConfiguration extensionConfiguration) {
+        this.extensionConfiguration = extensionConfiguration;
+    }
+
+    @Internal
+    public Configuration getRuntimeModuleClasspath() {
+        return this.runtimeModuleClasspath;
+    }
+
+    public void setRuntimeModuleClasspath(Configuration runtimeModuleClasspath) {
+        this.runtimeModuleClasspath = runtimeModuleClasspath;
+    }
+
+    @Internal
+    public Configuration getDeploymentModuleClasspath() {
+        return this.deploymentModuleClasspath;
+    }
+
+    public void setDeploymentModuleClasspath(Configuration deploymentModuleClasspath) {
+        this.deploymentModuleClasspath = deploymentModuleClasspath;
+    }
+
+    @TaskAction
+    public void validateExtension() {
+        Set<ResolvedArtifact> runtimeArtifacts = getRuntimeModuleClasspath().getResolvedConfiguration().getResolvedArtifacts();
+
+        List<AppArtifactKey> deploymentModuleKeys = collectRuntimeExtensionsDeploymentKeys(runtimeArtifacts);
+        List<AppArtifactKey> invalidRuntimeArtifacts = findExtensionInConfiguration(runtimeArtifacts, deploymentModuleKeys);
+
+        Set<ResolvedArtifact> deploymentArtifacts = getDeploymentModuleClasspath().getResolvedConfiguration()
+                .getResolvedArtifacts();
+        List<AppArtifactKey> existingDeploymentModuleKeys = findExtensionInConfiguration(deploymentArtifacts,
+                deploymentModuleKeys);
+        deploymentModuleKeys.removeAll(existingDeploymentModuleKeys);
+
+        boolean hasErrors = false;
+        if (!invalidRuntimeArtifacts.isEmpty()) {
+            hasErrors = true;
+        }
+        if (!deploymentModuleKeys.isEmpty()) {
+            hasErrors = true;
+        }
+
+        if (hasErrors) {
+            printValidationErrors(invalidRuntimeArtifacts, deploymentModuleKeys);
+        }
+    }
+
+    private List<AppArtifactKey> collectRuntimeExtensionsDeploymentKeys(Set<ResolvedArtifact> runtimeArtifacts) {
+        List<AppArtifactKey> runtimeExtensions = new ArrayList<>();
+        for (ResolvedArtifact resolvedArtifact : runtimeArtifacts) {
+            ExtensionDependency extension = DependencyUtils.getExtensionInfoOrNull(getProject(), resolvedArtifact);
+            if (extension != null) {
+                runtimeExtensions.add(new AppArtifactKey(extension.getDeploymentModule().getGroupId(),
+                        extension.getDeploymentModule().getArtifactId()));
+            }
+        }
+        return runtimeExtensions;
+    }
+
+    private List<AppArtifactKey> findExtensionInConfiguration(Set<ResolvedArtifact> deploymentArtifacts,
+            List<AppArtifactKey> extensions) {
+        List<AppArtifactKey> foundExtensions = new ArrayList<>();
+
+        for (ResolvedArtifact deploymentArtifact : deploymentArtifacts) {
+            AppArtifactKey key = toAppArtifactKey(deploymentArtifact.getModuleVersion());
+            if (extensions.contains(key)) {
+                foundExtensions.add(key);
+            }
+        }
+        return foundExtensions;
+    }
+
+    private void printValidationErrors(List<AppArtifactKey> invalidRuntimeArtifacts,
+            List<AppArtifactKey> missingDeploymentArtifacts) {
+        Logger log = getLogger();
+        log.error("Quarkus Extension Dependency Verification Error");
+
+        if (!invalidRuntimeArtifacts.isEmpty()) {
+            log.error("The following deployment artifact(s) appear on the runtime classpath: ");
+            for (AppArtifactKey invalidRuntimeArtifact : invalidRuntimeArtifacts) {
+                log.error("- " + invalidRuntimeArtifact);
+            }
+        }
+
+        if (!missingDeploymentArtifacts.isEmpty()) {
+            log.error("The following deployment artifact(s) were found to be missing in the deployment module: ");
+            for (AppArtifactKey missingDeploymentArtifact : missingDeploymentArtifacts) {
+                log.error("- " + missingDeploymentArtifact);
+            }
+        }
+
+        throw new GradleException("Quarkus Extension Dependency Verification Error. See logs below");
+    }
+
+    private static AppArtifactKey toAppArtifactKey(ResolvedModuleVersion artifactId) {
+        return new AppArtifactKey(artifactId.getId().getGroup(), artifactId.getId().getName());
+    }
+}

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.assertj.core.api.Assertions;
@@ -36,7 +37,7 @@ public class QuarkusExtensionPluginTest {
 
     @Test
     public void jarShouldContainsExtensionPropertiesFile() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent());
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
 
         BuildResult jarResult = GradleRunner.create()
                 .withPluginClasspath()
@@ -65,7 +66,7 @@ public class QuarkusExtensionPluginTest {
 
     @Test
     public void pluginShouldAddAnnotationProcessor() throws IOException {
-        TestUtils.createExtensionProject(testProjectDir);
+        TestUtils.createExtensionProject(testProjectDir, false, Collections.emptyList(), Collections.emptyList());
         BuildResult dependencies = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir)
@@ -77,7 +78,7 @@ public class QuarkusExtensionPluginTest {
 
     @Test
     public void pluginShouldAddAnnotationProcessorToDeploymentModule() throws IOException {
-        TestUtils.createExtensionProject(testProjectDir);
+        TestUtils.createExtensionProject(testProjectDir, false, Collections.emptyList(), Collections.emptyList());
         BuildResult dependencies = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(testProjectDir)

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -36,7 +37,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldCreateFilesWithDefaultValues() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent());
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
         TestUtils.runExtensionDescriptorTask(testProjectDir);
 
         File extensionPropertiesFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.properties");
@@ -74,7 +75,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldUseCustomDeploymentArtifactName() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent()
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
                 + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
                 "deploymentArtifact = 'custom.group:custom-deployment-artifact:0.1.0'" +
                 "}";
@@ -90,7 +91,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldContainsConditionalDependencies() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent()
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
                 + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
                 "conditionalDependencies= ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
                 "}";
@@ -108,7 +109,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldContainsParentFirstArtifacts() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent()
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
                 + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
                 "parentFirstArtifacts = ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
                 "}";
@@ -125,7 +126,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldGenerateDescriptorBasedOnExistingFile() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent());
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
         File metaInfDir = new File(testProjectDir, "src/main/resources/META-INF");
         metaInfDir.mkdirs();
         String description = "name: extension-name\n" +

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ValidateExtensionTaskTest.java
@@ -1,0 +1,89 @@
+package io.quarkus.extension.gradle.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.quarkus.extension.gradle.QuarkusExtensionPlugin;
+import io.quarkus.extension.gradle.TestUtils;
+
+public class ValidateExtensionTaskTest {
+
+    @TempDir
+    File testProjectDir;
+
+    @Test
+    public void shouldValidateExtensionDependencies() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-core"),
+                List.of("io.quarkus:quarkus-core-deployment"));
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME)
+                .build();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void shouldDetectMissionExtensionDependency() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, false, List.of("io.quarkus:quarkus-jdbc-h2"), List.of());
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME)
+                .buildAndFail();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.FAILED);
+        assertThat(validationResult.getOutput()).contains("Quarkus Extension Dependency Verification Error");
+        assertThat(validationResult.getOutput())
+                .contains("The following deployment artifact(s) were found to be missing in the deployment module:");
+        assertThat(validationResult.getOutput()).contains("- io.quarkus:quarkus-jdbc-h2-deployment");
+    }
+
+    @Test
+    public void shouldDetectInvalidRuntimeDependency() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, false,
+                List.of("io.quarkus:quarkus-core", "io.quarkus:quarkus-core-deployment"), List.of());
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME)
+                .buildAndFail();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.FAILED);
+        assertThat(validationResult.getOutput()).contains("Quarkus Extension Dependency Verification Error");
+        assertThat(validationResult.getOutput())
+                .contains("The following deployment artifact(s) appear on the runtime classpath:");
+        assertThat(validationResult.getOutput()).contains("- io.quarkus:quarkus-core-deployment");
+    }
+
+    @Test
+    public void shouldSkipValidationWhenDisabled() throws IOException {
+        TestUtils.createExtensionProject(testProjectDir, true,
+                List.of("io.quarkus:quarkus-core", "io.quarkus:quarkus-core-deployment"), List.of());
+
+        BuildResult validationResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir)
+                .withArguments(QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME)
+                .build();
+
+        assertThat(validationResult.task(":runtime:" + QuarkusExtensionPlugin.VALIDATE_EXTENSION_TASK_NAME).getOutcome())
+                .isEqualTo(TaskOutcome.SKIPPED);
+    }
+}

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/deployment/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/deployment/build.gradle
@@ -8,6 +8,10 @@ dependencies {
     implementation 'io.quarkus:quarkus-core-deployment'
     implementation("org.acme:simple-dependency:1.0-SNAPSHOT")
 
+    implementation("io.quarkus:quarkus-hibernate-reactive-panache-deployment")
+    implementation("io.quarkus:quarkus-agroal-deployment")
+    implementation("io.quarkus:quarkus-narayana-jta-deployment")
+
     implementation project(':ext-a:runtime')
 }
 


### PR DESCRIPTION
This branch adds a new task that aims to validate extension dependencies. This checks (based on extension detected in the runtime module):

- all deployment artifact are declared in the deployment module 
- no deployment module appears in the runtime module classpath

This check can be disabled.

BTW, we start to have some tooling to create extension project. With some this could be externalize and re-used in other gradle tests.