### PR TITLE
Bump smallrye-jwt version to 3.3.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-graphql.version>1.3.5</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>3.3.1</smallrye-jwt.version>
+        <smallrye-jwt.version>3.3.2</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -172,10 +172,11 @@ String jwt = Jwt.subject("Bob").jwe()
     .encrypt();
 ----
 
-Alternatively, especially if the default `A256GCM` content encryption algorithm does not need to be changed, you can use a `smallrye.jwt.new-token.key-encryption-algorithm` property to customize a key encryption algorithm:
+Alternatively you can use `smallrye.jwt.new-token.key-encryption-algorithm` and `smallrye.jwt.new-token.content-encryption-algorithm` properties to customize the key and content encryption algorithms:
 
 ```properties
 smallrye.jwt.new-token.key-encryption-algorithm=RSA-OAEP-256
+smallrye.jwt.new-token.content-encryption-algorithm=A256CBC-HS512
 ```
 
 and write a simpler API sequence:
@@ -185,7 +186,7 @@ and write a simpler API sequence:
 import io.smallrye.jwt.build.Jwt;
 
 // Encrypt the claims using an RSA public key loaded from the location set with a 'smallrye.jwt.encrypt.key.location' property.
-// Key encryption algorithm is RSA-OAEP-256, content encryption algorithm is A256GCM.
+// Key encryption algorithm is RSA-OAEP-256, content encryption algorithm is A256CBC-HS512.
 String jwt = Jwt.subject("Bob").encrypt();
 ----
 
