### PR TITLE
Use immutable versions of logging formatters

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -153,7 +153,7 @@
         <dekorate.version>2.6.0</dekorate.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.1.1</awaitility.version>
-        <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
+        <jboss-logmanager.version>1.0.10-SNAPSHOT</jboss-logmanager.version>
         <jgit.version>6.0.0.202111291000-r</jgit.version>
         <flyway.version>8.1.0</flyway.version>
         <yasson.version>1.0.9</yasson.version>

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/BannerFormatter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/BannerFormatter.java
@@ -2,32 +2,24 @@ package io.quarkus.runtime.logging;
 
 import java.nio.charset.Charset;
 import java.util.function.Supplier;
-import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
 import org.jboss.logmanager.ExtLogRecord;
-import org.jboss.logmanager.formatters.ColorPatternFormatter;
-import org.jboss.logmanager.formatters.FormatStep;
-import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.formatters.ImmutablePatternFormatter;
 import org.wildfly.common.annotation.NotNull;
 
-public class BannerFormatter extends ColorPatternFormatter {
+public class BannerFormatter extends ImmutablePatternFormatter {
 
     private final Supplier<String> bannerSupplier;
-    private Formatter formatter;
-    private boolean isColorPattern;
+    private final ImmutablePatternFormatter formatter;
+    private final boolean isColorPattern;
 
-    BannerFormatter(@NotNull Formatter formatter, boolean isColorPattern, Supplier<String> bannerSupplier) {
+    BannerFormatter(@NotNull ImmutablePatternFormatter formatter, boolean isColorPattern, Supplier<String> bannerSupplier) {
+        super(formatter.getPattern());
         this.formatter = formatter;
         this.isColorPattern = isColorPattern;
         this.bannerSupplier = bannerSupplier;
-
-        if (isColorPattern) {
-            this.setPattern(((ColorPatternFormatter) formatter).getPattern());
-        } else {
-            this.setPattern(((PatternFormatter) formatter).getPattern());
-        }
     }
 
     @Override
@@ -40,21 +32,8 @@ public class BannerFormatter extends ColorPatternFormatter {
     }
 
     @Override
-    public void setSteps(FormatStep[] steps) {
-        if (isColorPattern) {
-            super.setSteps(steps);
-        } else {
-            ((PatternFormatter) formatter).setSteps(steps);
-        }
-    }
-
-    @Override
     public String format(ExtLogRecord extLogRecord) {
-        if (isColorPattern) {
-            return ((ColorPatternFormatter) formatter).format(extLogRecord);
-        } else {
-            return ((PatternFormatter) formatter).format(extLogRecord);
-        }
+        return formatter.format(extLogRecord);
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -28,7 +28,8 @@ import org.jboss.logmanager.EmbeddedConfigurator;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
 import org.jboss.logmanager.errormanager.OnlyOnceErrorManager;
-import org.jboss.logmanager.formatters.ColorPatternFormatter;
+import org.jboss.logmanager.formatters.ImmutableColorPatternFormatter;
+import org.jboss.logmanager.formatters.ImmutablePatternFormatter;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.logmanager.handlers.ConsoleHandler;
@@ -401,7 +402,7 @@ public class LoggingSetupRecorder {
             }
             if (ColorSupport.isColorEnabled(consoleRuntimeConfig, config)) {
                 color = true;
-                ColorPatternFormatter colorPatternFormatter = new ColorPatternFormatter(config.darken,
+                ImmutableColorPatternFormatter colorPatternFormatter = new ImmutableColorPatternFormatter(config.darken,
                         config.format);
                 if (bannerSupplier != null) {
                     formatter = new BannerFormatter(colorPatternFormatter, true, bannerSupplier);
@@ -409,7 +410,7 @@ public class LoggingSetupRecorder {
                     formatter = colorPatternFormatter;
                 }
             } else {
-                PatternFormatter patternFormatter = new PatternFormatter(config.format);
+                ImmutablePatternFormatter patternFormatter = new ImmutablePatternFormatter(config.format);
                 if (bannerSupplier != null) {
                     formatter = new BannerFormatter(patternFormatter, false, bannerSupplier);
                 } else {
@@ -481,7 +482,7 @@ public class LoggingSetupRecorder {
             handler = periodicRotatingFileHandler;
         }
 
-        final PatternFormatter formatter = new PatternFormatter(config.format);
+        final ImmutablePatternFormatter formatter = new ImmutablePatternFormatter(config.format);
         handler.setFormatter(formatter);
         handler.setAppend(true);
         try {
@@ -512,7 +513,7 @@ public class LoggingSetupRecorder {
             handler.setTruncate(config.truncate);
             handler.setUseCountingFraming(config.useCountingFraming);
             handler.setLevel(config.level);
-            final PatternFormatter formatter = new PatternFormatter(config.format);
+            final ImmutablePatternFormatter formatter = new ImmutablePatternFormatter(config.format);
             handler.setFormatter(formatter);
             handler.setErrorManager(errorManager);
             handler.setFilter(logCleanupFilter);

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -48,7 +48,7 @@
         <commons-lang.version>3.12.0</commons-lang.version>
         <guava.version>30.1.1-jre</guava.version>
         <shrinkwrap-depchain.version>1.2.6</shrinkwrap-depchain.version>
-        <jboss-logmanager-embedded.version>1.0.9</jboss-logmanager-embedded.version>
+        <jboss-logmanager-embedded.version>1.0.10-SNAPSHOT</jboss-logmanager-embedded.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <graal-sdk.version>21.3.0</graal-sdk.version>

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
@@ -4,7 +4,7 @@ import io.quarkus.bootstrap.graal.ImageInfo;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import org.jboss.logmanager.EmbeddedConfigurator;
-import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.formatters.ImmutablePatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 
 /**
@@ -41,7 +41,7 @@ public final class InitialConfigurator implements EmbeddedConfigurator {
     }
 
     public static ConsoleHandler createDefaultHandler() {
-        ConsoleHandler handler = new ConsoleHandler(new PatternFormatter("%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
+        ConsoleHandler handler = new ConsoleHandler(new ImmutablePatternFormatter("%d{HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"));
         handler.setLevel(Level.INFO);
         return handler;
     }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/QuarkusDelayedHandler.java
@@ -35,7 +35,7 @@ import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
 import org.jboss.logmanager.Level;
 import org.jboss.logmanager.StandardOutputStreams;
-import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.formatters.ImmutablePatternFormatter;
 
 /**
  * A handler that queues messages until it's at least one child handler is {@linkplain #addHandler(Handler) added} or
@@ -146,7 +146,7 @@ public class QuarkusDelayedHandler extends ExtHandler {
             if (!logRecords.isEmpty()) {
                 Formatter formatter = getFormatter();
                 if (formatter == null) {
-                    formatter = new PatternFormatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
+                    formatter = new ImmutablePatternFormatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
                 }
                 StandardOutputStreams.printError("The DelayedHandler was closed before any children handlers were " +
                         "configured. Messages will be written to stderr.");


### PR DESCRIPTION
In Quarkus these formatters cannot be changed at runtime
so we can get a small performance improvement
by using versions of the formatters that don't need
to read `volatile` fields

P.S. In draft because if we want this, we would need https://github.com/dmlloyd/jboss-logmanager-embedded/compare/master...geoand:immutable?expand=1 to be merged and a new version including it released