### PR TITLE
Update Flyway to 8.2.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -152,7 +152,7 @@
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.1.1</awaitility.version>
         <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
-        <flyway.version>8.1.0</flyway.version>
+        <flyway.version>8.2.2</flyway.version>
         <yasson.version>1.0.10</yasson.version>
         <liquibase.version>4.6.2</liquibase.version>
         <liquibase-mongodb.version>4.6.2</liquibase-mongodb.version>
@@ -4915,6 +4915,11 @@
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-sqlserver</artifactId>
+                <version>${flyway.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-mysql</artifactId>
                 <version>${flyway.version}</version>
             </dependency>
             <dependency>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>


### PR DESCRIPTION
`flyway-mysql` is now a separate artifact. It requires an addition to the migration guide.