### PR TITLE
Leverage lazy configuration when building gradle model

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.language.jvm.tasks.ProcessResources;
 import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
@@ -495,9 +494,8 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         final FileCollection allClassesDirs = sourceSet.getOutput().getClassesDirs();
         // some plugins do not add source directories to source sets and they may be missing from sourceSet.getAllJava()
         // see https://github.com/quarkusio/quarkus/issues/20755
-        final TaskCollection<AbstractCompile> compileTasks = project.getTasks().withType(AbstractCompile.class);
 
-        compileTasks.forEach(t -> {
+        project.getTasks().withType(AbstractCompile.class, t -> {
             if (!t.getEnabled()) {
                 return;
             }
@@ -528,8 +526,8 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         });
 
         final File resourcesOutputDir = sourceSet.getOutput().getResourcesDir();
-        final TaskCollection<ProcessResources> resources = project.getTasks().withType(ProcessResources.class);
-        resources.forEach(t -> {
+
+        project.getTasks().withType(ProcessResources.class, t -> {
             if (!t.getEnabled()) {
                 return;
             }


### PR DESCRIPTION
When adding the `"com.github.davidmc24.gradle.plugin.avro"` plugin, we end up with a `ConcurrentModificationException` while looking for all compile task when building the model. This just catch and ignore the exception. 

A better implementation would be to move this block of code either in the extension or in the configuration phase. I will try to investigate that.

close #21422 