### PR TITLE
CLI: add support for RSA command

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Genkey.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Genkey.java
@@ -1,0 +1,89 @@
+package io.quarkus.cli;
+
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BaseBuildCommand;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+@CommandLine.Command(name = "genkey", sortOptions = false, header = "Generate RSA or EC public/private keys.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
+public class Genkey extends BaseBuildCommand implements Callable<Integer> {
+
+    @Option(names = { "-f", "--force" }, description = "Overwrite existing private/public keys")
+    boolean force;
+
+    @Option(names = { "-s", "--size" }, description = "Key size (Defaults to 2048 for RSA, 256 for EC)")
+    int size;
+
+    @Option(names = { "-a", "--algo" }, description = "Key algorithm: RSA or EC (Defaults to RSA)")
+    String algo;
+
+    @Override
+    public Integer call() throws Exception {
+        if (algo != null) {
+            if (algo.equalsIgnoreCase("RSA")) {
+                algo = "RSA";
+            } else if (algo.equalsIgnoreCase("EC")) {
+                algo = "EC";
+            } else {
+                throw new RuntimeException("Algorithm not supported: " + algo);
+            }
+        } else {
+            algo = "RSA";
+        }
+        if (algo.equals("RSA")) {
+            if (size == 0) {
+                size = 2048;
+            }
+        } else {
+            if (size == 0) {
+                size = 256;
+            }
+        }
+
+        Path resourcesFolder = projectRoot().resolve("src/main/resources");
+        if (!Files.exists(resourcesFolder))
+            Files.createDirectories(resourcesFolder);
+        Path privateKey = resourcesFolder.resolve("private-key.pem");
+        Path publicKey = resourcesFolder.resolve("public-key.pem");
+        if (force || (!Files.exists(privateKey) && !Files.exists(publicKey))) {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(algo);
+            kpg.initialize(size);
+            KeyPair kp = kpg.generateKeyPair();
+
+            try (FileWriter fw = new FileWriter(privateKey.toFile())) {
+                fw.append("-----BEGIN PRIVATE KEY-----\n");
+                fw.append(Base64.getMimeEncoder().encodeToString(kp.getPrivate().getEncoded()));
+                fw.append("\n");
+                fw.append("-----END PRIVATE KEY-----\n");
+            }
+            try (FileWriter fw = new FileWriter(publicKey.toFile())) {
+                fw.append("-----BEGIN PUBLIC KEY-----\n");
+                fw.append(Base64.getMimeEncoder().encodeToString(kp.getPublic().getEncoded()));
+                fw.append("\n");
+                fw.append("-----END PUBLIC KEY-----\n");
+            }
+            output.info("Public and private keys created in %s and %s\nYou can use this configuration for JWT:\n", publicKey,
+                    privateKey);
+            output.info("mp.jwt.verify.publickey.location=public-key.pem\n"
+                    + "mp.jwt.decrypt.key.location=private-key.pem\n"
+                    + "smallrye.jwt.sign.key.location=private-key.pem\n"
+                    + "smallrye.jwt.encrypt.key.location=public-key.pem\n"
+                    + " \n"
+                    + "quarkus.native.resources.includes=public-key.pem\n"
+                    + "quarkus.native.resources.includes=private-key.pem");
+        } else {
+            output.info("Public and private keys already exist in %s and %s (use --force to overwrite them).",
+                    publicKey, privateKey);
+        }
+
+        return CommandLine.ExitCode.OK;
+    }
+
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/Genkey.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Genkey.java
@@ -1,0 +1,89 @@
+package io.quarkus.cli;
+
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+@CommandLine.Command(name = "genkey", sortOptions = false, header = "Generate RSA or EC public/private keys.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
+public class Genkey extends BaseBuildCommand implements Callable<Integer> {
+
+    @Option(names = { "-f", "--force" }, description = "Overwrite existing private/public keys")
+    boolean force;
+
+    @Option(names = { "-s",
+            "--size" }, description = "Key size (Defaults to 2048 for RSA, 256 for EC. EC supports 256, 384, or 521)")
+    int size;
+
+    @Option(names = { "-a", "--algo" }, description = "Key algorithm: RSA or EC (Defaults to RSA)")
+    String algo;
+
+    @Override
+    public Integer call() throws Exception {
+        if (algo != null) {
+            if (algo.equalsIgnoreCase("RSA")) {
+                algo = "RSA";
+            } else if (algo.equalsIgnoreCase("EC")) {
+                algo = "EC";
+            } else {
+                throw new RuntimeException("Algorithm not supported: " + algo);
+            }
+        } else {
+            algo = "RSA";
+        }
+        if (algo.equals("RSA")) {
+            if (size == 0) {
+                size = 2048;
+            }
+        } else {
+            if (size == 0) {
+                size = 256;
+            }
+        }
+
+        Path resourcesFolder = projectRoot().resolve("src/main/resources");
+        if (!Files.exists(resourcesFolder))
+            Files.createDirectories(resourcesFolder);
+        Path privateKey = resourcesFolder.resolve("private-key.pem");
+        Path publicKey = resourcesFolder.resolve("public-key.pem");
+        if (force || (!Files.exists(privateKey) && !Files.exists(publicKey))) {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(algo);
+            kpg.initialize(size);
+            KeyPair kp = kpg.generateKeyPair();
+
+            try (FileWriter fw = new FileWriter(privateKey.toFile())) {
+                fw.append("-----BEGIN PRIVATE KEY-----\n");
+                fw.append(Base64.getMimeEncoder().encodeToString(kp.getPrivate().getEncoded()));
+                fw.append("\n");
+                fw.append("-----END PRIVATE KEY-----\n");
+            }
+            try (FileWriter fw = new FileWriter(publicKey.toFile())) {
+                fw.append("-----BEGIN PUBLIC KEY-----\n");
+                fw.append(Base64.getMimeEncoder().encodeToString(kp.getPublic().getEncoded()));
+                fw.append("\n");
+                fw.append("-----END PUBLIC KEY-----\n");
+            }
+            output.info("Public and private keys created in %s and %s\nYou can use this configuration for JWT:\n", publicKey,
+                    privateKey);
+            output.info("mp.jwt.verify.publickey.location=public-key.pem\n"
+                    + "mp.jwt.decrypt.key.location=private-key.pem\n"
+                    + "smallrye.jwt.sign.key.location=private-key.pem\n"
+                    + "smallrye.jwt.encrypt.key.location=public-key.pem\n"
+                    + " \n"
+                    + "quarkus.native.resources.includes=public-key.pem\n"
+                    + "quarkus.native.resources.includes=private-key.pem");
+        } else {
+            output.info("Public and private keys already exist in %s and %s (use --force to overwrite them).",
+                    publicKey, privateKey);
+        }
+
+        return CommandLine.ExitCode.OK;
+    }
+
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -21,7 +21,7 @@ import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.UnmatchedArgumentException;
 
 @CommandLine.Command(name = "quarkus", versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = true, subcommands = {
-        Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Version.class,
+        Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Genkey.class, Version.class,
         Completion.class }, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     static {

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -54,6 +54,7 @@ import picocli.CommandLine.UnmatchedArgumentException;
         Run.class,
         Test.class,
         Config.class,
+        Genkey.class,
         ProjectExtensions.class,
         Image.class,
         Deploy.class,

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliGenkeyTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliGenkeyTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CliGenkeyTest {
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
+    static Path privateKey = workspaceRoot.resolve("src/main/resources/private-key.pem");
+    static Path publicKey = workspaceRoot.resolve("src/main/resources/public-key.pem");
+
+    @BeforeEach
+    public void clean() throws IOException {
+        if (Files.exists(privateKey)) {
+            Files.delete(privateKey);
+        }
+        if (Files.exists(publicKey)) {
+            Files.delete(publicKey);
+        }
+    }
+
+    @Test
+    public void testCommandRsa() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "genkey");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        List<String> privateKeyContents = Files.readAllLines(privateKey);
+        Assertions.assertTrue(privateKeyContents.size() >= 3);
+        Assertions.assertEquals("-----BEGIN PRIVATE KEY-----", privateKeyContents.get(0));
+        verifyKeyParameters(privateKeyContents, "RSA", 2048);
+        List<String> publicKeyContents = Files.readAllLines(publicKey);
+        Assertions.assertTrue(publicKeyContents.size() >= 3);
+        Assertions.assertEquals("-----BEGIN PUBLIC KEY-----", publicKeyContents.get(0));
+        Assertions.assertTrue(result.stdout.contains("Public and private keys created in"));
+
+        // now run it again, it should complain but leave the files alone
+        result = CliDriver.execute(workspaceRoot, "genkey");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        List<String> privateKeyContents2 = Files.readAllLines(privateKey);
+        Assertions.assertEquals(privateKeyContents, privateKeyContents2);
+        List<String> publicKeyContents2 = Files.readAllLines(publicKey);
+        Assertions.assertEquals(publicKeyContents, publicKeyContents2);
+        Assertions.assertTrue(result.stdout.contains("Public and private keys already exist in"));
+
+        // now run it again in force, to override the files
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        privateKeyContents2 = Files.readAllLines(privateKey);
+        Assertions.assertNotEquals(privateKeyContents, privateKeyContents2);
+        publicKeyContents2 = Files.readAllLines(publicKey);
+        Assertions.assertNotEquals(publicKeyContents, publicKeyContents2);
+        Assertions.assertTrue(result.stdout.contains("Public and private keys created in"));
+
+        // run it for 4096
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--size", "4096");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "RSA", 4096);
+
+        // run it for EC
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--algo", "EC");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "EC", 256);
+
+        // run it for EC/512
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--algo", "EC", "--size", "512");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "EC", 512);
+    }
+
+    private void verifyKeyParameters(List<String> privateKeyContents, String algo, int keySize) {
+        StringBuilder key = new StringBuilder();
+        for (int i = 1; i < privateKeyContents.size() - 1; i++) {
+            key.append(privateKeyContents.get(i));
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(key.toString());
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+        try {
+            PrivateKey privateKey = KeyFactory.getInstance(algo).generatePrivate(keySpec);
+            int observedSize;
+            if (algo.equals("RSA")) {
+                observedSize = ((RSAPrivateKey) privateKey).getModulus().bitLength();
+            } else {
+                observedSize = ((ECPrivateKey) privateKey).getS().bitLength();
+            }
+            Assertions.assertTrue(observedSize > keySize - 8 && observedSize <= keySize,
+                    "Key size is not valid: " + observedSize + " (expected " + keySize + ")");
+        } catch (InvalidKeySpecException e) {
+            Assertions.fail("Key is not of the expected algo: " + algo, e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliGenkeyTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliGenkeyTest.java
@@ -1,0 +1,111 @@
+package io.quarkus.cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CliGenkeyTest {
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath().resolve("target/test-project");
+    static Path privateKey = workspaceRoot.resolve("src/main/resources/private-key.pem");
+    static Path publicKey = workspaceRoot.resolve("src/main/resources/public-key.pem");
+
+    @BeforeEach
+    public void clean() throws IOException {
+        if (Files.exists(privateKey)) {
+            Files.delete(privateKey);
+        }
+        if (Files.exists(publicKey)) {
+            Files.delete(publicKey);
+        }
+    }
+
+    @Test
+    public void testCommandRsa() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "genkey");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        List<String> privateKeyContents = Files.readAllLines(privateKey);
+        Assertions.assertTrue(privateKeyContents.size() >= 3);
+        Assertions.assertEquals("-----BEGIN PRIVATE KEY-----", privateKeyContents.get(0));
+        verifyKeyParameters(privateKeyContents, "RSA", 2048);
+        List<String> publicKeyContents = Files.readAllLines(publicKey);
+        Assertions.assertTrue(publicKeyContents.size() >= 3);
+        Assertions.assertEquals("-----BEGIN PUBLIC KEY-----", publicKeyContents.get(0));
+        Assertions.assertTrue(result.stdout.contains("Public and private keys created in"));
+
+        // now run it again, it should complain but leave the files alone
+        result = CliDriver.execute(workspaceRoot, "genkey");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        List<String> privateKeyContents2 = Files.readAllLines(privateKey);
+        Assertions.assertEquals(privateKeyContents, privateKeyContents2);
+        List<String> publicKeyContents2 = Files.readAllLines(publicKey);
+        Assertions.assertEquals(publicKeyContents, publicKeyContents2);
+        Assertions.assertTrue(result.stdout.contains("Public and private keys already exist in"));
+
+        // now run it again in force, to override the files
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force");
+        Assertions.assertTrue(Files.exists(privateKey));
+        Assertions.assertTrue(Files.exists(publicKey));
+        privateKeyContents2 = Files.readAllLines(privateKey);
+        Assertions.assertNotEquals(privateKeyContents, privateKeyContents2);
+        publicKeyContents2 = Files.readAllLines(publicKey);
+        Assertions.assertNotEquals(publicKeyContents, publicKeyContents2);
+        Assertions.assertTrue(result.stdout.contains("Public and private keys created in"));
+
+        // run it for 4096
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--size", "4096");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "RSA", 4096);
+
+        // run it for EC
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--algo", "EC");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "EC", 256);
+
+        // run it for EC/521
+        result = CliDriver.execute(workspaceRoot, "genkey", "--force", "--algo", "EC", "--size", "521");
+        Assertions.assertTrue(Files.exists(privateKey));
+        verifyKeyParameters(Files.readAllLines(privateKey), "EC", 521);
+    }
+
+    private void verifyKeyParameters(List<String> privateKeyContents, String algo, int keySize) {
+        StringBuilder key = new StringBuilder();
+        for (int i = 1; i < privateKeyContents.size() - 1; i++) {
+            key.append(privateKeyContents.get(i));
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(key.toString());
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+        try {
+            PrivateKey privateKey = KeyFactory.getInstance(algo).generatePrivate(keySpec);
+            int observedSize;
+            if (algo.equals("RSA")) {
+                observedSize = ((RSAPrivateKey) privateKey).getModulus().bitLength();
+                Assertions.assertTrue(observedSize > keySize - 8 && observedSize <= keySize,
+                        "RSA key size is not valid: " + observedSize + " (expected " + keySize + ")");
+            } else {
+                observedSize = ((ECKey) privateKey).getParams().getCurve().getField().getFieldSize();
+                Assertions.assertEquals(keySize, observedSize,
+                        "EC key field size is not valid: " + observedSize + " (expected " + keySize + ")");
+            }
+        } catch (InvalidKeySpecException e) {
+            Assertions.fail("Key is not of the expected algo: " + algo, e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -167,6 +167,14 @@ public class CliHelpTest {
         Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
     }
 
+    @Test
+    @Order(51)
+    public void testGenkeyHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "genkey", "--help");
+        result.echoSystemOut();
+        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+    }
+
     @Order(60)
     @Test
     public void testGenerateCompletionHelp() throws Exception {

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -173,6 +173,18 @@ public class CliHelpTest {
         assertThat(result.stdout).contains("Usage");
     }
 
+    @Test
+    @Order(55)
+    public void testGenkeyHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "genkey", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+        assertThat(result.stdout).contains("Generate RSA or EC public/private keys.");
+        assertThat(result.stdout).contains("--force");
+        assertThat(result.stdout).contains("--size");
+        assertThat(result.stdout).contains("--algo");
+    }
+
     @Order(60)
     @Test
     public void testGenerateCompletionHelp() throws Exception {


### PR DESCRIPTION
This allows users to create RSA pairs easier than the current `openssl` usage we document:

```shell
$ openssl genrsa -out rsaPrivateKey.pem 2048
$ openssl rsa -pubout -in rsaPrivateKey.pem -out src/main/resources/publicKey.pem
$ openssl pkcs8 -topk8 -nocrypt -inform pem -in rsaPrivateKey.pem -outform pem -out src/main/resources/privateKey.pem
```

Versus:

```shell
$ quarkus rsa
Public and private keys created in /home/stephane/src/java-eclipse/aviouf/src/main/resources/public-key.pem and /home/stephane/src/java-eclipse/aviouf/src/main/resources/private-key.pem
You can use this configuration for JWT:

mp.jwt.verify.publickey.location=public-key.pem
mp.jwt.decrypt.key.location=private-key.pem
smallrye.jwt.sign.key.location=private-key.pem
smallrye.jwt.encrypt.key.location=public-key.pem
 
quarkus.native.resources.includes=public-key.pem
quarkus.native.resources.includes=private-key.pem
```