### PR TITLE
Update Log4j 2 API to 2.15.0 - 2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: com.jcraft:jzlib
       - dependency-name: org.jboss.logging:*
       - dependency-name: org.jboss.logmanager:*
+      - dependency-name: org.apache.logging.log4j:log4j-api
       - dependency-name: org.glassfish:jakarta-el
       # Quarkus
       - dependency-name: io.quarkus.gizmo:gizmo

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -198,6 +198,7 @@
         <gson.version>2.8.6</gson.version>
         <webjars-locator-core.version>0.46</webjars-locator-core.version>
         <log4j2-jboss-logmanager.version>1.0.0.Final</log4j2-jboss-logmanager.version>
+        <log4j2-api.version>2.15.0</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.2.2.Final</log4j-jboss-logmanager.version>
         <avro.version>1.10.2</avro.version>
         <apicurio-registry.version>2.0.1.Final</apicurio-registry.version>
@@ -2779,6 +2780,15 @@
                         <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!--
+            While we are not affected by CVE-2021-4428 as we are only using the Log4j2 API,
+            we enforce an updated version so that security scanners don't detect false positives.
+            -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
Please don't merge, I will merge it myself.

While we are not affected by CVE-2021-4428 as we are only using the
Log4j2 API and not the implementation which contains the security flaw,
security scanners are known to not always be as fine grained as we would
have liked and we don't want Quarkus to be reported as unsafe because of
false positives.

(cherry picked from commit aead1da0e08a4fc8f57036de83afc78ad472c072)