### PR TITLE
RabbitMQ dynamic credentials via credentials provider

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -63,7 +63,7 @@
         {
             "category": "Messaging2",
             "timeout": 70,
-            "test-modules": "reactive-messaging-amqp, reactive-messaging-http, reactive-messaging-rabbitmq",
+            "test-modules": "reactive-messaging-amqp, reactive-messaging-http, reactive-messaging-rabbitmq, reactive-messaging-rabbitmq-dyn",
             "os-name": "ubuntu-latest"
         },
         {

--- a/docs/src/main/asciidoc/credentials-provider.adoc
+++ b/docs/src/main/asciidoc/credentials-provider.adoc
@@ -35,6 +35,7 @@ by the following credentials consumer extensions:
 * `reactive-pg-client`
 * `oidc`
 * `oidc-client`
+* `smallrye-reactive-messaging-rabbitmq`
 
 All extensions that rely on username/password authentication also allow setting configuration
 properties in the `application.properties` as an alternative. But the `Credentials Provider` is the only option

--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -393,6 +393,67 @@ Note that a message processing failures nacks the message, which is then handled
 It's the responsibility of the `failure-strategy` to report the failure and influence the outcome of the checks.
 The `fail` failure strategy reports the failure, and so the check will report the fault.
 
+[[dynamic-credentials]]
+== Dynamic Credentials
+
+Quarkus and the RabbitMQ connector support https://www.vaultproject.io/docs/secrets/rabbitmq[Vault's RabbitMQ secrets engine]
+for generating short-lived dynamic credentials. This allows Vault to create and retire RabbitMQ credentials on a regular basis.
+
+First we need to enable Vault's `rabbitmq` secret engine, configure it with RabbitMQ's connection and authentication
+information, and create a Vault role `my-role` (replace `10.0.0.3` by the actual host that is running the
+RabbitMQ container):
+[source,bash, subs=attributes+]
+----
+vault secrets enable rabbitmq
+
+vault write rabbitmq/config/connection \
+    connection_uri=http://10.0.0.3:15672 \
+    username=guest \
+    password=guest
+
+vault write rabbitmq/roles/my-role \
+    vhosts='{"/":{"write": ".*", "read": ".*"}}'
+----
+
+[NOTE]
+====
+For this use case, user `guest` configured above needs to be a RabbitMQ admin user with the capability to create
+credentials.
+====
+
+Then we need to give a read capability to the Quarkus application on path `rabbitmq/creds/my-role`.
+[source,bash]
+----
+cat <<EOF | vault policy write vault-rabbitmq-policy -
+path "secret/data/myapps/vault-rabbitmq-test/*" {
+  capabilities = ["read"]
+}
+path "rabbitmq/creds/my-role" {
+  capabilities = [ "read" ]
+}
+EOF
+----
+
+Now that Vault knows how to create users in RabbitMQ, we need to configure Quarkus to use a credentials-provider
+for RabbitMQ.
+
+First we tell Quarkus to request dynamic credentials using a credentials-provider named `rabbitmq`.
+----
+quarkus.rabbitmq.credentials-provider = rabbitmq
+----
+
+Next we configure the `rabbitmq` credentials provider. The `credentials-role` option must be set to the name of the
+role we created in Vault, in our case `my-role`. The `credentials-mount` option must be set to `rabbitmq`.
+[source, properties]
+----
+quarkus.vault.credentials-provider.rabbitmq.credentials-role = my-role
+quarkus.vault.credentials-provider.rabbitmq.credentials-mount = rabbitmq
+----
+
+NOTE: The `credentials-mount` is used directly as the mount of the secret engine in Vault. Here we are using
+the default mount path of `rabbitmq`. If the RabbitMQ secret engine was mounted at a custom path, the
+`credentials-mount` option must be set to that path instead.
+
 [[configuration-reference]]
 == RabbitMQ Connector Configuration Reference
 

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQBuildTimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -12,4 +14,21 @@ public class RabbitMQBuildTimeConfig {
      */
     @ConfigItem
     public RabbitMQDevServicesBuildTimeConfig devservices;
+
+    /**
+     * The credentials provider name.
+     */
+    @ConfigItem
+    public Optional<String> credentialsProvider = Optional.empty();
+
+    /**
+     * The credentials provider bean name.
+     * <p>
+     * It is the {@code &#64;Named} value of the credentials provider bean. It is used to discriminate if multiple
+     * CredentialsProvider beans are available.
+     * <p>
+     * For Vault it is: vault-credentials-provider. Not necessary if there is only one credentials provider available.
+     */
+    @ConfigItem
+    public Optional<String> credentialsProviderName = Optional.empty();
 }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/SmallRyeReactiveMessagingRabbitMQProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/SmallRyeReactiveMessagingRabbitMQProcessor.java
@@ -1,14 +1,63 @@
 package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 
+import javax.enterprise.context.ApplicationScoped;
+
+import com.rabbitmq.client.impl.CredentialsProvider;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem.ExtendedBeanConfigurator;
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.CredentialsProviderLink;
+import io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.RabbitMQRecorder;
+import io.smallrye.common.annotation.Identifier;
 
 public class SmallRyeReactiveMessagingRabbitMQProcessor {
 
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.SMALLRYE_REACTIVE_MESSAGING_RABBITMQ);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void dynamicCredentials(RabbitMQRecorder recorder,
+            RabbitMQBuildTimeConfig rabbitMQBuildTimeConfig,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> configDefaults) {
+
+        additionalBeans.produce(AdditionalBeanBuildItem.builder().addBeanClass(Identifier.class).build());
+
+        if (rabbitMQBuildTimeConfig.credentialsProvider.isPresent()) {
+            String credentialsProvider = rabbitMQBuildTimeConfig.credentialsProvider.get();
+
+            RuntimeValue<CredentialsProviderLink> credentialsProviderLink = recorder.configureOptions(
+                    credentialsProvider,
+                    rabbitMQBuildTimeConfig.credentialsProviderName);
+
+            String identifier = "credentials-provider-link-" + credentialsProvider;
+
+            ExtendedBeanConfigurator rabbitMQOptionsConfigurator = SyntheticBeanBuildItem
+                    .configure(CredentialsProviderLink.class)
+                    .defaultBean()
+                    .addType(CredentialsProvider.class)
+                    .addQualifier().annotation(Identifier.class).addValue("value", identifier).done()
+                    .scope(ApplicationScoped.class)
+                    .runtimeValue(credentialsProviderLink)
+                    .unremovable()
+                    .setRuntimeInit();
+
+            configDefaults.produce(new RunTimeConfigurationDefaultBuildItem("rabbitmq-credentials-provider-name", identifier));
+            syntheticBeans.produce(rabbitMQOptionsConfigurator.done());
+        }
     }
 
 }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/pom.xml
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/pom.xml
@@ -32,6 +32,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/CredentialsProviderLink.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/CredentialsProviderLink.java
@@ -1,0 +1,62 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime;
+
+import static io.quarkus.credentials.CredentialsProvider.EXPIRATION_TIMESTAMP_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.PASSWORD_PROPERTY_NAME;
+import static io.quarkus.credentials.CredentialsProvider.USER_PROPERTY_NAME;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import io.quarkus.credentials.CredentialsProvider;
+
+public class CredentialsProviderLink implements com.rabbitmq.client.impl.CredentialsProvider {
+
+    private final CredentialsProvider credentialsProvider;
+    private final String credentialsProviderName;
+    private String username;
+    private String password;
+    private Instant expiresAt;
+
+    public CredentialsProviderLink(CredentialsProvider credentialsProvider, String credentialsProviderName) {
+        this.credentialsProvider = credentialsProvider;
+        this.credentialsProviderName = credentialsProviderName;
+        this.expiresAt = Instant.MIN;
+    }
+
+    private void refreshIfExpired() {
+        if (expiresAt.isAfter(Instant.now())) {
+            return;
+        }
+        refresh();
+    }
+
+    @Override
+    public String getUsername() {
+        refreshIfExpired();
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        refreshIfExpired();
+        return password;
+    }
+
+    @Override
+    public Duration getTimeBeforeExpiration() {
+        return Duration.between(Instant.now(), expiresAt);
+    }
+
+    @Override
+    public void refresh() {
+        Map<String, String> credentials = credentialsProvider.getCredentials(credentialsProviderName);
+        username = credentials.get(USER_PROPERTY_NAME);
+        password = credentials.get(PASSWORD_PROPERTY_NAME);
+        expiresAt = Instant.parse(credentials.getOrDefault(EXPIRATION_TIMESTAMP_PROPERTY_NAME, getDefaultExpiresAt()));
+    }
+
+    private String getDefaultExpiresAt() {
+        return Instant.now().plusSeconds(10).toString();
+    }
+}

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/RabbitMQRecorder.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/RabbitMQRecorder.java
@@ -1,0 +1,20 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.credentials.CredentialsProvider;
+import io.quarkus.credentials.runtime.CredentialsProviderFinder;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class RabbitMQRecorder {
+
+    public RuntimeValue<CredentialsProviderLink> configureOptions(String credentialsProviderName,
+            Optional<String> credentialsProviderBeanName) {
+
+        CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(credentialsProviderBeanName.orElse(null));
+
+        return new RuntimeValue<>(new CredentialsProviderLink(credentialsProvider, credentialsProviderName));
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -263,6 +263,7 @@
                 <module>reactive-messaging-kafka</module>
                 <module>reactive-messaging-http</module>
                 <module>reactive-messaging-rabbitmq</module>
+                <module>reactive-messaging-rabbitmq-dyn</module>
                 <module>rest-client</module>
                 <module>resteasy-reactive-kotlin</module>
                 <module>rest-client-reactive</module>

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/pom.xml
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/pom.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-reactive-messaging-rabbitmq-dyn</artifactId>
+    <name>Quarkus - Integration Tests - Reactive Messaging - RabbitMQ (Dynamic Credentials)</name>
+    <description>The RabbitMQ Reactive Messaging integration tests module</description>
+
+    <properties>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-shared-library</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb</artifactId>
+        </dependency>
+
+        <!-- Health -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
+        </dependency>
+
+
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>vault</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-rabbitmq</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
+</project>

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/PeopleManager.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/PeopleManager.java
@@ -1,0 +1,25 @@
+package io.quarkus.it.rabbitmq;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+public class PeopleManager {
+
+    private final List<Person> list = new CopyOnWriteArrayList<>();
+
+    @Incoming("people-in")
+    public void consume(JsonObject message) {
+        list.add(message.mapTo(Person.class));
+    }
+
+    public List<Person> getPeople() {
+        return list;
+    }
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/PeopleProducer.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/PeopleProducer.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.rabbitmq;
+
+import java.time.Duration;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class PeopleProducer {
+    @Outgoing("people-out")
+    public Multi<Person> generatePeople() {
+        return Uni.createFrom().nullItem()
+                .onItem().delayIt().by(Duration.ofSeconds(3))
+                .onItem().transformToMulti(n -> Multi.createFrom()
+                        .items(new Person("bob"),
+                                new Person("alice"),
+                                new Person("tom"),
+                                new Person("jerry"),
+                                new Person("anna"),
+                                new Person("ken")));
+    }
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/Person.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/Person.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.rabbitmq;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Person {
+    public String name;
+
+    public Person() {
+        // default no-arg constructor.
+    }
+
+    public Person(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/RabbitMQEndpoint.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/RabbitMQEndpoint.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.rabbitmq;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/rabbitmq")
+public class RabbitMQEndpoint {
+    @Inject
+    PeopleManager people;
+
+    @GET
+    @Path("/people")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Person> getPeople() {
+        return people.getPeople();
+    }
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/TestCredentialsProvider.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/java/io/quarkus/it/rabbitmq/TestCredentialsProvider.java
@@ -1,0 +1,30 @@
+package io.quarkus.it.rabbitmq;
+
+import java.time.Instant;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.credentials.CredentialsProvider;
+
+@ApplicationScoped
+@Named("test-creds-provider")
+public class TestCredentialsProvider implements CredentialsProvider {
+
+    @ConfigProperty(name = "test-creds-provider.username")
+    String username;
+
+    @ConfigProperty(name = "test-creds-provider.password")
+    String password;
+
+    @Override
+    public Map<String, String> getCredentials(String credentialsProviderName) {
+        return Map.of(
+                CredentialsProvider.USER_PROPERTY_NAME, username,
+                CredentialsProvider.PASSWORD_PROPERTY_NAME, password,
+                CredentialsProvider.EXPIRATION_TIMESTAMP_PROPERTY_NAME, Instant.now().plusSeconds(90).toString());
+    }
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+
+mp.messaging.outgoing.people-out.connector=smallrye-rabbitmq
+mp.messaging.outgoing.people-out.exchange.name=people
+
+mp.messaging.incoming.people-in.connector=smallrye-rabbitmq
+mp.messaging.incoming.people-in.queue.name=people
+mp.messaging.incoming.people-in.exchange.name=people
+
+quarkus.rabbitmq.devservices.enabled=false
+quarkus.rabbitmq.credentials-provider=rabbitmq

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsIT.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.rabbitmq;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class RabbitMQConnectorDynCredsIT extends RabbitMQConnectorDynCredsTest {
+
+}

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.it.rabbitmq;
+
+import static io.restassured.RestAssured.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.it.rabbitmq.RabbitMQConnectorDynCredsTest.VaultResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+@QuarkusTestResource(VaultResource.class)
+public class RabbitMQConnectorDynCredsTest {
+
+    public static class VaultResource implements QuarkusTestResourceLifecycleManager {
+
+        RabbitMQContainer rabbit;
+
+        @Override
+        public Map<String, String> start() {
+            String username = "tester";
+            String password = RandomStringUtils.random(10);
+
+            rabbit = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3.9-management"))
+                    .withNetwork(Network.SHARED)
+                    .withNetworkAliases("rabbitmq")
+                    .withUser(username, password)
+                    .withPermission("/", username, ".*", ".*", ".*");
+            rabbit.start();
+
+            return Map.of(
+                    "rabbitmq-host", rabbit.getHost(),
+                    "rabbitmq-port", rabbit.getAmqpPort().toString(),
+                    "rabbitmq-username", "invalid",
+                    "rabbitmq-password", "invalid",
+                    "test-creds-provider.username", username,
+                    "test-creds-provider.password", password);
+        }
+
+        @Override
+        public void stop() {
+            rabbit.stop();
+        }
+    }
+
+    protected static final TypeRef<List<Person>> TYPE_REF = new TypeRef<List<Person>>() {
+    };
+
+    @Test
+    public void test() {
+        await().atMost(30, SECONDS)
+                .untilAsserted(() -> Assertions.assertEquals(6, get("/rabbitmq/people").as(TYPE_REF).size()));
+    }
+
+}

--- a/integration-tests/reactive-messaging-rabbitmq/src/main/resources/application.properties
+++ b/integration-tests/reactive-messaging-rabbitmq/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 
-mp.messaging.outgoing.people-out.connector=smallrye-rabbitmq
 mp.messaging.outgoing.people-out.exchange.name=people
 
-mp.messaging.incoming.people-in.connector=smallrye-rabbitmq
 mp.messaging.incoming.people-in.queue.name=people
 mp.messaging.incoming.people-in.exchange.name=people


### PR DESCRIPTION
~This builds on PR #21279. Once it has been merged this PR will be rebased.~

It adds RabbitMQ to the supported services that work with the credentials provider for dynamic credentials.

It's a fairly simple change that adds a runtime initialized `CredentialsProviderLink` that implements RabbitMQ's `com.rabbitmq.client.impl.CredentialsProvider` by pulling credentials from the configured Quarkus credentials provider. Finally, it configures the RabbitMQ connector to the link instance.

PR #21279 already included all the changes necessary to support RabbitMQ dynamic credentials without any code changes. Additionally, this PR updates the `VaultITCase` to ensure that RabbitMQ's dynamic credentials support is tested.
