### PR TITLE
Clean up how entries are ignored in jar building

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/mutability/DevModeTask.java
@@ -172,6 +172,11 @@ public class DevModeTask {
                                 Files.createDirectories(target);
                             } else {
                                 if (!Files.exists(target)) {
+                                    // make sure the parent directories are created first
+                                    // META-INF/MANIFEST.MF is often written first,
+                                    // even before META-INF is written probably due to
+                                    // https://bugs.openjdk.java.net/browse/JDK-8031748
+                                    Files.createDirectories(target.getParent());
                                     try (OutputStream out = Files.newOutputStream(target)) {
                                         IoUtils.copy(out, fs);
                                     }

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/QuarkusEntryPoint.java
@@ -1,6 +1,7 @@
 package io.quarkus.bootstrap.runner;
 
 import io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThread;
+import io.quarkus.bootstrap.logging.InitialConfigurator;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +26,13 @@ public class QuarkusEntryPoint {
         System.setProperty("java.util.concurrent.ForkJoinPool.common.threadFactory",
                 "io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");
         Timing.staticInitStarted(false);
-        doRun(args);
+
+        try {
+            doRun(args);
+        } catch (Exception e) {
+            InitialConfigurator.DELAYED_HANDLER.close();
+            throw e;
+        }
     }
 
     private static void doRun(Object args) throws IOException, ClassNotFoundException, IllegalAccessException,


### PR DESCRIPTION
The module-info.class ignore predicate was incorrect (it was testing if
"module-info.class" was ending with the path).
Also we used the list of ignored entries built to avoid duplicates in
uber jars for thin jar building. This was wrong as it could lead to us
ignoring the license for instance. Thin jar building shouldn't take this
list into account.