### PR TITLE
Better error for missing Vault config when using credentials provider

### DIFF
--- a/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
+++ b/extensions/vault/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
@@ -31,8 +31,13 @@ public class VaultCredentialsProvider implements CredentialsProvider {
     @Override
     public Map<String, String> getCredentials(String credentialsProviderName) {
 
-        CredentialsProviderConfig config = getConfig().credentialsProvider.get(credentialsProviderName);
+        VaultBootstrapConfig vaultConfig = getConfig();
+        if (vaultConfig == null) {
+            throw new VaultException(
+                    "missing vault configuration required for credentials providers with name " + credentialsProviderName);
+        }
 
+        CredentialsProviderConfig config = vaultConfig.credentialsProvider.get(credentialsProviderName);
         if (config == null) {
             throw new VaultException("unknown credentials provider with name " + credentialsProviderName);
         }


### PR DESCRIPTION
Replaces an NPE with a better exception & message if you have a missing Vault configuration when you are trying to use the Vault credentials provider.