### PR TITLE
Retrieve the application archives from TCCL

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ClassPathUtils.java
@@ -127,7 +127,7 @@ public class ClassPathUtils {
             } catch (MalformedURLException e) {
                 throw new RuntimeException("Failed to create a URL for '" + file.substring(0, exclam) + "'", e);
             }
-            try (FileSystem jarFs = ZipUtils.newFileSystem(jar, null)) {
+            try (FileSystem jarFs = ZipUtils.newFileSystem(jar)) {
                 Path localPath = jarFs.getPath("/");
                 if (exclam >= 0) {
                     localPath = localPath.resolve(file.substring(exclam + 1));


### PR DESCRIPTION
Prevents opening (and closing) ZFS just to check if it contains an application marker.
The new solution is seperated in 3 steps.
* Ask TTCL for paths to the marker resources, and normalize them. This will in the end point be an artifact path.
* Match these artifact paths to the apps runtime dependencies, resulting in a list of all application archives.
* Index the application archives, and create ApplicationArchiveImpl's for them

This patch also removes usages of the deprecated ZipUtils.newFileSystem(Path, CL) method.

This saves about 170ms of dev mode startup time (on windows).

Related to #21552