### PR TITLE
Deprecate ProcessInheritIODisabled on behalf of ProcessInheritIODisabledBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesSharedNetworkBuildItem.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import io.quarkus.builder.BuildChainBuilder;
 import io.quarkus.builder.BuildStepBuilder;
 import io.quarkus.builder.item.MultiBuildItem;
-import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 
 /**
  * A marker build item that, if any instances are provided during the build, the containers started by DevServices
@@ -21,7 +20,7 @@ public final class DevServicesSharedNetworkBuildItem extends MultiBuildItem {
 
     /**
      * Generates a {@code List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step
-     * producing the {@link ProcessInheritIODisabled} build item
+     * producing the {@link DevServicesSharedNetworkBuildItem} build item
      */
     public static final class Factory implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/jbang/JBangAugmentorImpl.java
@@ -29,7 +29,7 @@ import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.DeploymentResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
-import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
+import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
 import io.quarkus.dev.spi.DevModeType;
 import io.quarkus.runtime.LaunchMode;
 
@@ -76,9 +76,9 @@ public class JBangAugmentorImpl implements BiConsumer<CuratedApplication, Map<St
             @Override
             public void accept(BuildChainBuilder builder) {
                 final BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
-                    ctx.produce(new ProcessInheritIODisabled());
+                    ctx.produce(new ProcessInheritIODisabledBuildItem());
                 });
-                stepBuilder.produces(ProcessInheritIODisabled.class).build();
+                stepBuilder.produces(ProcessInheritIODisabledBuildItem.class).build();
             }
         });
         builder.excludeFromIndexing(quarkusBootstrap.getExcludeFromClassPath());

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/ProcessInheritIODisabledBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/ProcessInheritIODisabledBuildItem.java
@@ -17,14 +17,12 @@ import io.quarkus.builder.item.SimpleBuildItem;
  * made available
  *
  * @see io.quarkus.deployment.util.ProcessUtil
- * @deprecated use {@link ProcessInheritIODisabledBuildItem} instead
  */
-@Deprecated
-public final class ProcessInheritIODisabled extends SimpleBuildItem {
+public final class ProcessInheritIODisabledBuildItem extends SimpleBuildItem {
 
     /**
      * Generates a {@link List<Consumer<BuildChainBuilder>> build chain builder} which creates a build step
-     * producing the {@link ProcessInheritIODisabled} build item
+     * producing the {@link ProcessInheritIODisabledBuildItem} build item
      */
     public static final class Factory implements Function<Map<String, Object>, List<Consumer<BuildChainBuilder>>> {
 
@@ -32,9 +30,9 @@ public final class ProcessInheritIODisabled extends SimpleBuildItem {
         public List<Consumer<BuildChainBuilder>> apply(final Map<String, Object> props) {
             return Collections.singletonList((builder) -> {
                 final BuildStepBuilder stepBuilder = builder.addBuildStep((ctx) -> {
-                    ctx.produce(new ProcessInheritIODisabled());
+                    ctx.produce(new ProcessInheritIODisabledBuildItem());
                 });
-                stepBuilder.produces(ProcessInheritIODisabled.class).build();
+                stepBuilder.produces(ProcessInheritIODisabledBuildItem.class).build();
             });
         }
     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -40,6 +40,7 @@ import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
+import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
 import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
@@ -150,7 +151,8 @@ public class NativeImageBuildStep {
             List<JPMSExportBuildItem> jpmsExportBuildItems,
             List<NativeMinimalJavaVersionBuildItem> nativeMinimalJavaVersions,
             List<UnsupportedOSBuildItem> unsupportedOses,
-            Optional<ProcessInheritIODisabled> processInheritIODisabled) {
+            Optional<ProcessInheritIODisabled> processInheritIODisabled,
+            Optional<ProcessInheritIODisabledBuildItem> processInheritIODisabledBuildItem) {
         if (nativeConfig.debug.enabled) {
             copyJarSourcesToLib(outputTargetBuildItem, curateOutcomeBuildItem);
             copySourcesToSourceCache(outputTargetBuildItem);
@@ -176,7 +178,7 @@ public class NativeImageBuildStep {
 
         NativeImageBuildRunner buildRunner = getNativeImageBuildRunner(nativeConfig, outputDir,
                 nativeImageName, resultingExecutableName);
-        buildRunner.setup(processInheritIODisabled.isPresent());
+        buildRunner.setup(processInheritIODisabled.isPresent() || processInheritIODisabledBuildItem.isPresent());
         final GraalVM.Version graalVMVersion = buildRunner.getGraalVMVersion();
 
         if (graalVMVersion.isDetected()) {
@@ -224,7 +226,8 @@ public class NativeImageBuildStep {
 
             NativeImageBuildRunner.Result buildNativeResult = buildRunner.build(nativeImageArgs, nativeImageName,
                     resultingExecutableName, outputDir,
-                    nativeConfig.debug.enabled, processInheritIODisabled.isPresent());
+                    nativeConfig.debug.enabled,
+                    processInheritIODisabled.isPresent() || processInheritIODisabledBuildItem.isPresent());
             if (buildNativeResult.getExitCode() != 0) {
                 throw imageGenerationFailed(buildNativeResult.getExitCode(), nativeConfig.isContainerBuild());
             }


### PR DESCRIPTION
As I suggested in https://github.com/quarkusio/quarkus/pull/22011#issuecomment-989903861, it would be nice to follow the same pattern for build items