### PR TITLE
Support all hibernate-envers configuration options

### DIFF
--- a/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
+++ b/extensions/hibernate-envers/deployment/src/main/java/io/quarkus/hibernate/envers/deployment/HibernateEnversProcessor.java
@@ -34,7 +34,8 @@ public final class HibernateEnversProcessor {
     }
 
     @BuildStep
-    public void registerEnversReflections(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+    public void registerEnversReflections(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            HibernateEnversBuildTimeConfig buildTimeConfig) {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, "org.hibernate.envers.DefaultRevisionEntity"));
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false,
                 "org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity"));
@@ -42,6 +43,9 @@ public final class HibernateEnversProcessor {
                 .produce(new ReflectiveClassBuildItem(false, false, "org.hibernate.tuple.entity.DynamicMapEntityTuplizer"));
         reflectiveClass.produce(
                 new ReflectiveClassBuildItem(false, false, "org.hibernate.tuple.component.DynamicMapComponentTuplizer"));
+
+        buildTimeConfig.revisionListener.ifPresent(s -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, s)));
+        buildTimeConfig.auditStrategy.ifPresent(s -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, s)));
     }
 
     @BuildStep

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/AbstractEnversResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/AbstractEnversResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.envers;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.UserTransaction;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.configuration.internal.AuditEntitiesConfiguration;
+import org.hibernate.envers.configuration.internal.GlobalConfiguration;
+import org.hibernate.envers.strategy.AuditStrategy;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.persister.entity.EntityPersister;
+
+public abstract class AbstractEnversResource {
+    @Inject
+    public EntityManager em;
+
+    @Inject
+    public UserTransaction transaction;
+
+    public String getDefaultAuditEntityName(Class<?> clazz) {
+        return clazz.getName() + "_AUD";
+    }
+
+    public EntityPersister getEntityPersister(String entityName) {
+        return ((SessionImpl) em.getDelegate()).getSessionFactory().getMetamodel().entityPersister(entityName);
+    }
+
+    public AuditEntitiesConfiguration getAuditEntitiesConfiguration() {
+        return getEnversService().getAuditEntitiesConfiguration();
+    }
+
+    public GlobalConfiguration getGlobalConfiguration() {
+        return getEnversService().getGlobalConfiguration();
+    }
+
+    public AuditStrategy getAuditStrategy() {
+        return getEnversService().getAuditStrategy();
+    }
+
+    public EnversService getEnversService() {
+        return ((((SessionImpl) em.getDelegate()).getFactory().getServiceRegistry())
+                .getParentServiceRegistry())
+                        .getService(EnversService.class);
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyAuditedVersionEntity.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyAuditedVersionEntity.java
@@ -1,0 +1,43 @@
+package io.quarkus.hibernate.orm.envers;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+import org.hibernate.envers.Audited;
+
+@Entity
+@Audited
+public class MyAuditedVersionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "myAuditedEntitySeq")
+    private long id;
+
+    private String name;
+
+    @Version
+    private long version;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyListenerlessRevisionEntity.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyListenerlessRevisionEntity.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.orm.envers;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.hibernate.envers.RevisionEntity;
+import org.hibernate.envers.RevisionNumber;
+import org.hibernate.envers.RevisionTimestamp;
+
+@Entity
+@RevisionEntity
+public class MyListenerlessRevisionEntity {
+
+    @Id
+    @RevisionNumber
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "myRevisionEntitySeq")
+    private Long id;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @RevisionTimestamp
+    private Date revisionTimestamp;
+
+    private String listenerValue;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Date getRevisionTimestamp() {
+        return revisionTimestamp;
+    }
+
+    public void setRevisionTimestamp(Date revisionTimestamp) {
+        this.revisionTimestamp = revisionTimestamp;
+    }
+
+    public String getListenerValue() {
+        return listenerValue;
+    }
+
+    public void setListenerValue(String listenerValue) {
+        this.listenerValue = listenerValue;
+    }
+
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyListenerlessRevisionListener.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/MyListenerlessRevisionListener.java
@@ -1,0 +1,12 @@
+package io.quarkus.hibernate.orm.envers;
+
+import org.hibernate.envers.RevisionListener;
+
+public class MyListenerlessRevisionListener implements RevisionListener {
+
+    @Override
+    public void newRevision(Object revisionEntity) {
+        MyListenerlessRevisionEntity.class.cast(revisionEntity).setListenerValue(this.toString());
+    }
+
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversAllowIdentifierReuseTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversAllowIdentifierReuseTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversAllowIdentifierReuseTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestAllowIdentifierReuseResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-allow-identifier-reuse.properties",
+                            "application.properties"));
+
+    @Test
+    public void testValidityStrategyFieldNameOverrides() {
+        RestAssured.when().get("/envers-allow-identifier-reuse").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversAuditStrategyTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversAuditStrategyTestCase.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversAuditStrategyTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestAuditStrategyResource.class, AbstractEnversResource.class)
+                    .addAsResource("application-with-audit-strategy.properties", "application.properties"));
+
+    @Test
+    public void testAuditStrategy() {
+        RestAssured.when().get("/envers-audit-strategy").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversDefaultSchemaCatalogTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversDefaultSchemaCatalogTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversDefaultSchemaCatalogTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestDefaultSchemaCatalogResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-default-schema-catalog.properties",
+                            "application.properties"));
+
+    @Test
+    public void testDefaultSchemaAndCatalog() {
+        RestAssured.when().get("/envers-default-schema-catalog").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversDoNotAuditOptimisticLockingFieldTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversDoNotAuditOptimisticLockingFieldTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedVersionEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversDoNotAuditOptimisticLockingFieldTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedVersionEntity.class, EnversTestDoNotAuditOptimisticLockingFieldResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-do-not-audit-optimistic-locking-field.properties",
+                            "application.properties"));
+
+    @Test
+    public void testDoNotAuditOptimisticLockingFieldAsNonDefault() {
+        RestAssured.when().get("/envers-do-not-audit-optimistic-locking-field").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversEmbeddableSetOrdinalFieldNameTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversEmbeddableSetOrdinalFieldNameTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversEmbeddableSetOrdinalFieldNameTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestEmbeddableSetOrdinalFieldNameResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-embeddable-set-ordinal-field-name.properties",
+                            "application.properties"));
+
+    @Test
+    public void testDoNotAuditOptimisticLockingFieldAsNonDefault() {
+        RestAssured.when().get("/envers-embeddable-set-ordinal-field-name").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversModifiedColumnNamingStrategyTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversModifiedColumnNamingStrategyTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversModifiedColumnNamingStrategyTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestModifiedColumnNamingStrategyResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-modified-column-naming-strategy.properties",
+                            "application.properties"));
+
+    @Test
+    public void testModifiedColumnNamingStrategy() {
+        RestAssured.when().get("/envers-modified-column-naming-strategy").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversModifiedFlagsTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversModifiedFlagsTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversModifiedFlagsTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestModifiedFlagsResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-modified-flags.properties",
+                            "application.properties"));
+
+    @Test
+    public void testModifiedFlags() {
+        RestAssured.when().get("/envers-modified-flags").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversOriginalIdPropNameTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversOriginalIdPropNameTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversOriginalIdPropNameTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestOriginalIdPropNameResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-original-id-prop-name.properties",
+                            "application.properties"));
+
+    @Test
+    public void testOriginalIdPropNameOverride() {
+        RestAssured.when().get("/envers-original-id-prop-name").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversRevisionListenerTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversRevisionListenerTestCase.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.hibernate.orm.envers.MyListenerlessRevisionEntity;
+import io.quarkus.hibernate.orm.envers.MyListenerlessRevisionListener;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversRevisionListenerTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, MyListenerlessRevisionEntity.class,
+                            MyListenerlessRevisionListener.class, EnversTestRevisionListenerResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-revision-listener.properties",
+                            "application.properties"));
+
+    @Test
+    public void testRevisionListener() {
+        RestAssured.when().get("/envers-revision-listener").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversRevisionOnCollectionChangeTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversRevisionOnCollectionChangeTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversRevisionOnCollectionChangeTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestRevisionOnCollectionChangeResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-revision-on-collection-change.properties",
+                            "application.properties"));
+
+    @Test
+    public void testRevisionOnCollectionChange() {
+        RestAssured.when().get("/envers-revision-on-collection-change").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestAllowIdentifierReuseResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestAllowIdentifierReuseResource.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-allow-identifier-reuse")
+@ApplicationScoped
+public class EnversTestAllowIdentifierReuseResource extends AbstractEnversResource {
+    @GET
+    public String getAllowIdentifierReuse() {
+        boolean identifierReuse = getGlobalConfiguration().isAllowIdentifierReuse();
+        if (!identifierReuse) {
+            return "Expected allow_identifier_reuse to be true but was false";
+        }
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestAuditStrategyResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestAuditStrategyResource.java
@@ -1,0 +1,27 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hibernate.envers.strategy.AuditStrategy;
+import org.hibernate.envers.strategy.ValidityAuditStrategy;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-audit-strategy")
+@ApplicationScoped
+public class EnversTestAuditStrategyResource extends AbstractEnversResource {
+    @GET
+    public String getConfiguredAuditStrategy() {
+        final AuditStrategy auditStrategy = getAuditStrategy();
+        final Class<?> expectedClass = ValidityAuditStrategy.class;
+        final Class<?> actualClass = auditStrategy.getClass();
+        if (expectedClass.equals(actualClass)) {
+            return "OK";
+        }
+
+        return "Expected that audit strategy " + actualClass.getName() + " is not as expected: " + expectedClass.getName();
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestDefaultSchemaCatalogResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestDefaultSchemaCatalogResource.java
@@ -1,0 +1,27 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-default-schema-catalog")
+@ApplicationScoped
+public class EnversTestDefaultSchemaCatalogResource extends AbstractEnversResource {
+    @GET
+    public String getDefaultSchemaAndCatalog() {
+        String defaultSchema = getGlobalConfiguration().getDefaultSchemaName();
+        if (!"public".equals(defaultSchema)) {
+            return "Expected default_schema to be public but was: " + defaultSchema;
+        }
+
+        String defaultCatalog = getGlobalConfiguration().getDefaultCatalogName();
+        if (!"".equals(defaultCatalog)) {
+            return "Expected default_catalog to be an empty string but was: " + defaultCatalog;
+        }
+
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestDoNotAuditOptimisticLockingFieldResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestDoNotAuditOptimisticLockingFieldResource.java
@@ -1,0 +1,28 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hibernate.persister.entity.EntityPersister;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedVersionEntity;
+
+@Path("/envers-do-not-audit-optimistic-locking-field")
+@ApplicationScoped
+public class EnversTestDoNotAuditOptimisticLockingFieldResource extends AbstractEnversResource {
+    @GET
+    public String getDoNotAuditOptimisticLockingFieldDisabled() {
+        if (!getGlobalConfiguration().isDoNotAuditOptimisticLockingField()) {
+            EntityPersister persister = getEntityPersister(MyAuditedVersionEntity.class.getName() + "_AUD");
+            for (String propertyName : persister.getPropertyNames()) {
+                if (propertyName.equals("version")) {
+                    return "OK";
+                }
+            }
+        }
+        return "Expected false is not as expected: " + getGlobalConfiguration().isDoNotAuditOptimisticLockingField();
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestEmbeddableSetOrdinalFieldNameResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestEmbeddableSetOrdinalFieldNameResource.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-embeddable-set-ordinal-field-name")
+@ApplicationScoped
+public class EnversTestEmbeddableSetOrdinalFieldNameResource extends AbstractEnversResource {
+    @GET
+    public String getEntityWithEmbeddableSetMappingNameOverride() {
+        String embeddableSetOrdinalName = getAuditEntitiesConfiguration().getEmbeddableSetOrdinalPropertyName();
+        if (embeddableSetOrdinalName.equals("ORD")) {
+            return "OK";
+        }
+        return "Expected ORD as embeddable_set_ordinal_field_name but was: " + embeddableSetOrdinalName;
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestModifiedColumnNamingStrategyResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestModifiedColumnNamingStrategyResource.java
@@ -1,0 +1,25 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hibernate.envers.boot.internal.ImprovedModifiedColumnNamingStrategy;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-modified-column-naming-strategy")
+@ApplicationScoped
+public class EnversTestModifiedColumnNamingStrategyResource extends AbstractEnversResource {
+    @GET
+    public String getModifiedNamingStrategy() {
+        Class<?> expectedClass = ImprovedModifiedColumnNamingStrategy.class;
+        Class<?> actualClass = getGlobalConfiguration().getModifiedColumnNamingStrategy().getClass();
+        if (actualClass.equals(expectedClass)) {
+            return "OK";
+        }
+        return "Expected modified_column_naming_strategy to be " + expectedClass.getName() + " but was: "
+                + actualClass.getName();
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestModifiedFlagsResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestModifiedFlagsResource.java
@@ -1,0 +1,27 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-modified-flags")
+@ApplicationScoped
+public class EnversTestModifiedFlagsResource extends AbstractEnversResource {
+    @GET
+    public String getModifiedFlags() {
+        boolean globalWithModifiedFlags = getGlobalConfiguration().isGlobalWithModifiedFlag();
+        if (!globalWithModifiedFlags) {
+            return "Expected global_with_modified_flag to be true but was false";
+        }
+
+        String modifiedFlagSuffix = getGlobalConfiguration().getModifiedFlagSuffix();
+        if (!"_changed".equals(modifiedFlagSuffix)) {
+            return "Expected modified_flag_suffix to be _changed but was: " + modifiedFlagSuffix;
+        }
+
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestOriginalIdPropNameResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestOriginalIdPropNameResource.java
@@ -1,0 +1,30 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hibernate.persister.entity.EntityPersister;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+
+@Path("/envers-original-id-prop-name")
+@ApplicationScoped
+public class EnversTestOriginalIdPropNameResource extends AbstractEnversResource {
+    @GET
+    public String getOriginalIdPropNameOverride() {
+        String originalIdFieldName = getAuditEntitiesConfiguration().getOriginalIdPropName();
+        if (!originalIdFieldName.equals("oid")) {
+            return "Expected original_id_prop_name to be oid but was: " + originalIdFieldName;
+        }
+
+        EntityPersister persister = getEntityPersister(getDefaultAuditEntityName(MyAuditedEntity.class));
+        if (!persister.getIdentifierPropertyName().equals("oid")) {
+            return "Expected identifier property name to be oid but was: " + persister.getIdentifierPropertyName();
+        }
+
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestRevisionListenerResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestRevisionListenerResource.java
@@ -1,0 +1,61 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.hibernate.orm.envers.MyListenerlessRevisionEntity;
+import io.quarkus.hibernate.orm.envers.MyListenerlessRevisionListener;
+
+@Path("/envers-revision-listener")
+@ApplicationScoped
+public class EnversTestRevisionListenerResource extends AbstractEnversResource {
+    private static final String NAME = "test";
+
+    @GET
+    public String getRevisionListener() {
+        Class<?> expectedClass = MyListenerlessRevisionListener.class;
+        Class<?> listenerClass = getGlobalConfiguration().getRevisionListenerClass();
+        if (listenerClass.equals(expectedClass)) {
+            try {
+                transaction.begin();
+                MyAuditedEntity entity = new MyAuditedEntity();
+                entity.setName(NAME);
+                em.persist(entity);
+                transaction.commit();
+
+                AuditReader auditReader = AuditReaderFactory.get(em);
+                List<Number> revisions = auditReader.getRevisions(MyAuditedEntity.class, entity.getId());
+                if (revisions.size() != 1) {
+                    return "Expected a single revision but was: " + revisions.size();
+                }
+
+                List results = auditReader.createQuery().forRevisionsOfEntity(MyAuditedEntity.class, false, false)
+                        .getResultList();
+                if (results.size() != 1) {
+                    return "Expected a single revision but was: " + results.size();
+                }
+
+                Object[] values = (Object[]) results.get(0);
+                String actualListenerValue = ((MyListenerlessRevisionEntity) values[1]).getListenerValue();
+                String expectedListenerValue = MyListenerlessRevisionListener.class.getName();
+                if (!actualListenerValue.startsWith(expectedListenerValue)) {
+                    return "Expected listener value to start with " + expectedListenerValue + " but was: "
+                            + actualListenerValue;
+                }
+            } catch (Exception e) {
+                return e.getMessage();
+            }
+            return "OK";
+        }
+        return "Expected listener class " + expectedClass.getName() + " but was: " + listenerClass.getName();
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestRevisionOnCollectionChangeResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestRevisionOnCollectionChangeResource.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-revision-on-collection-change")
+@ApplicationScoped
+public class EnversTestRevisionOnCollectionChangeResource extends AbstractEnversResource {
+    @GET
+    public String getRevisionOnCollectionChange() {
+        boolean revisionsForCollections = getGlobalConfiguration().isGenerateRevisionsForCollections();
+        if (revisionsForCollections) {
+            return "Expected revision_on_collect_change to be false but was true";
+        }
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestTrackEntitiesChangedInRevisionResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestTrackEntitiesChangedInRevisionResource.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-track-entities-changed-in-revision")
+@ApplicationScoped
+public class EnversTestTrackEntitiesChangedInRevisionResource extends AbstractEnversResource {
+    @GET
+    public String getTrackEntitiesChangedInRevision() {
+        boolean trackEntityChangesInRevision = getGlobalConfiguration().isTrackEntitiesChangedInRevision();
+        if (!trackEntityChangesInRevision) {
+            return "Expected track_entities_changed_in_revision to be true but was false";
+        }
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestUseRevisionEntityWithNativeIdResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestUseRevisionEntityWithNativeIdResource.java
@@ -1,0 +1,21 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-use-revision-entity-with-native-id")
+@ApplicationScoped
+public class EnversTestUseRevisionEntityWithNativeIdResource extends AbstractEnversResource {
+    @GET
+    public String getUseRevisionEntityWithNativeId() {
+        boolean revisionEntityWithNativeId = getGlobalConfiguration().isUseRevisionEntityWithNativeId();
+        if (revisionEntityWithNativeId) {
+            return "Expected use_revision_entity_with_native_id to be false but was true";
+        }
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestValidityStrategyFieldNameOverridesResource.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTestValidityStrategyFieldNameOverridesResource.java
@@ -1,0 +1,33 @@
+
+package io.quarkus.hibernate.orm.envers.config;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+
+@Path("/envers-validity-strategy-field-name-overrides")
+@ApplicationScoped
+public class EnversTestValidityStrategyFieldNameOverridesResource extends AbstractEnversResource {
+    @GET
+    public String getValidityStrategyFieldNameOverrides() {
+        boolean isRevEndTimestampIncluded = getAuditEntitiesConfiguration().isRevisionEndTimestampEnabled();
+        if (!isRevEndTimestampIncluded) {
+            return "Expected audit_strategy_validity_store_revend_timestamp to be true but was false";
+        }
+
+        String revEndFieldName = getAuditEntitiesConfiguration().getRevisionEndFieldName();
+        if (!revEndFieldName.equals("REV_END")) {
+            return "Expected audit_strategy_validity_end_rev_field_name to be REV_END but was: " + revEndFieldName;
+        }
+
+        String revEndTimestampFieldName = getAuditEntitiesConfiguration().getRevisionEndTimestampFieldName();
+        if (!revEndTimestampFieldName.equals("REV_END_TSTMP")) {
+            return "Expected audit_strategy_validity_revend_timestamp_field_name to be REV_END_TSTMP but was: "
+                    + revEndTimestampFieldName;
+        }
+
+        return "OK";
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTrackEntitiesChangedInRevisionTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversTrackEntitiesChangedInRevisionTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversTrackEntitiesChangedInRevisionTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestTrackEntitiesChangedInRevisionResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-track-entities-changed-in-revision.properties",
+                            "application.properties"));
+
+    @Test
+    public void testTrackEntitiesChangedInRevision() {
+        RestAssured.when().get("/envers-track-entities-changed-in-revision").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversUseRevisionEntityWithNativeIdTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversUseRevisionEntityWithNativeIdTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversUseRevisionEntityWithNativeIdTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestUseRevisionEntityWithNativeIdResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-use-revision-entity-with-native-id.properties",
+                            "application.properties"));
+
+    @Test
+    public void testUseRevisionEntityWithNativeId() {
+        RestAssured.when().get("/envers-use-revision-entity-with-native-id").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversValidityStrategyFieldNameOverridesTestCase.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/EnversValidityStrategyFieldNameOverridesTestCase.java
@@ -1,0 +1,28 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.envers.AbstractEnversResource;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class EnversValidityStrategyFieldNameOverridesTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyAuditedEntity.class, EnversTestValidityStrategyFieldNameOverridesResource.class,
+                            AbstractEnversResource.class)
+                    .addAsResource("application-with-validity-strategy-field-name-overrides.properties",
+                            "application.properties"));
+
+    @Test
+    public void testValidityStrategyFieldNameOverrides() {
+        RestAssured.when().get("/envers-validity-strategy-field-name-overrides").then()
+                .body(is("OK"));
+    }
+}

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-allow-identifier-reuse.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-allow-identifier-reuse.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy
+quarkus.hibernate-envers.allow-identifier-reuse=true

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-audit-strategy.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-audit-strategy.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-default-schema-catalog.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-default-schema-catalog.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.default-schema=public
+quarkus.hibernate-envers.default-catalog=

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-do-not-audit-optimistic-locking-field.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-do-not-audit-optimistic-locking-field.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.do-not-audit-optimistic-locking-field=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-embeddable-set-ordinal-field-name.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-embeddable-set-ordinal-field-name.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.embeddable-set-ordinal-field-name=ORD

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-column-naming-strategy.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-column-naming-strategy.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.modified-column-naming-strategy=org.hibernate.envers.boot.internal.ImprovedModifiedColumnNamingStrategy

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-flags.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-modified-flags.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.global-with-modified-flag=true
+quarkus.hibernate-envers.modified-flag-suffix=_changed

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-original-id-prop-name.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-original-id-prop-name.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.original-id-prop-name=oid

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-listener.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-listener.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.revision-listener=io.quarkus.hibernate.orm.envers.MyListenerlessRevisionListener

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-on-collection-change.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-revision-on-collection-change.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.revision-on-collection-change=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-track-entities-changed-in-revision.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-track-entities-changed-in-revision.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.track-entities-changed-in-revision=true

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-use-revision-entity-with-native-id.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-use-revision-entity-with-native-id.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.use-revision-entity-with-native-id=false

--- a/extensions/hibernate-envers/deployment/src/test/resources/application-with-validity-strategy-field-name-overrides.properties
+++ b/extensions/hibernate-envers/deployment/src/test/resources/application-with-validity-strategy-field-name-overrides.properties
@@ -1,0 +1,7 @@
+quarkus.datasource.db-kind=h2
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-envers.audit-strategy=org.hibernate.envers.strategy.ValidityAuditStrategy
+quarkus.hibernate-envers.audit-strategy-validity-store-revend-timestamp=true
+quarkus.hibernate-envers.audit-strategy-validity-end-rev-field-name=REV_END
+quarkus.hibernate-envers.audit-strategy-validity-revend-timestamp-field-name=REV_END_TSTMP

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
@@ -43,4 +43,125 @@ public class HibernateEnversBuildTimeConfig {
     @ConfigItem(defaultValue = "REVTYPE")
     public Optional<String> revisionTypeFieldName;
 
+    /**
+     * Enable the revision_on_collection_change feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#REVISION_ON_COLLECTION_CHANGE}.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean revisionOnCollectionChange;
+
+    /**
+     * Enable the do_not_audit_optimistic_locking_field feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#DO_NOT_AUDIT_OPTIMISTIC_LOCKING_FIELD}.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean doNotAuditOptimisticLockingField;
+
+    /**
+     * Defines the default schema of where audit tables are to be created.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#DEFAULT_SCHEMA}.
+     */
+    @ConfigItem(defaultValue = "")
+    public Optional<String> defaultSchema;
+
+    /**
+     * Defines the default catalog of where audit tables are to be created.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#DEFAULT_CATALOG}.
+     */
+    @ConfigItem(defaultValue = "")
+    public Optional<String> defaultCatalog;
+
+    /**
+     * Enables the track_entities_changed_in_revision feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#TRACK_ENTITIES_CHANGED_IN_REVISION}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean trackEntitiesChangedInRevision;
+
+    /**
+     * Enables the use_revision_entity_with_native_id feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#USE_REVISION_ENTITY_WITH_NATIVE_ID}.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useRevisionEntityWithNativeId;
+
+    /**
+     * Enables the global_with_modified_flag feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#GLOBAL_WITH_MODIFIED_FLAG}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean globalWithModifiedFlag;
+
+    /**
+     * Defines the suffix to be used for modified flag columns. Defaults to {@literal _MOD}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#MODIFIED_FLAG_SUFFIX}
+     */
+    @ConfigItem(defaultValue = "_MOD")
+    public Optional<String> modifiedFlagSuffix;
+
+    /**
+     * Defines the fully qualified class name of a user defined revision listener.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#REVISION_LISTENER}.
+     */
+    @ConfigItem
+    public Optional<String> revisionListener;
+
+    /**
+     * Defines the fully qualified class name of the audit strategy to be used.
+     * 
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#AUDIT_STRATEGY}.
+     */
+    @ConfigItem(defaultValue = "org.hibernate.envers.strategy.DefaultAuditStrategy")
+    public Optional<String> auditStrategy;
+
+    /**
+     * Defines the property name for the audit entity's composite primary key. Defaults to {@literal originalId}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#ORIGINAL_ID_PROP_NAME}.
+     */
+    @ConfigItem(defaultValue = "originalId")
+    public Optional<String> originalIdPropName;
+
+    /**
+     * Defines the column name that holds the end revision number in audit entities. Defaults to {@literal REVEND}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#AUDIT_STRATEGY_VALIDITY_END_REV_FIELD_NAME}.
+     */
+    @ConfigItem(defaultValue = "REVEND")
+    public Optional<String> auditStrategyValidityEndRevFieldName;
+
+    /**
+     * Enables the audit_strategy_validity_store_revend_timestamp feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#AUDIT_STRATEGY_VALIDITY_STORE_REVEND_TIMESTAMP}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean auditStrategyValidityStoreRevendTimestamp;
+
+    /**
+     * Defines the column name of the revision end timestamp in the audit tables. Defaults to {@literal REVEND_TSTMP}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#AUDIT_STRATEGY_VALIDITY_REVEND_TIMESTAMP_FIELD_NAME}.
+     */
+    @ConfigItem(defaultValue = "REVEND_TSTMP")
+    public Optional<String> auditStrategyValidityRevendTimestampFieldName;
+
+    /**
+     * Defines the name of the column used for storing collection ordinal values for embeddable elements.
+     * Defaults to {@literal SETORDINAL}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#EMBEDDABLE_SET_ORDINAL_FIELD_NAME}.
+     */
+    @ConfigItem(defaultValue = "SETORDINAL")
+    public Optional<String> embeddableSetOrdinalFieldName;
+
+    /**
+     * Enables the allow_identifier_reuse feature.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#ALLOW_IDENTIFIER_REUSE}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean allowIdentifierReuse;
+
+    /**
+     * Defines the naming strategy to be used for modified columns.
+     * Defaults to {@literal org.hibernate.envers.boot.internal.LegacyModifiedColumnNamingStrategy}.
+     * Maps to {@link org.hibernate.envers.configuration.EnversSettings#MODIFIED_COLUMN_NAMING_STRATEGY}.
+     */
+    @ConfigItem(defaultValue = "org.hibernate.envers.boot.internal.LegacyModifiedColumnNamingStrategy")
+    public Optional<String> modifiedColumnNamingStrategy;
 }

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
@@ -31,6 +31,32 @@ public class HibernateEnversRecorder {
             addConfig(propertyCollector, EnversSettings.AUDIT_TABLE_PREFIX, buildTimeConfig.auditTablePrefix);
             addConfig(propertyCollector, EnversSettings.REVISION_FIELD_NAME, buildTimeConfig.revisionFieldName);
             addConfig(propertyCollector, EnversSettings.REVISION_TYPE_FIELD_NAME, buildTimeConfig.revisionTypeFieldName);
+            addConfig(propertyCollector, EnversSettings.REVISION_ON_COLLECTION_CHANGE,
+                    buildTimeConfig.revisionOnCollectionChange);
+            addConfig(propertyCollector, EnversSettings.DO_NOT_AUDIT_OPTIMISTIC_LOCKING_FIELD,
+                    buildTimeConfig.doNotAuditOptimisticLockingField);
+            addConfig(propertyCollector, EnversSettings.DEFAULT_SCHEMA, buildTimeConfig.defaultSchema);
+            addConfig(propertyCollector, EnversSettings.DEFAULT_CATALOG, buildTimeConfig.defaultCatalog);
+            addConfig(propertyCollector, EnversSettings.TRACK_ENTITIES_CHANGED_IN_REVISION,
+                    buildTimeConfig.trackEntitiesChangedInRevision);
+            addConfig(propertyCollector, EnversSettings.USE_REVISION_ENTITY_WITH_NATIVE_ID,
+                    buildTimeConfig.useRevisionEntityWithNativeId);
+            addConfig(propertyCollector, EnversSettings.GLOBAL_WITH_MODIFIED_FLAG, buildTimeConfig.globalWithModifiedFlag);
+            addConfig(propertyCollector, EnversSettings.MODIFIED_FLAG_SUFFIX, buildTimeConfig.modifiedFlagSuffix);
+            addConfigIfPresent(propertyCollector, EnversSettings.REVISION_LISTENER, buildTimeConfig.revisionListener);
+            addConfigIfPresent(propertyCollector, EnversSettings.AUDIT_STRATEGY, buildTimeConfig.auditStrategy);
+            addConfigIfPresent(propertyCollector, EnversSettings.ORIGINAL_ID_PROP_NAME, buildTimeConfig.originalIdPropName);
+            addConfigIfPresent(propertyCollector, EnversSettings.AUDIT_STRATEGY_VALIDITY_END_REV_FIELD_NAME,
+                    buildTimeConfig.auditStrategyValidityEndRevFieldName);
+            addConfig(propertyCollector, EnversSettings.AUDIT_STRATEGY_VALIDITY_STORE_REVEND_TIMESTAMP,
+                    buildTimeConfig.auditStrategyValidityStoreRevendTimestamp);
+            addConfigIfPresent(propertyCollector, EnversSettings.AUDIT_STRATEGY_VALIDITY_REVEND_TIMESTAMP_FIELD_NAME,
+                    buildTimeConfig.auditStrategyValidityRevendTimestampFieldName);
+            addConfigIfPresent(propertyCollector, EnversSettings.EMBEDDABLE_SET_ORDINAL_FIELD_NAME,
+                    buildTimeConfig.embeddableSetOrdinalFieldName);
+            addConfig(propertyCollector, EnversSettings.ALLOW_IDENTIFIER_REUSE, buildTimeConfig.allowIdentifierReuse);
+            addConfigIfPresent(propertyCollector, EnversSettings.MODIFIED_COLUMN_NAMING_STRATEGY,
+                    buildTimeConfig.modifiedColumnNamingStrategy);
         }
 
         public static <T> void addConfig(BiConsumer<String, Object> propertyCollector, String configPath, T value) {
@@ -43,6 +69,11 @@ public class HibernateEnversRecorder {
             } else {
                 propertyCollector.accept(configPath, "");
             }
+        }
+
+        public static <T> void addConfigIfPresent(BiConsumer<String, Object> propertyCollector, String configPath,
+                Optional<T> value) {
+            value.ifPresent(t -> propertyCollector.accept(configPath, t));
         }
 
         @Override


### PR DESCRIPTION
Hi @Sanne and @gsmet, this PR enables all `hibernate-envers` configuration options for use in Quarkus.