### PR TITLE
Bump jquery from 3.5.1 to 3.6.0 and use maven managed versions in webjars tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -143,6 +143,12 @@ updates:
       - dependency-name: org.eclipse.microprofile.openapi:microprofile-openapi-tck
       - dependency-name: org.eclipse.microprofile.opentracing:microprofile-opentracing-tck*
       - dependency-name: org.eclipse.microprofile.rest.client:microprofile-rest-client-tck
+      # Dev UI web dependencies
+      - dependency-name: org.webjars:bootstrap
+      - dependency-name: org.webjars:font-awesome
+      - dependency-name: org.webjars:jquery
+      - dependency-name: org.webjars:codemirror
+      - dependency-name: org.webjars.npm:mermaid
       # Others
       - dependency-name: com.puppycrawl.tools:checkstyle
       - dependency-name: com.google.cloud.functions:*
@@ -160,7 +166,6 @@ updates:
       - dependency-name: org.jboss.modules:jboss-modules
       - dependency-name: com.unboundid:unboundid-ldapsdk
       - dependency-name: org.commonmark:commonmark
-      - dependency-name: org.webjars:*
       - dependency-name: org.asciidoctor:asciidoctorj
       - dependency-name: com.github.javaparser:javaparser-core
       - dependency-name: org.jboss.jdeparser:jdeparser

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -111,7 +111,7 @@
         <!-- Webjars -->
         <webjar.bootstrap.version>4.6.0</webjar.bootstrap.version>
         <webjar.font-awesome.version>5.15.2</webjar.font-awesome.version>
-        <webjar.jquery.version>3.5.1</webjar.jquery.version>
+        <webjar.jquery.version>3.6.0</webjar.jquery.version>
         <webjar.codemirror.version>5.62.2</webjar.codemirror.version>
         <webjar.mermaid.version>8.9.1</webjar.mermaid.version>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -108,11 +108,12 @@
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
 
-        <!-- Webjars -->
+        <!-- Webjars used by the Dev UI -->
         <webjar.bootstrap.version>4.6.0</webjar.bootstrap.version>
         <webjar.font-awesome.version>5.15.2</webjar.font-awesome.version>
         <webjar.jquery.version>3.6.0</webjar.jquery.version>
         <webjar.codemirror.version>5.62.2</webjar.codemirror.version>
+        <!-- we don't add mermaid as a dependency as it brings a ton of things we don't use -->
         <webjar.mermaid.version>8.9.1</webjar.mermaid.version>
 
         <!-- revapi API check -->

--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
+        <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
     </properties>
 
     <dependencies>
@@ -45,19 +46,19 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- Using setForcedDependencies only works if the dependency is in the pom's test scope. -->
         <dependency>
