### PR TITLE
Fix recommended Maven version for 2.2

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -54,7 +54,7 @@
         <!--
         Supported Maven versions, interpreted as a version range
          -->
-        <supported-maven-versions>[3.6.2,)</supported-maven-versions>
+        <supported-maven-versions>[3.8.1,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
         <proposed-maven-version>3.8.1</proposed-maven-version>


### PR DESCRIPTION
Quarkus 2.2 requires Maven 3.8.1+.
Fixes #22472