### PR TITLE
Fall back to compiled parameter names for spring data repository `@Query`

### DIFF
--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -581,6 +581,8 @@ public interface MovieRepository extends CrudRepository<Movie, Long> {
 ----
 All methods that are annotated with `@Modifying` will automatically be annotated with `@Transactional`.
 
+TIP: In Quarkus, `@Param` is optional when parameter names have been compiled to bytecode (which is active by default in generated projects).
+
 ==== Naming Strategies
 
 Hibernate ORM maps property names using a physical naming strategy and an implicit naming strategy. If you wish to use Spring Boot's default naming strategies, the following properties need to be set:

--- a/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
+++ b/extensions/spring-data-jpa/deployment/src/test/java/io/quarkus/spring/data/deployment/UserRepository.java
@@ -23,7 +23,9 @@ public interface UserRepository extends JpaRepository<User, String> {
     @Query("UPDATE LoginEvent e SET e.processed = true")
     void processLoginEventsPlainAutoClearAndFlush();
 
-    User getUserByFullNameUsingNamedQuery(@Param("name") String name);
+    // purposely without @Param to also test fallback to compiled parameter name
+    User getUserByFullNameUsingNamedQuery(String name);
 
-    User getUserByFullNameUsingNamedQueries(@Param("name") String name);
+    // purposely with compiled parameter name not matching the query to also test that @Param takes precedence
+    User getUserByFullNameUsingNamedQueries(@Param("name") String arg);
 }


### PR DESCRIPTION
This PR leverages compilation of parameter names to bytecode (if active), so that you don't need to use `@Param`.

I also ran the deployments tests with `-Dmaven.compiler.parameters=false` and as expected the following test (and only that one!) failed with:
```
getUserByFullNameUsingNamedQuery of Repository io.quarkus.spring.data.deployment.UserRepository is missing the named parameters [name], provided are []. Ensure that the parameters are correctly annotated with @Param.
```