### PR TITLE
Use Keycloak-X by default in DevServices for Keycloak

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -172,7 +172,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>15.0.2</keycloak.version>
+        <keycloak.version>16.0.0</keycloak.version>
         <logstash-gelf.version>1.14.1</logstash-gelf.version>
         <checker-qual.version>3.21.0</checker-qual.version>
         <error-prone-annotations.version>2.10.0</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.docker.image>quay.io/keycloak/keycloak:15.0.2</keycloak.docker.image>
+        <keycloak.docker.image>quay.io/keycloak/keycloak:16.0.0</keycloak.docker.image>
 
         <unboundid-ldap.version>6.0.3</unboundid-ldap.version>
 

--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -182,8 +182,8 @@ Please see xref:security-openid-connect.adoc#integration-testing-keycloak-devser
 [[keycloak-initialization]]
 === Keycloak Initialization
 
-The `quay.io/keycloak/keycloak:15.0.2` image which contains a `Keycloak` distribution powered by `WildFly` is currently used to start a container by default.
-`quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak-x:15.0.2` to use a `Keycloak-X` distribution powered by `Quarkus`. `Dev Services for Keycloak` will use a Keycloak-X based image by default soon.
+The `quay.io/keycloak/keycloak-x:16.0.0` image which contains a `Keycloak-X` distribution powered by `Quarkus` is used to start a container by default.
+`quarkus.keycloak.devservices.image-name` can be used to change the Keycloak image name. For example, set it to `quay.io/keycloak/keycloak:16.0.0` to use a `Keycloak` distribution powered by `WildFly`.
 
 `Dev Services for Keycloak` will initialize a launched Keycloak server next.
 
@@ -202,8 +202,6 @@ Also the Keycloak page offers an option to `Sign In To Keycloak To Configure Rea
 image::dev-ui-keycloak-admin.png[alt=Dev UI OpenId Connect Keycloak Page - Keycloak Admin,role="center"]
 
 Sign in to Keycloak as `admin:admin` in order to further customize the realm properties, create or import a new realm, export the realm.
-
-Note that at the moment, if you use a `Keycloak-X` image then auto-importing a custom realm file does not work - for now use a `Keycloak Admin` Dev UI option to import a custom realm if required. In this case you may also want to set `quarkus.keycloak.devservices.create-realm=false` for `Dev Services for Keycloak` to avoid creating a default realm.
 
 Note that even if you initialize Keycloak from a realm file, it is still needed to set `quarkus.keycloak.devservices.users` property if a `password` grant is used to acquire the tokens to test the OIDC `service` applications.
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -25,16 +25,16 @@ public class DevServicesConfig {
     /**
      * The container image name to use, for container based DevServices providers.
      *
-     * Image with a WildFly based Keycloak distribution is used by default.
-     * Image with a Quarkus based Keycloak-X distribution can be selected instead, for example:
-     * 'quay.io/keycloak/keycloak-x:15.0.2'.
+     * Image with a Quarkus based Keycloak-X distribution is used by default.
+     * Image with a WildFly based Keycloak distribution can be selected instead, for example:
+     * 'quay.io/keycloak/keycloak:16.0.0'.
      * <p>
      * Note Keycloak-X and Keycloak images are initialized differently.
      * By default, Dev Services for Keycloak will assume it is a Keycloak-X image if the image name contains a 'keycloak-x'
      * string.
      * Set 'quarkus.devservices.keycloak.keycloak-x-image' to override this check.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:15.0.2")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak-x:16.0.0")
     public String imageName;
 
     /**


### PR DESCRIPTION
This PR makes `Keycloak 16.0.0` a default image for Dev Services for Keycloak; The changes to `KeycloakDevServicesProcessor` are all about using `RealmRepresentation` - at the moment it is the only way to import the realm into Keycloak-X at startup - but I've also found it helped to remove a few extra flags which were passed around.
