### PR TITLE
Qute user tags - use defaulted keys if appropriate

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -962,8 +962,8 @@ NOTE: The evaluated template is parsed and evaluated every time the section is e
 [[user_tags]]
 ==== User-defined Tags
 
-User-defined tags can be used to include a template and optionally pass some parameters.
-Let's suppose we have a template called `itemDetail.html`:
+User-defined tags can be used to include a tag template and optionally pass some parameters.
+Let's suppose we have a tag template called `itemDetail.html`:
 
 [source]
 ----
@@ -973,21 +973,21 @@ Let's suppose we have a template called `itemDetail.html`:
 {/if}
 ----
 <1> `showImage` is a named parameter.
-<2> `it` is a special key that is replaced with the first unnamed param of the tag.
+<2> `it` is a special key that is replaced with the first unnamed parameter of the tag.
 <3> (optional) `nested-content` is a special key that will be replaced by the content of the tag.
 
-Now if we register this template under the name `itemDetail.html` and if we add a `UserTagSectionHelper` to the engine:
+In Quarkus, all files from the `src/main/resources/templates/tags` are registered and monitored automatically.
+For Qute standalone, you need to put the parsed template under the name `itemDetail.html` and register a relevant `UserTagSectionHelper` to the engine:
 
 [source,java]
 ----
 Engine engine = Engine.builder()
                    .addSectionHelper(new UserTagSectionHelper.Factory("itemDetail","itemDetail.html"))
                    .build();
+engine.putTemplate("itemDetail.html", engine.parse("..."));
 ----
 
-NOTE: In Quarkus, all files from the `src/main/resources/templates/tags` are registered and monitored automatically!
-
-We can include the tag like this:
+Then, we can call the tag like this:
 
 [source,html]
 ----
@@ -1003,6 +1003,11 @@ We can include the tag like this:
 ----
 <1> `item` is resolved to an iteration element and can be referenced using the `it` key in the tag template.
 <2> Tag content injected using the `nested-content` key in the tag template.
+
+By default, the tag template can reference data from the parent context.
+For example, the tag above could use the following expression `{items.size}`.
+However, sometimes it might be useful to disable this behavior and execute the tag as an _isolated_ template, i.e. without access to the context of the template that calls the tag.
+In this case, just add `_isolated` or `_isolated=true` argument to the call site, e.g. `{#itemDetail item showImage=true _isolated /}`.
 
 === Rendering Output
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -170,7 +170,7 @@ public class LoopSectionHelper implements SectionHelper {
             return ParametersInfo.builder()
                     .addParameter(ALIAS, EMPTY)
                     .addParameter(IN, EMPTY)
-                    .addParameter(new Parameter(ITERABLE, null, true))
+                    .addParameter(Parameter.builder(ITERABLE).optional())
                     .build();
         }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ResolutionContextImpl.java
