### PR TITLE
Define concurrency for epicissues workflow

### DIFF
--- a/.github/workflows/epicissues.yml
+++ b/.github/workflows/epicissues.yml
@@ -1,18 +1,18 @@
 name: "Epic issue lists"
 on:
-    issues:
-      types: [opened, edited, labeled]
+  issues:
+    types: [opened, edited, labeled]
 
 concurrency:
-    group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, issue = ${{ github.event.issue.id }}"
-    cancel-in-progress: ${{ github.event_name == 'issues' || github.repository != 'quarkusio/quarkus' }}
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, issue = ${{ github.event.issue.id }}"
+  cancel-in-progress: ${{ github.event_name == 'issues' || github.repository != 'quarkusio/quarkus' }}
 
 jobs:
-    autolabel:
-      if: github.repository == 'quarkusio/quarkus'
-      runs-on: ubuntu-latest
-      name: auto label
-      steps:
+  autolabel:
+    if: github.repository == 'quarkusio/quarkus'
+    runs-on: ubuntu-latest
+    name: auto label
+    steps:
 #      - name: Debug Action
 #        uses: hmarr/debug-action@v1.0.0
       - name: epicmaker

--- a/.github/workflows/epicissues.yml
+++ b/.github/workflows/epicissues.yml
@@ -3,6 +3,10 @@ on:
     issues:
       types: [opened, edited, labeled]
 
+concurrency:
+    group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, issue = ${{ github.event.issue.id }}"
+    cancel-in-progress: ${{ github.event_name == 'issues' || github.repository != 'quarkusio/quarkus' }}
+
 jobs:
     autolabel:
       if: github.repository == 'quarkusio/quarkus'


### PR DESCRIPTION
When an issue is edited a lot, we end up with a ton of builds piling up,
no need for that.