### PR TITLE
Update Redpanda to v21.11.2

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaDevServicesBuildTimeConfig.java
@@ -32,7 +32,7 @@ public class KafkaDevServicesBuildTimeConfig {
      * Note that only Redpanda images are supported.
      * See https://vectorized.io/docs/quick-start-docker/ and https://hub.docker.com/r/vectorized/redpanda
      */
-    @ConfigItem(defaultValue = "vectorized/redpanda:v21.5.5")
+    @ConfigItem(defaultValue = "vectorized/redpanda:v21.11.2")
     public String imageName;
 
     /**


### PR DESCRIPTION
This is a minor PR to update Redpanda from `v21.5.5` to `v21.11.2`. There have been 24 releases and many improvements since the latter version (too many features and bug fixes to list in full here). More details on these improvements can be found on the project's release page: https://github.com/vectorizedio/redpanda/releases

One new feature I want to draw attention to is the schema registry subsystem. More details on this feature can be found here: https://redpanda.com/blog/schema_registry/

There have been [mentions](https://github.com/quarkusio/quarkus/pull/17468#issuecomment-849533346) of creating a schema registry dev service for quarkus so that developers would have easy access to a schema registry in the same way that they currently have access to an event bus during development. With this Redpanda update, there is now another simple and performant option for this future dev service.