### PR TITLE
Don't execute undertow build steps if servlet is not available

### DIFF
--- a/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
+++ b/extensions/undertow/spi/src/main/java/io/quarkus/undertow/deployment/UndertowStaticResourcesBuildStep.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Set;
 
 import io.quarkus.deployment.ApplicationArchive;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -32,8 +34,11 @@ public class UndertowStaticResourcesBuildStep {
     protected static final String META_INF_RESOURCES = "META-INF/resources";
 
     @BuildStep
-    void handleGeneratedWebResources(BuildProducer<GeneratedResourceBuildItem> generatedResources,
+    void handleGeneratedWebResources(Capabilities capabilities, BuildProducer<GeneratedResourceBuildItem> generatedResources,
             List<GeneratedWebResourceBuildItem> generatedWebResources) throws Exception {
+        if (!capabilities.isPresent(Capability.SERVLET)) {
+            return;
+        }
         for (GeneratedWebResourceBuildItem genResource : generatedWebResources) {
             generatedResources.produce(new GeneratedResourceBuildItem(META_INF_RESOURCES_SLASH + genResource.getName(),
                     genResource.getClassData()));
@@ -41,12 +46,14 @@ public class UndertowStaticResourcesBuildStep {
     }
 
     @BuildStep
-    void scanStaticResources(ApplicationArchivesBuildItem applicationArchivesBuildItem,
+    void scanStaticResources(Capabilities capabilities, ApplicationArchivesBuildItem applicationArchivesBuildItem,
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<KnownPathsBuildItem> knownPathsBuilds,
             List<GeneratedWebResourceBuildItem> generatedWebResources,
             LaunchModeBuildItem launchModeBuildItem) throws Exception {
-
+        if (!capabilities.isPresent(Capability.SERVLET)) {
+            return;
+        }
         //we need to check for web resources in order to get welcome files to work
         //this kinda sucks
         Set<String> knownFiles = new HashSet<>();
@@ -108,7 +115,11 @@ public class UndertowStaticResourcesBuildStep {
     }
 
     @BuildStep
-    void nativeImageResources(KnownPathsBuildItem paths, BuildProducer<NativeImageResourceBuildItem> nativeImage) {
+    void nativeImageResources(Capabilities capabilities, KnownPathsBuildItem paths,
+            BuildProducer<NativeImageResourceBuildItem> nativeImage) {
+        if (!capabilities.isPresent(Capability.SERVLET)) {
+            return;
+        }
         for (String i : paths.knownFiles) {
             nativeImage.produce(new NativeImageResourceBuildItem(META_INF_RESOURCES_SLASH + i));
         }


### PR DESCRIPTION
The quarkus-undertow-deployment-spi is a dependency of micrometer and smallry metrics, causing the buildsteps to be executed.
This happens even if no undertow or resteasy-reactive-servlet is present in the project.
Another solution would have been to create a sperate deployment-common module, and move the BuildStep there, but not worth it for only one class imo.

Saves about 10ms of dev mode startup time.

related to #21552