### PR TITLE
Make Keycloak DevService work with @QuarkusIntegrationTest and container launches

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -15,7 +15,23 @@ public final class ConfigureUtil {
         // When a shared network is requested for the launched containers, we need to configure
         // the container to use it. We also need to create a hostname that will be applied to the returned
         // URL
-        container.setNetwork(Network.SHARED);
+
+        var tccl = Thread.currentThread().getContextClassLoader();
+        if (tccl.getName().contains("Deployment")) {
+            // we need to use the shared network loaded from the Augmentation ClassLoader because that ClassLoader
+            // is what the test launching process (that has access to the curated application) has access to
+            try {
+                Class<?> networkClass = tccl.getParent()
+                        .loadClass("org.testcontainers.containers.Network");
+                Object sharedNetwork = networkClass.getField("SHARED").get(null);
+                container.setNetwork((Network) sharedNetwork);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to obtain SHARED network from testcontainers", e);
+            }
+        } else {
+            container.setNetwork(Network.SHARED);
+        }
+
         String hostName = hostNamePrefix + "-" + Base58.randomString(5);
         container.setNetworkAliases(Collections.singletonList(hostName));
 

--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -16,7 +16,7 @@ import io.restassured.specification.RequestSpecification;
 
 public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
-    private final static String AUTH_SERVER_URL_PROP = "quarkus.oidc.auth-server-url";
+    private final static String AUTH_SERVER_URL_PROP = "quarkus.oidc.auth-server-url-localhost";
     private final static String CLIENT_ID_PROP = "quarkus.oidc.client-id";
     private final static String CLIENT_SECRET_PROP = "quarkus.oidc.credentials.secret";
 


### PR DESCRIPTION
This is a WIP to fix #21935.

@sberyozkin unfortunately this does not yet work, (I think) because the token received from the `KeycloakTestClient` has `iss` of `http://localhost:49267/auth/realms/quarkus` (which is the URL the test can access Keycloak from - i.e. a URL accessible on the host machine), but the Quarkus application under test accesses the application using something like `http://keycloak-uX81K:8080/auth/realms/quarkus ` - i.e. the URL that is usable in the container network.
What can we do to address this issue? Can we "patch" the token somehow?

P.S. This contains a lot of hacks, but for most of them, I don't see a way around them for this use case.