### PR TITLE
Introduce context awareness into QuarkusTestResourceLifecycleManager

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GreetingProfileTestCase.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,11 @@ public class GreetingProfileTestCase {
         Assertions.assertEquals(155, DummyTestResource.state.get());
     }
 
+    @Test
+    public void testContext() {
+        Assertions.assertEquals(MyProfile.class.getName(), DummyTestResource.testProfile.get());
+    }
+
     public static class MyProfile implements QuarkusTestProfile {
 
         @Override
@@ -79,9 +85,15 @@ public class GreetingProfileTestCase {
     public static class DummyTestResource implements QuarkusTestResourceLifecycleManager {
 
         public static final AtomicInteger state = new AtomicInteger(0);
+        public static final AtomicReference<String> testProfile = new AtomicReference<>(null);
         public static final int START_DELTA = 55;
 
         private Integer numArg;
+
+        @Override
+        public void setContext(Context context) {
+            testProfile.set(context.testProfile());
+        }
 
         @Override
         public void init(Map<String, String> initArgs) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -38,6 +38,16 @@ public interface QuarkusTestResourceLifecycleManager {
     void stop();
 
     /**
+     * Set the context in which this {@link QuarkusTestResourceLifecycleManager} is being used.
+     * This method is executed before the {@code init} method.
+     *
+     * The {@code context} is never null.
+     */
+    default void setContext(Context context) {
+
+    }
+
+    /**
      * Arguments passed to the lifecycle manager before it starts
      * These arguments are taken from {@code QuarkusTestResource#initArgs()}
      *
@@ -139,5 +149,16 @@ public interface QuarkusTestResourceLifecycleManager {
                 return field.getType().isAssignableFrom(expectedFieldType);
             }
         }
+    }
+
+    interface Context {
+
+        /**
+         * When a {@link QuarkusTestResourceLifecycleManager} is used with a type of test that supports test profiles,
+         * this method gives the name of the active test profile, or {@code null} if no test profile is active.
+         * In the case of {@code QuarkusTestProfile}, this method gives the name of the class that implements
+         * {@code QuarkusTestProfile}.
+         */
+        String testProfile();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -88,10 +88,16 @@ public class TestResourceManager implements Closeable {
         }
     }
 
-    public void init() {
+    public void init(String testProfileName) {
         for (TestResourceEntry entry : allTestResourceEntries) {
             try {
                 QuarkusTestResourceLifecycleManager testResource = entry.getTestResource();
+                testResource.setContext(new QuarkusTestResourceLifecycleManager.Context() {
+                    @Override
+                    public String testProfile() {
+                        return testProfileName;
+                    }
+                });
                 if (testResource instanceof QuarkusTestResourceConfigurableLifecycleManager
                         && entry.getConfigAnnotation() != null) {
                     ((QuarkusTestResourceConfigurableLifecycleManager<Annotation>) testResource)

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -249,7 +249,7 @@ public class QuarkusDevModeTest
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
             TestResourceManager testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());
-            testResourceManager.init();
+            testResourceManager.init(null);
             Map<String, String> properties = testResourceManager.start();
             TestResourceManager tm = testResourceManager;
 

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -373,7 +373,7 @@ public class QuarkusProdModeTest
         ExtensionContext.Store store = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
         if (store.get(TestResourceManager.class.getName()) == null) {
             TestResourceManager manager = new TestResourceManager(extensionContext.getRequiredTestClass());
-            manager.init();
+            manager.init(null);
             testResourceProperties = manager.start();
             store.put(TestResourceManager.class.getName(), manager);
             store.put(TestResourceManager.CLOSEABLE_NAME, new ExtensionContext.Store.CloseableResource() {

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -464,7 +464,7 @@ public class QuarkusUnitTest
         TestResourceManager testResourceManager = (TestResourceManager) store.get(TestResourceManager.class.getName());
         if (testResourceManager == null) {
             testResourceManager = new TestResourceManager(extensionContext.getRequiredTestClass());
-            testResourceManager.init();
+            testResourceManager.init(null);
             testResourceManager.start();
             TestResourceManager tm = testResourceManager;
             store.put(TestResourceManager.class.getName(), testResourceManager);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -126,7 +126,9 @@ public class NativeTestExtension
                     getAdditionalTestResources(testProfileAndProperties.testProfile, currentJUnitTestClass.getClassLoader()),
                     testProfileAndProperties.testProfile != null
                             && testProfileAndProperties.testProfile.disableGlobalTestResources());
-            testResourceManager.init();
+            testResourceManager.init(
+                    testProfileAndProperties.testProfile != null ? testProfileAndProperties.testProfile.getClass().getName()
+                            : null);
             hasPerTestResources = testResourceManager.hasPerTestResources();
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -143,7 +143,9 @@ public class QuarkusIntegrationTestExtension
                     testProfileAndProperties.testProfile != null
                             && testProfileAndProperties.testProfile.disableGlobalTestResources(),
                     devServicesProps, containerNetworkId == null ? Optional.empty() : Optional.of(containerNetworkId));
-            testResourceManager.init();
+            testResourceManager.init(
+                    testProfileAndProperties.testProfile != null ? testProfileAndProperties.testProfile.getClass().getName()
+                            : null);
             hasPerTestResources = testResourceManager.hasPerTestResources();
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -119,7 +119,9 @@ public class QuarkusMainIntegrationTestExtension implements BeforeEachCallback, 
                                 context.getRequiredTestClass().getClassLoader()),
                         testProfileAndProperties.testProfile != null
                                 && testProfileAndProperties.testProfile.disableGlobalTestResources());
-                testResourceManager.init();
+                testResourceManager.init(
+                        testProfileAndProperties.testProfile != null ? testProfileAndProperties.testProfile.getClass().getName()
+                                : null);
                 Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
                 additionalProperties.putAll(QuarkusMainIntegrationTestExtension.devServicesProps);
                 Map<String, String> resourceManagerProps = testResourceManager.start();

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -149,7 +149,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources(),
                             startupAction.getDevServicesProperties(), Optional.empty());
-            testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
+            testResourceManager.getClass().getMethod("init", String.class).invoke(testResourceManager,
+                    profile != null ? profile.getName() : null);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
                     .invoke(testResourceManager);
             startupAction.overrideConfig(properties);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -230,7 +230,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                             getAdditionalTestResources(profileInstance, startupAction.getClassLoader()),
                             profileInstance != null && profileInstance.disableGlobalTestResources(),
                             startupAction.getDevServicesProperties(), Optional.empty());
-            testResourceManager.getClass().getMethod("init").invoke(testResourceManager);
+            testResourceManager.getClass().getMethod("init", String.class).invoke(testResourceManager,
+                    profile != null ? profile.getName() : null);
             Map<String, String> properties = (Map<String, String>) testResourceManager.getClass().getMethod("start")
                     .invoke(testResourceManager);
             startupAction.overrideConfig(properties);


### PR DESCRIPTION
This allows implementations to take different actions based on the
profile they are being used with.

Closes: #22074