### PR TITLE
Don't require Docker when devservices are locally or globally disable via the Neo4j extension

### DIFF
--- a/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
+++ b/extensions/neo4j/deployment/src/main/java/io/quarkus/neo4j/deployment/Neo4jDevServicesProcessor.java
@@ -6,12 +6,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BooleanSupplier;
 
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -36,18 +36,9 @@ class Neo4jDevServicesProcessor {
     static volatile Neo4jDevServiceConfig runningConfiguration;
     static volatile boolean first = true;
 
-    static final class IsDockerWorking implements BooleanSupplier {
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
 
-        private final io.quarkus.deployment.IsDockerWorking delegate = new io.quarkus.deployment.IsDockerWorking(true);
-
-        @Override
-        public boolean getAsBoolean() {
-
-            return delegate.getAsBoolean();
-        }
-    }
-
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { IsDockerWorking.class, GlobalDevServicesConfig.Enabled.class })
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
     public Neo4jDevServiceBuildItem startNeo4jDevService(
             LaunchModeBuildItem launchMode,
             Neo4jBuildTimeConfig neo4jBuildTimeConfig,
@@ -108,6 +99,11 @@ class Neo4jDevServicesProcessor {
     }
 
     private Neo4jContainer<?> startNeo4j(Neo4jDevServiceConfig configuration, Optional<Duration> timeout) {
+
+        if (!isDockerWorking.getAsBoolean()) {
+            log.debug("Not starting Dev Services for Neo4j, as Docker is not working.");
+            return null;
+        }
 
         if (!configuration.devServicesEnabled) {
             log.debug("Not starting Dev Services for Neo4j, as it has been disabled in the config.");

--- a/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
+++ b/extensions/neo4j/deployment/src/test/java/io/quarkus/neo4j/deployment/Neo4jDevModeTests.java
@@ -69,7 +69,6 @@ public class Neo4jDevModeTests {
         }
     }
 
-    @Testcontainers(disabledWithoutDocker = true)
     static class WithLocallyDisabledDevServicesTest {
 
         @RegisterExtension
@@ -80,6 +79,25 @@ public class Neo4jDevModeTests {
                 .overrideConfigKey("quarkus.neo4j.devservices.enabled", "false")
                 .assertLogRecords(records -> assertThat(records).extracting(LogRecord::getMessage)
                         .contains("Not starting Dev Services for Neo4j, as it has been disabled in the config."));
+
+        @Inject
+        Driver driver;
+
+        @Test
+        public void shouldNotBeAbleToConnect() {
+
+            assertThatExceptionOfType(ServiceUnavailableException.class).isThrownBy(() -> driver.verifyConnectivity());
+        }
+    }
+
+    static class WithGloballyDisabledDevServicesTest {
+
+        @RegisterExtension
+        static QuarkusUnitTest test = new QuarkusUnitTest()
+                .withEmptyApplication()
+                .setLogRecordPredicate(record -> true)
+                .withConfigurationResource("application.properties")
+                .overrideConfigKey("quarkus.devservices.enabled", "false");
 
         @Inject
         Driver driver;


### PR DESCRIPTION
Move `isDockerWorking` check into start method: Having it in the `@BuildStep` annotation causes unnecessary initialization of the Testcontainers environment (Ryuk and other). Fixes #22167.