### PR TITLE
Fix OIDC web-app guide link to the token introspection and user info cache section

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -351,7 +351,7 @@ Additionally a custom `SecurityIdentityAugmentor` can also be used to add the ro
 [[token-verification-introspection]]
 === Token Verification And Introspection
 
-Please see link:security-openid-connect#token-verification-introspection for details about how the tokens are verified and introspected.
+Please see link:security-openid-connect#token-verification-introspection[Token Verification And Introspection] for details about how the tokens are verified and introspected.
 
 Note that in case of `web-app` applications only `IdToken` is verified by default since the access token is not used by default to access the current Quarkus `web-app` endpoint and instead meant to be propagated to the services expecting this access token, for example, to the OpenId Connect Provider's UserInfo endpoint, etc. However if you expect the access token to contain the roles required to access the current Quarkus endpoint (`quarkus.oidc.roles.source=accesstoken`) then it will also be verified.
 
@@ -360,7 +360,7 @@ Note that in case of `web-app` applications only `IdToken` is verified by defaul
 
 Code flow access tokens are not introspected unless they are expected to be the source of roles but will be used to get `UserInfo`. So there will be one or two remote calls with the code flow access token, if the token introspection and/or `UserInfo` are required.
 
-Please see link:security-openid-connect#token-introspection-userinfo-cache for more information about using a default token cache or registering a custom cache implementation.
+Please see link:security-openid-connect#token-introspection-userinfo-cache[Token Introspection and UserInfo cache] for more information about using a default token cache or registering a custom cache implementation.
 
 [[jwt-claim-verification]]
 === JSON Web Token Claim Verification


### PR DESCRIPTION
I've noticed the links at https://quarkus.io/guides/security-openid-connect-web-authentication#token-introspection  and https://quarkus.io/guides/security-openid-connect-web-authentication#token-introspection-userinfo-cache are not shown as links