### PR TITLE
Update Log4j 2 API to 2.15.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: com.vackosar.gitflowincrementalbuilder:gitflow-incremental-builder
       - dependency-name: org.jboss.logging:*
       - dependency-name: org.jboss.logmanager:*
+      - dependency-name: org.apache.logging.log4j:log4j-api
       - dependency-name: org.ow2.asm:*
       - dependency-name: org.glassfish:jakarta-el
       - dependency-name: com.google.cloud.tools:jib-core

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -186,6 +186,7 @@
         <gson.version>2.8.6</gson.version>
         <webjars-locator-core.version>0.46</webjars-locator-core.version>
         <log4j2-jboss-logmanager.version>1.0.0.Final</log4j2-jboss-logmanager.version>
+        <log4j2-api.version>2.15.0</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.2.2.Final</log4j-jboss-logmanager.version>
         <avro.version>1.11.0</avro.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
@@ -2654,6 +2655,15 @@
                         <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!--
+            While we are not affected by CVE-2021-4428 as we are only using the Log4j2 API,
+            we enforce an updated version so that security scanners don't detect false positives.
+            -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
While we are not affected by CVE-2021-4428 as we are only using the
Log4j2 API and not the implementation which contains the security flaw,
security scanners are known to not always be as fine grained as we would
have liked and we don't want Quarkus to be reported as unsafe because of
false positives.

@tqvarnst @maxandersen I plan to backport this to 2.2.4.Final. In the end, it only impacts the Elasticsearch High Level REST Client so it doesn't have a big impact but I can see how security scanners could start complaining for no reasons because some dependency in our BOM brings the log4j-api of the unsafe version.