@@ -226,11 +227,35 @@ As mentioned above, `iat` (issued at), `exp` (expires at), `jti` (token identifi
 
 == Dealing with the keys
 
+`smallrye.jwt.sign.key.location` and `smallrye.jwt.encrypt.key.location` properties can be used to point to signing and encryption key locations. The keys can be located on the local file system, classpath, or fetched from the remote endpoints and can be in `PEM` or `JSON Web Key` (`JWK`) formats. For example:
+
+[source,properties]
+----
+smallrye.jwt.sign.key=privateKey.pem
+smallrye.jwt.encrypt.key=publicKey.pem
+----
+
+You can also use MicroProfile `ConfigSource` to fetch the keys from the external services such as link:vault[HashiCorp Vault] or other secret managers and use `smallrye.jwt.sign.key` and `smallrye.jwt.encrypt.key` properties instead:
+
+[source,properties]
+----
+smallrye.jwt.sign.key=${private.key.from.vault}
+smallrye.jwt.encrypt.key=${public.key.from.vault}
+----
+
+where both `private.key.from.vault` and `public.key.from.vault` are the `PEM` or `JWK` formatted key values provided by the custom `ConfigSource`.
+`smallrye.jwt.sign.key` and `smallrye.jwt.encrypt.key` can also contain only the Base64-encoded private or public keys values.
+
+However, please note, directly inlining the private keys in the configuration is not recommended. Use the `smallrye.jwt.sign.key` property only if you need to fetch a signing key value from the remote secret manager.
+
+The keys can also be loaded by the code which builds the token and supplied to JWT Build API.
+
 If you need to sign and/or encrypt the token using the symmetric secret key then consider using `io.smallrye.jwt.util.KeyUtils` to generate a SecretKey of the required length.
 
 For example, one needs to have a 64 byte key to sign using the `HS512` algorithm (`512/8`) and a 32 byte key to encrypt the content encryption key with the `A256KW` algorithm (`256/8`):
 
-```java
+[source,java]
+----
 import javax.crypto.SecretKey;
 import io.smallrye.jwt.KeyEncryptionAlgorithm;
 import io.smallrye.jwt.SignatureAlgorithm;
@@ -240,21 +265,23 @@ import io.smallrye.jwt.util.KeyUtils;
 SecretKey signingKey = KeyUtils.generateSecretKey(SignatureAlgorithm.HS512);
 SecretKey encryptionKey = KeyUtils.generateSecretKey(KeyEncryptionAlgorithm.A256KW);
 String jwt = Jwt.claim("sensitiveClaim", getSensitiveClaim()).innerSign(signingKey).encrypt(encryptionKey);
-```
+----
 
 You can also consider using a `JSON Web Key` (JWK) or `JSON Web Key Set` (JWK Set) format to store a secret key on a secure file system and refer to it using either `smallrye.jwt.sign.key.location` or `smallrye.jwt.encrypt.key.location` properties, for example:
 
-```json
+[source,json]
+----
 {
  "kty":"oct",
  "kid":"secretKey",
  "k":"Fdh9u8rINxfivbrianbbVT1u232VQBZYKx1HGAGPt2I"
 }
-```
+----
 
 or
 
-```json
+[source,json]
+----
 {
  "keys": [
    {
@@ -269,7 +296,7 @@ or
    }
  ]
 }
-```
+----
 
 `io.smallrye.jwt.util.KeyUtils` can also be used to generate a pair of assymetric RSA or EC keys. These keys can be stored using a `JWK`, `JWK Set` or `PEM` format.
 
@@ -281,11 +308,14 @@ SmallRye JWT supports the following properties which can be used to customize th
 |===
 |Property Name|Default|Description
 |smallrye.jwt.sign.key.location|`none`|Location of a private key which will be used to sign the claims when either a no-argument `sign()` or `innerSign()` method is called.
+|smallrye.jwt.sign.key|none|Key value which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key.id|`none`|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.encrypt.key.location|`none`|Location of a public key which will be used to encrypt the claims or inner JWT when a no-argument `encrypt()` method is called.
+|smallrye.jwt.encrypt.key|none|Key value which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
 |smallrye.jwt.encrypt.key.id|`none`|Encryption key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
 |smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
+|smallrye.jwt.new-token.content-encryption-algorithm|A256GCM|Content encryption algorithm. This property will be checked if the JWT encryption builder has not already set the content encryption algorithm.
 |smallrye.jwt.new-token.lifespan|300|Token lifespan in seconds which will be used to calculate an `exp` (expiry) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.issuer|none|Token issuer which can be used to set an `iss` (issuer) claim value if this claim has not already been set.
 |smallrye.jwt.new-token.audience|none|Token audience which can be used to set an `aud` (audience) claim value if this claim has not already been set.

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsSignEncryptConfigSourceUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsSignEncryptConfigSourceUnitTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.jwt.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.jwt.build.Jwt;
+
+public class DefaultGroupsSignEncryptConfigSourceUnitTest {
+    private static Class<?>[] testClasses = {
+            DefaultGroupsEndpoint.class,
+            TestConfigSource.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsServiceProvider(ConfigSource.class, TestConfigSource.class)
+                    .addAsResource("publicKey.pem")
+                    .addAsResource("privateKey.pem")
+                    .addAsResource("applicationSignEncryptConfigSource.properties", "application.properties"));
+
+    /**
+     * Validate a request with MP-JWT without a 'groups' claim is successful
+     * due to the default value being provided in the configuration
+     *
+     */
+    @Test
+    public void echoGroups() {
+        String token = Jwt.issuer("https://server.example.com").upn("upn").innerSign()
+                .encrypt();
+
+        RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/echo")
+                .then().assertThat().statusCode(200)
+                .body(equalTo("User"));
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestConfigSource.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/TestConfigSource.java
@@ -1,0 +1,41 @@
+package io.quarkus.jwt.test;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.jwt.util.KeyUtils;
+
+public class TestConfigSource implements ConfigSource {
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Set.of("sign-key", "encrypt-key");
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        if ("sign-key".equals(propertyName)) {
+            return readKeyContent("/privateKey.pem");
+        } else if ("encrypt-key".equals(propertyName)) {
+            return readKeyContent("/publicKey.pem");
+        } else {
+            return null;
+        }
+    }
+
+    private String readKeyContent(String keyLocation) {
+        try {
+            return KeyUtils.readKeyContent(keyLocation);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "jwt";
+    }
+
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationSignEncryptConfigSource.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationSignEncryptConfigSource.properties
@@ -1,0 +1,11 @@
+mp.jwt.verify.publickey.location=/publicKey.pem
+smallrye.jwt.decrypt.key.location=/privateKey.pem
+
+smallrye.jwt.sign.key=${sign-key}
+smallrye.jwt.encrypt.key=${encrypt-key}
+
+mp.jwt.verify.issuer=https://server.example.com
+smallrye.jwt.claims.groups=User
+
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".min-level=TRACE
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE


### PR DESCRIPTION
This PR bumps the smallrye-jwt version to 3.3.2, adds the test and updates the docs to show how to use the new `smallrye.jwt.sign.key` and `smallrye.jwt.encrypt.key` properties.  Using `smallrye.jwt.sign.key` can be of interest to the Vault users who would like to avoid dealing the private keys on the local file system