@@ -2,20 +2,21 @@ package io.quarkus.qute;
 
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 class ResolutionContextImpl implements ResolutionContext {
 
     private final Object data;
     private final Evaluator evaluator;
     private final Map<String, SectionBlock> extendingBlocks;
-    private final TemplateInstance templateInstance;
+    private final Function<String, Object> attributeFun;
 
     ResolutionContextImpl(Object data,
-            Evaluator evaluator, Map<String, SectionBlock> extendingBlocks, TemplateInstance templateInstance) {
+            Evaluator evaluator, Map<String, SectionBlock> extendingBlocks, Function<String, Object> attributeFun) {
         this.data = data;
         this.evaluator = evaluator;
         this.extendingBlocks = extendingBlocks;
-        this.templateInstance = templateInstance;
+        this.attributeFun = attributeFun;
     }
 
     @Override
@@ -53,7 +54,7 @@ class ResolutionContextImpl implements ResolutionContext {
 
     @Override
     public Object getAttribute(String key) {
-        return templateInstance.getAttribute(key);
+        return attributeFun.apply(key);
     }
 
     @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -159,7 +159,7 @@ public final class Results {
             if (name != null) {
                 Object base = getBase().orElse(null);
                 List<Expression> params = getParams();
-                boolean isDataMap = (base instanceof Map) && ((Map<?, ?>) base).containsKey(TemplateInstanceBase.DATA_MAP_KEY);
+                boolean isDataMap = isDataMap(base);
                 // Entry "foo" not found in the data map
                 // Property "foo" not found on base object "org.acme.Bar"
                 // Method "getDiscount(value)" not found on base object "org.acme.Item"
@@ -188,6 +188,15 @@ public final class Results {
             } else {
                 return "NOT_FOUND";
             }
+        }
+
+        private boolean isDataMap(Object base) {
+            if (base instanceof Map) {
+                return ((Map<?, ?>) base).containsKey(TemplateInstanceBase.DATA_MAP_KEY);
+            } else if (base instanceof Mapper) {
+                return ((Mapper) base).get(TemplateInstanceBase.DATA_MAP_KEY) != null;
+            }
+            return false;
         }
 
         @Override

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelper.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -27,6 +28,14 @@ public interface SectionHelper {
          * @return the current resolution context
          */
         ResolutionContext resolutionContext();
+
+        /**
+         *
+         * @param data
+         * @param extendingBlocks
+         * @return a new resolution context
+         */
+        ResolutionContext newResolutionContext(Object data, Map<String, SectionBlock> extendingBlocks);
 
         /**
          * Execute the main block with the current resolution context.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
@@ -3,6 +3,7 @@ package io.quarkus.qute;
 import io.quarkus.qute.SectionHelper.SectionResolutionContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -158,6 +159,12 @@ class SectionNode implements TemplateNode {
         @Override
         public ResolutionContext resolutionContext() {
             return resolutionContext;
+        }
+
+        @Override
+        public ResolutionContext newResolutionContext(Object data, Map<String, SectionBlock> extendingBlocks) {
+            return new ResolutionContextImpl(data, resolutionContext.getEvaluator(), extendingBlocks,
+                    resolutionContext::getAttribute);
         }
 
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -98,7 +98,7 @@ class TemplateImpl implements Template {
         private CompletionStage<Void> renderData(Object data, Consumer<String> consumer) {
             CompletableFuture<Void> result = new CompletableFuture<>();
             ResolutionContext rootContext = new ResolutionContextImpl(data,
-                    engine.getEvaluator(), null, this);
+                    engine.getEvaluator(), null, this::getAttribute);
             setAttribute(DataNamespaceResolver.ROOT_CONTEXT, rootContext);
             // Async resolution
             root.resolve(rootContext).whenComplete((r, t) -> {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
@@ -51,7 +51,7 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
             return data;
         }
         if (dataMap != null) {
-            return dataMap;
+            return Mapper.wrap(dataMap);
         }
         return EMPTY_DATA_MAP;
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -197,7 +197,7 @@ public final class ValueResolvers {
             @Override
             public int getPriority() {
                 // mapper is used in loops so we use a higher priority to jump the queue
-                return 5;
+                return 15;
             }
 
             @Override

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/EscaperTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/EscaperTest.java
@@ -27,7 +27,7 @@ public class EscaperTest {
     public void testRawStringRevolver() {
 
         Escaper escaper = Escaper.builder().add('a', "A").build();
-        Engine engine = Engine.builder().addValueResolver(ValueResolvers.mapResolver())
+        Engine engine = Engine.builder().addValueResolver(ValueResolvers.mapperResolver())
                 .addValueResolver(ValueResolvers.rawResolver()).addResultMapper(new ResultMapper() {
 
                     @Override

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
@@ -93,7 +93,7 @@ public class SimpleTest {
     @Test
     public void testTernaryOperator() {
         Engine engine = Engine.builder()
-                .addValueResolvers(ValueResolvers.mapResolver(), ValueResolvers.trueResolver(),
+                .addValueResolvers(ValueResolvers.mapperResolver(), ValueResolvers.trueResolver(),
                         ValueResolvers.orResolver())
                 .build();
 
@@ -255,7 +255,7 @@ public class SimpleTest {
                 return super.getParameters();
             }
         };
-        Engine engine = Engine.builder().addSectionHelper(customIfFactory).addValueResolver(ValueResolvers.mapResolver())
+        Engine engine = Engine.builder().addSectionHelper(customIfFactory).addValueResolver(ValueResolvers.mapperResolver())
                 .build();
         assertEquals(":1:1",
                 engine.parse("{#if foo}:1{/if}{#if bar}:0{/if}{#if foo}:1{/if}")
@@ -278,7 +278,7 @@ public class SimpleTest {
                 return false;
             }
         };
-        Engine engine = Engine.builder().addSectionHelper(customIfFactory).addValueResolver(ValueResolvers.mapResolver())
+        Engine engine = Engine.builder().addSectionHelper(customIfFactory).addValueResolver(ValueResolvers.mapperResolver())
                 .build();
         assertEquals(":1:1",
                 engine.parse("{#if foo}:1{/if}{#if bar}:0{/if}{#if foo}:1{/if}")

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/UserTagTest.java
@@ -108,4 +108,22 @@ public class UserTagTest {
                         .data("items", Map.of(1, Map.of("quantity", 10, "unit", "kg"))).render());
     }
 
+    @Test
+    public void testDefaultedKey() {
+        Engine engine = Engine.builder()
+                .addDefaults()
+                .addSectionHelper(new UserTagSectionHelper.Factory("myTag", "my-tag-id"))
+                .strictRendering(false)
+                .build();
+
+        Template tag = engine.parse("{it}:{name}:{isCool}:{age}:{foo.bar}:{foo}");
+        engine.putTemplate("my-tag-id", tag);
+        assertEquals("Ondrej:Ondrej:true:2:NOT_FOUND:NOT_FOUND",
+                engine.parse("{#myTag name age=2 isCool foo.length _isolated=true/}")
+                        .data("name", "Ondrej", "isCool", true, "foo", "bzzz").render());
+        assertEquals("Ondrej:Ondrej:true:2:NOT_FOUND:NOT_FOUND",
+                engine.parse("{#myTag name age=2 isCool foo.length _isolated /}")
+                        .data("name", "Ondrej", "isCool", true, "foo", "bzzz").render());
+    }
+
 }


### PR DESCRIPTION
- i.e. for params that define no key and contain only single part
- also use Mapper instead of Map for the data passed to a template
- Mapper value resolver has priority 15, i.e. is called before a
generated value resolver
- resolves #21855
- related to #21861