### PR TITLE
Repeat the grant request if OidcClient refresh token has expired

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClientConfig.java
@@ -113,10 +113,16 @@ public class OidcClientConfig extends OidcCommonConfig {
         public String refreshTokenProperty = OidcConstants.REFRESH_TOKEN_VALUE;
 
         /**
-         * Refresh token property name in a token grant response
+         * Access token expiry property name in a token grant response
          */
         @ConfigItem(defaultValue = OidcConstants.EXPIRES_IN)
         public String expiresInProperty = OidcConstants.EXPIRES_IN;
+
+        /**
+         * Refresh token expiry property name in a token grant response
+         */
+        @ConfigItem(defaultValue = OidcConstants.REFRESH_EXPIRES_IN)
+        public String refreshExpiresInProperty = OidcConstants.REFRESH_EXPIRES_IN;
 
         public Type getType() {
             return type;
@@ -148,6 +154,14 @@ public class OidcClientConfig extends OidcCommonConfig {
 
         public void setExpiresInProperty(String expiresInProperty) {
             this.expiresInProperty = expiresInProperty;
+        }
+
+        public String getRefreshExpiresInProperty() {
+            return refreshExpiresInProperty;
+        }
+
+        public void setRefreshExpiresInProperty(String refreshExpiresInProperty) {
+            this.refreshExpiresInProperty = refreshExpiresInProperty;
         }
     }
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/Tokens.java
@@ -12,14 +12,16 @@ public class Tokens {
     final private Long accessTokenExpiresAt;
     final private Long refreshTokenTimeSkew;
     final private String refreshToken;
+    final Long refreshTokenExpiresAt;
     final private JsonObject grantResponse;
 
     public Tokens(String accessToken, Long accessTokenExpiresAt, Duration refreshTokenTimeSkewDuration, String refreshToken,
-            JsonObject grantResponse) {
+            Long refreshTokenExpiresAt, JsonObject grantResponse) {
         this.accessToken = accessToken;
         this.accessTokenExpiresAt = accessTokenExpiresAt;
         this.refreshTokenTimeSkew = refreshTokenTimeSkewDuration == null ? null : refreshTokenTimeSkewDuration.getSeconds();
         this.refreshToken = refreshToken;
+        this.refreshTokenExpiresAt = refreshTokenExpiresAt;
         this.grantResponse = grantResponse;
     }
 
@@ -44,11 +46,11 @@ public class Tokens {
     }
 
     public boolean isAccessTokenExpired() {
-        if (accessTokenExpiresAt == null) {
-            return false;
-        }
-        final long nowSecs = System.currentTimeMillis() / 1000;
-        return nowSecs > accessTokenExpiresAt;
+        return isExpired(accessTokenExpiresAt);
+    }
+
+    public boolean isRefreshTokenExpired() {
+        return isExpired(refreshTokenExpiresAt);
     }
 
     public boolean isAccessTokenWithinRefreshInterval() {
@@ -57,5 +59,13 @@ public class Tokens {
         }
         final long nowSecs = System.currentTimeMillis() / 1000;
         return nowSecs + refreshTokenTimeSkew > accessTokenExpiresAt;
+    }
+
+    private static boolean isExpired(Long expiresAt) {
+        if (expiresAt == null) {
+            return false;
+        }
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        return nowSecs > expiresAt;
     }
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/TokensHelper.java
@@ -40,9 +40,10 @@ public class TokensHelper {
             } else {
                 Tokens tokens = currentState.tokens;
                 if (tokens.isAccessTokenExpired() || tokens.isAccessTokenWithinRefreshInterval()) {
-                    newState = new TokenRequestState(prepareUni(tokens.getRefreshToken() != null
-                            ? oidcClient.refreshTokens(tokens.getRefreshToken())
-                            : oidcClient.getTokens()));
+                    newState = new TokenRequestState(
+                            prepareUni((tokens.getRefreshToken() != null && !tokens.isRefreshTokenExpired())
+                                    ? oidcClient.refreshTokens(tokens.getRefreshToken())
+                                    : oidcClient.getTokens()));
                     if (tokenRequestStateUpdater.compareAndSet(this, currentState, newState)) {
                         return newState.tokenUni;
                     }

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -48,4 +48,5 @@ public final class OidcConstants {
     public static final String EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
 
     public static final String EXPIRES_IN = "expires_in";
+    public static final String REFRESH_EXPIRES_IN = "refresh_expires_in";
 }

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -50,7 +50,7 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .aResponse()
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
-                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_2\", \"refresh_expires_in\":1}")));
 
         server.stubFor(WireMock.post("/refresh-token-only")
                 .withRequestBody(matching("grant_type=refresh_token&refresh_token=shared_refresh_token"))


### PR DESCRIPTION
Fixes #21873

When `OidcClient` acquires the tokens it gets an access token, and possibly a refresh token. If the access token has expired then, if the refresh token is available - it will use a refresh token grant to get a new access token / refresh token pair - and if no refresh token is available then it will try to get this new pair by repeating the same grant request which was used to acquire the original pair, etc.

What has been reported in #21873 is that when the access token has expired and `OidcClient` uses an available refresh token, it can fail if this refresh token has also expired.

So, when the access token has expired, the same grant request (for ex `password`) has to be used to acquire a new pair of tokens not only when the refresh token is not available but also when it is available but has expired too. It is really the only way to address it. 

So this PR applies a small update to `TokensHelper` accordingly. Additionally it introduces a `refreshExpiresInProperty`, similarly to how it is done for the standard `expires_in` property - but while `expires_in` is a standard property, no standard property for conveying the refresh token expiry time exists - so it is really needed for the refresh token case. By default it is set to `refresh_expires_in` which is what Keycloak returns.

`OidcClientImpl` calculates the time the refresh token will expire the same way it does for the access token - first this property is checked - and if it is not available, then, if RT is JWT (Json) then it tries to get the expiry claim.

`OidcClientWiremock` test which refreshes the token has been updated to check a grant request is repeated when the refresh token has also expired - comments have been added to clarify how the test works.