### PR TITLE
Spring Boot Data JPA: Support NamedQuery

### DIFF
--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/DotNames.java
@@ -27,6 +27,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Version;
 
 import org.jboss.jandex.DotName;
@@ -89,6 +91,8 @@ public final class DotNames {
     public static final DotName JPA_INHERITANCE = DotName.createSimple(Inheritance.class.getName());
     public static final DotName JPA_MAPPED_SUPERCLASS = DotName.createSimple(MappedSuperclass.class.getName());
     public static final DotName JPA_ENTITY = DotName.createSimple(Entity.class.getName());;
+    public static final DotName JPA_NAMED_QUERY = DotName.createSimple(NamedQuery.class.getName());
+    public static final DotName JPA_NAMED_QUERIES = DotName.createSimple(NamedQueries.class.getName());
     public static final DotName VOID = DotName.createSimple(void.class.getName());
     public static final DotName LONG = DotName.createSimple(Long.class.getName());
     public static final DotName PRIMITIVE_LONG = DotName.createSimple(long.class.getName());

--- a/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
+++ b/extensions/spring-data-jpa/deployment/src/main/java/io/quarkus/spring/data/deployment/generate/DerivedMethodsAdder.java
@@ -1,6 +1,7 @@
 package io.quarkus.spring.data.deployment.generate;
 
 import static io.quarkus.gizmo.FieldDescriptor.of;
+import static io.quarkus.spring.data.deployment.generate.GenerationUtil.getNamedQueryForMethod;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -70,6 +71,11 @@ public class DerivedMethodsAdder extends AbstractMethodsAdder {
         }
         for (MethodInfo method : repoMethods) {
             if (method.annotation(DotNames.SPRING_DATA_QUERY) != null) { // handled by CustomQueryMethodsAdder
+                continue;
+            }
+
+            // If method is a named query placed in the entity, we skip it to be handled by CustomQueryMethodsAdder
+            if (getNamedQueryForMethod(method, entityClassInfo) != null) {
                 continue;
             }
 

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/ModifyingQueryWithFlushAndClearTest.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/ModifyingQueryWithFlushAndClearTest.java
@@ -88,6 +88,20 @@ public class ModifyingQueryWithFlushAndClearTest {
         assertThat(allProcessed).describedAs("all LoginEvents are marked as processed").isTrue();
     }
 
+    @Test
+    @Transactional
+    public void testNamedQueryOnEntities() {
+        User user = repo.getUserByFullNameUsingNamedQuery("John Doe");
+        assertThat(user).isNotNull();
+    }
+
+    @Test
+    @Transactional
+    public void testNamedQueriesOnEntities() {
+        User user = repo.getUserByFullNameUsingNamedQueries("John Doe");
+        assertThat(user).isNotNull();
+    }
+
     private LoginEvent createLoginEvent(User user) {
         final LoginEvent loginEvent = new LoginEvent();
         loginEvent.setUser(user);

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/User.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/User.java
@@ -7,9 +7,13 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 
 @Entity
+@NamedQuery(name = "User.getUserByFullNameUsingNamedQuery", query = "select u from User u where u.fullName=:name")
+@NamedQueries(@NamedQuery(name = "User.getUserByFullNameUsingNamedQueries", query = "select u from User u where u.fullName=:name"))
 public class User {
 
     @Id

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
@@ -3,6 +3,7 @@ package io.quarkus.spring.data.deployment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
@@ -21,4 +22,8 @@ public interface UserRepository extends JpaRepository<User, String> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE LoginEvent e SET e.processed = true")
     void processLoginEventsPlainAutoClearAndFlush();
+
+    User getUserByFullNameUsingNamedQuery(@Param("name") String name);
+
+    User getUserByFullNameUsingNamedQueries(@Param("name") String name);
 }


### PR DESCRIPTION
We now support having @NamedQuery and @NamedQueries annotated in the Entity class and set in the Repository.

Example:

```java
@Entity
@NamedQuery(name = "User.getUserByFullNameUsingNamedQuery", query = "select u from User u where u.fullName=:name")
@NamedQueries(@NamedQuery(name = "User.getUserByFullNameUsingNamedQueries", query = "select u from User u where u.name=:name"))
public class User {

    String name;
}
```

And repository:

```java
public interface UserRepository extends JpaRepository<User, String> {
    User getUserByFullNameUsingNamedQuery(@Param("name") String name);

    User getUserByFullNameUsingNamedQueries(@Param("name") String name);
}
```

Usage:

```java
User user = repo.getUserByFullNameUsingNamedQuery("John Doe");
        assertThat(user).isNotNull();
```

Fix https://github.com/quarkusio/quarkus/issues/22115