### PR TITLE
Moving Elastisearch low level client to stable

### DIFF
--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -14,8 +14,6 @@ In this guide, we will see how you can get your REST services to use an Elastics
 Quarkus provides two ways of accessing Elasticsearch: via the lower level `RestClient` or via the `RestHighLevelClient` we will call them
 the low level and the high level clients.
 
-include::./status-include.adoc[]
-
 == Prerequisites
 
 To complete this guide, you need:
@@ -344,6 +342,8 @@ Quarkus provides support for the Elasticsearch High Level REST Client but keep i
 
 - It drags a lot of dependencies - especially Lucene -, which doesn't fit well with Quarkus philosophy. The Elasticsearch team is aware of this issue and it might improve sometime in the future.
 - It is tied to a certain version of the Elasticsearch server: you cannot use a High Level REST Client version 7 to access a server version 6.
+
+include::./status-include.adoc[]
 
 Here is a version of the `FruitService` using the high level client instead of the low level one:
 

--- a/extensions/elasticsearch-rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elasticsearch-rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,6 +9,6 @@ metadata:
   guide: "https://quarkus.io/guides/elasticsearch"
   categories:
   - "data"
-  status: "preview"
+  status: "stable"
   config:
   - "quarkus.elasticsearch."


### PR DESCRIPTION
Following a discussion on the quarkus-dev mailing list, I move the Elasticsearch low level client to stable.
The high level one remains preview untill we decide what to do with it ...

By the way, on the FAQ https://quarkus.io/faq/#extension-status there is no deprecated status maybe we need to add one.