### PR TITLE
AWT - resource files lookup: Replaces MethodHandles.lookup()

### DIFF
--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
@@ -1,7 +1,6 @@
 package io.quarkus.awt.runtime;
 
 import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
 import java.util.PropertyResourceBundle;
 
 import com.oracle.svm.core.annotate.Substitute;
@@ -17,12 +16,10 @@ final class Target_com_sun_imageio_plugins_common_I18NImpl {
 
     @Substitute
     private static String getString(String className, String resource_name, String key) {
-        // The property file is now stored in the root of the tree
-        resource_name = "/" + resource_name;
         PropertyResourceBundle bundle = null;
         try {
             // className ignored, there is only one such file in the imageio anyway
-            InputStream stream = MethodHandles.lookup().lookupClass().getResourceAsStream(resource_name);
+            InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource_name);
             bundle = new PropertyResourceBundle(stream);
         } catch (Throwable e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Fixes #22097

The previously used method of reading the property file baked in the native image
executable is no longer valid in Graal (Mandrel) 22+. It seems that the
method this commit uses is what both major versions have still in common:

| Method       |22.1.0-dev Java 11| 21.3.0.0 Java 11 |
|--------------|:----------------:|-----------------:|
| MethodHandles.lookup().lookupClass().getResourceAsStream(R)                       | :x:                | :x:                |
| MethodHandles.lookup().lookupClass().getResourceAsStream(S_R)                     | :x:                | :heavy_check_mark: |
| Class.forName("com.sun.imageio.plugins.common.I18NImpl").getResourceAsStream(R)   | :x:                | :x:                |
| Class.forName("com.sun.imageio.plugins.common.I18NImpl").getResourceAsStream(S_R) | :x:                | :heavy_check_mark: |
| Class.forName("com.sun.imageio.plugins.common.I18N").getResourceAsStream(R)       | :x:                | :x:                |
| Class.forName("com.sun.imageio.plugins.common.I18N").getResourceAsStream(S_R)     | :x:                | :heavy_check_mark: |
| Thread.currentThread().getContextClassLoader().getResourceAsStream(R)             | :heavy_check_mark: | :heavy_check_mark: |
| Thread.currentThread().getContextClassLoader().getResourceAsStream(S_R)           | :x:                | :x:                |

Legend: `R = "iio-plugin.properties"` and `S_R = "/iio-plugin.properties"`