### PR TITLE
Upgrade recommended postgres image to version 14.1

### DIFF
--- a/docs/src/main/asciidoc/getting-started-reactive.adoc
+++ b/docs/src/main/asciidoc/getting-started-reactive.adoc
@@ -297,10 +297,10 @@ For example, you can use Docker to run your database:
 
 [source, bash]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
+docker run -it --rm=true \
     --name postgres-quarkus -e POSTGRES_USER=quarkus \
     -e POSTGRES_PASSWORD=quarkus -e POSTGRES_DB=fruits \
-    -p 5432:5432 postgres:13.1
+    -p 5432:5432 postgres:14.1
 ----
 
 Then, launch the application using:

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -184,7 +184,7 @@ Want to start a PostgreSQL server on the side with Docker?
 ----
 docker run --rm=true --name postgres-quarkus-hibernate -e POSTGRES_USER=hibernate \
            -e POSTGRES_PASSWORD=hibernate -e POSTGRES_DB=hibernate_db \
-           -p 5432:5432 postgres:13.1
+           -p 5432:5432 postgres:14.1
 ----
 
 This will start a non-durable empty database: ideal for a quick experiment!

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -624,7 +624,7 @@ docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:
 
 [source,bash]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name postgresql_quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:13.1
+docker run -it --rm=true --name postgresql_quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
 ----
 
 == Time to play with your application

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -353,7 +353,7 @@ services:
       - tasks-network
 
   postgres: <3>
-    image: postgres:13.1
+    image: postgres:14.1
     container_name: quarkus_test
     environment:
       - POSTGRES_USER=quarkus_test

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -52,7 +52,7 @@ Do you need a ready-to-use PostgreSQL server to try out the examples?
 
 [source,bash]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:10.5
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
 ----
 ====
 

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -143,7 +143,7 @@ A very easy way to accomplish that is by using the following Docker command:
 
 [source,bash]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:11.5
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
 ----
 
 If you plan on using a different setup, please change your `application.properties` accordingly.

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -159,7 +159,7 @@ A very easy way to accomplish that is by using the following Docker command:
 
 [source,bash]
 ----
-docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:11.5
+docker run -it --rm=true --name quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
 ----
 
 If you plan on using a different setup, please change your `application.properties` accordingly.

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -26,7 +26,7 @@ public class PostgresqlDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(PostgresqlDevServicesProcessor.class);
 
-    public static final String TAG = "13.2";
+    public static final String TAG = "14.1";
 
     @BuildStep
     ConsoleCommandBuildItem psqlCommand(DevServicesLauncherConfigResultBuildItem devServices) {

--- a/extensions/hibernate-reactive/deployment/pom.xml
+++ b/extensions/hibernate-reactive/deployment/pom.xml
@@ -14,7 +14,7 @@
 
     <!-- Defaults, to simplify local testing -->
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/deployment/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -15,7 +15,7 @@
     <name>Quarkus - Reactive PostgreSQL Client - Deployment</name>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <reactive-postgres.url>vertx-reactive:postgresql:///hibernate_orm_test</reactive-postgres.url>
     </properties>
 

--- a/integration-tests/hibernate-reactive-panache-blocking/pom.xml
+++ b/integration-tests/hibernate-reactive-panache-blocking/pom.xml
@@ -14,7 +14,7 @@
     <description>To test proper error reporting and safeguards when Panache Reactive is being used in combination with blocking technologies</description>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/integration-tests/hibernate-reactive-panache/pom.xml
+++ b/integration-tests/hibernate-reactive-panache/pom.xml
@@ -17,7 +17,7 @@
         PanacheQuery.project(Class) needs it.
     -->
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/integration-tests/hibernate-reactive-postgresql/pom.xml
+++ b/integration-tests/hibernate-reactive-postgresql/pom.xml
@@ -14,7 +14,7 @@
     <description>Hibernate Reactive related tests running with the PostgreSQL database</description>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/integration-tests/jpa-postgresql-withxml/pom.xml
+++ b/integration-tests/jpa-postgresql-withxml/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
     </properties>
 
     <dependencies>

--- a/integration-tests/jpa-postgresql/pom.xml
+++ b/integration-tests/jpa-postgresql/pom.xml
@@ -14,7 +14,7 @@
     <description>Module that contains JPA related tests running with the PostgreSQL database</description>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
     </properties>
 
     <dependencies>

--- a/integration-tests/kubernetes-service-binding-jdbc/pom.xml
+++ b/integration-tests/kubernetes-service-binding-jdbc/pom.xml
@@ -14,7 +14,7 @@
     <name>Quarkus - Integration Tests - Kubernetes Service Binding JDBC</name>
 
     <properties>
-        <postgres.image>postgres:13.1</postgres.image>
+        <postgres.image>postgres:14.1</postgres.image>
     </properties>
 
     <dependencies>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/kubernetes/minikube.json
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/src/main/kubernetes/minikube.json
@@ -5,7 +5,7 @@
     "metadata": {
       "labels": {
         "app.kubernetes.io/name": "postgres",
-        "app.kubernetes.io/version" : "10.6"
+        "app.kubernetes.io/version" : "14.1"
       },
       "name": "postgres"
     },

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -592,7 +592,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>postgres:13.1</name>
+                                    <name>postgres:14.1</name>
                                     <alias>postgresql</alias>
                                     <run>
                                         <env>

--- a/integration-tests/reactive-pg-client/pom.xml
+++ b/integration-tests/reactive-pg-client/pom.xml
@@ -173,7 +173,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>postgres:13.1</name>
+                                    <name>postgres:14.1</name>
                                     <alias>postgresql</alias>
                                     <run>
                                         <env>


### PR DESCRIPTION
Also removed `--ulimit memlock=-1:-1 --memory-swappiness=0 ` from the recommended parameters in starting scripts: that's making bootstrap slightly faster on linux, but the difference is negligible and not worth the hassle as I've learned Mac users can't use these.