### PR TITLE
Adjust @RegisterForReflection recommendation in cache.adoc

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -777,7 +777,7 @@ When you encounter this error, you can easily fix it by adding the following ann
 
 [source,java]
 ----
-@RegisterForReflection(targets = { com.github.benmanes.caffeine.cache.PSAMS.class }) <1>
+@RegisterForReflection(classNames = { "com.github.benmanes.caffeine.cache.PSAMS" }) <1>
 ----
 <1> It is an array so you can register several cache implementations in one go if your configuration requires several of them.
 


### PR DESCRIPTION
The cache implementations are package protected so we need to use
classNames.