### PR TITLE
Recalculate the local artifacts for continuous testing to take into account test-scoped dependencies

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -190,6 +190,7 @@ public class TestSupport implements TestController {
                             .setHostApplicationIsTestOnly(devModeType == DevModeType.TEST_ONLY)
                             .setProjectRoot(Paths.get(module.getProjectDirectory()))
                             .setApplicationRoot(PathsCollection.from(paths))
+                            .clearLocalArtifacts() // we want to re-discover the local dependencies with test scope
                             .build()
                             .bootstrap();
                     if (mainModule) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -602,6 +602,11 @@ public class QuarkusBootstrap implements Serializable {
             return this;
         }
 
+        public Builder clearLocalArtifacts() {
+            localArtifacts.clear();
+            return this;
+        }
+
         public Builder setRebuild(boolean value) {
             this.rebuild = value;
             return this;


### PR DESCRIPTION
Fixes #21355 As discussed, @famod, this could be backported to 2.6.