### PR TITLE
ArcContextProvider optimizations

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
@@ -14,15 +14,15 @@ import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.arc.ManagedContext;
 
 /**
- * Context propagation for Arc
- * Only handles Request context as that's currently the only one in Arc that needs propagation.
+ * Context propagation for ArC.
+ * <p>
+ * Only handles the request context as that's currently the only one in ArC that needs propagation.
  */
 public class ArcContextProvider implements ThreadContextProvider {
 
     protected static final ThreadContextController NOOP_CONTROLLER = new ThreadContextController() {
         @Override
         public void endContext() throws IllegalStateException {
-
         }
     };
 
@@ -31,18 +31,14 @@ public class ArcContextProvider implements ThreadContextProvider {
 
     @Override
     public ThreadContextSnapshot currentContext(Map<String, String> map) {
-        ArcContainer arc = Arc.container();
-        if (arc == null || !arc.isRunning()) {
+        ArcContainer container = Arc.container();
+        if (container == null || !container.isRunning()) {
             //return null as per docs to state that propagation of this context is not supported
             return null;
         }
 
         // capture the state, null indicates no active context while capturing snapshot
-        InjectableContext.ContextState state = null;
-        ManagedContext requestContext = arc.requestContext();
-        if (requestContext.isActive()) {
-            state = requestContext.getState();
-        }
+        InjectableContext.ContextState state = container.requestContext().getStateIfActive();
         if (state == null) {
             return NULL_CONTEXT_SNAPSHOT;
         } else {
@@ -53,8 +49,8 @@ public class ArcContextProvider implements ThreadContextProvider {
     @Override
     public ThreadContextSnapshot clearedContext(Map<String, String> map) {
         // note that by cleared we mean that we still activate context if need be, just leave the contents blank
-        ArcContainer arc = Arc.container();
-        if (arc == null || !arc.isRunning()) {
+        ArcContainer container = Arc.container();
+        if (container == null || !container.isRunning()) {
             //return null as per docs to state that propagation of this context is not supported
             return null;
         }
@@ -71,18 +67,19 @@ public class ArcContextProvider implements ThreadContextProvider {
         @Override
         public ThreadContextController begin() {
             // can be called later on, we should retrieve the container again
-            ArcContainer arcContainer = Arc.container();
-            if (arcContainer == null || !arcContainer.isRunning()) {
+            ArcContainer container = Arc.container();
+            if (container == null || !container.isRunning()) {
                 return NOOP_CONTROLLER;
             }
-            ManagedContext requestContext = arcContainer.requestContext();
+
+            ManagedContext requestContext = container.requestContext();
+            InjectableContext.ContextState toRestore = requestContext.getStateIfActive();
             // this is executed on another thread, context can but doesn't need to be active here
-            if (requestContext.isActive()) {
+            if (toRestore != null) {
                 // context active, store current state, start blank context anew and restore state afterwards
-                InjectableContext.ContextState stateToRestore = requestContext.getState();
-                requestContext.deactivate();
+                // it is not necessary to deactivate the context first - just overwrite the previous state
                 requestContext.activate();
-                return new RestoreContextController(requestContext, stateToRestore);
+                return new RestoreContextController(requestContext, toRestore);
             } else {
                 // context not active, activate blank one, deactivate afterwards
                 requestContext.activate();
@@ -96,22 +93,22 @@ public class ArcContextProvider implements ThreadContextProvider {
         @Override
         public ThreadContextController begin() {
             // can be called later on, we should retrieve the container again
-            ArcContainer arcContainer = Arc.container();
-            if (arcContainer == null || !arcContainer.isRunning()) {
+            ArcContainer container = Arc.container();
+            if (container == null || !container.isRunning()) {
                 //this happens on shutdown, if we blow up here it can break shutdown, and stop
                 //resources from being cleaned up, causing tests to fail
                 return NOOP_CONTROLLER;
             }
-            ManagedContext requestContext = arcContainer.requestContext();
+            ManagedContext requestContext = container.requestContext();
+            InjectableContext.ContextState toRestore = requestContext.getStateIfActive();
             // this is executed on another thread, context can but doesn't need to be active here
-            if (requestContext.isActive()) {
+            if (toRestore != null) {
                 // context active, store current state, feed it new one and restore state afterwards
-                InjectableContext.ContextState stateToRestore = requestContext.getState();
                 requestContext.deactivate();
                 return new ThreadContextController() {
                     @Override
                     public void endContext() throws IllegalStateException {
-                        requestContext.activate(stateToRestore);
+                        requestContext.activate(toRestore);
                     }
                 };
             } else {
@@ -132,20 +129,20 @@ public class ArcContextProvider implements ThreadContextProvider {
         @Override
         public ThreadContextController begin() {
             // can be called later on, we should retrieve the container again
-            ArcContainer arcContainer = Arc.container();
-            if (arcContainer == null || !arcContainer.isRunning()) {
+            ArcContainer container = Arc.container();
+            if (container == null || !container.isRunning()) {
                 //this happens on shutdown, if we blow up here it can break shutdown, and stop
                 //resources from being cleaned up, causing tests to fail
                 return NOOP_CONTROLLER;
             }
-            ManagedContext requestContext = arcContainer.requestContext();
+            ManagedContext requestContext = container.requestContext();
+            InjectableContext.ContextState toRestore = requestContext.getStateIfActive();
             // this is executed on another thread, context can but doesn't need to be active here
-            if (requestContext.isActive()) {
+            if (toRestore != null) {
                 // context active, store current state, feed it new one and restore state afterwards
-                InjectableContext.ContextState stateToRestore = requestContext.getState();
-                requestContext.deactivate();
+                // it is not necessary to deactivate the context first - just overwrite the previous state
                 requestContext.activate(state);
-                return new RestoreContextController(requestContext, stateToRestore);
+                return new RestoreContextController(requestContext, toRestore);
             } else {
                 // context not active, activate and pass it new instance, deactivate afterwards
                 requestContext.activate(state);
@@ -155,7 +152,7 @@ public class ArcContextProvider implements ThreadContextProvider {
 
     }
 
-    private static class RestoreContextController implements ThreadContextController {
+    private static final class RestoreContextController implements ThreadContextController {
 
         private final ManagedContext requestContext;
         private final InjectableContext.ContextState stateToRestore;
@@ -167,8 +164,7 @@ public class ArcContextProvider implements ThreadContextProvider {
 
         @Override
         public void endContext() throws IllegalStateException {
-            // clean up, reactivate context with previous values
-            requestContext.deactivate();
+            // it is not necessary to deactivate the context first - just overwrite the previous state
             requestContext.activate(stateToRestore);
         }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
@@ -2,6 +2,7 @@ package io.quarkus.arc;
 
 import java.util.Map;
 import java.util.function.Function;
+import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.NormalScope;
 import javax.enterprise.context.spi.AlterableContext;
 import javax.enterprise.context.spi.Contextual;
@@ -21,8 +22,18 @@ public interface InjectableContext extends AlterableContext {
 
     /**
      * @return the current state
+     * @throws ContextNotActiveException
      */
     ContextState getState();
+
+    /**
+     * If the context is active then return the current state.
+     * 
+     * @return the current state or {@code null} if the context is not active
+     */
+    default ContextState getStateIfActive() {
+        return isActive() ? getState() : null;
+    }
 
     /**
      * If the context is active then return an existing instance of certain contextual type or create a new instance, otherwise
@@ -80,9 +91,7 @@ public interface InjectableContext extends AlterableContext {
     interface ContextState {
 
         /**
-         * The changes to the map are not reflected in the underlying context.
-         * 
-         * @return a map of contextual instances
+         * @return an immutable map of contextual instances
          */
         Map<InjectableBean<?>, Object> getContextualInstances();
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
@@ -45,9 +45,14 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
     }
 
     @Override
+    public ContextState getStateIfActive() {
+        return this;
+    }
+
+    @Override
     public Map<InjectableBean<?>, Object> getContextualInstances() {
         return instances.getPresentValues().stream()
-                .collect(Collectors.toMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
+                .collect(Collectors.toUnmodifiableMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -322,7 +322,6 @@ public class ArcContainerImpl implements ArcContainer {
 
     @Override
     public ManagedContext requestContext() {
-        requireRunning();
         return requestContext;
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -138,6 +138,14 @@ class RequestContext implements ManagedContext {
         return new RequestContextState(ctx);
     }
 
+    public ContextState getStateIfActive() {
+        ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> ctx = currentContext.get();
+        if (ctx == null) {
+            return null;
+        }
+        return new RequestContextState(ctx);
+    }
+
     @Override
     public void deactivate() {
         currentContext.remove();
@@ -223,7 +231,7 @@ class RequestContext implements ManagedContext {
         @Override
         public Map<InjectableBean<?>, Object> getContextualInstances() {
             return value.values().stream()
-                    .collect(Collectors.toMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
+                    .collect(Collectors.toUnmodifiableMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
         }
 
     }


### PR DESCRIPTION
- introduce ManagedContext.getStateIfActive()
- removed "is running" check from ArcContainer.requestContext()
- these modifications should save a few volatile and threadlocal reads