### PR TITLE
Disable JNDI by default

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/AllowJNDIBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/AllowJNDIBuildItem.java
@@ -1,0 +1,12 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Build item that will allow the use of JNDI by default.
+ * <p>
+ * This should only be provided by extensions that rely on JNDI as a core part of the extension (e.g. if LDAP is a core part of
+ * what the extension does).
+ */
+public final class AllowJNDIBuildItem extends MultiBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/naming/NamingConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/naming/NamingConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.naming;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot
+public class NamingConfig {
+
+    /**
+     * By default Quarkus will install a non functional JNDI initial context, to help
+     * mitigate against log4shell style attacks.
+     *
+     * If your application does need to use JNDI you can change this flag.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableJndi;
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/naming/DisabledInitialContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/naming/DisabledInitialContext.java
@@ -1,0 +1,372 @@
+package io.quarkus.runtime.naming;
+
+import java.util.Hashtable;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ExtendedRequest;
+import javax.naming.ldap.ExtendedResponse;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+
+/**
+ * Initial context that won't allow you to actually do anything.
+ *
+ * As most Quarkus applications don't let you
+ */
+public class DisabledInitialContext extends InitialLdapContext {
+
+    public static final String MESSAGE = "JNDI has been disabled, enable it with quarkus.naming.enable-jndi=true";
+
+    public DisabledInitialContext() throws NamingException {
+    }
+
+    public DisabledInitialContext(Hashtable<?, ?> environment, Control[] connCtls) throws NamingException {
+        super(environment, connCtls);
+    }
+
+    @Override
+    public ExtendedResponse extendedOperation(ExtendedRequest request) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public LdapContext newInstance(Control[] reqCtls) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void reconnect(Control[] connCtls) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Control[] getConnectControls() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void setRequestControls(Control[] requestControls) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Control[] getRequestControls() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Control[] getResponseControls() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Attributes getAttributes(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name, String[] attrIds) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void modifyAttributes(String name, int mod_op, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, int mod_op, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void modifyAttributes(String name, ModificationItem[] mods) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, ModificationItem[] mods) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void bind(String name, Object obj, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void bind(Name name, Object obj, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rebind(String name, Object obj, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext createSubcontext(String name, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext createSubcontext(Name name, Attributes attrs) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext getSchema(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext getSchema(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes, String[] attributesToReturn)
+            throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes, String[] attributesToReturn)
+            throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filter, SearchControls cons) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filterExpr, Object[] filterArgs, SearchControls cons)
+            throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filterExpr, Object[] filterArgs, SearchControls cons)
+            throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    protected void init(Hashtable<?, ?> environment) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    protected Context getDefaultInitCtx() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    protected Context getURLOrDefaultInitCtx(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    protected Context getURLOrDefaultInitCtx(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void bind(String name, Object obj) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void bind(Name name, Object obj) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rebind(String name, Object obj) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void unbind(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rename(String oldName, String newName) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void rename(Name oldName, Name newName) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void destroySubcontext(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Context createSubcontext(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object lookupLink(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NameParser getNameParser(String name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public String composeName(String name, String prefix) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Name composeName(Name name, Name prefix) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Object removeFromEnvironment(String propName) throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public void close() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        throw new NamingException(MESSAGE);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/naming/DisabledInitialContextManager.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/naming/DisabledInitialContextManager.java
@@ -1,0 +1,32 @@
+package io.quarkus.runtime.naming;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import javax.naming.spi.NamingManager;
+
+public class DisabledInitialContextManager implements InitialContextFactoryBuilder {
+
+    public static synchronized void register() {
+        if (!NamingManager.hasInitialContextFactoryBuilder()) {
+            try {
+                NamingManager.setInitialContextFactoryBuilder(new DisabledInitialContextManager());
+            } catch (NamingException e) {
+                throw new RuntimeException("Failed to disable JNDI", e);
+            }
+        }
+    }
+
+    @Override
+    public InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) throws NamingException {
+        return new InitialContextFactory() {
+            @Override
+            public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+                return new DisabledInitialContext();
+            }
+        };
+    }
+}

--- a/core/test-extension/deployment/src/test/java/io/quarkus/naming/DisableJNDITestCase.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/naming/DisableJNDITestCase.java
@@ -1,0 +1,63 @@
+package io.quarkus.naming;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Hashtable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DisableJNDITestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest();
+
+    @Test
+    public void testJNDIDisabled() throws Exception {
+        CompletableFuture<Boolean> cf = new CompletableFuture<>();
+        //we just want to test that there is a connection attempt
+        //we open a socket and will fail the test if anything actually manages
+        //to connect to it
+        int port = 0;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+            System.out.println("Bound server to " + port);
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        s.accept().close();
+                        cf.complete(true);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+            t.setDaemon(true);
+            t.start();
+            final int finalPort = port;
+            Assertions.assertThrows(NamingException.class, () -> {
+                new InitialContext().lookup("ldap://127.0.0.1:" + finalPort + "/a");
+            });
+            Assertions.assertThrows(NamingException.class, () -> {
+                //now test explicitly setting the initial context
+                Hashtable<Object, Object> environment = new Hashtable<>();
+                environment.put(Context.INITIAL_CONTEXT_FACTORY, "javax.naming.ldap.InitialLdapContext");
+                new InitialContext(environment).lookup("ldap://127.0.0.1:" + finalPort + "/a");
+            });
+            Assertions.assertThrows(TimeoutException.class, () -> {
+                cf.get(1, TimeUnit.SECONDS);
+            });
+        }
+    }
+}

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -31,6 +31,9 @@ The `/api/public` endpoint can be accessed anonymously.
 The `/api/admin` endpoint is protected with RBAC (Role-Based Access Control) where only users granted with the `adminRole` role can access. At this endpoint, we use the `@RolesAllowed` annotation to declaratively enforce the access constraint.
 The `/api/users/me` endpoint is also protected with RBAC (Role-Based Access Control) where only users granted with the `standardRole` role can access. As a response, it returns a JSON document with details about the user.
 
+WARNING: By default Quarkus will restrict the use of JNDI within an application, as a precaution to try and mitigate any future vulnerabilities similar to log4shell. Because LDAP based auth requires JNDI
+this protection will be automatically disabled.
+
 == Solution
 
 We recommend that you follow the instructions in the next sections and create the application step by step.

--- a/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
+++ b/extensions/elytron-security-ldap/deployment/src/main/java/io/quarkus/elytron/security/ldap/deployment/ElytronSecurityLdapProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AllowJNDIBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.elytron.security.deployment.ElytronPasswordMarkerBuildItem;
@@ -23,6 +24,12 @@ class ElytronSecurityLdapProcessor {
     @BuildStep()
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.SECURITY_LDAP);
+    }
+
+    @BuildStep
+    AllowJNDIBuildItem enableJndi() {
+        //unfortunatly we can't really use LDAP without JNDI
+        return new AllowJNDIBuildItem();
     }
 
     /**

--- a/integration-tests/jpa-oracle/src/main/resources/application.properties
+++ b/integration-tests/jpa-oracle/src/main/resources/application.properties
@@ -10,3 +10,4 @@ quarkus.datasource.ldap.db-kind=oracle
 quarkus.datasource.ldap.username=SYSTEM
 quarkus.datasource.ldap.password=hibernate_orm_test
 quarkus.datasource.ldap.jdbc.url=jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com
+quarkus.naming.enable-jndi=true


### PR DESCRIPTION
The vast majority of Quarkus applications will not be using this, so it
seems safest to just disable this by default.

Do not merge until this has been discussed on the dev list.