### PR TITLE
Qute - introduce "cdi" namespace to inject CDI beans in templates

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1191,16 +1191,19 @@ NOTE: When using `quarkus-resteasy-qute` the content negotiation is performed au
 
 === Injecting Beans Directly In Templates
 
-A CDI bean annotated with `@Named` can be referenced in any template through the `inject` namespace:
+A CDI bean annotated with `@Named` can be referenced in any template through `cdi` and/or `inject` namespaces:
 
 [source,html]
 ----
-{inject:foo.price} <1>
+{cdi:personService.findPerson(10).name} <1>
+{inject:foo.price} <2>
 ----
-<1> First, a bean with name `foo` is found and then used as the base object.
+<1> First, a bean with name `personService` is found and then used as the base object.
+<2> First, a bean with name `foo` is found and then used as the base object.
 
-All expressions using the `inject` namespace are validated during build.
-For the expression `inject:foo.price` the implementation class of the injected bean must either have the `price` property (e.g. a `getPrice()` method) or a matching <<template_extension_methods,template extension method>> must exist. 
+All expressions with `cdi` and `inject` namespaces are validated during build.
+For the expression `cdi:personService.findPerson(10).name` the implementation class of the injected bean must either declare the `findPerson` method or a matching <<template_extension_methods,template extension method>> must exist.
+For the expression `inject:foo.price` the implementation class of the injected bean must either have the `price` property (e.g. a `getPrice()` method) or a matching <<template_extension_methods,template extension method>> must exist.
 
 NOTE: A `ValueResolver` is also generated for all beans annotated with `@Named` so that it's possible to access its properties without reflection.
 

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.qute.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+import static io.quarkus.qute.runtime.EngineProducer.CDI_NAMESPACE;
 import static io.quarkus.qute.runtime.EngineProducer.INJECT_NAMESPACE;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toMap;
@@ -631,7 +632,7 @@ public class QuteProcessor {
         List<TemplateExtensionMethodBuildItem> extensionMethods = null;
 
         if (namespace != null) {
-            if (namespace.equals(INJECT_NAMESPACE)) {
+            if (namespace.equals(INJECT_NAMESPACE) || namespace.equals(CDI_NAMESPACE)) {
                 BeanInfo bean = findBean(expression, index, incorrectExpressions, namedBeans);
                 if (bean != null) {
                     rootClazz = bean.getImplClazz();

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectNamespaceResolverTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectNamespaceResolverTest.java
@@ -2,8 +2,12 @@ package io.quarkus.qute.deployment.inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.concurrent.atomic.LongAdder;
+
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
@@ -17,23 +21,36 @@ public class InjectNamespaceResolverTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
+            .withApplicationRoot(root -> root
                     .addClasses(SimpleBean.class, Hello.class)
-                    .addAsResource(new StringAsset("{inject:hello.ping}"), "templates/foo.html"));
+                    .addAsResource(
+                            new StringAsset(
+                                    "{inject:hello.ping} != {inject:simple.ping} and {cdi:hello.ping} != {cdi:simple.ping}"),
+                            "templates/foo.html"));
 
     @Inject
-    SimpleBean simpleBean;
+    Template foo;
 
     @Test
     public void testInjection() {
-        assertEquals("pong", simpleBean.foo.render());
+        assertEquals("pong != simple and pong != simple", foo.render());
+        assertEquals(2, SimpleBean.DESTROYS.longValue());
     }
 
+    @Named("simple")
     @Dependent
     public static class SimpleBean {
 
-        @Inject
-        Template foo;
+        static final LongAdder DESTROYS = new LongAdder();
+
+        public String ping() {
+            return "simple";
+        }
+
+        @PreDestroy
+        void destroy() {
+            DESTROYS.increment();
+        }
 
     }
 


### PR DESCRIPTION
- it is an alias for the current "inject" namespace
- also destroy dependent beans correctly after the expression is
evaluated