### PR TITLE
Optimize the ByteCodeRecorder to not check IgnoredProperty on java. classes

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1201,17 +1201,19 @@ public class BytecodeRecorderImpl implements RecorderContext {
         Set<String> handledProperties = new HashSet<>();
         Property[] desc = PropertyUtils.getPropertyDescriptors(param);
         for (Property i : desc) {
-            // check if the getter is ignored
-            if ((i.getReadMethod() != null) && (i.getReadMethod().getAnnotation(IgnoreProperty.class) != null)) {
-                continue;
-            }
-            // check if the matching field is ignored
-            try {
-                if (param.getClass().getDeclaredField(i.getName()).getAnnotation(IgnoreProperty.class) != null) {
+            if (!i.getDeclaringClass().getPackageName().startsWith("java.")) {
+                // check if the getter is ignored
+                if ((i.getReadMethod() != null) && (i.getReadMethod().getAnnotation(IgnoreProperty.class) != null)) {
                     continue;
                 }
-            } catch (NoSuchFieldException ignored) {
+                // check if the matching field is ignored
+                try {
+                    if (param.getClass().getDeclaredField(i.getName()).getAnnotation(IgnoreProperty.class) != null) {
+                        continue;
+                    }
+                } catch (NoSuchFieldException ignored) {
 
+                }
             }
             Integer ctorParamIndex = constructorParamNameMap.remove(i.name);
             if (i.getReadMethod() != null && i.getWriteMethod() == null && ctorParamIndex == null) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/PropertyUtils.java
@@ -102,6 +102,10 @@ final class PropertyUtils {
             return propertyType;
         }
 
+        public Class<?> getDeclaringClass() {
+            return readMethod != null ? readMethod.getDeclaringClass() : writeMethod.getDeclaringClass();
+        }
+
         public Object read(Object target) {
             try {
                 return readMethod.invoke(target);


### PR DESCRIPTION
Properties in `java.*` classes will never have the `io.quarkus.runtime.annotation.IgnoredProperty` annotation set.
Preventing the check for `IgnoredProperty` saves a few calls to `getDeclaredField`, which would throw `NoSuchFieldException` anyway. E.g. `getClass` on `java.lang.Object` has no backing `class` property.

This saves about 5-10ms of dev mode startup time.
Related to #21552