### PR TITLE
Reject illegal placeholder in Maven CI friendly version property

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtils.java
@@ -239,6 +239,11 @@ public class ModelUtils {
             if (resolved == null) {
                 return null;
             }
+            if (resolved.contains("${")) {
+                throw new IllegalArgumentException("Illegal placeholder in Maven CI friendly version property \""
+                        + matcher.group(1) + "\": " + resolved
+                        + "\n\tPlease consult https://maven.apache.org/maven-ci-friendly.html#single-project-setup");
+            }
             matcher.appendReplacement(sb, resolved);
         }
         matcher.appendTail(sb);

--- a/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtilsTest.java
+++ b/independent-projects/bootstrap/maven-resolver/src/test/java/io/quarkus/bootstrap/resolver/maven/workspace/ModelUtilsTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.bootstrap.resolver.maven.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.maven.model.Model;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ModelUtilsTest {
+
+    @Test
+    void resolveVersion_literal() {
+        assertThat(ModelUtils.resolveVersion("1.0.0", new Model())).isEqualTo("1.0.0");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "${revision}", "${sha1}", "${changelist}" })
+    void resolveVersion_notResolvable(String rawVersion) {
+        assertThat(ModelUtils.resolveVersion(rawVersion, new Model())).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "revision", "sha1", "changelist" })
+    void resolveVersion_resolvable(String ciFriendlyPropertyName) {
+        var model = new Model();
+        model.getProperties().put(ciFriendlyPropertyName, "1.0.0");
+
+        assertThat(ModelUtils.resolveVersion("${" + ciFriendlyPropertyName + "}", model)).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void resolveVersion_allCiFriendlyPropertyNames() {
+        var model = new Model();
+        model.getProperties().put("revision", "1");
+        model.getProperties().put("sha1", "2");
+        model.getProperties().put("changelist", "3");
+
+        assertThat(ModelUtils.resolveVersion("${revision}.${sha1}.${changelist}", model)).isEqualTo("1.2.3");
+    }
+
+    @Test
+    void resolveVersion_illegalPlaceholder() {
+        var model = new Model();
+        model.getProperties().put("revision", "${main.project.version}");
+        model.getProperties().put("main.project.version", "1.6.0-SNAPSHOT");
+
+        assertThatThrownBy(() -> ModelUtils.resolveVersion("${revision}", model))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll("revision", "main.project.version");
+    }
+}


### PR DESCRIPTION
Results in a more useful error message than:
```
java.lang.IllegalArgumentException: named capturing group is missing trailing '}'
```
e.g. (from the test):
```
java.lang.IllegalArgumentException: Illegal placeholder in Maven CI friendly version property "revision": ${main.project.version}
	Please consult https://maven.apache.org/maven-ci-friendly.html#single-project-setup
```

Came up more than once, last time I noticed was here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/BootstrapMavenException.20when.20using.20.24.7Brevision.7D