### PR TITLE
Fix refcnt exception

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxOutputStream.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/VertxOutputStream.java
@@ -77,6 +77,8 @@ public class VertxOutputStream extends AsyncOutputStream {
         } catch (Exception e) {
             if (buffer != null && buffer.refCnt() > 0) {
                 buffer.release();
+                pooledBuffer = null;
+                closed = true;
             }
             throw new IOException(e);
         }


### PR DESCRIPTION
This can happen if the stream is used after an exception is thrown.

Fixes #22263