### PR TITLE
Do not use a moving target webjar for tests

### DIFF
--- a/extensions/webjars-locator/deployment/pom.xml
+++ b/extensions/webjars-locator/deployment/pom.xml
@@ -13,6 +13,7 @@
     <name>Quarkus - WebJar Locator - Deployment</name>
 
     <properties>
+        <!-- do not update these dependencies, they are only used for testing -->
         <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
         <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
     </properties>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -18,6 +18,9 @@
         <datasource.url>jdbc:h2:tcp://localhost/mem:test</datasource.url>
         <datasource.username></datasource.username>
         <datasource.password></datasource.password>
+
+        <!-- do not update this dependency, it is only used for testing -->
+        <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
     </properties>
 
     <dependencies>
@@ -162,8 +165,8 @@
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
-            <artifactId>bootstrap</artifactId>
-            <version>${webjar.bootstrap.version}</version>
+            <artifactId>jquery-ui</artifactId>
+            <version>${webjar.jquery-ui.version}</version>
         </dependency>
         <!-- Issue 2707: used to test if web-fragments.xml is being read properly -->
         <dependency>

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ServletTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ServletTestCase.java
@@ -62,7 +62,7 @@ public class ServletTestCase {
     @Test
     public void testWebjars() {
         RestAssured
-                .when().get("webjars/bootstrap/4.6.0/css/bootstrap.min.css").then()
+                .when().get("webjars/jquery-ui/1.13.0/jquery-ui.min.js").then()
                 .statusCode(200);
     }
 }

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/DevMojoIT.java
@@ -203,7 +203,7 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
         assertThat(profile).isEqualTo("dev");
 
         //make sure webjars work
-        DevModeTestUtils.getHttpResponse("webjars/bootstrap/4.6.0/css/bootstrap.min.css");
+        DevModeTestUtils.getHttpResponse("webjars/jquery-ui/1.13.0/jquery-ui.min.js");
 
         assertThatOutputWorksCorrectly(running.log());
 

--- a/integration-tests/maven/src/test/resources/projects/classic-inst/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-inst/pom.xml
@@ -41,11 +41,6 @@
       <artifactId>quarkus-websockets</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>${webjar.bootstrap.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>

--- a/integration-tests/maven/src/test/resources/projects/classic-no-build/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-no-build/pom.xml
@@ -37,11 +37,6 @@
       <artifactId>quarkus-websockets</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>${webjar.bootstrap.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>

--- a/integration-tests/maven/src/test/resources/projects/classic-noconfig/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-noconfig/pom.xml
@@ -41,11 +41,6 @@
       <artifactId>quarkus-logging-json</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>${webjar.bootstrap.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>

--- a/integration-tests/maven/src/test/resources/projects/classic-remote-dev/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic-remote-dev/pom.xml
@@ -37,11 +37,6 @@
       <artifactId>quarkus-websockets</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>${webjar.bootstrap.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>

--- a/integration-tests/maven/src/test/resources/projects/classic/pom.xml
+++ b/integration-tests/maven/src/test/resources/projects/classic/pom.xml
@@ -13,6 +13,9 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
+
+    <!-- do not update this dependency, it needs to be stable for testing -->
+    <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -42,8 +45,8 @@
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>${webjar.bootstrap.version}</version>
+      <artifactId>jquery-ui</artifactId>
+      <version>${webjar.jquery-ui.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/integration-tests/webjars-locator/pom.xml
+++ b/integration-tests/webjars-locator/pom.xml
@@ -15,6 +15,7 @@
     <name>Quarkus - Integration Tests - WebJar Locator</name>
 
     <properties>
+        <!-- do not update these dependencies, they are only used for testing -->
         <webjar.momentjs.version>2.24.0</webjar.momentjs.version>
         <webjar.jquery-ui.version>1.13.0</webjar.jquery-ui.version>
     </properties>


### PR DESCRIPTION
The idea is to avoid breaking the tests when upgrading Bootstrap.

@famod I was a bit shy of pushing the version to the tests as the infra here is a bit more cumbersome and I don't think it's really worth it given the idea is to keep the version static.