### PR TITLE
Mark DevMojo as threadSafe

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -105,7 +105,7 @@ import io.quarkus.runtime.LaunchMode;
  * <p>
  * You can use this dev mode in a remote container environment with {@code remote-dev}.
  */
-@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class DevMojo extends AbstractMojo {
 
     private static final String EXT_PROPERTIES_PATH = "META-INF/quarkus-extension.properties";


### PR DESCRIPTION
https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/dev.20goal.20threadSafe.3F

My initial motivation was to get rid of the Maven warning we now have in my current multi-module project because of `-T0.5C` in `.mvn/maven.config` (something that Maven shouldn't even warn about, as we are using `mvn -f ...` so we are only building a single module).
But I can now see actual use cases, e.g. a git repo with multiple services or a kind of modular monolith.

As written on Zulip, you can only control via keyboard the instance that booted up last, but this is not a showstopper, IMO.