### PR TITLE
Enhanced character set support for Oracle database

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/ExtendedCharactersSupport.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/ExtendedCharactersSupport.java
@@ -1,0 +1,19 @@
+package io.quarkus.jdbc.oracle.deployment;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.jdbc.oracle.runtime.OracleInitRecorder;
+
+public final class ExtendedCharactersSupport {
+
+    @Record(STATIC_INIT)
+    @BuildStep(onlyIf = NativeBuild.class)
+    public void preinitializeCharacterSets(NativeConfig config, OracleInitRecorder recorder) {
+        recorder.setupCharSets(config.addAllCharsets);
+    }
+
+}

--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -118,4 +118,10 @@ public final class OracleMetadataOverrides {
                 Collections.singleton("oracle/nativeimage/Target_java_io_ObjectStreamClass.class"));
     }
 
+    @BuildStep
+    RemovedResourceBuildItem enhancedCharsetSubstitutions() {
+        return new RemovedResourceBuildItem(GACT.fromString("com.oracle.database.jdbc:ojdbc11"),
+                Collections.singleton("oracle/nativeimage/CharacterSetFeature.class"));
+    }
+
 }

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleInitRecorder.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleInitRecorder.java
@@ -1,0 +1,41 @@
+package io.quarkus.jdbc.oracle.runtime;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.runtime.annotations.Recorder;
+import oracle.sql.CharacterSet;
+
+@Recorder
+public class OracleInitRecorder {
+
+    public void setupCharSets(boolean addAllCharsets) {
+        if (addAllCharsets) {
+            for (short id : reflectivelyReadAllCharacterSetIdentifiers()) {
+                oracle.sql.CharacterSet.make(id);
+            }
+        } else {
+            //By default, support at least the following charsets;
+            //without these, we're unable to connect to an Oracle container image which is using default settings.
+            oracle.sql.CharacterSet.make(CharacterSet.AL32UTF8_CHARSET);
+            oracle.sql.CharacterSet.make(CharacterSet.AL16UTF16_CHARSET);
+        }
+    }
+
+    private List<Short> reflectivelyReadAllCharacterSetIdentifiers() {
+        final Field[] fields = CharacterSet.class.getFields();
+        final ArrayList<Short> collectedIds = new ArrayList<>(fields.length);
+        for (Field field : fields) {
+            if (field.getType() == short.class && field.getName().endsWith("_CHARSET")) {
+                try {
+                    collectedIds.add(field.getShort(null));
+                } catch (IllegalAccessException e) {
+                    //ignore
+                }
+            }
+        }
+        return collectedIds;
+    }
+
+}


### PR DESCRIPTION

This was an interesting one, as I had to guess how to trigger initialization of these charactersets.

Unfortunately no automated integration test included, as it would require a custom Oracle database container and I'm not sure about how to re-distribute these.

Fixes #19712 