### PR TITLE
Bump kubernetes-client-bom from 5.11.0 to 5.11.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.11.0</kubernetes-client.version>
+        <kubernetes-client.version>5.11.1</kubernetes-client.version>
         <flapdoodle.mongo.version>3.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Kubernetes Client 5.11.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.11.1

After the dependency bump in #22314, native image builds of projects including the Kubernetes Client extension fail. (See https://github.com/fabric8io/kubernetes-client/issues/3672)

Apparently GraalVM traverses code that's only used during runtime (for specific cases), and fails because an **optional** dependency is not present.

We _fixed_ this upstream by [removing the optional dependency](https://github.com/fabric8io/kubernetes-client/pull/3682) altogether and using an alternative. However, this doesn't address the root cause which is GraalVM requiring a runtime only optional dependency.

/cc @geoand @metacosm 

In case #22314 is subject to backporting, this one should be backported too.