### PR TITLE
Add shared attribute to the Reactive Rest Client

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -39,6 +39,8 @@ public class RestClientConfig {
         EMPTY.connectionPoolSize = Optional.empty();
         EMPTY.maxRedirects = Optional.empty();
         EMPTY.headers = Collections.emptyMap();
+        EMPTY.shared = Optional.empty();
+        EMPTY.name = Optional.empty();
     }
 
     /**
@@ -171,6 +173,24 @@ public class RestClientConfig {
     @ConfigItem
     public Map<String, String> headers;
 
+    /**
+     * Set to true to share the HTTP client between REST clients.
+     * There can be multiple shared clients distinguished by <em>name</em>, when no specific name is set,
+     * the name <code>__vertx.DEFAULT</code> is used.
+     *
+     * This property is applicable to reactive REST clients only.
+     */
+    @ConfigItem
+    public Optional<Boolean> shared;
+
+    /**
+     * Set the HTTP client name, used when the client is shared, otherwise ignored.
+     *
+     * This property is applicable to reactive REST clients only.
+     */
+    @ConfigItem
+    public Optional<String> name;
+
     public static RestClientConfig load(String configKey) {
         final RestClientConfig instance = new RestClientConfig();
 
@@ -194,6 +214,8 @@ public class RestClientConfig {
         instance.connectionPoolSize = getConfigValue(configKey, "connection-pool-size", Integer.class);
         instance.maxRedirects = getConfigValue(configKey, "max-redirects", Integer.class);
         instance.headers = getConfigValues(configKey, "headers", String.class, String.class);
+        instance.shared = getConfigValue(configKey, "shared", Boolean.class);
+        instance.name = getConfigValue(configKey, "name", String.class);
 
         return instance;
     }
@@ -221,6 +243,8 @@ public class RestClientConfig {
         instance.connectionPoolSize = getConfigValue(interfaceClass, "connection-pool-size", Integer.class);
         instance.maxRedirects = getConfigValue(interfaceClass, "max-redirects", Integer.class);
         instance.headers = getConfigValues(interfaceClass, "headers", String.class, String.class);
+        instance.shared = getConfigValue(interfaceClass, "shared", Boolean.class);
+        instance.name = getConfigValue(interfaceClass, "name", String.class);
 
         return instance;
     }

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -68,6 +68,7 @@ public class RestClientCDIDelegateBuilder<T> {
         configureRedirects(builder);
         configureQueryParamStyle(builder);
         configureProxy(builder);
+        configureShared(builder);
         configureCustomProperties(builder);
         return builder.build(jaxrsInterface);
     }
@@ -147,6 +148,23 @@ public class RestClientCDIDelegateBuilder<T> {
                 clientConfigByConfigKey().followRedirects);
         if (maybeFollowRedirects.isPresent()) {
             builder.followRedirects(maybeFollowRedirects.get());
+        }
+    }
+
+    private void configureShared(RestClientBuilder builder) {
+        Optional<Boolean> shared = oneOf(clientConfigByClassName().shared,
+                clientConfigByConfigKey().shared);
+        if (shared.isPresent()) {
+            builder.property(QuarkusRestClientProperties.SHARED, shared.get());
+
+            if (shared.get()) {
+                // Name is only used if shared = true
+                Optional<String> name = oneOf(clientConfigByClassName().name,
+                        clientConfigByConfigKey().name);
+                if (name.isPresent()) {
+                    builder.property(QuarkusRestClientProperties.NAME, name.get());
+                }
+            }
         }
     }
 

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -92,6 +92,8 @@ public class RestClientCDIDelegateBuilderTest {
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 30); // value in seconds
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 103);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MAX_REDIRECTS, 104);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.SHARED, true);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.NAME, "my-client");
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE,
                 HttpPostRequestEncoder.EncoderMode.HTML5);
     }
@@ -120,6 +122,8 @@ public class RestClientCDIDelegateBuilderTest {
         clientConfig.connectionPoolSize = Optional.of(103);
         clientConfig.maxRedirects = Optional.of(104);
         clientConfig.headers = Collections.emptyMap();
+        clientConfig.shared = Optional.of(true);
+        clientConfig.name = Optional.of("my-client");
 
         RestClientsConfig configRoot = new RestClientsConfig();
         configRoot.multipartPostEncoderMode = Optional.of("HTML5");

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -1,11 +1,16 @@
 package org.jboss.resteasy.reactive.client.api;
 
 public class QuarkusRestClientProperties {
+
+    /**
+     * Configure the connect timeout in ms.
+     */
     public static final String CONNECT_TIMEOUT = "io.quarkus.rest.client.connect-timeout";
     /**
      * maximum number of redirects for a client call. Works only if the client has `followingRedirects enabled
      */
     public static final String MAX_REDIRECTS = "io.quarkus.rest.client.max-redirects";
+
     public static final String READ_TIMEOUT = "io.quarkus.rest.client.read-timeout";
 
     /**
@@ -24,4 +29,17 @@ public class QuarkusRestClientProperties {
     public static final String CONNECTION_POOL_SIZE = "io.quarkus.rest.client.connection-pool-size";
 
     public static final String STATIC_HEADERS = "io.quarkus.rest.client.static-headers";
+
+    /**
+     * Set to true to share the HTTP client between REST clients.
+     * There can be multiple shared clients distinguished by <em>name</em>, when no specific name is set,
+     * the name <code>__vertx.DEFAULT</code> is used.
+     */
+    public static final String SHARED = "io.quarkus.rest.client.shared";
+
+    /**
+     * Set the HTTP client name, used when the client is shared, otherwise ignored.
+     */
+    public static final String NAME = "io.quarkus.rest.client.name";
+
 }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -4,6 +4,8 @@ import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.CONNECTION_TTL;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.CONNECT_TIMEOUT;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.MAX_REDIRECTS;
+import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.NAME;
+import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.SHARED;
 
 import io.netty.channel.EventLoopGroup;
 import io.vertx.core.AsyncResult;
@@ -135,12 +137,24 @@ public class ClientImpl implements Client {
         if (connectionPoolSize == null) {
             connectionPoolSize = DEFAULT_CONNECTION_POOL_SIZE;
         } else {
-            log.debugf("Setting connectionPoolSize to %d s", connectionPoolSize);
+            log.debugf("Setting connectionPoolSize to %d", connectionPoolSize);
         }
         options.setMaxPoolSize((int) connectionPoolSize);
 
         if (loggingScope == LoggingScope.ALL) {
             options.setLogActivity(true);
+        }
+
+        Object name = configuration.getProperty(NAME);
+        if (name != null) {
+            log.debugf("Setting client name to %s", name);
+            options.setName((String) name);
+        }
+
+        Object shared = configuration.getProperty(SHARED);
+        if (shared != null && (boolean) shared) {
+            log.debugf("Sharing of the HTTP client '%s' enabled", options.getName());
+            options.setShared(true);
         }
 
         httpClient = this.vertx.createHttpClient(options);


### PR DESCRIPTION
Expose the `shared` attribute introduced in Vert.x 4.2.2.