### PR TITLE
Skip OIDC DevConsole setup if `quarkus.oidc.auth-server-url` can not be accessed at build time

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -73,7 +73,13 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                 closeBuildItem.addCloseTask(closeTask, true);
             }
 
-            String authServerUrl = getConfigProperty(AUTH_SERVER_URL_CONFIG_KEY);
+            String authServerUrl = null;
+            try {
+                authServerUrl = getConfigProperty(AUTH_SERVER_URL_CONFIG_KEY);
+            } catch (Exception ex) {
+                // It is not possible to initialize OIDC Dev Console UI without being able to access this property at the build time
+                return;
+            }
             JsonObject metadata = null;
             if (isDiscoveryEnabled()) {
                 metadata = discoverMetadata(authServerUrl);

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -100,13 +100,13 @@ var port = {config:property('quarkus.http.port')};
 
     function signInToOidcProviderAndGetTokens() {
       {#if info:oidcGrantType is 'implicit'}
-        window.location.href = '{info:authorizationUrl}'
+        window.location.href = '{info:authorizationUrl??}'
           + "?client_id=" + '{info:clientId}'
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
           + "&scope=openid&response_type=token id_token&response_mode=query&prompt=login"
           + "&nonce=" + makeid();
       {#else}
-        window.location.href = '{info:authorizationUrl}'
+        window.location.href = '{info:authorizationUrl??}'
           + "?client_id=" + '{info:clientId}'
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
           + "&scope=openid&response_type=code&response_mode=query&prompt=login"
@@ -193,7 +193,7 @@ var port = {config:property('quarkus.http.port')};
     function exchangeCodeForTokens(code){
         $.post("exchangeCodeForTokens",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               authorizationCode: code,
@@ -258,7 +258,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithPassword(userName, password, servicePath){
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               serviceUrl: "http://localhost:" + port + servicePath,
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
@@ -274,7 +274,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithPasswordInSwaggerUi(userName, password){
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               user: userName,
@@ -289,7 +289,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithPasswordInGraphQLUi(userName){
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               user: userName,
@@ -305,7 +305,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithClientCredentials(servicePath) {
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               serviceUrl: "http://localhost:" + port + servicePath,
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
@@ -318,7 +318,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithClientCredentialsInSwaggerUi(){
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               grant: '{info:oidcGrantType}'
@@ -331,7 +331,7 @@ var port = {config:property('quarkus.http.port')};
     function testServiceWithClientCredentialsInGraphQLUi(){
         $.post("testService",
             {
-              tokenUrl: '{info:tokenUrl}',
+              tokenUrl: '{info:tokenUrl??}',
               client: '{info:clientId}',
               clientSecret: '{info:clientSecret}',
               grant: '{info:oidcGrantType}'
@@ -350,8 +350,8 @@ function navigateToSwaggerUiWithToken(token){
         "SecurityScheme":{
             "schema":{
                 "flow":"implicit",
-                "authorizationUrl":"{info:authorizationUrl}",
-                "tokenUrl":"{info:tokenUrl}",
+                "authorizationUrl":"{info:authorizationUrl??}",
+                "tokenUrl":"{info:tokenUrl??}",
                 "type":"oauth2",
                 "description":"Authentication"
             },

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcConfigPropertySupplier.java
@@ -37,21 +37,21 @@ public class OidcConfigPropertySupplier implements Supplier<String> {
         if (defaultValue != null || END_SESSION_PATH_KEY.equals(oidcConfigProperty)) {
             Optional<String> value = ConfigProvider.getConfig().getOptionalValue(oidcConfigProperty, String.class);
             if (value.isPresent()) {
-                return checkUrlProperty(value.get());
+                return checkUrlProperty(value);
             }
             return defaultValue;
         } else {
-            return checkUrlProperty(ConfigProvider.getConfig().getValue(oidcConfigProperty, String.class));
+            return checkUrlProperty(ConfigProvider.getConfig().getOptionalValue(oidcConfigProperty, String.class));
         }
     }
 
-    private String checkUrlProperty(String value) {
-        if (urlProperty && !value.startsWith("http:")) {
-            String authServerUrl = ConfigProvider.getConfig().getValue(AUTH_SERVER_URL_CONFIG_KEY, String.class);
-            return OidcCommonUtils.getOidcEndpointUrl(authServerUrl, Optional.of(value));
-        } else {
-            return value;
+    private String checkUrlProperty(Optional<String> value) {
+        if (urlProperty && value.isPresent() && !value.get().startsWith("http:")) {
+            Optional<String> authServerUrl = ConfigProvider.getConfig().getOptionalValue(AUTH_SERVER_URL_CONFIG_KEY,
+                    String.class);
+            return authServerUrl.isPresent() ? OidcCommonUtils.getOidcEndpointUrl(authServerUrl.get(), value) : null;
         }
+        return value.orElse(null);
     }
 
     public String getOidcConfigProperty() {

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleOidcNoDiscoverySmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleOidcNoDiscoverySmokeTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.devconsole;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Note that this test cannot be placed under the relevant {@code -deployment} module because then the DEV UI processor would
+ * not be able to locate the template resources correctly.
+ */
+public class DevConsoleOidcNoDiscoverySmokeTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addAsResource(createApplicationProperties(),
+                    "application.properties"));
+
+    @Test
+    public void testOidcProviderTemplate() {
+        RestAssured.get("q/dev/io.quarkus.quarkus-oidc/provider")
+                .then()
+                .statusCode(200).body(Matchers.containsString("OpenId Connect Dev Console"));
+    }
+
+    private static StringAsset createApplicationProperties() {
+        return new StringAsset("quarkus.oidc.auth-server-url=http://localhost/oidc\n"
+                + "quarkus.oidc.client-id=client\n"
+                + "quarkus.oidc.discovery-enabled=false\n"
+                + "quarkus.oidc.introspection-path=introspect\n");
+
+    }
+}


### PR DESCRIPTION
Fixes #21951

Unfortunately this property is required to initialize Dev Console; I've been thinking, may be using `OidcConfigurationMetadata` in the runtime supplier can be possible - I've tried it today and unfortunately the Arc context is not active at the point the supplier is called. So if the `auth-server-url` is kept in Vault then `OidcDevConsole` will not be available - which is not a big problem.
I may create another issue to check what can be done to access `OidcConfigurationMetadata` in the supplier (it would make the code there cleaner as well).

@phillip-kruger I've also reproduced the error you saw yesterday - it happens in the dev mode, when the discovery is disabled and either `authorization-path` or `token-path` are not configured - which is what OIDC Dev UI needs. So I've updated the supplier to do the optional checks only and added a test (which was failing before the updates :-) )
