### PR TITLE
Make sure to reset TCCL if initTestState() fails

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -703,9 +703,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             old = setCCL(runningQuarkusApplication.getClassLoader());
         }
 
-        initTestState(extensionContext, state);
-        if (old != null) {
-            setCCL(old);
+        try {
+            initTestState(extensionContext, state);
+        } finally {
+            if (old != null) {
+                setCCL(old);
+            }
         }
         return result;
     }


### PR DESCRIPTION
This fixes a strange test classloading issue I had the other day (order of execution is important!):
- test 1 runs fine:
  ```java
  @QuarkusTest
  public class Config1Test {
  
      @Inject
      // MyConfig is a simple @ConfigMapping
      MyConfig myConfig;
  
      @Test
      void test() {
          assertNotNull(myConfig.property());
      }
  }
  ```
- test 2 fails (as expected):
  ```java
  @QuarkusTest
  public class Config2Test {
  
      // provoke an exception on CreateMockitoMocksCallback.java:107
      // because there is no impl for Connector interface
      @InjectMock
      Connector conn;
  
      @Test
      void test() {
      }
  }
  ```
- test 3 also fails (but shoudn't):
  ```java
  @ExtendWith(MockitoExtension.class)
  public class Config3Test {
  
      @Mock
      MyConfig mock;
  
      @Test
      void test() {
          assertNotNull(mock);
      }
  }
  ```

FTR, the second test fails with:
```
Caused by: java.lang.IllegalStateException: Invalid use of io.quarkus.test.junit.mockito.InjectMock - could not resolve the bean of type: org.acme.Connector. Offending field is conn of test class class org.acme.Config2Test
        at io.quarkus.test.junit.mockito.internal.CreateMockitoMocksCallback.getBeanInstance(CreateMockitoMocksCallback.java:107)
        at io.quarkus.test.junit.mockito.internal.CreateMockitoMocksCallback.afterConstruct(CreateMockitoMocksCallback.java:36)
        ... 71 more
```

Now the actual problem, the third test fails with:
```
[INFO] Running org.acme.Config3Test
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.121 s <<< FAILURE! - in org.acme.Config3Test
[ERROR] org.acme.Config3Test.test  Time elapsed: 0.116 s  <<< ERROR!
org.mockito.exceptions.base.MockitoException:

ClassCastException occurred while creating the mockito mock :
  class to mock : 'org.acme.MyConfig', loaded by classloader : 'jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc'
  created class : 'org.mockito.codegen.MyConfig$MockitoMock$526882129', loaded by classloader : 'QuarkusClassLoader:Quarkus Runtime ClassLoader: TEST restart no:0@63e4484d'
  proxy instance class : 'org.mockito.codegen.MyConfig$MockitoMock$526882129', loaded by classloader : 'QuarkusClassLoader:Quarkus Runtime ClassLoader: TEST restart no:0@63e4484d'
  instance creation by : ObjenesisInstantiator
```
which is clearly a leak issue; that non-QuarkusTest should not be influenced by the previously failed QuarkusTest.

This PR makes sure to reset the previously active TCCL when `initTestState(...)` fails (in which also the `@InjectMock` stuff is called).