### PR TITLE
Move failsafe config out of native profile

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -229,55 +229,7 @@ You can do so by prepending the flag with `-J` and passing it as additional nati
 
 == Testing the native executable
 
-Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file.
-
-In the `pom.xml` file, the `native` profile contains:
-
-[source, xml]
-----
-<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-failsafe-plugin</artifactId>
-    <version>${surefire-plugin.version}</version>
-    <executions>
-        <execution>
-            <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-            </goals>
-            <configuration>
-                <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    <maven.home>${maven.home}</maven.home>
-                </systemPropertyVariables>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
-----
-
-This instructs the failsafe-maven-plugin to run integration-test and indicates the location of the produced native executable.
-
-Then, open the `src/test/java/org/acme/quickstart/GreetingResourceIT.java`. It contains:
-
-[source,java]
-----
-package org.acme.quickstart;
-
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-
-@QuarkusIntegrationTest // <1>
-public class GreetingResourceIT extends GreetingResourceTest { // <2>
-
-    // Run the same tests
-
-}
-----
-<1> Use another test runner that starts the application from the native file before the tests.
-The executable is retrieved using the `native.image.path` system property configured in the _Failsafe Maven Plugin_.
-<2> We extend our previous tests, but you can also implement your tests
+Producing a native executable can lead to a few issues, and so it's also a good idea to run some tests against the application running in the native file. The reasoning is explained in the link:getting-started-testing#quarkus-integration-test[Testing Guide].
 
 To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Pnative`:
 [source,shell]
@@ -342,14 +294,18 @@ you can only test via HTTP calls. Your test code does not actually run natively,
 that does not call your HTTP endpoints, it's probably not a good idea to run them as part of native tests.
 
 If you share your test class between JVM and native executions like we advise above, you can mark certain tests
-with the `@DisabledOnNativeImage` annotation in order to only run them on the JVM.
+with the `@DisabledOnIntegrationTest` annotation in order to skip them when testing against a native image.
 
+[NOTE]
+====
+Using `@DisabledOnIntegrationTest` will also disable the test in all integration test instances, including
+testing the application in JVM mode, in a container image, and native image.
+====
 
 === Testing an existing native executable
 
 It is also possible to re-run the tests against a native executable that has already been built. To do this run
-`./mvnw test-compile failsafe:integration-test`. This will discover the existing native image and run the tests against it using
-failsafe.
+`./mvnw test-compile failsafe:integration-test -Pnative`. This will discover the existing native image and run the tests against it using failsafe.
 
 If the process cannot find the native image for some reason, or you want to test a native image that is no longer in the
 target directory you can specify the executable with the `-Dnative.image.path=` system property.

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1221,9 +1221,59 @@ As is the case with `@NativeImageTest`, this is a black box test that supports t
 
 [NOTE]
 ====
-As a test annotated with `@QuarkusIntegrationTest` tests the result of the build, it should be run as part of the integration test suite - i.e. via the `maven-failsafe-plugin` if using Maven or the `quarkusIntTest` task if using Gradle.
+As a test annotated with `@QuarkusIntegrationTest` tests the result of the build, it should be run as part of the integration test suite - i.e. by setting `-DskipITs=false` if using Maven or the `quarkusIntTest` task if using Gradle.
 These tests will **not** work if run in the same phase as `@QuarkusTest` as Quarkus has not yet created the final artifact.
 ====
+
+The `pom.xml` file contains:
+
+[source, xml]
+----
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-failsafe-plugin</artifactId>
+    <version>${surefire-plugin.version}</version>
+    <executions>
+        <execution>
+            <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+            </goals>
+            <configuration>
+                <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <maven.home>${maven.home}</maven.home>
+                </systemPropertyVariables>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+----
+
+This instructs the failsafe-maven-plugin to run integration-test.
+
+Then, open the `src/test/java/org/acme/quickstart/GreetingResourceIT.java`. It contains:
+
+[source,java]
+----
+package org.acme.quickstart;
+
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest // <1>
+public class GreetingResourceIT extends GreetingResourceTest { // <2>
+
+    // Run the same tests
+
+}
+----
+<1> Use another test runner that starts the application from the native file before the tests.
+The executable is retrieved by the _Failsafe Maven Plugin_.
+<2> We extend our previous tests as a convenience, but you can also implement your tests.
+
+More information can be found in the link:building-native-image#testing-the-native-executable[Testing the native executable Guide].
 
 === Launching containers
 

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -448,9 +448,13 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 
 [source,xml,subs=attributes+]
 ----
+<properties>
+    <skipITs>true</skipITs> <1>
+</properties>
+
 <dependencyManagement>
     <dependencies>
-        <dependency> <1>
+        <dependency> <2>
             <groupId>${quarkus.platform.group-id}</groupId>
             <artifactId>quarkus-bom</artifactId>
             <version>${quarkus.platform.version}</version>
@@ -462,11 +466,11 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 
 <build>
     <plugins>
-        <plugin> <2>
+        <plugin> <3>
             <groupId>${quarkus.platform.group-id}</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
             <version>${quarkus.platform.version}</version>
-            <extensions>true</extensions> <3>
+            <extensions>true</extensions> <4>
             <executions>
                 <execution>
                     <goals>
@@ -477,7 +481,7 @@ If you have not used <<project-creation,project scaffolding>>, add the following
                 </execution>
             </executions>
         </plugin>
-        <plugin> <4>
+        <plugin> <5>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${surefire-plugin.version}</version>
@@ -488,51 +492,53 @@ If you have not used <<project-creation,project scaffolding>>, add the following
                 </systemPropertyVariables>
             </configuration>
         </plugin>
+        <plugin> <6>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>integration-test</goal>
+                        <goal>verify</goal>
+                    </goals>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <maven.home>${maven.home}</maven.home>
+                        </systemPropertyVariables>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
 </build>
 
 <profiles>
-    <profile> <5>
+    <profile> <7>
         <id>native</id>
-        <properties> <6>
+        <properties> <8>
             <quarkus.package.type>native</quarkus.package.type>
+            <skipITs>false</skipITs> <9>
         </properties>
-        <build>
-            <plugins>
-                <plugin> <7>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${surefire-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                            <configuration>
-                                <systemPropertyVariables>
-                                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                    <maven.home>${maven.home}</maven.home>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </build>
     </profile>
 </profiles>
 ----
 
-<1> Optionally use a BOM file to omit the version of the different Quarkus dependencies.
-<2> Use the Quarkus Maven plugin that will hook into the build process.
-<3> Enabling Maven plugin extensions will register a Quarkus `MavenLifecycleParticipant` which will make sure the Quarkus classloaders used during the build are properly closed. During the `generate-code` and `generate-code-tests` goals the Quarkus application bootstrap is initialized and re-used in the `build` goal (which actually builds and packages a production application). The Quarkus classloaders will be properly closed in the `build` goal of the `quarkus-maven-plugin`. However, if the build fails in between the `generate-code` or `generate-code-tests` and `build` then the Quarkus augmentation classloader won't be properly closed, which may lead to locking of JAR files that happened to be on the classpath on Windows OS.
-<4> Add system properties to `maven-surefire-plugin`. +
+<1> Disable running of integration tests (test names `*IT` and annotated with `@QuarkusIntegrationTest`) on all builds. To run these tests all the time, either remove this property, set its value to `false`, or set `-DskipITs=false` on the command line when you run the build. +
+As mentioned below, this is overridden in the `native` profile.
+<2> Optionally use a BOM file to omit the version of the different Quarkus dependencies.
+<3> Use the Quarkus Maven plugin that will hook into the build process.
+<4> Enabling Maven plugin extensions will register a Quarkus `MavenLifecycleParticipant` which will make sure the Quarkus classloaders used during the build are properly closed. During the `generate-code` and `generate-code-tests` goals the Quarkus application bootstrap is initialized and re-used in the `build` goal (which actually builds and packages a production application). The Quarkus classloaders will be properly closed in the `build` goal of the `quarkus-maven-plugin`. However, if the build fails in between the `generate-code` or `generate-code-tests` and `build` then the Quarkus augmentation classloader won't be properly closed, which may lead to locking of JAR files that happened to be on the classpath on Windows OS.
+<5> Add system properties to `maven-surefire-plugin`. +
 `maven.home` is only required if you have custom configuration in `${maven.home}/conf/settings.xml`.
-<5> Use a specific `native` profile for native executable building.
-<6> Enable the `native` package type. The build will therefore produce a native executable.
-<7> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` or `@QuarkusIntegrationTest` will be run against the native executable. See the xref:building-native-image.adoc[Native executable guide] for more info.
+<6> If you want to test the artifact produced by your build with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated with `@QuarkusIntegrationTest` will be run against the artifact produced by the build (JAR file, container image, etc). See the xref:getting-started-testing.adoc#quarkus-integration-test[Integration Testing guide] for more info. +
+`maven.home` is only required if you have custom configuration in `${maven.home}/conf/settings.xml`.
+<7> Use a specific `native` profile for native executable building.
+<8> Enable the `native` package type. The build will therefore produce a native executable.
+<9> Always run integration tests when building a native image (test names `*IT` and annotated with `@QuarkusIntegrationTest` or `@NativeImageTest`). +
+If you do not wish to run integration tests when building a native image, simply remove this property altogether or set its value to `true`.
 
 [[fast-jar]]
 === Using fast-jar

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/integration-tests/java/integration-tests/pom.tpl.qute.xml
@@ -18,6 +18,10 @@
 <name>{namespace.name}{extension.name} - Integration Tests</name>
 {/if}
 
