### PR TITLE
Respect disabling container-image build

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -70,8 +70,12 @@ public class DockerProcessor {
             @SuppressWarnings("unused") // used to ensure that the jar has been built
             JarBuildItem jar) {
 
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 
@@ -104,8 +108,12 @@ public class DockerProcessor {
             // used to ensure that the native binary has been built
             NativeImageBuildItem nativeImage) {
 
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 
@@ -151,7 +159,7 @@ public class DockerProcessor {
             createAdditionalTags(containerImageInfo.getImage(), containerImageInfo.getAdditionalImageTags(), dockerConfig);
         }
 
-        if (pushRequested || containerImageConfig.push) {
+        if (pushRequested || containerImageConfig.isPushExplicitlyEnabled()) {
             String registry = "docker.io";
             if (!containerImageInfo.getRegistry().isPresent()) {
                 log.info("No container image registry was set, so 'docker.io' will be used");

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -89,7 +89,7 @@ public class JibProcessor {
     public void appCDS(ContainerImageConfig containerImageConfig, JibConfig jibConfig,
             BuildProducer<AppCDSContainerImageBuildItem> producer) {
 
-        if (!containerImageConfig.build && !containerImageConfig.push) {
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()) {
             return;
         }
 
@@ -110,8 +110,10 @@ public class JibProcessor {
             Optional<AppCDSResultBuildItem> appCDSResult,
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
 
-        Boolean buildContainerImage = containerImageConfig.build || buildRequest.isPresent();
-        Boolean pushContainerImage = containerImageConfig.push || pushRequest.isPresent();
+        Boolean buildContainerImage = containerImageConfig.isBuildExplicitlyEnabled()
+                || (buildRequest.isPresent() && !containerImageConfig.isBuildExplicitlyDisabled());
+        Boolean pushContainerImage = containerImageConfig.isPushExplicitlyEnabled()
+                || (pushRequest.isPresent() && !containerImageConfig.isPushExplicitlyDisabled());
         if (!buildContainerImage && !pushContainerImage) {
             return;
         }
@@ -151,8 +153,10 @@ public class JibProcessor {
             List<ContainerImageLabelBuildItem> containerImageLabels,
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
 
-        Boolean buildContainerImage = containerImageConfig.build || buildRequest.isPresent();
-        Boolean pushContainerImage = containerImageConfig.push || pushRequest.isPresent();
+        Boolean buildContainerImage = containerImageConfig.isBuildExplicitlyEnabled()
+                || (buildRequest.isPresent() && !containerImageConfig.isBuildExplicitlyDisabled());
+        Boolean pushContainerImage = containerImageConfig.isPushExplicitlyEnabled()
+                || (pushRequest.isPresent() && !containerImageConfig.isPushExplicitlyDisabled());
         if (!buildContainerImage && !pushContainerImage) {
             return;
         }
@@ -187,7 +191,7 @@ public class JibProcessor {
             log.info("Starting container image build");
             JibContainer container = jibContainerBuilder.containerize(containerizer);
             log.infof("%s container image %s (%s)\n",
-                    containerImageConfig.push ? "Pushed" : "Created",
+                    containerImageConfig.isPushExplicitlyEnabled() ? "Pushed" : "Created",
                     container.getTargetImage(),
                     container.getDigest());
             return container;
@@ -203,7 +207,7 @@ public class JibProcessor {
         ImageReference imageReference = ImageReference.of(containerImage.getRegistry().orElse(null),
                 containerImage.getRepository(), containerImage.getTag());
 
-        if (pushRequested || containerImageConfig.push) {
+        if (pushRequested || containerImageConfig.isPushExplicitlyEnabled()) {
             if (!containerImageConfig.registry.isPresent()) {
                 log.info("No container image registry was set, so 'docker.io' will be used");
             }

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -222,8 +222,12 @@ public class OpenshiftProcessor {
             JarBuildItem jar) {
 
         OpenshiftConfig config = mergeConfig(openshiftConfig, s2iConfig);
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 
@@ -283,8 +287,13 @@ public class OpenshiftProcessor {
             NativeImageBuildItem nativeImage) {
 
         OpenshiftConfig config = mergeConfig(openshiftConfig, s2iConfig);
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -176,8 +176,12 @@ public class S2iProcessor {
             // used to ensure that the jar has been built
             JarBuildItem jar) {
 
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 
@@ -212,8 +216,12 @@ public class S2iProcessor {
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer,
             NativeImageBuildItem nativeImage) {
 
-        if (!containerImageConfig.build && !containerImageConfig.push && !buildRequest.isPresent()
-                && !pushRequest.isPresent()) {
+        if (containerImageConfig.isBuildExplicitlyDisabled()) {
+            return;
+        }
+
+        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
+                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
             return;
         }
 

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageConfig.java
@@ -80,13 +80,13 @@ public class ContainerImageConfig {
      * Whether or not a image build will be performed.
      */
     @ConfigItem
-    public boolean build;
+    public Optional<Boolean> build;
 
     /**
      * Whether or not an image push will be performed.
      */
     @ConfigItem
-    public boolean push;
+    public Optional<Boolean> push;
 
     /**
      * The name of the container image extension to use (e.g. docker, jib, s2i).
@@ -94,6 +94,22 @@ public class ContainerImageConfig {
      */
     @ConfigItem
     public Optional<String> builder;
+
+    public boolean isBuildExplicitlyEnabled() {
+        return build.isPresent() && build.get();
+    }
+
+    public boolean isBuildExplicitlyDisabled() {
+        return build.isPresent() && !build.get();
+    }
+
+    public boolean isPushExplicitlyEnabled() {
+        return push.isPresent() && push.get();
+    }
+
+    public boolean isPushExplicitlyDisabled() {
+        return push.isPresent() && !push.get();
+    }
 
     /**
      * Since user.name which is default value can be uppercase and uppercase values are not allowed


### PR DESCRIPTION
The pull request allows the image build to be explicitly disabled when deploying on Kubernetes/Openshift etc.
Currently, if the user tweaks the manifests and triggers a redeployment, the image will also get rebuild, even if the user adds `-Dquarkus.contianer-image.build=false` to the build parameters. 

This pull request addresses that.