### PR TITLE
Don't throw an exception when finishing a closed RESTEasy response

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxHttpResponse.java
@@ -138,7 +138,7 @@ public class VertxHttpResponse implements HttpResponse {
 
     public void finish() throws IOException {
         checkException();
-        if (finished || response.ended())
+        if (finished || response.ended() || response.closed())
             return;
         try {
             if (os != null) {


### PR DESCRIPTION
Relates to: https://github.com/quarkusio/quarkus/issues/21762#issuecomment-985995830