### PR TITLE
Remove unsafe cast to mutable extension catalog

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -155,8 +155,9 @@ public class ToolsUtils {
                         final OriginPreference originPreference = new OriginPreference(1, 1, 1, ++memberIndex, 1);
                         Map<String, Object> metadata = new HashMap<>(memberCatalog.getMetadata());
                         metadata.put("origin-preference", originPreference);
-                        ((ExtensionCatalog.Mutable) memberCatalog).setMetadata(metadata);
-                        catalogs.add(memberCatalog);
+                        ExtensionCatalog.Mutable mutableMemberCatalog = memberCatalog.mutable();
+                        mutableMemberCatalog.setMetadata(metadata);
+                        catalogs.add(mutableMemberCatalog.build());
                     }
                     catalog = CatalogMergeUtility.merge(catalogs);
                 }


### PR DESCRIPTION
This makes sure the catalog is mutable by explicitly converting it. 

close #22498 
close #22496