-          <groupId>org.webjars</groupId>
-          <artifactId>jquery</artifactId>
-          <version>${webjar.jquery.version}</version>
-          <scope>test</scope>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery-ui</artifactId>
+            <version>${webjar.jquery-ui.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.webjars</groupId>
-          <artifactId>momentjs</artifactId>
-          <version>${webjar.momentjs.version}</version>
-          <scope>test</scope>
+            <groupId>org.webjars</groupId>
+            <artifactId>momentjs</artifactId>
+            <version>${webjar.momentjs.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.dc-js</groupId>
@@ -66,9 +67,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-resteasy-deployment</artifactId>
-          <scope>test</scope>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -90,7 +91,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <webjar.jquery.version>${webjar.jquery.version}</webjar.jquery.version>
+                        <webjar.jquery-ui.version>${webjar.jquery-ui.version}</webjar.jquery-ui.version>
                         <webjar.momentjs.version>${webjar.momentjs.version}</webjar.momentjs.version>
                     </systemPropertyVariables>
                 </configuration>

--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>quarkus-webjars-locator-deployment</artifactId>
     <name>Quarkus - WebJar Locator - Deployment</name>
 
+    <properties>
+        <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.webjars</groupId>
@@ -52,7 +56,7 @@
         <dependency>
           <groupId>org.webjars</groupId>
           <artifactId>momentjs</artifactId>
-          <version>2.24.0</version>
+          <version>${webjar.momentjs.version}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,6 +84,15 @@
                             <version>${project.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <webjar.jquery.version>${webjar.jquery.version}</webjar.jquery.version>
+                        <webjar.momentjs.version>${webjar.momentjs.version}</webjar.momentjs.version>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-public class WebJarLocatorDevModeTest {
+public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
     private static final String META_INF_RESOURCES = "META-INF/resources/";
 
     @RegisterExtension
@@ -48,9 +48,9 @@ public class WebJarLocatorDevModeTest {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/3.5.1/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
                 .statusCode(200);
-        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+        RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar
@@ -95,9 +95,9 @@ public class WebJarLocatorDevModeTest {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/3.5.1/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
                 .statusCode(200);
-        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+        RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorDevModeTest.java
@@ -42,13 +42,13 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
                 .body(is("Test"));
 
         // Test Existing Web Jars
-        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);
@@ -95,7 +95,7 @@ public class WebJarLocatorDevModeTest extends WebJarLocatorTestSupport {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -12,7 +12,7 @@ import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class WebJarLocatorTest {
+public class WebJarLocatorTest extends WebJarLocatorTestSupport {
     private static final String META_INF_RESOURCES = "META-INF/resources/";
 
     @RegisterExtension
@@ -20,8 +20,8 @@ public class WebJarLocatorTest {
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
                     .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
-            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery", "3.5.1"),
-                    new AppArtifact("org.webjars", "momentjs", "2.24.0")));
+            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery", JQUERY_VERSION),
+                    new AppArtifact("org.webjars", "momentjs", MOMENTJS_VERSION)));
 
     @Test
     public void test() {
@@ -45,9 +45,9 @@ public class WebJarLocatorTest {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/3.5.1/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
                 .statusCode(200);
-        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+        RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -20,7 +20,7 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
                     .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
-            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery", JQUERY_VERSION),
+            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
                     new AppArtifact("org.webjars", "momentjs", MOMENTJS_VERSION)));
 
     @Test
@@ -39,13 +39,13 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
                 .body(is("Test"));
 
         // Test Existing Web Jars
-        RestAssured.get("/webjars/jquery/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
@@ -1,0 +1,7 @@
+package io.quarkus.webjar.locator.test;
+
+class WebJarLocatorTestSupport {
+
+    static final String JQUERY_VERSION = System.getProperty("webjar.jquery.version");
+    static final String MOMENTJS_VERSION = System.getProperty("webjar.momentjs.version");
+}

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTestSupport.java
@@ -2,6 +2,6 @@ package io.quarkus.webjar.locator.test;
 
 class WebJarLocatorTestSupport {
 
-    static final String JQUERY_VERSION = System.getProperty("webjar.jquery.version");
+    static final String JQUERY_UI_VERSION = System.getProperty("webjar.jquery-ui.version");
     static final String MOMENTJS_VERSION = System.getProperty("webjar.momentjs.version");
 }

--- a/integration-tests/webjars-locator/pom.xml
+++ b/integration-tests/webjars-locator/pom.xml
@@ -13,7 +13,10 @@
     <artifactId>quarkus-integration-test-webjars-locator</artifactId>
 
     <name>Quarkus - Integration Tests - WebJar Locator</name>
-    
+
+    <properties>
+        <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -32,7 +35,7 @@
         <dependency>
           <groupId>org.webjars</groupId>
           <artifactId>momentjs</artifactId>
-          <version>2.24.0</version>
+          <version>${webjar.momentjs.version}</version>
         </dependency>
 
         <dependency>
@@ -87,6 +90,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <webjar.jquery.version>${webjar.jquery.version}</webjar.jquery.version>
+                        <webjar.momentjs.version>${webjar.momentjs.version}</webjar.momentjs.version>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/webjars-locator/pom.xml
+++ b/integration-tests/webjars-locator/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
+        <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
     </properties>
 
     <dependencies>
@@ -29,8 +30,8 @@
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>${webjar.jquery.version}</version>
+            <artifactId>jquery-ui</artifactId>
+            <version>${webjar.jquery-ui.version}</version>
         </dependency>
         <dependency>
           <groupId>org.webjars</groupId>
@@ -95,7 +96,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <webjar.jquery.version>${webjar.jquery.version}</webjar.jquery.version>
+                        <webjar.jquery-ui.version>${webjar.jquery-ui.version}</webjar.jquery-ui.version>
                         <webjar.momentjs.version>${webjar.momentjs.version}</webjar.momentjs.version>
                     </systemPropertyVariables>
                 </configuration>

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
@@ -8,6 +8,9 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class WebJarResourceTest {
 
+    private static final String JQUERY_VERSION = System.getProperty("webjar.jquery.version");
+    private static final String MOMENTJS_VERSION = System.getProperty("webjar.momentjs.version");
+
     @Test
     void testWebJar() {
         // Test Existing Web Jars
@@ -17,9 +20,9 @@ public class WebJarResourceTest {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/3.5.1/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
                 .statusCode(200);
-        RestAssured.get("/webjars/momentjs/2.24.0/min/moment.min.js").then()
+        RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);
 
         // Test non-existing Web Jar

--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceTest.java
@@ -8,7 +8,7 @@ import io.restassured.RestAssured;
 @QuarkusTest
 public class WebJarResourceTest {
 
-    private static final String JQUERY_VERSION = System.getProperty("webjar.jquery.version");
+    private static final String JQUERY_UI_VERSION = System.getProperty("webjar.jquery-ui.version");
     private static final String MOMENTJS_VERSION = System.getProperty("webjar.momentjs.version");
 
     @Test
@@ -20,7 +20,7 @@ public class WebJarResourceTest {
                 .statusCode(200);
 
         // Test using version in url of existing Web Jar
-        RestAssured.get("/webjars/jquery/" + JQUERY_VERSION + "/jquery.min.js").then()
+        RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
                 .statusCode(200);
         RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
                 .statusCode(200);


### PR DESCRIPTION
Follows up on #22372.