### PR TITLE
Fix Jaxb build issue with Apache Camel on Windows 

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.jaxb.deployment;
 
-import java.io.File;
 import java.io.IOError;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -336,7 +335,7 @@ class JaxbProcessor {
         try {
             String path = p.toAbsolutePath().toString().substring(1);
             String pkg = p.toAbsolutePath().getParent().toString().substring(1)
-                    .replace(File.separator, ".") + ".";
+                    .replace(p.getFileSystem().getSeparator(), ".") + ".";
 
             resource.produce(new NativeImageResourceBuildItem(path));
 


### PR DESCRIPTION
Fixes: #22395 

The replace char in jaxb extension was `/`, and changed to `File.separator` in PR #13408. In fact, the paths of `jaxb.index` files are based on the file system provided by the archive file (`ZipFileSystem`), not real OS file system. That's why `File.separator` will fail on Windows.

Although  the method `getSeparator()` of `ZipFileSystem` always returns `/`,  it's better to avoid hard-coding the separator, so the value obtained from `Path.getFileSystem().getSeparator()` is used. 