+    <properties>
+        <skipITs>true</skipITs>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -57,6 +61,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <native.image.path>$\{project.build.directory}/$\{project.build.finalName}-runner</native.image.path>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <maven.home>$\{maven.home}</maven.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -70,6 +93,7 @@
             </activation>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
+                <skipITs>false</skipITs>
             </properties>
             <build>
                 <plugins>
@@ -79,25 +103,6 @@
                         <configuration>
                             <skipTests>$\{native.surefire.skip}</skipTests>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <native.image.path>$\{project.build.directory}/$\{project.build.finalName}-runner</native.image.path>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                        <maven.home>$\{maven.home}</maven.home>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -17,6 +17,7 @@
         <quarkus-plugin.version>{quarkus.maven-plugin.version}</quarkus-plugin.version>
         {/if}
         <compiler-plugin.version>{maven-compiler-plugin.version}</compiler-plugin.version>
+        <skipITs>true</skipITs>
         <surefire-plugin.version>{maven-surefire-plugin.version}</surefire-plugin.version>
         <failsafe.useModulePath>false</failsafe.useModulePath>
         {#if uberjar}
@@ -160,6 +161,27 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <!-- Run the tests with the executable produced by the build (could be native, jvm, or container image) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>$\{surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <native.image.path>$\{project.build.directory}/$\{project.build.finalName}-runner</native.image.path>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <maven.home>$\{maven.home}</maven.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -173,32 +195,8 @@
             </activation>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
+                <skipITs>false</skipITs>
             </properties>
-            <build>
-                <plugins>
-                    <!-- Run the tests with the native executable -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>$\{surefire-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <native.image.path>$\{project.build.directory}/$\{project.build.finalName}-runner</native.image.path>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                        <maven.home>$\{maven.home}</maven.home>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -14,6 +14,7 @@
     <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-MOCK</quarkus.platform.version>
+    <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -74,6 +75,25 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -84,30 +104,8 @@
           <name>native</name>
         </property>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    <maven.home>${maven.home}</maven.home>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
       <properties>
+        <skipITs>false</skipITs>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -14,6 +14,7 @@
     <quarkus.platform.artifact-id>quarkus-mock-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-MOCK</quarkus.platform.version>
+    <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-MOCK</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -89,6 +90,25 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -99,30 +119,8 @@
           <name>native</name>
         </property>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    <maven.home>${maven.home}</maven.home>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
       <properties>
+        <skipITs>false</skipITs>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>


### PR DESCRIPTION
This PR moves the `maven-failsafe-plugin` config out of the `native` profile and into the main profile. This PR coincides with #23488 (that one was originally part of this one before it was moved out to its own PR). 

The logic is that why should integration tests only be run when building native images? Aren't their results valuable for JVM-based applications as well as apps packaged inside a container?

The history on this PR contains the conversation around this (& also the conversation as to why part of it was split off into a separate PR).
