### PR TITLE
Update the Elasticsearch low level client to 7.16.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -151,6 +151,9 @@ updates:
       - dependency-name: org.webjars:jquery
       - dependency-name: org.webjars:codemirror
       - dependency-name: org.webjars.npm:mermaid
+      # Elasticsearch - we do not update the high level client
+      - dependency-name: org.elasticsearch.client:elasticsearch-rest-client
+      - dependency-name: org.elasticsearch.client:elasticsearch-rest-client-sniffer
       # Others
       - dependency-name: com.puppycrawl.tools:checkstyle
       - dependency-name: com.google.cloud.functions:*

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -101,7 +101,7 @@
         <elasticsearch-rest-client.version>7.16.2</elasticsearch-rest-client.version>
         <elasticsearch-opensource-components.version>${elasticsearch-rest-client.version}</elasticsearch-opensource-components.version>
         <!-- for the now proprietary components of Elasticsearch, we use the last Open Source version -->
-        <elasticsearch-proprietary-components-keeping-old-opensource-version.version>7.10.0</elasticsearch-proprietary-components-keeping-old-opensource-version.version>
+        <elasticsearch-proprietary-components-keeping-old-opensource-version.version>7.10.2</elasticsearch-proprietary-components-keeping-old-opensource-version.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.2.1.Final</jboss-logging-annotations.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -98,7 +98,10 @@
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.14</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
-        <elasticsearch-rest-client.version>7.10.0</elasticsearch-rest-client.version>
+        <elasticsearch-rest-client.version>7.16.2</elasticsearch-rest-client.version>
+        <elasticsearch-opensource-components.version>${elasticsearch-rest-client.version}</elasticsearch-opensource-components.version>
+        <!-- for the now proprietary components of Elasticsearch, we use the last Open Source version -->
+        <elasticsearch-proprietary-components-keeping-old-opensource-version.version>7.10.0</elasticsearch-proprietary-components-keeping-old-opensource-version.version>
         <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.2.1.Final</jboss-logging-annotations.version>
@@ -4409,12 +4412,12 @@
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client</artifactId>
-                <version>${elasticsearch-rest-client.version}</version>
+                <version>${elasticsearch-opensource-components.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-high-level-client</artifactId>
-                <version>${elasticsearch-rest-client.version}</version>
+                <version>${elasticsearch-proprietary-components-keeping-old-opensource-version.version}</version>
                 <exclusions>
                     <!-- exclude log4j2 to get its version from log4j2-jboss-logmanager -->
                     <exclusion>
@@ -4426,7 +4429,7 @@
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client-sniffer</artifactId>
-                <version>${elasticsearch-rest-client.version}</version>
+                <version>${elasticsearch-opensource-components.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -5,7 +5,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Connecting to an Elasticsearch cluster
 include::./attributes.adoc[]
-:extension-status: preview
 
 Elasticsearch is a well known full text search engine and NoSQL datastore.
 
@@ -343,7 +342,24 @@ Quarkus provides support for the Elasticsearch High Level REST Client but keep i
 - It drags a lot of dependencies - especially Lucene -, which doesn't fit well with Quarkus philosophy. The Elasticsearch team is aware of this issue and it might improve sometime in the future.
 - It is tied to a certain version of the Elasticsearch server: you cannot use a High Level REST Client version 7 to access a server version 6.
 
-include::./status-include.adoc[]
+[WARNING]
+====
+Due to the license change made by Elastic for the Elasticsearch High Level REST Client,
+we are keeping in Quarkus the last Open Source version of this particular client, namely 7.10,
+and it won't be upgraded to newer versions.
+
+Given this client was deprecated by Elastic and replaced by a new Open Source Java client,
+the Elasticsearch High Level REST Client extension is considered deprecated and will be removed from the Quarkus codebase at some point in the future.
+
+Note that contrary to the High Level REST client, we are using the latest version of the Low Level REST client (which is still Open Source),
+and, while we believe it should work, the situation is less than ideal and might cause some issues.
+Feel free to override the versions of the clients in your applications depending on your requirements,
+but be aware of https://www.elastic.co/blog/elastic-license-v2[the new licence of the High Level REST Client] for versions 7.11+:
+it is not Open Source and has several usage restrictions.
+
+We will eventually provide an extension for the new Open Source Java client but it will require changes in your applications
+as it is an entirely new client.
+====
 
 Here is a version of the `FruitService` using the high level client instead of the low level one:
 

--- a/extensions/elasticsearch-rest-high-level-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/elasticsearch-rest-high-level-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,6 +9,6 @@ metadata:
   guide: "https://quarkus.io/guides/elasticsearch"
   categories:
   - "data"
-  status: "preview"
+  status: "deprecated"
   config:
   - "quarkus.elasticsearch."


### PR DESCRIPTION
We only upgrade the low level client and we keep the high level client
in version 7.10.0 due to licensing issues affecting this particular
client.