### PR TITLE
OIDC bug fixes

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -364,7 +364,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private String generateInternalIdToken(OidcTenantConfig oidcConfig) {
-        return Jwt.claims().sign(KeyUtils.createSecretKeyFromSecret(oidcConfig.credentials.secret.get()));
+        String tenant = oidcConfig.tenantId.orElse("default");
+        return Jwt.claims().issuer(tenant).sign(KeyUtils.createSecretKeyFromSecret(oidcConfig.credentials.secret.get()));
     }
 
     private Uni<Void> processSuccessfulAuthentication(RoutingContext context,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -28,6 +28,7 @@ import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -309,6 +310,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         context.put(NEW_AUTHENTICATION, Boolean.TRUE);
                         context.put(OidcConstants.ACCESS_TOKEN_VALUE, tokens.getAccessToken());
                         context.put(AuthorizationCodeTokens.class.getName(), tokens);
+                        // make sure JWT doesn't try to validate our token, since we handle it and it will throw
+                        context.put(IdentityProvider.class.getName(), OidcIdentityProvider.class);
 
                         return authenticate(identityProviderManager, context,
                                 new IdTokenCredential(tokens.getIdToken(), internalIdToken))

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -67,6 +67,9 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 .transformToUni(new Function<TenantConfigContext, Uni<? extends SecurityIdentity>>() {
                     @Override
                     public Uni<SecurityIdentity> apply(TenantConfigContext tenantConfigContext) {
+                        // make sure we don't authenticate if this tenant is disabled
+                        if (!tenantConfigContext.oidcConfig.tenantEnabled)
+                            return Uni.createFrom().nullItem();
                         return Uni.createFrom().deferred(new Supplier<Uni<? extends SecurityIdentity>>() {
                             @Override
                             public Uni<SecurityIdentity> get() {

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
@@ -20,6 +20,7 @@ import io.quarkus.security.identity.request.TokenAuthenticationRequest;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.jwt.auth.AbstractBearerTokenExtractor;
 import io.smallrye.jwt.auth.principal.JWTAuthContextInfo;
 import io.smallrye.mutiny.Uni;
@@ -43,10 +44,13 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
             IdentityProviderManager identityProviderManager) {
         String jwtToken = new VertxBearerTokenExtractor(authContextInfo, context).getBearerToken();
         if (jwtToken != null) {
+            TokenAuthenticationRequest tokenAuthenticationRequest = new TokenAuthenticationRequest(
+                    new JsonWebTokenCredential(jwtToken));
+            HttpSecurityUtils.setRoutingContextAttribute(tokenAuthenticationRequest, context);
             // make sure we know we're in charge here
             context.put(IdentityProvider.class.getName(), MpJwtValidator.class);
             return identityProviderManager
-                    .authenticate(new TokenAuthenticationRequest(new JsonWebTokenCredential(jwtToken)));
+                    .authenticate(tokenAuthenticationRequest);
         }
         return Uni.createFrom().optional(Optional.empty());
     }

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/JWTAuthMechanism.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -42,6 +43,8 @@ public class JWTAuthMechanism implements HttpAuthenticationMechanism {
             IdentityProviderManager identityProviderManager) {
         String jwtToken = new VertxBearerTokenExtractor(authContextInfo, context).getBearerToken();
         if (jwtToken != null) {
+            // make sure we know we're in charge here
+            context.put(IdentityProvider.class.getName(), MpJwtValidator.class);
             return identityProviderManager
                     .authenticate(new TokenAuthenticationRequest(new JsonWebTokenCredential(jwtToken)));
         }


### PR DESCRIPTION
This PR fixes a few issues I've had with OIDC and JWT:

- Store the tenant ID in the generated JWT IdToken for github/facebook, so we know where it came from
- Store the `IdentityProvider` in the Vert.x Context during authentication so that JWT and OIDC don't try to participate in each-other's authentication, which happened to me and cause mayhem
- Do not authenticate disabled OIDC tenants
- Store the Vert.x context in the `tokenAuthenticationRequest` like other extensions do, otherwise JWT will create the request, not put the Vert.x context in it, and OIDC will have an NPE because it expects it there.