### PR TITLE
Fix log capturing for instances of Logger in QuarkusMainTests

### DIFF
--- a/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/WithMethodSubCommand.java
+++ b/integration-tests/picocli-native/src/main/java/io/quarkus/it/picocli/WithMethodSubCommand.java
@@ -1,13 +1,22 @@
 package io.quarkus.it.picocli;
 
+import org.jboss.logging.Logger;
+
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "with-method-sub-command")
 public class WithMethodSubCommand {
 
+    private final static Logger LOGGER = Logger.getLogger(WithMethodSubCommand.class);
+
     @CommandLine.Command
     void hello(@CommandLine.Option(names = { "-n", "--names" }, description = "Parameter option") String name) {
         System.out.println("Hello " + name);
+    }
+
+    @CommandLine.Command
+    void loggingHello(@CommandLine.Option(names = { "-n", "--names" }, description = "Parameter option") String name) {
+        LOGGER.error("Hello " + name);
     }
 
     @CommandLine.Command

--- a/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
+++ b/integration-tests/picocli-native/src/test/java/io/quarkus/it/picocli/PicocliTest.java
@@ -36,11 +36,21 @@ public class PicocliTest {
     }
 
     @Test
-    public void testLogCapturing(QuarkusMainLauncher launcher) {
+    public void testExcludeLogCapturing(QuarkusMainLauncher launcher) {
         org.jboss.logging.Logger.getLogger("test").error("error");
         LaunchResult result = launcher.launch("with-method-sub-command", "hello", "-n", "World!");
         assertThat(result.exitCode()).isZero();
         assertThat(result.getOutput()).isEqualTo("Hello World!");
+    }
+
+    @Test
+    public void testIncludeLogCommand(QuarkusMainLauncher launcher) {
+        org.jboss.logging.Logger.getLogger("test").error("error");
+        LaunchResult result = launcher.launch("with-method-sub-command", "loggingHello", "-n", "World!");
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.getOutput()).contains("ERROR [io.qua.it.pic.WithMethodSubCommand] (main) Hello World!");
+        assertThat(result.getOutputStream().size()).isEqualTo(1);
+        assertThat(result.getOutput()).doesNotContain("ERROR [test] (main) error");
     }
 
     @Test

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -4,13 +4,12 @@ import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.getAdditionalTestResources;
 
 import java.io.Closeable;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Handler;
 
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.handlers.OutputStreamHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -23,6 +22,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 
 import io.quarkus.bootstrap.app.StartupAction;
 import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.deployment.dev.testing.LogCapturingOutputFilter;
 import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.dev.testing.TracingHandler;
@@ -130,6 +130,54 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         result = null;
     }
 
+    private static Handler ORIGINAL_QUARKUS_CONSOLE_HANDLER = null;
+    private static Handler REDIRECT_QUARKUS_CONSOLE_HANDLER = null;
+
+    private static void installLoggerRedirect() throws Exception {
+        var rootLogger = LogContext.getLogContext().getLogger("");
+
+        ORIGINAL_QUARKUS_CONSOLE_HANDLER = null;
+        REDIRECT_QUARKUS_CONSOLE_HANDLER = null;
+
+        for (var topLevelHandler : rootLogger.getHandlers()) {
+            if (topLevelHandler instanceof QuarkusDelayedHandler) {
+                ORIGINAL_QUARKUS_CONSOLE_HANDLER = topLevelHandler;
+                for (var h : ((QuarkusDelayedHandler) topLevelHandler).getHandlers()) {
+                    if (h instanceof org.jboss.logmanager.handlers.ConsoleHandler) {
+                        REDIRECT_QUARKUS_CONSOLE_HANDLER = new OutputStreamHandler(QuarkusConsole.REDIRECT_OUT,
+                                h.getFormatter());
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+
+        if (REDIRECT_QUARKUS_CONSOLE_HANDLER != null) {
+            rootLogger.removeHandler(ORIGINAL_QUARKUS_CONSOLE_HANDLER);
+            rootLogger.addHandler(REDIRECT_QUARKUS_CONSOLE_HANDLER);
+        }
+    }
+
+    private static void uninstallLoggerRedirect() throws Exception {
+        var rootLogger = LogContext.getLogContext().getLogger("");
+        if (REDIRECT_QUARKUS_CONSOLE_HANDLER != null) {
+            rootLogger.addHandler(ORIGINAL_QUARKUS_CONSOLE_HANDLER);
+            rootLogger.removeHandler(REDIRECT_QUARKUS_CONSOLE_HANDLER);
+        }
+    }
+
+    private void flushAllLoggers() {
+        Enumeration<String> loggerNames = org.jboss.logmanager.LogContext.getLogContext().getLoggerNames();
+        while (loggerNames != null && loggerNames.hasMoreElements()) {
+            String loggerName = loggerNames.nextElement();
+            var logger = org.jboss.logmanager.LogContext.getLogContext().getLogger(loggerName);
+            for (Handler h : logger.getHandlers()) {
+                h.flush();
+            }
+        }
+    }
+
     private int doJavaStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile, String[] arguments)
             throws Exception {
         TracingHandler.quarkusStarting();
@@ -138,6 +186,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             StartupAction startupAction = prepareResult.augmentAction.createInitialRuntimeApplication();
             Thread.currentThread().setContextClassLoader(startupAction.getClassLoader());
             QuarkusConsole.installRedirects();
+            flushAllLoggers();
+            installLoggerRedirect();
 
             QuarkusTestProfile profileInstance = prepareResult.profileInstance;
 
@@ -157,7 +207,9 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             hasPerTestResources = (boolean) testResourceManager.getClass().getMethod("hasPerTestResources")
                     .invoke(testResourceManager);
 
-            return startupAction.runMainClassBlocking(arguments);
+            var result = startupAction.runMainClassBlocking(arguments);
+            flushAllLoggers();
+            return result;
         } catch (Throwable e) {
             if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
                 activateLogging();
@@ -172,6 +224,7 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
             }
             throw e;
         } finally {
+            uninstallLoggerRedirect();
             QuarkusConsole.uninstallRedirects();
             if (originalCl != null) {
                 Thread.currentThread().setContextClassLoader(originalCl);


### PR DESCRIPTION
This is a problem that we found still present after the previous fix #22302 .

I can confirm that, with this fix we can remove the last workaround around the log capturing mechanism here (tested locally):
https://github.com/keycloak/keycloak/pull/9282/files#diff-aa081e5f62b9bbde53e18c058aae57608573561e504dedd279b1737badba3f64R77

cc. @pedroigor 