### PR TITLE
QUARKUS-1490: Use BuildItem to enable use of TestContainers shared network

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
@@ -8,16 +8,41 @@ import java.util.function.Function;
 
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildStepBuilder;
-import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.builder.item.BuildItem;
+import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 
 /**
- * A marker build item that if present during the build, then the containers started by DevServices
- * will use a shared network.
+ * A marker build item that, if any instances are provided during the build, the containers started by DevServices
+ * will use a shared network and be accessible across the Docker network. The default is that containers started by
+ * DevServices will only be accessible from the Docker host.
  * This is mainly useful in integration tests where the application container needs to be able
  * to communicate with the services containers
  */
-public final class DevServicesSharedNetworkBuildItem extends SimpleBuildItem {
+public final class DevServicesSharedNetworkBuildItem extends MultiBuildItem {
+
+    private boolean exposeOnDockerHost;
+
+    /**
+     * Construct the {@link BuildItem} exposing services only on the shared network.
+     */
+    public DevServicesSharedNetworkBuildItem() {
+        this(false);
+    }
+
+    /**
+     * Construct the {@link BuildItem} exposing services on both the shared network and Docker host.
+     * This is mainly used by {@see DevServicesKafkaProcessor}.
+     * 
+     * @param exposeOnDockerHost
+     */
+    public DevServicesSharedNetworkBuildItem(boolean exposeOnDockerHost) {
+        this.exposeOnDockerHost = exposeOnDockerHost;
+    }
+
+    public boolean isExposedOnDockerHost() {
+        return exposeOnDockerHost;
+    }
 
     /**
      * Generates a {@link List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -13,8 +13,7 @@ public interface DevServicesDatasourceProvider {
     RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
             Optional<String> datasourceName,
             Optional<String> imageName, Map<String, String> additionalProperties,
-            OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout,
-            boolean useTestContainersSharedNetwork);
+            OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout);
 
     default boolean isDockerRequired() {
         return true;

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -267,8 +267,7 @@ public class DevServicesDatasourceProcessor {
                             ConfigProvider.getConfig().getOptionalValue(prefix + "password", String.class),
                             Optional.ofNullable(dbName), dataSourceBuildTimeConfig.devservices.imageName,
                             dataSourceBuildTimeConfig.devservices.properties,
-                            dataSourceBuildTimeConfig.devservices.port, launchMode, globalDevServicesConfig.timeout,
-                            dataSourceBuildTimeConfig.devservices.useTestContainersSharedNetwork);
+                            dataSourceBuildTimeConfig.devservices.port, launchMode, globalDevServicesConfig.timeout);
             closeableList.add(datasource.getCloseTask());
 
             propertiesMap.put(prefix + "db-kind", dataSourceBuildTimeConfig.dbKind.orElse(null));

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -55,12 +55,4 @@ public class DevServicesBuildTimeConfig {
     @ConfigItem
     public OptionalInt port;
 
-    /**
-     * Whether this particular data source's container should join TestContainers Shared Network.
-     * <p>
-     * By default, the data source container will join Docker's default network.
-     */
-    @ConfigItem(defaultValue = "false")
-    public boolean useTestContainersSharedNetwork;
-
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -3,13 +3,13 @@ package io.quarkus.devservices.db2.deployment;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.Db2Container;
-import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -31,15 +31,14 @@ public class DB2DevServicesProcessor {
 
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupDB2(
-            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
         return new DevServicesDatasourceProviderBuildItem(DatabaseKind.DB2, new DevServicesDatasourceProvider() {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
-                    boolean useTestContainersSharedNetwork) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
                 QuarkusDb2Container container = new QuarkusDb2Container(imageName, fixedExposedPort,
-                        devServicesSharedNetworkBuildItem.isPresent(), useTestContainersSharedNetwork);
+                        !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
                 container.withPassword(password.orElse("quarkus"))
                         .withUsername(username.orElse("quarkus"))
@@ -69,15 +68,11 @@ public class DB2DevServicesProcessor {
 
         private String hostName = null;
 
-        public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork,
-                boolean useTestContainersSharedNetwork) {
+        public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName.parse(imageName.orElse("ibmcom/db2:" + DB2DevServicesProcessor.TAG))
                     .asCompatibleSubstituteFor(DockerImageName.parse("ibmcom/db2")));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
-            if (useTestContainersSharedNetwork) {
-                withNetwork(Network.SHARED);
-            }
         }
 
         @Override
@@ -91,6 +86,8 @@ public class DB2DevServicesProcessor {
 
             if (fixedExposedPort.isPresent()) {
                 addFixedExposedPort(fixedExposedPort.getAsInt(), DB2_PORT);
+            } else {
+                addExposedPorts(DB2_PORT);
             }
         }
 

--- a/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
+++ b/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
@@ -31,8 +31,7 @@ public class DerbyDevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout,
-                    boolean useTestContainersSharedNetwork) {
+                    OptionalInt fixedExposedPort, LaunchMode launchMode, Optional<Duration> startupTimeout) {
                 try {
                     int port = fixedExposedPort.isPresent() ? fixedExposedPort.getAsInt()
                             : 1527 + (launchMode == LaunchMode.TEST ? 0 : 1);

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -30,8 +30,7 @@ public class H2DevServicesProcessor {
             @Override
             public RunningDevServicesDatasource startDatabase(Optional<String> username, Optional<String> password,
                     Optional<String> datasourceName, Optional<String> imageName, Map<String, String> additionalProperties,
-                    OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout,
-                    boolean useTestContainersSharedNetwork) {
+                    OptionalInt port, LaunchMode launchMode, Optional<Duration> startupTimeout) {
                 try {
                     final Server tcpServer = Server.createTcpServer("-tcpPort",
                             port.isPresent() ? String.valueOf(port.getAsInt()) : "0");

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -5,7 +5,6 @@ import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -14,8 +13,6 @@ import java.util.function.Supplier;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.server.test.core.InfinispanContainer;
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.Network;
-import org.testcontainers.utility.Base58;
 
 import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormal;
@@ -29,6 +26,7 @@ import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.infinispan.client.deployment.InfinispanClientDevServiceBuildTimeConfig;
 import io.quarkus.runtime.LaunchMode;
@@ -56,7 +54,7 @@ public class InfinispanDevServiceProcessor {
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
     public void startInfinispanContainers(LaunchModeBuildItem launchMode,
-            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             BuildProducer<DevServicesConfigResultBuildItem> devConfigProducer, InfinispanClientDevServiceBuildTimeConfig config,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
@@ -89,7 +87,7 @@ public class InfinispanDevServiceProcessor {
         try {
             StartResult startResult = startContainer(config.devService.devservices,
                     launchMode.getLaunchMode(),
-                    devServicesSharedNetworkBuildItem.isPresent(), devServicesConfig.timeout);
+                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout);
             if (startResult == null) {
                 compressor.close();
                 return;
@@ -217,12 +215,7 @@ public class InfinispanDevServiceProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                // When a shared network is requested for the launched containers, we need to configure
-                // the container to use it. We also need to create a hostname that will be applied to the returned
-                // Infinispan URL
-                setNetwork(Network.SHARED);
-                hostName = "infinispan-" + Base58.randomString(5);
-                setNetworkAliases(Collections.singletonList(hostName));
+                hostName = ConfigureUtil.configureSharedNetwork(this, "infinispan");
                 return;
             }
 

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -50,7 +50,7 @@ public class DevServicesMongoProcessor {
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
     public void startMongo(List<MongoConnectionNameBuildItem> mongoConnections,
             MongoClientBuildTimeConfig mongoClientBuildTimeConfig,
-            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             BuildProducer<DevServicesConfigResultBuildItem> devServices,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
@@ -102,7 +102,7 @@ public class DevServicesMongoProcessor {
                 loggingSetupBuildItem);
         try {
             startResult = startMongo(connectionName, currentCapturedProperties.get(connectionName),
-                    devServicesSharedNetworkBuildItem.isPresent(), globalDevServicesConfig.timeout);
+                    !devServicesSharedNetworkBuildItem.isEmpty(), globalDevServicesConfig.timeout);
             compressor.close();
         } catch (Throwable t) {
             compressor.closeAndDumpCaptured();
@@ -314,6 +314,8 @@ public class DevServicesMongoProcessor {
 
             if (fixedExposedPort != null) {
                 addFixedExposedPort(fixedExposedPort, MONGODB_INTERNAL_PORT);
+            } else {
+                addExposedPort(MONGODB_INTERNAL_PORT);
             }
         }
 

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
@@ -6,7 +6,6 @@ import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +16,6 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.deployment.IsDockerWorking.IsDockerRunningSilent;
@@ -33,6 +30,7 @@ import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.redis.client.deployment.RedisBuildTimeConfig.DevServiceConfiguration;
 import io.quarkus.redis.client.runtime.RedisClientUtil;
@@ -63,7 +61,7 @@ public class DevServicesRedisProcessor {
 
     @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
     public void startRedisContainers(LaunchModeBuildItem launchMode,
-            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             BuildProducer<DevServicesConfigResultBuildItem> devConfigProducer, RedisBuildTimeConfig config,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
@@ -102,7 +100,7 @@ public class DevServicesRedisProcessor {
                 String connectionName = entry.getKey();
                 StartResult startResult = startContainer(connectionName, entry.getValue().devservices,
                         launchMode.getLaunchMode(),
-                        devServicesSharedNetworkBuildItem.isPresent(), devServicesConfig.timeout);
+                        !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout);
                 if (startResult == null) {
                     continue;
                 }
@@ -217,6 +215,7 @@ public class DevServicesRedisProcessor {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
+
             if (serviceName != null) {
                 withLabel(DEV_SERVICE_LABEL, serviceName);
             }
@@ -227,12 +226,7 @@ public class DevServicesRedisProcessor {
             super.configure();
 
             if (useSharedNetwork) {
-                // When a shared network is requested for the launched containers, we need to configure
-                // the container to use it. We also need to create a hostname that will be applied to the returned
-                // Redis URL
-                setNetwork(Network.SHARED);
-                hostName = "redis-" + Base58.randomString(5);
-                setNetworkAliases(Collections.singletonList(hostName));
+                hostName = ConfigureUtil.configureSharedNetwork(this, "redis");
                 return;
             }
 


### PR DESCRIPTION
Following the discussion on [Zulip](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Re-use.20DevServices.20services.20.28Kafka.2C.20PostgreSQL.20etc.29.20from.20.2E.2E.2E/near/263197329) and [JIRA](https://issues.redhat.com/browse/QUARKUS-1490) this PR corrects the erroneous attempt to control build time behaviour with properties.