### PR TITLE
Qute - ReflectionValueResolver should ignore static members

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ReflectionValueResolver.java
@@ -108,10 +108,7 @@ public class ReflectionValueResolver implements ValueResolver {
 
         for (Class<?> clazzToTest : classes) {
             for (Method method : clazzToTest.getMethods()) {
-                if (!isMethodValid(method)) {
-                    continue;
-                }
-                if (method.isBridge()) {
+                if (!isMethodProperty(method)) {
                     continue;
                 }
                 if (name.equals(method.getName())) {
@@ -137,7 +134,8 @@ public class ReflectionValueResolver implements ValueResolver {
     private Field findField(Class<?> clazz, String name) {
         Field found = null;
         for (Field field : clazz.getFields()) {
-            if (field.getName().equals(name)) {
+            if (!Modifier.isStatic(field.getModifiers())
+                    && field.getName().equals(name)) {
                 found = field;
             }
         }
@@ -158,26 +156,28 @@ public class ReflectionValueResolver implements ValueResolver {
 
         for (Class<?> clazzToTest : hierarchy) {
             for (Method method : clazzToTest.getMethods()) {
-                if (!Modifier.isPublic(method.getModifiers())
-                        || (!method.isVarArgs() && method.getParameterCount() != numberOfParams)
-                        || method.getReturnType().equals(Void.TYPE)
-                        || Object.class.equals(method.getDeclaringClass())
-                        || method.isBridge()
-                        || !name.equals(method.getName())) {
-                    continue;
+                if (isMethodCandidate(method)
+                        && name.equals(method.getName())) {
+                    foundMatch.add(method);
+                    method.trySetAccessible();
                 }
-                foundMatch.add(method);
-                method.trySetAccessible();
             }
         }
         return foundMatch.size() == 1 ? Collections.singletonList(foundMatch.get(0)) : foundMatch;
     }
 
-    private static boolean isMethodValid(Method method) {
-        return method != null && Modifier.isPublic(method.getModifiers())
-                && method.getParameterCount() == 0
+    private static boolean isMethodCandidate(Method method) {
+        return method != null
+                && Modifier.isPublic(method.getModifiers())
+                && !Modifier.isStatic(method.getModifiers())
                 && !method.getReturnType().equals(Void.TYPE)
+                && !method.isBridge()
                 && !Object.class.equals(method.getDeclaringClass());
+    }
+
+    private static boolean isMethodProperty(Method method) {
+        return isMethodCandidate(method)
+                && method.getParameterCount() == 0;
     }
 
     private static boolean matchesPrefix(String name, String methodName,

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ReflectionResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ReflectionResolverTest.java
@@ -42,9 +42,17 @@ public class ReflectionResolverTest {
                 .parse("{foo.compute(foo.name,1,2)}").data("foo", new Foo("box")).render());
     }
 
+    @Test
+    public void testStaticMembersIgnored() {
+        assertEquals("baz::baz", Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build()
+                .parse("{foo.bar ?: 'baz'}::{foo.BAR ?: 'baz'}").data("foo", new Foo("box")).render());
+    }
+
     public static class Foo {
 
         public final String name;
+
+        public static final String BAR = "bar";
 
         public Foo(String name) {
             this.name = name;
@@ -62,6 +70,10 @@ public class ReflectionResolverTest {
             StringBuilder builder = new StringBuilder();
             IntStream.of(counts).forEach(i -> builder.append(val).append(":"));
             return builder.toString();
+        }
+
+        public static String bar() {
+            return "BAR";
         }
 
     }


### PR DESCRIPTION
- static members should be accessed in a static way
- the generated value resolvers ignore static members as well
- TemplateData#namespace() is the way to go in quarkus