### PR TITLE
Fix DefaultTokenIntrospectionUserInfoCache injection

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -25,6 +25,8 @@ import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.SecurityEvent;
+import io.quarkus.oidc.TokenIntrospectionCache;
+import io.quarkus.oidc.UserInfoCache;
 import io.quarkus.oidc.runtime.DefaultTenantConfigResolver;
 import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.oidc.runtime.DefaultTokenStateManager;
@@ -95,7 +97,7 @@ public class OidcBuildStep {
             OidcRecorder recorder,
             CoreVertxBuildItem vertxBuildItem) {
         return SyntheticBeanBuildItem.configure(DefaultTokenIntrospectionUserInfoCache.class).unremovable()
-                .types(DefaultTokenIntrospectionUserInfoCache.class)
+                .types(DefaultTokenIntrospectionUserInfoCache.class, TokenIntrospectionCache.class, UserInfoCache.class)
                 .supplier(recorder.setupTokenCache(config, vertxBuildItem.getVertx()))
                 .scope(Singleton.class)
                 .setRuntimeInit()

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfig.java
@@ -30,7 +30,9 @@ public class OidcConfig {
     public Map<String, OidcTenantConfig> namedTenants;
 
     /**
-     * Default TokenIntrospection and UserInfo Cache configuration which is used for all the tenants if it is enabled.
+     * Default TokenIntrospection and UserInfo Cache configuration which is used for all the tenants if it is enabled
+     * with the build-time 'quarkus.oidc.default-token-cache-enabled' property ('true' by default) and also activated,
+     * see its `max-size` property.
      */
     @ConfigItem
     public TokenCache tokenCache = new TokenCache();

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowResource.java
@@ -5,6 +5,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -14,10 +15,13 @@ public class CodeFlowResource {
     @Inject
     SecurityIdentity identity;
 
+    @Inject
+    DefaultTokenIntrospectionUserInfoCache tokenCache;
+
     @GET
     @Authenticated
     public String access() {
-        return identity.getPrincipal().getName();
+        return identity.getPrincipal().getName() + ", cache size: " + tokenCache.getCacheSize();
     }
 
     @GET

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -5,6 +5,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 import io.quarkus.oidc.UserInfo;
+import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
@@ -18,8 +19,14 @@ public class CodeFlowUserInfoResource {
     @Inject
     SecurityIdentity identity;
 
+    @Inject
+    DefaultTokenIntrospectionUserInfoCache tokenCache;
+
     @GET
     public String access() {
-        return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username");
+        int cacheSize = tokenCache.getCacheSize();
+        tokenCache.clearCache();
+        return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username") + ", cache size: "
+                + cacheSize;
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -31,11 +31,15 @@ quarkus.oidc.code-flow-user-info-only.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-only.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-user-info-only.application-type=web-app
 
+quarkus.oidc.token-cache.max-size=1
+
 quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer.client-id=quarkus-app
 quarkus.oidc.bearer.credentials.secret=secret
 quarkus.oidc.bearer.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer.token.audience=https://service.example.com
+quarkus.oidc.bearer.token.audience=https://service.example.com
+quarkus.oidc.bearer.allow-token-introspection-cache=false
 
 quarkus.oidc.bearer-no-introspection.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-no-introspection.client-id=quarkus-app

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -42,7 +42,7 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice", page.getBody().asText());
+            assertEquals("alice, cache size: 0", page.getBody().asText());
             assertNotNull(getSessionCookie(webClient, "code-flow"));
 
             page = webClient.getPage("http://localhost:8081/code-flow/logout");
@@ -66,7 +66,8 @@ public class CodeFlowAuthorizationTest {
 
             page = form.getInputByValue("login").click();
 
-            assertEquals("alice:alice", page.getBody().asText());
+            assertEquals("alice:alice, cache size: 1", page.getBody().asText());
+
             assertNotNull(getSessionCookie(webClient, "code-flow-user-info-only"));
             webClient.getCookieManager().clearCookies();
         }


### PR DESCRIPTION
Fixes #21925

This cache is already tested in `integration-tests/oidc-tenancy` [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java#L347) and [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java#L374). But it is injected into a [custom bean](https://github.com/quarkusio/quarkus/blob/main/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomIntrospectionUserInfoCache.java) to also verify it can be replaced - the custom bean is injected as an alternative implementation.

It has been confirmed twice by @FroMage and reported by a user on Zulip that it can not be injected as either `UserInfoCache` or `TokenIntrospectionCache`. As Steph confirmed the problem was using the `DefaultTokenIntrospectionUserInfoCache.class` alone with the synthetic bean (I assumed its interfaces would be used as well).

So this PR does a simple update to the `DefaultTokenIntrospectionUserInfoCache` bean registration and updates `oidc-wiremock` test to verify the default cache is activated. This cache is activated globally (and uses a single entry to store both the introspection and userinfo data) but individual tenants can disable either the token introspection or useinfo cache or both - so in the test I disable the token introspection for the bearer token tests - without it, depending on which order tests run, one of the CodeFlow tests expecting a `0` cache size will get `1` instead even though it does not use the cache.

Also did another clarification to the docs.

@FroMage Steph, I've reviewed the guide and Java docs and with the latest Java doc update IMHO it is all very clear and non-ambiguous. Note the cache can't start taking entries by default nor can it grow unconstrained, but I also did not want users to type 2 properties to activate it (enable, max-size), hence it is only `token-cache.max-size` which is enough to have it activated.