### PR TITLE
Make sure quarkusGenerateCode is run before tests

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -177,6 +177,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                             });
                     tasks.named(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaCompile.class,
                             compileTestJava -> {
+                                compileTestJava.dependsOn(quarkusGenerateCode);
                                 compileTestJava.dependsOn(quarkusGenerateCodeTests);
                                 if (project.getGradle().getStartParameter().getTaskNames().contains(QUARKUS_DEV_TASK_NAME)) {
                                     compileTestJava.getOptions().setFailOnError(false);

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -151,6 +151,16 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
     }
 
+    @Test
+    public void generateCodeBeforeTests() throws Exception {
+        createProject(SourceType.JAVA);
+
+        BuildResult firstBuild = runGradleWrapper(projectRoot, "test", "--stacktrace");
+        assertThat(firstBuild.getOutput()).contains("Task :quarkusGenerateCode");
+        assertThat(firstBuild.getOutput()).contains("Task :quarkusGenerateCodeTests");
+        assertThat(firstBuild.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
     private void createProject(SourceType sourceType) throws Exception {
         Map<String, Object> context = new HashMap<>();
         context.put("path", "/greeting");


### PR DESCRIPTION
If we only ask for the `test` task, we are only running the `quarkusGenerateCodeTests` task but not the `quarkusGenerateCode` which generate code for the main sourceSet. 
This adds a dependency between `quarkusGenerateCode` task and the test task.

close #21878 