### PR TITLE
OidcProviderClient has to be closed only when getting the JWK set failed

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -1,7 +1,6 @@
 package io.quarkus.oidc.client.runtime;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -34,7 +33,6 @@ public class OidcClientRecorder {
 
     private static final Logger LOG = Logger.getLogger(OidcClientRecorder.class);
     private static final String DEFAULT_OIDC_CLIENT_ID = "Default";
-    private static final Duration CONNECTION_BACKOFF_DURATION = Duration.ofSeconds(2);
 
     public OidcClients setup(OidcClientsConfig oidcClientsConfig, TlsConfig tlsConfig, Supplier<Vertx> vertx) {
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -259,6 +259,7 @@ public class OidcRecorder {
                     .expireIn(connectionDelayInMillisecs)
                     .onFailure()
                     .transform(t -> toOidcException(t, oidcConfig.authServerUrl.get()))
+                    .onFailure()
                     .invoke(client::close);
         } else {
             return client.getJsonWebKeySet();


### PR DESCRIPTION
Fixes #21984

This PR also removes the unused constant in `OidcClientRecorder`