### PR TITLE
Arc - when evaluating parameter type information, handle primitive arrays properly

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -554,7 +554,11 @@ final class Methods {
                     }
                     DotName typeName = type.name();
                     if (type.kind() == Kind.ARRAY) {
-                        typeName = type.asArrayType().component().name();
+                        Type componentType = type.asArrayType().component();
+                        if (componentType.kind() == Kind.PRIMITIVE) {
+                            continue;
+                        }
+                        typeName = componentType.name();
                     }
                     ClassInfo param = beanArchiveIndex.getClassByName(typeName);
                     if (param == null) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/nonpublicparams/NonPublicParametersTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/nonpublicparams/NonPublicParametersTest.java
@@ -42,6 +42,11 @@ public class NonPublicParametersTest {
             return "foo";
         }
 
+        @Simple
+        String primitiveArray(int[] ints) {
+            return "foo";
+        }
+
         private static class Foo {
         }
 


### PR DESCRIPTION
This is a minor oversight from previous.
Related to this comment - https://github.com/quarkusio/quarkus/pull/21781#issuecomment-984998982