### PR TITLE
Prevent creating a FSWatchUtil thread if there is nothing to watch

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/FSWatchUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/FSWatchUtil.java
@@ -32,6 +32,10 @@ public class FSWatchUtil {
      */
     public void observe(Collection<Watcher> watchers,
             long intervalMs) {
+        if (watchers.isEmpty()) {
+            return;
+        }
+
         ThreadFactory tf = (Runnable r) -> new Thread(r, "FSWatchUtil");
         ExecutorService executorService = Executors.newSingleThreadExecutor(tf);
         executorService.execute(


### PR DESCRIPTION
Currently, the FSWatchUtil is only used to generate code for avro and grpc. Even when their respective extensions are not present in a project, a thread for FileSystem watching is created.

Related to #21552