### PR TITLE
Upgrade to Jackson 2.13.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -85,7 +85,7 @@
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
         <graal-sdk.version>21.3.0</graal-sdk.version>
         <gizmo.version>1.0.10.Final</gizmo.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.13.0</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/OverrideZonedDateTimeSerializerTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/OverrideZonedDateTimeSerializerTest.java
@@ -33,7 +33,7 @@ public class OverrideZonedDateTimeSerializerTest {
     @Test
     public void test() throws JsonProcessingException {
         assertThat(new ArrayList<>(objectMapper.getRegisteredModuleIds())).asList()
-                .contains("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+                .contains("jackson-datatype-jsr310");
         assertThat(objectMapper.writeValueAsString(ZonedDateTime.now())).isEqualTo("\"dummy\"");
     }
 

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,7 @@
         <maven-wagon.version>3.4.3</maven-wagon.version>
         <httpcore.version>4.4.15</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.13.0</jackson.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.inject-api.version>1.0</jakarta.inject-api.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -56,7 +56,7 @@
         <rest-assured.version>4.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.13.0</jackson.version>
         <smallrye-stork.version>1.0.0.Alpha7</smallrye-stork.version>
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <yasson.version>2.0.2</yasson.version>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Versions -->
         <assertj.version>3.21.0</assertj.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.13.0</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>
         <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>

--- a/tcks/microprofile-rest-client-reactive/pom.xml
+++ b/tcks/microprofile-rest-client-reactive/pom.xml
@@ -153,7 +153,16 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/tcks/microprofile-rest-client/pom.xml
+++ b/tcks/microprofile-rest-client/pom.xml
@@ -116,7 +116,16 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
Had to fix a dependency convergence issue in passing. I thought about defining junit:junit in a dependency management of build-parent but thought it was a good idea to have an error when we're using JUnit 4.