### PR TITLE
Qute - cache SectionHelperFactory config by default

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
@@ -8,7 +8,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -81,15 +80,15 @@ public class IfSectionHelper implements SectionHelper {
 
         @Override
         public ParametersInfo getParameters() {
-            ParametersInfo.Builder builder = ParametersInfo.builder();
-            // {#if} must declare at least one condition param
-            builder.addParameter("condition");
-            return builder
+            return ParametersInfo.builder()
+                    .checkNumberOfParams(false)
+                    // {#if} must declare at least one condition param
+                    .addParameter("condition")
                     .build();
         }
 
         public List<String> getBlockLabels() {
-            return Collections.singletonList(ELSE);
+            return ImmutableList.of(ELSE);
         }
 
         @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ImmutableList.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ImmutableList.java
@@ -55,6 +55,16 @@ public final class ImmutableList {
     }
 
     /**
+     * 
+     * @param <T>
+     * @param element
+     * @return an immutable list
+     */
+    public static <T> List<T> of(T element) {
+        return Collections.singletonList(element);
+    }
+
+    /**
      *
      * @return a builder
      */

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -19,6 +19,7 @@ public interface SectionHelperFactory<T extends SectionHelper> {
     /**
      * 
      * @return the list of default aliases used to match the helper
+     * @see #cacheFactoryConfig()
      */
     default List<String> getDefaultAliases() {
         return Collections.emptyList();
@@ -27,6 +28,7 @@ public interface SectionHelperFactory<T extends SectionHelper> {
     /**
      * 
      * @return the info about the expected parameters
+     * @see #cacheFactoryConfig()
      */
     default ParametersInfo getParameters() {
         return ParametersInfo.EMPTY;
@@ -36,9 +38,21 @@ public interface SectionHelperFactory<T extends SectionHelper> {
      * A nested section tag that matches a name of a block will be added as a block to the current section.
      * 
      * @return the list of block labels
+     * @see #cacheFactoryConfig()
      */
     default List<String> getBlockLabels() {
         return Collections.emptyList();
+    }
+
+    /**
+     * If the return value is {@code true} then {@link #getDefaultAliases()}, {@link #getParameters()} and
+     * {@link #getBlockLabels()} methods are called exactly once and the results are cached when the factory is being
+     * registered.
+     * 
+     * @return {@code true} the config should be cached, {@code false} otherwise
+     */
+    default boolean cacheFactoryConfig() {
+        return true;
     }
 
     /**
@@ -191,9 +205,11 @@ public interface SectionHelperFactory<T extends SectionHelper> {
         public static final ParametersInfo EMPTY = builder().build();
 
         private final Map<String, List<Parameter>> parameters;
+        private final boolean checkNumberOfParams;
 
-        private ParametersInfo(Map<String, List<Parameter>> parameters) {
+        private ParametersInfo(Map<String, List<Parameter>> parameters, boolean checkNumberOfParams) {
             this.parameters = new HashMap<>(parameters);
+            this.checkNumberOfParams = checkNumberOfParams;
         }
 
         public List<Parameter> get(String blockLabel) {
@@ -205,12 +221,18 @@ public interface SectionHelperFactory<T extends SectionHelper> {
             return parameters.values().iterator();
         }
 
+        public boolean isCheckNumberOfParams() {
+            return checkNumberOfParams;
+        }
+
         public static class Builder {
 
             private final Map<String, List<Parameter>> parameters;
+            private boolean checkNumberOfParams;
 
             Builder() {
                 this.parameters = new HashMap<>();
+                this.checkNumberOfParams = true;
             }
 
             public Builder addParameter(String name) {
@@ -234,8 +256,13 @@ public interface SectionHelperFactory<T extends SectionHelper> {
                 return this;
             }
 
+            public Builder checkNumberOfParams(boolean value) {
+                this.checkNumberOfParams = value;
+                return this;
+            }
+
             public ParametersInfo build() {
-                return new ParametersInfo(parameters);
+                return new ParametersInfo(parameters, checkNumberOfParams);
             }
         }
 


### PR DESCRIPTION
- and reduce the parser allocations
- also make it possible to skip a DEBUG log message if too many params
are specified