### PR TITLE
Check test target is present to avoid NPE

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -162,10 +162,12 @@ public class TestSupport implements TestController {
 
                 try {
                     Set<Path> paths = new LinkedHashSet<>();
-                    paths.add(Paths.get(module.getTest().get().getClassesPath()));
-                    if (module.getTest().get().getResourcesOutputPath() != null) {
-                        paths.add(Paths.get(module.getTest().get().getResourcesOutputPath()));
-                    }
+                    module.getTest().ifPresent(test -> {
+                        paths.add(Paths.get(test.getClassesPath()));
+                        if (test.getResourcesOutputPath() != null) {
+                            paths.add(Paths.get(test.getResourcesOutputPath()));
+                        }
+                    });
                     if (mainModule) {
                         paths.addAll(curatedApplication.getQuarkusBootstrap().getApplicationRoot().toList());
                     } else {


### PR DESCRIPTION
This simple fix to avoid NPE when running multi-modules project some of which do not have any test.