### PR TITLE
Explicitly register io.fabric8.kubernetes.client.VersionInfo class for reflection

### DIFF
--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -142,6 +142,8 @@ public class KubernetesClientProcessor {
                 .produce(new ReflectiveClassBuildItem(true, false, "io.fabric8.kubernetes.api.model.IntOrString"));
         reflectiveClasses
                 .produce(new ReflectiveClassBuildItem(true, false, "io.fabric8.kubernetes.internal.KubernetesDeserializer"));
+        reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, true, "io.fabric8.kubernetes.client.VersionInfo"));
 
         if (log.isDebugEnabled()) {
             final String watchedClassNames = watchedClasses

--- a/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Version.java
+++ b/integration-tests/kubernetes-client/src/main/java/io/quarkus/it/kubernetes/client/Version.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.kubernetes.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@Path("/version")
+public class Version {
+
+    private final KubernetesClient kubernetesClient;
+
+    public Version(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    @GET
+    public Response version() {
+        return Response.ok(kubernetesClient.getKubernetesVersion().getPlatform()).build();
+    }
+}

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -48,6 +48,9 @@ public class KubernetesClientTest {
 
         RestAssured.when().post("/pod/test").then()
                 .body(containsString("54321"));
+
+        RestAssured.when().get("/version").then()
+                .statusCode(200);
     }
 
     @Test


### PR DESCRIPTION
Fix #22367 

methods are needed to be registered because the class is not decorated with `@JsonProperty`.