### PR TITLE
Allow Jib to set the base JVM image based on the target Java version

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
@@ -2,7 +2,7 @@ package io.quarkus.deployment.pkg.builditem;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
-public class CompiledJavaVersionBuildItem extends SimpleBuildItem {
+public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
 
     private final JavaVersion javaVersion;
 
@@ -28,13 +28,13 @@ public class CompiledJavaVersionBuildItem extends SimpleBuildItem {
 
         Status isJava17OrHigher();
 
-        public enum Status {
+        enum Status {
             TRUE,
             FALSE,
             UNKNOWN
         }
 
-        static final class Unknown implements JavaVersion {
+        final class Unknown implements JavaVersion {
 
             Unknown() {
             }
@@ -50,10 +50,10 @@ public class CompiledJavaVersionBuildItem extends SimpleBuildItem {
             }
         }
 
-        static final class Known implements JavaVersion {
+        final class Known implements JavaVersion {
 
-            private static int JAVA_11_MAJOR = 55;
-            private static int JAVA_17_MAJOR = 62;
+            private static final int JAVA_11_MAJOR = 55;
+            private static final int JAVA_17_MAJOR = 61;
 
             private final int determinedMajor;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
@@ -1,0 +1,79 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public class CompiledJavaVersionBuildItem extends SimpleBuildItem {
+
+    private final JavaVersion javaVersion;
+
+    private CompiledJavaVersionBuildItem(JavaVersion javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+
+    public static CompiledJavaVersionBuildItem unknown() {
+        return new CompiledJavaVersionBuildItem(new JavaVersion.Unknown());
+    }
+
+    public static CompiledJavaVersionBuildItem fromMajorJavaVersion(int majorJavaVersion) {
+        return new CompiledJavaVersionBuildItem(new JavaVersion.Known(majorJavaVersion));
+    }
+
+    public JavaVersion getJavaVersion() {
+        return javaVersion;
+    }
+
+    public interface JavaVersion {
+
+        Status isJava11OrHigher();
+
+        Status isJava17OrHigher();
+
+        public enum Status {
+            TRUE,
+            FALSE,
+            UNKNOWN
+        }
+
+        static final class Unknown implements JavaVersion {
+
+            Unknown() {
+            }
+
+            @Override
+            public Status isJava11OrHigher() {
+                return Status.UNKNOWN;
+            }
+
+            @Override
+            public Status isJava17OrHigher() {
+                return Status.UNKNOWN;
+            }
+        }
+
+        static final class Known implements JavaVersion {
+
+            private static int JAVA_11_MAJOR = 55;
+            private static int JAVA_17_MAJOR = 62;
+
+            private final int determinedMajor;
+
+            Known(int determinedMajor) {
+                this.determinedMajor = determinedMajor;
+            }
+
+            @Override
+            public Status isJava11OrHigher() {
+                return getStatus(JAVA_11_MAJOR);
+            }
+
+            @Override
+            public Status isJava17OrHigher() {
+                return getStatus(JAVA_17_MAJOR);
+            }
+
+            private Status getStatus(int javaMajor) {
+                return determinedMajor >= javaMajor ? Status.TRUE : Status.FALSE;
+            }
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CompiledJavaVersionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CompiledJavaVersionBuildStep.java
@@ -1,0 +1,61 @@
+package io.quarkus.deployment.steps;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
+
+public class CompiledJavaVersionBuildStep {
+
+    /**
+     * Determines the Java version by looking up the major version of the first successfully parsed
+     * application .class file that is found
+     */
+    @BuildStep
+    public CompiledJavaVersionBuildItem compiledJavaVersion(ApplicationArchivesBuildItem applicationArchivesBuildItem) {
+        var rootDirectories = applicationArchivesBuildItem.getRootArchive().getRootDirectories();
+        AtomicReference<Integer> majorVersion = new AtomicReference<>(null);
+        for (Path path : rootDirectories) {
+            try {
+                Files.walkFileTree(path, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                        if (file.getFileName().endsWith(".class")) {
+                            try (InputStream in = new FileInputStream(file.toFile())) {
+                                DataInputStream data = new DataInputStream(in);
+                                if (0xCAFEBABE == data.readInt()) {
+                                    data.readUnsignedShort(); // minor version -> we don't care about it
+                                    majorVersion.set(data.readUnsignedShort());
+                                    return FileVisitResult.TERMINATE;
+                                }
+                            } catch (IOException ignored) {
+
+                            }
+                        }
+                        // if this was not .class file or there was an error parsing its contents, we continue on to the next file
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException ignored) {
+
+            }
+            if (majorVersion.get() != null) {
+                break;
+            }
+        }
+        if (majorVersion.get() == null) {
+            return CompiledJavaVersionBuildItem.unknown();
+        }
+        return CompiledJavaVersionBuildItem.fromMajorJavaVersion(majorVersion.get());
+    }
+}

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -13,10 +13,14 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class JibConfig {
 
     /**
-     * The base image to be used when a container image is being produced for the jar build
+     * The base image to be used when a container image is being produced for the jar build.
+     *
+     * When the application is built against Java 17 or higher, {@code registry.access.redhat.com/ubi8/openjdk-17-runtime:1.10}
+     * is used as the default.
+     * Otherwise {@code registry.access.redhat.com/ubi8/openjdk-11-runtime:1.10} is used as the default.
      */
-    @ConfigItem(defaultValue = "fabric8/java-alpine-openjdk11-jre")
-    public String baseJvmImage;
+    @ConfigItem
+    public Optional<String> baseJvmImage;
 
     /**
      * The base image to be used when a container image is being produced for the native binary build

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -60,6 +60,7 @@ import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.AppCDSContainerImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.AppCDSResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
+import io.quarkus.deployment.pkg.builditem.CompiledJavaVersionBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.JarBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
@@ -77,6 +78,9 @@ public class JibProcessor {
     private static final IsClassPredicate IS_CLASS_PREDICATE = new IsClassPredicate();
     private static final String BINARY_NAME_IN_CONTAINER = "application";
 
+    private static final String JAVA_17_BASE_IMAGE = "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.10";
+    private static final String JAVA_11_BASE_IMAGE = "registry.access.redhat.com/ubi8/openjdk-11-runtime:1.10";
+
     @BuildStep
     public AvailableContainerImageExtensionBuildItem availability() {
         return new AvailableContainerImageExtensionBuildItem(JIB);
@@ -86,14 +90,27 @@ public class JibProcessor {
     // we want the AppCDS generation process to use the same JVM as the base image
     // in order to make the AppCDS usable by the runtime JVM
     @BuildStep(onlyIf = JibBuild.class)
-    public void appCDS(ContainerImageConfig containerImageConfig, JibConfig jibConfig,
+    public void appCDS(ContainerImageConfig containerImageConfig, CompiledJavaVersionBuildItem compiledJavaVersion,
+            JibConfig jibConfig,
             BuildProducer<AppCDSContainerImageBuildItem> producer) {
 
         if (!containerImageConfig.build && !containerImageConfig.push) {
             return;
         }
 
-        producer.produce(new AppCDSContainerImageBuildItem(jibConfig.baseJvmImage));
+        producer.produce(new AppCDSContainerImageBuildItem(determineBaseJvmImage(jibConfig, compiledJavaVersion)));
+    }
+
+    private String determineBaseJvmImage(JibConfig jibConfig, CompiledJavaVersionBuildItem compiledJavaVersion) {
+        if (jibConfig.baseJvmImage.isPresent()) {
+            return jibConfig.baseJvmImage.get();
+        }
+
+        var javaVersion = compiledJavaVersion.getJavaVersion();
+        if (javaVersion.isJava17OrHigher() == CompiledJavaVersionBuildItem.JavaVersion.Status.TRUE) {
+            return JAVA_17_BASE_IMAGE;
+        }
+        return JAVA_11_BASE_IMAGE;
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, JibBuild.class }, onlyIfNot = NativeBuild.class)
@@ -104,6 +121,7 @@ public class JibProcessor {
             MainClassBuildItem mainClass,
             OutputTargetBuildItem outputTarget,
             CurateOutcomeBuildItem curateOutcome,
+            CompiledJavaVersionBuildItem compiledJavaVersion,
             Optional<ContainerImageBuildRequestBuildItem> buildRequest,
             Optional<ContainerImagePushRequestBuildItem> pushRequest,
             List<ContainerImageLabelBuildItem> containerImageLabels,
@@ -119,10 +137,12 @@ public class JibProcessor {
         JibContainerBuilder jibContainerBuilder;
         String packageType = packageConfig.type;
         if (packageConfig.isLegacyJar() || packageType.equalsIgnoreCase(PackageConfig.UBER_JAR)) {
-            jibContainerBuilder = createContainerBuilderFromLegacyJar(jibConfig, containerImageConfig,
+            jibContainerBuilder = createContainerBuilderFromLegacyJar(determineBaseJvmImage(jibConfig, compiledJavaVersion),
+                    jibConfig, containerImageConfig,
                     sourceJar, outputTarget, mainClass, containerImageLabels);
         } else if (packageConfig.isFastJar()) {
-            jibContainerBuilder = createContainerBuilderFromFastJar(jibConfig, containerImageConfig, sourceJar, curateOutcome,
+            jibContainerBuilder = createContainerBuilderFromFastJar(determineBaseJvmImage(jibConfig, compiledJavaVersion),
+                    jibConfig, containerImageConfig, sourceJar, curateOutcome,
                     containerImageLabels,
                     appCDSResult);
         } else {
@@ -289,7 +309,7 @@ public class JibProcessor {
      * <li>app</li>
      * </ul>
      */
-    private JibContainerBuilder createContainerBuilderFromFastJar(JibConfig jibConfig,
+    private JibContainerBuilder createContainerBuilderFromFastJar(String baseJvmImage, JibConfig jibConfig,
             ContainerImageConfig containerImageConfig,
             JarBuildItem sourceJarBuildItem,
             CurateOutcomeBuildItem curateOutcome, List<ContainerImageLabelBuildItem> containerImageLabels,
@@ -368,7 +388,7 @@ public class JibProcessor {
         try {
 
             JibContainerBuilder jibContainerBuilder = Jib
-                    .from(toRegistryImage(ImageReference.parse(jibConfig.baseJvmImage), jibConfig.baseRegistryUsername,
+                    .from(toRegistryImage(ImageReference.parse(baseJvmImage), jibConfig.baseRegistryUsername,
                             jibConfig.baseRegistryPassword));
             if (fastChangingLibPaths.isEmpty()) {
                 // just create a layer with the entire lib structure intact
@@ -477,7 +497,7 @@ public class JibProcessor {
         jibConfig.platforms.map(PlatformHelper::parse).ifPresent(jibContainerBuilder::setPlatforms);
     }
 
-    private JibContainerBuilder createContainerBuilderFromLegacyJar(JibConfig jibConfig,
+    private JibContainerBuilder createContainerBuilderFromLegacyJar(String baseJvmImage, JibConfig jibConfig,
             ContainerImageConfig containerImageConfig,
             JarBuildItem sourceJarBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
@@ -488,7 +508,7 @@ public class JibProcessor {
             Path classesDir = outputTargetBuildItem.getOutputDirectory().resolve("jib");
             ZipUtils.unzip(sourceJarBuildItem.getPath(), classesDir);
             JavaContainerBuilder javaContainerBuilder = JavaContainerBuilder
-                    .from(toRegistryImage(ImageReference.parse(jibConfig.baseJvmImage), jibConfig.baseRegistryUsername,
+                    .from(toRegistryImage(ImageReference.parse(baseJvmImage), jibConfig.baseRegistryUsername,
                             jibConfig.baseRegistryPassword))
                     .addResources(classesDir, IS_CLASS_PREDICATE.negate())
                     .addClasses(classesDir, IS_CLASS_PREDICATE);


### PR DESCRIPTION
Based on https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Should.20.20jib.20autoconfig.20ubi.2017.20image.20for.20java.2017.20projects.3F