### PR TITLE
QUARKUS-1501: DevServicesKafkaProcessor: Always expose to Docker host network

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
@@ -8,41 +8,16 @@ import java.util.function.Function;
 
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildStepBuilder;
-import io.quarkus.builder.item.BuildItem;
 import io.quarkus.builder.item.MultiBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 
 /**
  * A marker build item that, if any instances are provided during the build, the containers started by DevServices
- * will use a shared network and be accessible across the Docker network. The default is that containers started by
- * DevServices will only be accessible from the Docker host.
+ * will use a shared network.
  * This is mainly useful in integration tests where the application container needs to be able
  * to communicate with the services containers
  */
 public final class DevServicesSharedNetworkBuildItem extends MultiBuildItem {
-
-    private boolean exposeOnDockerHost;
-
-    /**
-     * Construct the {@link BuildItem} exposing services only on the shared network.
-     */
-    public DevServicesSharedNetworkBuildItem() {
-        this(false);
-    }
-
-    /**
-     * Construct the {@link BuildItem} exposing services on both the shared network and Docker host.
-     * This is mainly used by {@see DevServicesKafkaProcessor}.
-     * 
-     * @param exposeOnDockerHost
-     */
-    public DevServicesSharedNetworkBuildItem(boolean exposeOnDockerHost) {
-        this.exposeOnDockerHost = exposeOnDockerHost;
-    }
-
-    public boolean isExposedOnDockerHost() {
-        return exposeOnDockerHost;
-    }
 
     /**
      * Generates a {@link List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -102,8 +102,6 @@ public class DevServicesKafkaProcessor {
 
             kafkaBroker = startKafka(configuration, launchMode,
                     !devServicesSharedNetworkBuildItem.isEmpty(),
-                    devServicesSharedNetworkBuildItem.stream()
-                            .anyMatch(DevServicesSharedNetworkBuildItem::isExposedOnDockerHost),
                     devServicesConfig.timeout);
             bootstrapServers = null;
             if (kafkaBroker != null) {
@@ -202,7 +200,7 @@ public class DevServicesKafkaProcessor {
     }
 
     private KafkaBroker startKafka(KafkaDevServiceCfg config,
-            LaunchModeBuildItem launchMode, boolean useSharedNetwork, boolean exposeOnDockerHost, Optional<Duration> timeout) {
+            LaunchModeBuildItem launchMode, boolean useSharedNetwork, Optional<Duration> timeout) {
         if (!config.devServicesEnabled) {
             // explicitly disabled
             log.debug("Not starting dev services for Kafka, as it has been disabled in the config.");
@@ -237,8 +235,7 @@ public class DevServicesKafkaProcessor {
                     DockerImageName.parse(config.imageName),
                     config.fixedExposedPort,
                     launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
-                    useSharedNetwork,
-                    exposeOnDockerHost);
+                    useSharedNetwork);
             timeout.ifPresent(container::withStartupTimeout);
             container.start();
 
@@ -343,18 +340,16 @@ public class DevServicesKafkaProcessor {
 
         private final Integer fixedExposedPort;
         private final boolean useSharedNetwork;
-        private final boolean exposeOnDockerHost;
 
         private String hostName = null;
 
         private static final String STARTER_SCRIPT = "/var/lib/redpanda/redpanda.sh";
 
         private RedPandaKafkaContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName,
-                boolean useSharedNetwork, boolean exposeOnDockerHost) {
+                boolean useSharedNetwork) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
-            this.exposeOnDockerHost = exposeOnDockerHost;
 
             if (serviceName != null) { // Only adds the label in dev mode.
                 withLabel(DEV_SERVICE_LABEL, serviceName);
@@ -394,9 +389,9 @@ public class DevServicesKafkaProcessor {
             if (useSharedNetwork) {
                 addresses.add("PLAINTEXT://0.0.0.0:29092");
             }
-            if (exposeOnDockerHost || !useSharedNetwork) {
-                addresses.add("OUTSIDE://0.0.0.0:9092");
-            }
+            // See https://github.com/quarkusio/quarkus/issues/21819
+            // Kafka is always available on the Docker host network
+            addresses.add("OUTSIDE://0.0.0.0:9092");
             return String.join(",", addresses);
         }
 
@@ -405,9 +400,9 @@ public class DevServicesKafkaProcessor {
             if (useSharedNetwork) {
                 addresses.add(String.format("PLAINTEXT://%s:29092", hostName));
             }
-            if (exposeOnDockerHost || !useSharedNetwork) {
-                addresses.add(String.format("OUTSIDE://%s:%d", getHost(), getMappedPort(KAFKA_PORT)));
-            }
+            // See https://github.com/quarkusio/quarkus/issues/21819
+            // Kafka is always exposed to the Docker host network
+            addresses.add(String.format("OUTSIDE://%s:%d", getHost(), getMappedPort(KAFKA_PORT)));
             return String.join(",", addresses);
         }
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/QUARKUS-1501