### PR TITLE
Remove constraint for org.slf4j:jcl-over-slf4j from BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4283,11 +4283,6 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logmanager</artifactId>
                 <version>${slf4j-jboss-logmanager.version}</version>


### PR DESCRIPTION
This dependency is banned from Quarkus and shouldn't be used.
Having the constraint prevents Dependabot upgrades for slf4j-api.

Will fix #22569 once Dependabot is triggered.

/cc @gunnarmorling 