### PR TITLE
Bump to Hibernate 5.6.3.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.2.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.6.3.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.1.1.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.1.Final</hibernate-validator.version>
         <hibernate-search.version>6.0.7.Final</hibernate-search.version>


### PR DESCRIPTION
It finally undeprecates the TypeDef annotations