### PR TITLE
Properly handle http.root-path in webjars-locator

### DIFF
--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
@@ -35,7 +35,7 @@ public class WebJarLocatorStandaloneBuildStep {
             String webjarRootPath = (rootPath.endsWith("/")) ? rootPath + "webjars/" : rootPath + "/webjars/";
             feature.produce(new FeatureBuildItem(Feature.WEBJARS_LOCATOR));
             routes.produce(
-                    RouteBuildItem.builder().route(webjarRootPath + "*")
+                    RouteBuildItem.builder().route("/webjars/*")
                             .handler(recorder.getHandler(webjarRootPath, webjarNameToVersionMap)).build());
         } else {
             log.warn("No WebJars were found in the project. Requests to the /webjars/ path will always return 404 (Not Found)");

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorRootPathTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorRootPathTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.webjar.locator.test;
+
+import static org.hamcrest.core.Is.is;
+
+import java.util.Arrays;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WebJarLocatorRootPathTest extends WebJarLocatorTestSupport {
+    private static final String META_INF_RESOURCES = "META-INF/resources/";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
+                    .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
+            .overrideConfigKey("quarkus.http.root-path", "/app")
+            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
+                    new AppArtifact("org.webjars", "momentjs", MOMENTJS_VERSION)));
+
+    @Test
+    public void test() {
+        // Test normal files
+        RestAssured.get("/").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/index.html").then()
+                .statusCode(200)
+                .body(is("<html>Hello!<html>"));
+
+        RestAssured.get("/some/path/test.txt").then()
+                .statusCode(200)
+                .body(is("Test"));
+
+        // Test Existing Web Jars
+        RestAssured.get("/webjars/jquery-ui/jquery-ui.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test using version in url of existing Web Jar
+        RestAssured.get("/webjars/jquery-ui/" + JQUERY_UI_VERSION + "/jquery-ui.min.js").then()
+                .statusCode(200);
+        RestAssured.get("/webjars/momentjs/" + MOMENTJS_VERSION + "/min/moment.min.js").then()
+                .statusCode(200);
+
+        // Test non-existing Web Jar
+        RestAssured.get("/webjars/bootstrap/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").then()
+                .statusCode(404);
+        RestAssured.get("/webjars/momentjs/2.25.0/min/moment.min.js").then()
+                .statusCode(404);
+
+        // Test webjar that does not have a version in the jar path
+        RestAssured.get("/webjars/dcjs/dc.min.js").then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
closes: #22558

## Cause

It seems to me that `RouteBuildItem.builder().route()` will set up a route relative to the configured HTTP root path.

The current implementation includes the root path prefix in `webjarRootPath` used in the `.route()` call.

```java
routes.produce(
        RouteBuildItem.builder().route(webjarRootPath + "*")
                .handler(recorder.getHandler(webjarRootPath, webjarNameToVersionMap)).build());
```

When `quarkus.http.root-path=/`, then `webjarRootPath=/webjars/`. The handler will be set up for calls to `/webjars/*`, and calls to e.g. `/webjars/jquery-ui/jquery-ui.min.js` will be mapped to `/webjars/jquery-ui/1.13.0/jquery-ui.min.js`.

When `quarkus.http.root-path=/app`, then `webjarRootPath=/app/webjars/`. The handler will be set up for calls to `/app/app/webjars/*` (note the extra `/app`), not `/app/webjars/*`. Calls to `/app/webjars/jquery-ui/jquery-ui.min.js` will not be properly mapped to `/app/webjars/jquery-ui/1.13.0/jquery-ui.min.js`. I found this out by injecting some log statements in `WebjarLocatorRecorder.getHandler`.

## Solution

Do not include the root path prefix when setting up the route handler.

```java
routes.produce(
        RouteBuildItem.builder().route("/webjars/*")
                .handler(recorder.getHandler(webjarRootPath, webjarNameToVersionMap)).build());
```

I found this hard to verify with tests since RESTEasy will abstract away `quarkus.http.root-path`. I verified that, after this change, the handler is set up properly in both cases (`quarkus.http.root-path=/` and `quarkus.http.root-path=/app`) by building `webjars-locator` locally (`./mvnw install -f extensions/webjars-locator`) and using it in [the issue reproduction repo][1]: 

```xml
    <dependency>
      <groupId>io.quarkus</groupId>
      <artifactId>quarkus-webjars-locator</artifactId>
      <version>999-SNAPSHOT</version>
    </dependency>
```

```bash
❯ ./mvnw quarkus:dev
❯ ./curl_webjar.sh
curl with version
200
curl without version
200

❯ ./mvnw quarkus:dev -Dquarkus.http.root-path=/app
❯ ./curl_webjar.sh /app
curl with version
200
curl without version
200
```

[1]: https://github.com/eliasnorrby/quarkus-webjars-locator-bug-reproduction
