### PR TITLE
Better error message when a POM of a deployment artifact could not be resolved

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -338,6 +338,13 @@ public class DeploymentInjectingDependencyVisitor {
             throws BootstrapDependencyProcessingException {
         log.debugf("Injecting deployment dependency %s", extDep.info.deploymentArtifact);
         final DependencyNode deploymentNode = collectDependencies(extDep.info.deploymentArtifact, extDep.exclusions);
+        if (deploymentNode.getChildren().isEmpty()) {
+            throw new BootstrapDependencyProcessingException(
+                    "Failed to collect dependencies of " + deploymentNode.getArtifact()
+                            + ": either its POM could not be resolved from the available Maven repositories "
+                            + "or the artifact does not have any dependencies while at least a dependency on the runtime artifact "
+                            + extDep.info.runtimeArtifact + " is expected");
+        }
 
         if (resolver.getProjectModuleResolver() != null) {
             clearReloadable(deploymentNode);


### PR DESCRIPTION
Currently, it fails with
````
Quarkus extension deployment artifact XXX does not appear to depend on the corresponding runtime artifact YYY
````