### PR TITLE
Only print stacktrace of conflicting buildsteps if activated

### DIFF
--- a/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
@@ -15,6 +15,8 @@ import io.quarkus.builder.item.EmptyBuildItem;
  * a destructor for items it produces, which will be run (in indeterminate order) at the end of processing.
  */
 public final class BuildStepBuilder {
+    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+
     private final BuildChainBuilder buildChainBuilder;
     private final Map<ItemId, Consume> consumes = new HashMap<>();
     private final Map<ItemId, Produce> produces = new HashMap<>();
@@ -192,7 +194,11 @@ public final class BuildStepBuilder {
      */
     public BuildChainBuilder build() {
         final BuildChainBuilder chainBuilder = this.buildChainBuilder;
-        chainBuilder.addStep(this, new Exception().getStackTrace());
+        if (BuildChainBuilder.LOG_CONFLICT_CAUSING) {
+            chainBuilder.addStep(this, new Exception().getStackTrace());
+        } else {
+            chainBuilder.addStep(this, EMPTY_STACK_TRACE);
+        }
         return chainBuilder;
     }
 


### PR DESCRIPTION
The quarkus-core-builder detects conflicts between buildsteps, and throws exception for that.
This exception also included the stacktrace of the original caller of the build method. However, this pointed to a big lambda chain.
Since this stacktrace was created for each buildstep, this got costly fast.

Now, simply only include by default an empty ST, and add an option to include the full stacktrace.

This saves about 5-10ms of dev mode startup time, on the reproducer from #21552.

Relates to #21552, but again not a complete fix.