### PR TITLE
Rename Problem's attribute details in reactive-routes

### DIFF
--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/MultiValidationTest.java
@@ -44,7 +44,7 @@ public class MultiValidationTest {
                 .then().statusCode(400)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(400))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
     }

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/SyncValidationTest.java
@@ -51,7 +51,7 @@ public class SyncValidationTest {
                 .statusCode(400)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(400))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
@@ -71,7 +71,7 @@ public class SyncValidationTest {
                 .statusCode(500)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(500))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
@@ -81,7 +81,7 @@ public class SyncValidationTest {
                 .get("/invalid2").then().statusCode(500)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(500))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", anyOf(containsString("name"), containsString("welcome")))
                 .body("violations[0].message", is(not(emptyString())))
                 .body("violations[1].field", anyOf(containsString("name"), containsString("welcome")))
@@ -96,7 +96,7 @@ public class SyncValidationTest {
                 .then().statusCode(400)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(400))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
@@ -108,7 +108,7 @@ public class SyncValidationTest {
                 .then().statusCode(400)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(400))
-                .body("details", containsString("validation constraint violations"));
+                .body("detail", containsString("validation constraint violations"));
     }
 
     @ApplicationScoped

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/UniValidationTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/validation/UniValidationTest.java
@@ -53,7 +53,7 @@ public class UniValidationTest {
                 .statusCode(500)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(500))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
@@ -65,7 +65,7 @@ public class UniValidationTest {
                 .statusCode(500)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(500))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
 
@@ -75,7 +75,7 @@ public class UniValidationTest {
                 .get("/invalid2").then().statusCode(500)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(500))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", anyOf(containsString("name"), containsString("welcome")))
                 .body("violations[0].message", is(not(emptyString())))
                 .body("violations[1].field", anyOf(containsString("name"), containsString("welcome")))
@@ -90,7 +90,7 @@ public class UniValidationTest {
                 .then().statusCode(400)
                 .body("title", containsString("Constraint Violation"))
                 .body("status", is(400))
-                .body("details", containsString("validation constraint violations"))
+                .body("detail", containsString("validation constraint violations"))
                 .body("violations[0].field", containsString("name"))
                 .body("violations[0].message", is(not(emptyString())));
     }

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/ValidationSupport.java
@@ -20,7 +20,7 @@ public class ValidationSupport {
     public static final String APPLICATION_JSON = "application/json";
     public static final String ACCEPT_HEADER = "Accept";
     public static final String PROBLEM_TITLE = "title";
-    public static final String PROBLEM_DETAIL = "details";
+    public static final String PROBLEM_DETAIL = "detail";
     public static final String PROBLEM_FIELD = "field";
     public static final String PROBLEM_MESSAGE = "message";
     public static final String PROBLEM_STATUS = "status";


### PR DESCRIPTION
Quarkus documentation[1] states that Bean Validation follows Zalando's Problem format[2].
While it's technically true in this statement, Zalando's OpenAPI schema for Problem[3] defines attribute `detail` not `details`.
For someone who uses Zalando's Problem across all endpoints this causes inconsistent error responses.
The original change was introduced in PR https://github.com/quarkusio/quarkus/pull/11864. I'm not sure if `details` was chosen intentionally or was it just a typo.

Problem format can be found at https://opensource.zalando.com/problem/

[1] https://quarkus.io/guides/reactive-routes#using-bean-validation
[2] https://opensource.zalando.com/problem/constraint-violation/
[3] https://opensource.zalando.com/problem/schema.yaml

