### PR TITLE
Exit readline mode on windows

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/AeshConsole.java
@@ -202,7 +202,7 @@ public class AeshConsole extends QuarkusConsole {
                 }
                 if (doingReadline) {
                     for (var k : keys) {
-                        if (k == '\n') {
+                        if (k == '\n' || k == '\r') {
                             doingReadline = false;
                             connection.enterRawMode();
                         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/console/ConsoleStateManager.java
@@ -52,7 +52,7 @@ public class ConsoleStateManager {
         public void accept(int[] ints) {
             for (int i : ints) {
                 if (readLineBuilder != null) {
-                    if (i == '\n') {
+                    if (i == '\n' || i == '\r') {
                         readLineConsumer.accept(readLineBuilder.toString());
                         readLineBuilder = null;
                         readLineConsumer = null;

--- a/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
+++ b/core/devmode-spi/src/main/java/io/quarkus/dev/console/BasicConsole.java
@@ -73,7 +73,7 @@ public class BasicConsole extends QuarkusConsole {
                             if (readingLine) {
                                 //when doing a read line we want to discard the first \n
                                 //as this was the one that was needed to activate this mode
-                                if (val == '\n') {
+                                if (val == '\n' || val == '\r') {
                                     readingLine = false;
                                     continue;
                                 }


### PR DESCRIPTION
Windows still has an issue where the terminal won't exit raw mode, so
you can't see the input.

Partial fix for #22013