### PR TITLE
Upgrade quarkus-fs-util to 0.0.7 to avoid UOE

### DIFF
--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -55,7 +55,7 @@
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <smallrye-common.version>1.8.0</smallrye-common.version>
         <gradle-tooling.version>7.3.3</gradle-tooling.version>
-        <quarkus-fs-util.version>0.0.5</quarkus-fs-util.version>
+        <quarkus-fs-util.version>0.0.7</quarkus-fs-util.version>
     </properties>
     <modules>
         <module>bom</module>


### PR DESCRIPTION
While the CI appears to be passing currently, building `main` with `quarkus-fs-util` 0.0.5 fails for me with Java 11 on `io.quarkus.fs.util.ZipUtils.newFileSystem (Path p)`
````
Caused by: java.lang.UnsupportedOperationException
    at jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem (ZipFileSystemProvider.java:128)
    at io.quarkus.fs.util.ZipUtils.newFileSystem (ZipUtils.java:214)
    at io.quarkus.maven.ExtensionDescriptorMojo$1.visitEnter (ExtensionDescriptorMojo.java:545)
````
````
openjdk version "11.0.13" 2021-10-19
OpenJDK Runtime Environment 18.9 (build 11.0.13+8)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.13+8, mixed mode, sharing)
````

@Postremus found the issue (explained in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/main.20is.20broken/near/265959481) and fixed it in 0.0.7 release.