### PR TITLE
Fix `error: option --source cannot be used together with --release` on dev mode reload

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CompilerFlags.java
@@ -44,18 +44,21 @@ public class CompilerFlags {
 
         flagList.addAll(effectiveDefaultFlags);
 
-        // Add --release and -source and -target flags.
+        // Prefer --release over -source and -target flags to make sure to not run into:
+        // "error: option --source cannot be used together with --release"
+        // This is *not* checking defaultFlags; it is not expected that defaultFlags ever contain --release etc.!
         if (releaseJavaVersion != null) {
             flagList.add("--release");
             flagList.add(releaseJavaVersion);
-        }
-        if (sourceJavaVersion != null) {
-            flagList.add("-source");
-            flagList.add(sourceJavaVersion);
-        }
-        if (targetJavaVersion != null) {
-            flagList.add("-target");
-            flagList.add(targetJavaVersion);
+        } else {
+            if (sourceJavaVersion != null) {
+                flagList.add("-source");
+                flagList.add(sourceJavaVersion);
+            }
+            if (targetJavaVersion != null) {
+                flagList.add("-target");
+                flagList.add(targetJavaVersion);
+            }
         }
 
         flagList.addAll(userFlags);

--- a/core/deployment/src/test/java/io/quarkus/deployment/dev/CompilerFlagsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/dev/CompilerFlagsTest.java
@@ -56,11 +56,14 @@ public class CompilerFlagsTest {
                         new CompilerFlags(setOf(), listOf("-target", "3"), null, null, null)),
                 () -> assertEquals(
                         new CompilerFlags(setOf(), listOf(), "1", "2", "3"),
-                        new CompilerFlags(setOf(), listOf("--release", "1", "-source", "2", "-target", "3"), null, null, null)),
+                        new CompilerFlags(setOf(), listOf("--release", "1"), null, null, null)),
                 () -> assertEquals(
-                        new CompilerFlags(setOf(), listOf("--release", "4", "-source", "5", "-target", "6"), "1", "2", "3"),
-                        new CompilerFlags(setOf(), listOf("--release", "1", "-source", "2", "-target", "3", "--release", "4",
-                                "-source", "5", "-target", "6"), null, null, null)));
+                        new CompilerFlags(setOf(), listOf(), null, "2", "3"),
+                        new CompilerFlags(setOf(), listOf("-source", "2", "-target", "3"), null, null, null)),
+                () -> assertEquals(
+                        new CompilerFlags(setOf(), listOf("-source", "5", "-target", "6"), null, "2", "3"),
+                        new CompilerFlags(setOf(), listOf("-source", "2", "-target", "3", "-source", "5", "-target", "6"),
+                                null, null, null)));
     }
 
     @Test
@@ -68,8 +71,11 @@ public class CompilerFlagsTest {
         assertAll(
                 () -> assertEquals(
                         new CompilerFlags(setOf("-b", "-c", "-d"), listOf("-a", "-b", "-c"), "1", "2", "3"),
-                        new CompilerFlags(setOf(),
-                                listOf("-d", "--release", "1", "-source", "2", "-target", "3", "-a", "-b", "-c"),
+                        new CompilerFlags(setOf(), listOf("-d", "--release", "1", "-a", "-b", "-c"), null, null, null)));
+        assertAll(
+                () -> assertEquals(
+                        new CompilerFlags(setOf("-b", "-c", "-d"), listOf("-a", "-b", "-c"), null, "2", "3"),
+                        new CompilerFlags(setOf(), listOf("-d", "-source", "2", "-target", "3", "-a", "-b", "-c"),
                                 null, null, null)));
     }
 


### PR DESCRIPTION
This fixes a regression introduced by #21537 when both `maven.compiler.source` _and_ `maven.compiler.release` are set (e.g. to work around https://issues.apache.org/jira/browse/MCOMPILER-413).