### PR TITLE
Remove unnecessary warning

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Methods.java
@@ -558,9 +558,8 @@ final class Methods {
                     }
                     ClassInfo param = beanArchiveIndex.getClassByName(typeName);
                     if (param == null) {
-                        LOGGER.warn(String.format(
-                                "Parameter type info not available: %s - unable to validate the parameter type's visibility for method %s declared on %s",
-                                type.name(), method.name(), method.declaringClass().name()));
+                        //no need to warn here, if it was potentially a problem it would be in the index
+                        //otherwise this class would not be able to access it
                         continue;
                     }
                     if (Modifier.isPublic(param.flags()) || Modifier.isProtected(param.flags())) {


### PR DESCRIPTION
This warning can be triggered by legitimate code, but won't identify
real problems as a private type would be in the same index as the
current class.