### PR TITLE
Ban Logback dependencies from the build

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -562,6 +562,11 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- Ban Logback implementations -->
+                                            <exclude>ch.qos.logback:logback-classic</exclude>
+                                            <exclude>ch.qos.logback:logback-core</exclude>
+                                            <exclude>ch.qos.logback:logback-access</exclude>
+                                            <exclude>ch.qos.logback:logback</exclude>
                                             <exclude>org.osgi:org.osgi.annotation.versioning</exclude>
                                             <!-- Ban Spring Dependencies (since we have our own jars)-->
                                             <exclude>org.springframework:spring-core</exclude>


### PR DESCRIPTION
We shouldn't use Logback directly (and indeed we don't) so let's ban it
altogether to avoid potential issues.