### PR TITLE
ArC: added support for excluded type build items

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -154,6 +154,7 @@ public class ArcProcessor {
             BeanArchiveIndexBuildItem beanArchiveIndex,
             CombinedIndexBuildItem combinedIndex,
             ApplicationIndexBuildItem applicationIndex,
+            List<ExcludedTypeBuildItem> excludedTypes,
             List<AnnotationsTransformerBuildItem> annotationTransformers,
             List<InjectionPointTransformerBuildItem> injectionPointTransformers,
             List<ObserverTransformerBuildItem> observerTransformers,
@@ -365,6 +366,12 @@ public class ArcProcessor {
         if (arcConfig.excludeTypes.isPresent()) {
             for (Predicate<ClassInfo> predicate : initClassPredicates(
                     arcConfig.excludeTypes.get())) {
+                builder.addExcludeType(predicate);
+            }
+        }
+        if (!excludedTypes.isEmpty()) {
+            for (Predicate<ClassInfo> predicate : initClassPredicates(
+                    excludedTypes.stream().map(ExcludedTypeBuildItem::getMatch).collect(Collectors.toList()))) {
                 builder.addExcludeType(predicate);
             }
         }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ExcludedTypeBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ExcludedTypeBuildItem.java
@@ -1,0 +1,30 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * This build item is used to specify types to be excluded from discovery.
+ * 
+ * <p>
+ * An element value can be:
+ * <ul>
+ * <li>a fully qualified class name, i.e. {@code org.acme.Foo}</li>
+ * <li>a simple class name as defined by {@link Class#getSimpleName()}, i.e. {@code Foo}</li>
+ * <li>a package name with suffix {@code .*}, i.e. {@code org.acme.*}, matches a package</li>
+ * <li>a package name with suffix {@code .**}, i.e. {@code org.acme.**}, matches a package that starts with the value</li>
+ * </ul>
+ * If any element value matches a discovered type then the type is excluded from discovery, i.e. no beans and observer
+ * methods are created from this type.
+ */
+public final class ExcludedTypeBuildItem extends MultiBuildItem {
+
+    private final String match;
+
+    public ExcludedTypeBuildItem(String match) {
+        this.match = match;
+    }
+
+    public String getMatch() {
+        return match;
+    }
+}


### PR DESCRIPTION
This adds support for `ExcludedTypeBuildItem` to complement `arcConfig.excludeTypes`.

I need this in my Renarde extension to disable a Hibernate Validator interceptor and provide my own.