### PR TITLE
Set OIDC introspection result for JWT tokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -161,7 +161,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                                 JsonObject rolesJson = getRolesJson(vertxContext, resolvedContext, tokenCred, tokenJson,
                                         userInfo);
                                 SecurityIdentity securityIdentity = validateAndCreateIdentity(vertxContext, tokenCred,
-                                        resolvedContext, tokenJson, rolesJson, userInfo);
+                                        resolvedContext, tokenJson, rolesJson, userInfo, result.introspectionResult);
                                 if (tokenAutoRefreshPrepared(tokenJson, vertxContext, resolvedContext.oidcConfig)) {
                                     return Uni.createFrom().failure(new TokenAutoRefreshException(securityIdentity));
                                 } else {
@@ -339,7 +339,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             TokenVerificationResult result = resolvedContext.provider.verifyJwtToken(request.getToken().getToken());
             return Uni.createFrom()
                     .item(validateAndCreateIdentity(null, request.getToken(), resolvedContext,
-                            result.localVerificationResult, result.localVerificationResult, null));
+                            result.localVerificationResult, result.localVerificationResult, null, null));
         } catch (Throwable t) {
             return Uni.createFrom().failure(new AuthenticationFailedException(t));
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -143,7 +143,8 @@ public final class OidcUtils {
 
     static QuarkusSecurityIdentity validateAndCreateIdentity(
             RoutingContext vertxContext, TokenCredential credential,
-            TenantConfigContext resolvedContext, JsonObject tokenJson, JsonObject rolesJson, UserInfo userInfo) {
+            TenantConfigContext resolvedContext, JsonObject tokenJson, JsonObject rolesJson, UserInfo userInfo,
+            TokenIntrospection introspectionResult) {
 
         OidcTenantConfig config = resolvedContext.oidcConfig;
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
@@ -169,6 +170,7 @@ public final class OidcUtils {
         setRoutingContextAttribute(builder, vertxContext);
         setSecurityIdentityRoles(builder, config, rolesJson);
         setSecurityIdentityUserInfo(builder, userInfo);
+        setSecurityIdentityIntrospecton(builder, introspectionResult);
         setSecurityIdentityConfigMetadata(builder, resolvedContext);
         setBlockinApiAttribute(builder, vertxContext);
         setTenantIdAttribute(builder, config);
@@ -205,7 +207,9 @@ public final class OidcUtils {
     }
 
     public static void setSecurityIdentityIntrospecton(Builder builder, TokenIntrospection introspectionResult) {
-        builder.addAttribute(INTROSPECTION_ATTRIBUTE, introspectionResult);
+        if (introspectionResult != null) {
+            builder.addAttribute(INTROSPECTION_ATTRIBUTE, introspectionResult);
+        }
     }
 
     public static void setSecurityIdentityConfigMetadata(QuarkusSecurityIdentity.Builder builder,

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -13,6 +13,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.oidc.AccessTokenCredential;
 import io.quarkus.oidc.IdToken;
 import io.quarkus.oidc.OIDCException;
+import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.oidc.UserInfo;
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -54,7 +55,9 @@ public class TenantResource {
 
         String response = tenant + ":" + name;
         if (tenant.startsWith("tenant-oidc-introspection-only")) {
-            response += (":" + tokenCache.getCacheSize());
+            TokenIntrospection introspection = securityIdentity.getAttribute("introspection");
+            response += (",active:" + introspection.getBoolean("active"));
+            response += (",cache-size:" + tokenCache.getCacheSize());
         }
         return response;
     }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -360,7 +360,7 @@ public class BearerTokenAuthorizationTest {
                     .when().get("/tenant/tenant-oidc-introspection-only/api/user")
                     .then()
                     .statusCode(200)
-                    .body(equalTo("tenant-oidc-introspection-only:alice:0"));
+                    .body(equalTo("tenant-oidc-introspection-only:alice,active:true,cache-size:0"));
         }
 
         RestAssured.when().get("/oidc/jwk-endpoint-call-count").then().body(equalTo("0"));
@@ -404,7 +404,7 @@ public class BearerTokenAuthorizationTest {
                     .when().get("/tenant/tenant-oidc-introspection-only-cache/api/user")
                     .then()
                     .statusCode(200)
-                    .body(equalTo("tenant-oidc-introspection-only-cache:alice:" + expectedCacheSize));
+                    .body(equalTo("tenant-oidc-introspection-only-cache:alice,active:true,cache-size:" + expectedCacheSize));
         }
         RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("1"));
         RestAssured.when().post("/oidc/introspection-endpoint-call-count").then().body(equalTo("0"));


### PR DESCRIPTION
Fixes #21867 

This PR registers a `TokenIntrospection` result not only for the opaque but also JWT tokens, the tests where the remote JWT token introspection is done have been updated

CC @gastaldi 