### PR TITLE
Revert "Include more info if the gradle build fails"

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -454,7 +454,7 @@ jobs:
           name: "build-reports-Gradle Tests - JDK ${{matrix.java.name}}"
           path: |
             **/build/test-results/test/TEST-*.xml
-            **/target/**
+            **/target/*-reports/TEST-*.xml
             target/build-report.json
             LICENSE.txt
           retention-days: 2


### PR DESCRIPTION
This reverts commit 2fac515a5504b57f978e409817dd1c1534501f0c. (from #20464)

The resulting archive exceeds 400 megs and it appears to me that we don't need all that anymore, but I might be wrong.
Alternatively, we could try to fine tune the pattern instead of merely going back to just test reports.

Draft until the decision has been made.

/cc @glefloch @stuartwdouglas @aloubyansky 