### PR TITLE
Allow to combine the discovered and locally configured OIDC metadata

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -44,14 +44,29 @@ public class OidcConfigurationMetadata {
     }
 
     public OidcConfigurationMetadata(JsonObject wellKnownConfig) {
-        this.tokenUri = wellKnownConfig.getString(TOKEN_ENDPOINT);
-        this.introspectionUri = wellKnownConfig.getString(INTROSPECTION_ENDPOINT);
-        this.authorizationUri = wellKnownConfig.getString(AUTHORIZATION_ENDPOINT);
-        this.jsonWebKeySetUri = wellKnownConfig.getString(JWKS_ENDPOINT);
-        this.userInfoUri = wellKnownConfig.getString(USERINFO_ENDPOINT);
-        this.endSessionUri = wellKnownConfig.getString(END_SESSION_ENDPOINT);
-        this.issuer = wellKnownConfig.getString(ISSUER);
+        this(wellKnownConfig, null);
+    }
+
+    public OidcConfigurationMetadata(JsonObject wellKnownConfig, OidcConfigurationMetadata fallbackConfig) {
+        this.tokenUri = getMetadataValue(wellKnownConfig, TOKEN_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.tokenUri);
+        this.introspectionUri = getMetadataValue(wellKnownConfig, INTROSPECTION_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.introspectionUri);
+        this.authorizationUri = getMetadataValue(wellKnownConfig, AUTHORIZATION_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.authorizationUri);
+        this.jsonWebKeySetUri = getMetadataValue(wellKnownConfig, JWKS_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.jsonWebKeySetUri);
+        this.userInfoUri = getMetadataValue(wellKnownConfig, USERINFO_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.userInfoUri);
+        this.endSessionUri = getMetadataValue(wellKnownConfig, END_SESSION_ENDPOINT,
+                fallbackConfig == null ? null : fallbackConfig.endSessionUri);
+        this.issuer = getMetadataValue(wellKnownConfig, ISSUER, fallbackConfig == null ? null : fallbackConfig.issuer);
         this.json = wellKnownConfig;
+    }
+
+    private static String getMetadataValue(JsonObject wellKnownConfig, String propertyName, String fallbackValue) {
+        String value = wellKnownConfig.getString(propertyName);
+        return value != null ? value : fallbackValue;
     }
 
     public String getTokenUri() {

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -43,12 +43,19 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     OidcTenantConfig config = new OidcTenantConfig();
                     config.setTenantId("tenant-oidc");
                     String uri = context.request().absoluteURI();
+                    // authServerUri points to the JAX-RS `OidcResource`, root path is `/oidc`
                     String authServerUri = path.contains("tenant-opaque")
                             ? uri.replace("/tenant-opaque/tenant-oidc/api/user", "/oidc")
                             : uri.replace("/tenant/tenant-oidc/api/user", "/oidc");
                     config.setAuthServerUrl(authServerUri);
                     config.setClientId("client");
                     config.setAllowTokenIntrospectionCache(false);
+                    // auto-discovery in Quarkus is enabled but the OIDC server returns an empty document, set the required endpoints in the config
+                    // try the path relative to the authServerUri 
+                    config.setJwksPath("jwks");
+                    // try the absolute URI
+                    config.setIntrospectionPath(authServerUri + "/introspect");
+
                     return config;
                 } else if ("tenant-oidc-no-discovery".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -26,6 +26,7 @@ public class OidcResource {
     private volatile int jwkEndpointCallCount;
     private volatile int introspectionEndpointCallCount;
     private volatile int userInfoEndpointCallCount;
+    private volatile boolean enableDiscovery = true;
 
     @PostConstruct
     public void init() throws Exception {
@@ -39,13 +40,17 @@ public class OidcResource {
     @Produces("application/json")
     @Path(".well-known/openid-configuration")
     public String discovery() {
-        final String baseUri = ui.getBaseUriBuilder().path("oidc").build().toString();
-        return "{" +
-                "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
-                "   \"introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
-                "   \"userinfo_endpoint\":" + "\"" + baseUri + "/userinfo\"," +
-                "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
-                "  }";
+        if (enableDiscovery) {
+            final String baseUri = ui.getBaseUriBuilder().path("oidc").build().toString();
+            return "{" +
+                    "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
+                    "   \"introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
+                    "   \"userinfo_endpoint\":" + "\"" + baseUri + "/userinfo\"," +
+                    "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
+                    "  }";
+        } else {
+            return "{}";
+        }
     }
 
     @GET
@@ -159,6 +164,20 @@ public class OidcResource {
     public boolean disableIntrospection() {
         introspection = false;
         return introspection;
+    }
+
+    @POST
+    @Path("enable-discovery")
+    public boolean setDiscovery() {
+        enableDiscovery = true;
+        return enableDiscovery;
+    }
+
+    @POST
+    @Path("disable-discovery")
+    public boolean disableDiscovery() {
+        enableDiscovery = false;
+        return enableDiscovery;
     }
 
     @POST

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -266,6 +266,7 @@ public class BearerTokenAuthorizationTest {
         RestAssured.when().post("/oidc/jwk-endpoint-call-count").then().body(equalTo("0"));
         RestAssured.when().post("/oidc/introspection-endpoint-call-count").then().body(equalTo("0"));
         RestAssured.when().post("/oidc/disable-introspection").then().body(equalTo("false"));
+        RestAssured.when().post("/oidc/disable-discovery").then().body(equalTo("false"));
         // Quarkus OIDC is initialized with JWK set with kid '1' as part of the discovery process
         // Now enable the rotation
         RestAssured.when().post("/oidc/enable-rotate").then().body(equalTo("true"));
@@ -307,6 +308,7 @@ public class BearerTokenAuthorizationTest {
         // both requests with kid `3` and with the opaque token required the remote introspection
         RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("3"));
         RestAssured.when().post("/oidc/disable-introspection").then().body(equalTo("false"));
+        RestAssured.when().post("/oidc/enable-discovery").then().body(equalTo("true"));
         RestAssured.when().post("/oidc/disable-rotate").then().body(equalTo("false"));
     }
 

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -152,15 +152,6 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                 .withStatus(302)
                                 .withTransformers("response-template")));
 
-        // Logout Request
-        server.stubFor(
-                get(urlPathMatching("/auth/realms/quarkus/protocol/openid-connect/end-session"))
-                        .willReturn(aResponse()
-                                .withHeader("Location",
-                                        "{{request.query.returnTo}}?clientId={{request.query.client_id}}")
-                                .withStatus(302)
-                                .withTransformers("response-template")));
-
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());
         Map<String, String> conf = new HashMap<>();
         conf.put("keycloak.url", server.baseUrl() + "/auth");


### PR DESCRIPTION
Fixes #22006 

This PR updates `OidcRecorder` to fallback to the locally provided configuration if one of the expected URLs in the discovered doc is not provided. One of the `oidc-tenancy` tests has been updated.

Also did a minor cleanup by moving a test specific wiremock stub to the test which actually requires it (while I was planning to test this PR with a missing logout URL in the discovered doc - but then changed my mind as it is useful for `OidcWiremockTestResource` to return the end session/logout url and decided to change the `oidc-tenancy` test where it is simpler to control it at the JAX-RS `OidcResource` test endpoint level).

Making it a draft as I haven't run all the tests yet. Also CC @FroMage 

