### PR TITLE
Fix native-image arguments generation for native-sources package type

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -85,7 +85,8 @@ public class NativeImageBuildStep {
             PackageConfig packageConfig,
             List<NativeImageSystemPropertyBuildItem> nativeImageProperties,
             List<ExcludeConfigBuildItem> excludeConfigs,
-            NativeImageAllowIncompleteClasspathAggregateBuildItem incompleteClassPathAllowed) {
+            NativeImageAllowIncompleteClasspathAggregateBuildItem incompleteClassPathAllowed,
+            List<NativeImageSecurityProviderBuildItem> nativeImageSecurityProviders) {
 
         Path outputDir;
         try {
@@ -104,13 +105,14 @@ public class NativeImageBuildStep {
                 .setNativeConfig(nativeConfig)
                 .setOutputTargetBuildItem(outputTargetBuildItem)
                 .setNativeImageProperties(nativeImageProperties)
-                .setBrokenClasspath(incompleteClassPathAllowed.isAllow())
                 .setExcludeConfigs(excludeConfigs)
+                .setBrokenClasspath(incompleteClassPathAllowed.isAllow())
+                .setNativeImageSecurityProviders(nativeImageSecurityProviders)
                 .setOutputDir(outputDir)
                 .setRunnerJarName(runnerJar.getFileName().toString())
                 // the path to native-image is not known now, it is only known at the time the native-sources will be consumed
                 .setNativeImageName(nativeImageName)
-                .setContainerBuild(nativeConfig.containerRuntime.isPresent() || nativeConfig.containerBuild)
+                .setGraalVMVersion(GraalVM.Version.CURRENT)
                 .build();
         List<String> command = nativeImageArgs.getArgs();
         try (FileOutputStream commandFOS = new FileOutputStream(outputDir.resolve("native-image.args").toFile())) {


### PR DESCRIPTION
* Ensures the NativeImageSecurityProvidersBuildItem is taken into
  account to add -H:AdditionalSecurityProviders as needed
* Set the GraalVM version to `CURRENT`, since we can't know which
  version will eventually be used to build the native image.
  This enables us to at least make sure that the generated arguments
  will work properly with the currently supported GraalVM.
* Don't `setContainerBuild` since we don't really know whether it will
  eventually be built with a builder-image or locally.
  
  Backports https://github.com/quarkusio/quarkus/pull/21809