### PR TITLE
Use URLConnection to read jar content

### DIFF
--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -55,7 +55,7 @@
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <smallrye-common.version>1.8.0</smallrye-common.version>
         <gradle-tooling.version>7.3.2</gradle-tooling.version>
-        <quarkus-fs-util.version>0.0.3</quarkus-fs-util.version>
+        <quarkus-fs-util.version>0.0.4</quarkus-fs-util.version>
     </properties>
     <modules>
         <module>bom</module>


### PR DESCRIPTION
According to the comment, originally this method was introduced since the inputstream created by openConnection() was not closed.
Closing the IS was not working, because caching prevents the close. The check for caching is done in sun.net.www.protocol.jar.JarURLConnection.JarURLInputStream.

Saves about 60ms of devmode startup time, by again reducing the number of opened FileSystems.

Related to #21552

Draft, because:
* Waiting for https://github.com/quarkusio/quarkus-fs-util/pull/5