### PR TITLE
Add support for well-known OIDC providers

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -666,7 +666,7 @@ If the `OAuth2` provider supports the introspection endpoint then you may be abl
 
 Configuring the endpoint to request <<user-info,UserInfo>> is the only way `quarkus-oidc` can be integrated with the providers such as `GitHib`.
 
-Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want tp consider caching `UserInfo` data, see <<token-introspection-userinfo-cache,Token Introspection and UserInfo Cache> for more details.
+Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want to consider caching `UserInfo` data, see <<token-introspection-userinfo-cache,Token Introspection and UserInfo Cache> for more details.
 
 Also, OAuth2 servers may not support a well-known configuration endpoint in which case the discovery has to be disabled and the authorization, token, and introspection and/or userinfo endpoint paths have to be configured manually.
 
@@ -674,29 +674,16 @@ Here is how you can integrate `quarkus-oidc` with `GitHub` after you have link:h
 
 [source,properties]
 ----
-quarkus.oidc.auth-server-url=https://github.com/login/oauth
-quarkus.oidc.discovery-enabled=false
-quarkus.oidc.authorization-path=authorize
-quarkus.oidc.token-path=access_token
-quarkus.oidc.user-info-path=https://api.github.com/user
+quarkus.oidc.provider=github
+quarkus.oidc.client-id=github_app_clientid
+quarkus.oidc.credentials.secret=github_app_clientsecret
 
-# See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
-quarkus.oidc.authentication.scopes=user:email
-
-# Make sure a user info is required
-quarkus.oidc.authentication.user-info-required=true
+# user:email scope is requested by default, use 'quarkus.oidc.authentication.scopes' to request differrent scopes such as `read:user`.
+# See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps for more information.
 
 # Consider enabling UserInfo Cache 
 # quarkus.oidc.token-cache.max-size=1000
 # quarkus.oidc.token-cache.time-to-live=5M
-
-# Allow the code flow responses without ID tokens
-quarkus.oidc.authentication.id-token-required=false
-
-quarkus.oidc.application-type=web-app
-
-quarkus.oidc.client-id=github_app_clientid
-quarkus.oidc.credentials.secret=github_app_clientsecret
 ----
 
 This is all what is needed for an endpoint like this one to return the currently authenticated user's profile with `GET http://localhost:8080/github/userinfo` and access it as the individual `UserInfo` properties:
@@ -831,8 +818,7 @@ and configure Google OIDC properties:
 
 [source, properties]
 ----
-quarkus.oidc.auth-server-url=https://accounts.google.com
-quarkus.oidc.application-type=web-app
+quarkus.oidc.provider=google
 quarkus.oidc.client-id={GOOGLE_CLIENT_ID}
 quarkus.oidc.credentials.secret={GOOGLE_CLIENT_SECRET}
 quarkus.oidc.token.issuer=https://accounts.google.com
@@ -1001,12 +987,14 @@ Apple OpenID Connect Provider uses a `client_secret_post` method where a secret 
 
 [source,properties]
 ----
-quarkus.oidc.auth-server-url=${apple.url}
-quarkus.oidc.client-id=${apple.client-id}
-quarkus.oidc.credentials.client-secret.method=post-jwt
+# Apple provider configuration sets a 'client_secret_post_jwt' authentication method
+quarkus.oidc.provider=apple
 
+quarkus.oidc.client-id=${apple.client-id}
 quarkus.oidc.credentials.jwt.key-file=ecPrivateKey.pem
-quarkus.oidc.credentials.jwt.signature-algorithm=ES256
+quarkus.oidc.credentials.jwt.token-key-id=${apple.key-id}
+# Apple provider configuration sets ES256 signature algorithm
+
 quarkus.oidc.credentials.jwt.subject=${apple.subject}
 quarkus.oidc.credentials.jwt.issuer=${apple.issuer}
 ----

--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -15,6 +15,7 @@ import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerTenantConfig.Keyclo
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerTenantConfig.KeycloakConfigPolicyEnforcer.PathCacheConfig;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.OidcTenantConfig.Roles.Source;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Tls.Verification;
 import io.quarkus.oidc.runtime.OidcConfig;
@@ -55,7 +56,7 @@ public class KeycloakPolicyEnforcerRecorder {
             KeycloakPolicyEnforcerTenantConfig keycloakPolicyEnforcerConfig,
             TlsConfig tlsConfig) {
 
-        if (oidcConfig.applicationType == OidcTenantConfig.ApplicationType.WEB_APP
+        if (oidcConfig.applicationType.orElse(ApplicationType.SERVICE) == OidcTenantConfig.ApplicationType.WEB_APP
                 && oidcConfig.roles.source.orElse(null) != Source.accesstoken) {
             throw new OIDCException("Application 'web-app' type is only supported if access token is the source of roles");
         }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientRecorder.java
@@ -126,7 +126,7 @@ public class OidcClientRecorder {
             tokenRequestUriUni = Uni.createFrom().item(oidcConfig.tokenPath.get());
         } else {
             String authServerUriString = OidcCommonUtils.getAuthServerUrl(oidcConfig);
-            if (!oidcConfig.discoveryEnabled) {
+            if (!oidcConfig.discoveryEnabled.orElse(true)) {
                 tokenRequestUriUni = Uni.createFrom()
                         .item(OidcCommonUtils.getOidcEndpointUrl(authServerUriString, oidcConfig.tokenPath));
             } else {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -23,8 +23,8 @@ public class OidcCommonConfig {
      * Enables OIDC discovery.
      * If the discovery is disabled then the OIDC endpoint URLs must be configured individually.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean discoveryEnabled = true;
+    @ConfigItem(defaultValueDocumentation = "true")
+    public Optional<Boolean> discoveryEnabled = Optional.empty();
 
     /**
      * Relative path or absolute URL of the OIDC token endpoint which issues access and refresh tokens.
@@ -549,12 +549,12 @@ public class OidcCommonConfig {
         this.credentials = credentials;
     }
 
-    public boolean isDiscoveryEnabled() {
+    public Optional<Boolean> isDiscoveryEnabled() {
         return discoveryEnabled;
     }
 
     public void setDiscoveryEnabled(boolean enabled) {
-        this.discoveryEnabled = enabled;
+        this.discoveryEnabled = Optional.of(enabled);
     }
 
     public Proxy getProxy() {

--- a/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
+++ b/extensions/oidc/deployment/src/test/java/io/quarkus/oidc/test/CustomTenantConfigResolver.java
@@ -19,7 +19,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
             config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus");
             config.setClientId("quarkus-web-app");
             config.getCredentials().setSecret("secret");
-            config.applicationType = ApplicationType.WEB_APP;
+            config.setApplicationType(ApplicationType.WEB_APP);
             return Uni.createFrom().item(config);
         }
         return Uni.createFrom().nullItem();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -32,8 +32,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
     /**
      * The application type, which can be one of the following values from enum {@link ApplicationType}.
      */
-    @ConfigItem(defaultValue = "service")
-    public ApplicationType applicationType = ApplicationType.SERVICE;
+    @ConfigItem(defaultValueDocumentation = "service")
+    public Optional<ApplicationType> applicationType = Optional.empty();
 
     /**
      * Relative path or absolute URL of the OIDC authorization endpoint which authenticates the users.
@@ -535,10 +535,10 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<String> cookieDomain = Optional.empty();
 
         /**
-         * If this property is set to 'true' then an OIDC UserInfo endpoint will be called
+         * If this property is set to 'true' then an OIDC UserInfo endpoint will be called.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean userInfoRequired;
+        @ConfigItem(defaultValueDocumentation = "false")
+        public Optional<Boolean> userInfoRequired = Optional.empty();
 
         /**
          * Session age extension in minutes.
@@ -564,11 +564,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public boolean javaScriptAutoRedirect = true;
 
         /**
-         * Requires that ID token is available when the authorization code flow completes. In most case this property
-         * should be enabled. Disable this property only when you need to use the authorization code flow with OAuth2 providers.
+         * Requires that ID token is available when the authorization code flow completes.
+         * Disable this property only when you need to use the authorization code flow with OAuth2 providers which do not return
+         * ID token.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean idTokenRequired = true;
+        @ConfigItem(defaultValueDocumentation = "true")
+        public Optional<Boolean> idTokenRequired = Optional.empty();
 
         public boolean isJavaScriptAutoRedirect() {
             return javaScriptAutoRedirect;
@@ -590,8 +591,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
             return scopes;
         }
 
-        public void setScopes(Optional<List<String>> scopes) {
-            this.scopes = scopes;
+        public void setScopes(List<String> scopes) {
+            this.scopes = Optional.of(scopes);
         }
 
         public Map<String, String> getExtraParams() {
@@ -642,12 +643,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.cookieDomain = Optional.of(cookieDomain);
         }
 
-        public boolean isUserInfoRequired() {
+        public Optional<Boolean> isUserInfoRequired() {
             return userInfoRequired;
         }
 
         public void setUserInfoRequired(boolean userInfoRequired) {
-            this.userInfoRequired = userInfoRequired;
+            this.userInfoRequired = Optional.of(userInfoRequired);
         }
 
         public boolean isRemoveRedirectParameters() {
@@ -682,12 +683,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.cookiePathHeader = Optional.of(cookiePathHeader);
         }
 
-        public boolean isIdTokenRequired() {
+        public Optional<Boolean> isIdTokenRequired() {
             return idTokenRequired;
         }
 
         public void setIdTokenRequired(boolean idTokenRequired) {
-            this.idTokenRequired = idTokenRequired;
+            this.idTokenRequired = Optional.of(idTokenRequired);
         }
 
         public Optional<String> getCookieSuffix() {
@@ -928,12 +929,34 @@ public class OidcTenantConfig extends OidcCommonConfig {
         HYBRID
     }
 
-    public ApplicationType getApplicationType() {
+    /**
+     * Well known OpenId Connect provider identifier
+     */
+    @ConfigItem
+    public Optional<Provider> provider = Optional.empty();
+
+    public static enum Provider {
+        APPLE,
+        FACEBOOK,
+        GITHUB,
+        GOOGLE,
+        MICROSOFT
+    }
+
+    public Optional<Provider> getProvider() {
+        return provider;
+    }
+
+    public void setProvider(Provider provider) {
+        this.provider = Optional.of(provider);
+    }
+
+    public Optional<ApplicationType> getApplicationType() {
         return applicationType;
     }
 
     public void setApplicationType(ApplicationType type) {
-        this.applicationType = type;
+        this.applicationType = Optional.of(type);
     }
 
     public boolean isAllowTokenIntrospectionCache() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -106,7 +106,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         context.put(AuthorizationCodeTokens.class.getName(), session);
                         return authenticate(identityProviderManager, context,
                                 new IdTokenCredential(session.getIdToken(),
-                                        !configContext.oidcConfig.authentication.isIdTokenRequired()))
+                                        !configContext.oidcConfig.authentication.isIdTokenRequired().orElse(true)))
                                                 .call(new Function<SecurityIdentity, Uni<?>>() {
                                                     @Override
                                                     public Uni<Void> apply(SecurityIdentity identity) {
@@ -294,7 +294,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
                         boolean internalIdToken = false;
                         if (tokens.getIdToken() == null) {
-                            if (configContext.oidcConfig.authentication.isIdTokenRequired()) {
+                            if (configContext.oidcConfig.authentication.isIdTokenRequired().orElse(true)) {
                                 return Uni.createFrom()
                                         .failure(new AuthenticationCompletionException("ID Token is not available"));
                             } else {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -182,6 +182,8 @@ public class DefaultTenantConfigResolver {
                 if (oidcConfig == null) {
                     //shouldn't happen, but guard against it anyway
                     oidcConfig = Uni.createFrom().nullItem();
+                } else {
+                    oidcConfig = oidcConfig.onItem().transform(cfg -> OidcUtils.resolveProviderConfig(cfg));
                 }
                 context.put(CURRENT_DYNAMIC_TENANT_CONFIG, oidcConfig);
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenIntrospectionUserInfoCache.java
@@ -109,6 +109,7 @@ public class DefaultTokenIntrospectionUserInfoCache implements TokenIntrospectio
 
     public void clearCache() {
         cacheMap.clear();
+        size.set(0);
     }
 
     private void removeInvalidEntries() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcAuthenticationMechanism.java
@@ -8,6 +8,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -77,10 +78,11 @@ public class OidcAuthenticationMechanism implements HttpAuthenticationMechanism 
     }
 
     private boolean isWebApp(RoutingContext context, OidcTenantConfig oidcConfig) {
-        if (OidcTenantConfig.ApplicationType.HYBRID == oidcConfig.applicationType) {
+        ApplicationType applicationType = oidcConfig.applicationType.orElse(ApplicationType.SERVICE);
+        if (OidcTenantConfig.ApplicationType.HYBRID == applicationType) {
             return context.request().getHeader("Authorization") == null;
         }
-        return OidcTenantConfig.ApplicationType.WEB_APP == oidcConfig.applicationType;
+        return OidcTenantConfig.ApplicationType.WEB_APP == applicationType;
     }
 
     @Override

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -112,7 +112,7 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             vertxContext.put(CODE_ACCESS_TOKEN_RESULT, codeAccessTokenResult);
         }
 
-        Uni<UserInfo> userInfo = resolvedContext.oidcConfig.authentication.isUserInfoRequired()
+        Uni<UserInfo> userInfo = resolvedContext.oidcConfig.authentication.isUserInfoRequired().orElse(false)
                 ? getUserInfoUni(vertxContext, request, resolvedContext)
                 : NULL_USER_INFO_UNI;
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -127,11 +127,14 @@ public class OidcRecorder {
     }
 
     @SuppressWarnings("resource")
-    private Uni<TenantConfigContext> createTenantContext(Vertx vertx, OidcTenantConfig oidcConfig, TlsConfig tlsConfig,
+    private Uni<TenantConfigContext> createTenantContext(Vertx vertx, OidcTenantConfig oidcTenantConfig, TlsConfig tlsConfig,
             String tenantId) {
-        if (!oidcConfig.tenantId.isPresent()) {
-            oidcConfig.tenantId = Optional.of(tenantId);
+        if (!oidcTenantConfig.tenantId.isPresent()) {
+            oidcTenantConfig.tenantId = Optional.of(tenantId);
         }
+
+        final OidcTenantConfig oidcConfig = OidcUtils.resolveProviderConfig(oidcTenantConfig);
+
         if (!oidcConfig.tenantEnabled) {
             LOG.debugf("'%s' tenant configuration is disabled", tenantId);
             return Uni.createFrom().item(new TenantConfigContext(new OidcProvider(null, null, null), oidcConfig));
@@ -148,7 +151,7 @@ public class OidcRecorder {
             return Uni.createFrom().failure(t);
         }
 
-        if (!oidcConfig.discoveryEnabled) {
+        if (!oidcConfig.discoveryEnabled.orElse(true)) {
             if (!isServiceApp(oidcConfig)) {
                 if (!oidcConfig.authorizationPath.isPresent() || !oidcConfig.tokenPath.isPresent()) {
                     throw new ConfigurationException(
@@ -159,7 +162,8 @@ public class OidcRecorder {
             }
             // JWK and introspection endpoints have to be set for both 'web-app' and 'service' applications  
             if (!oidcConfig.jwksPath.isPresent() && !oidcConfig.introspectionPath.isPresent()) {
-                if (!oidcConfig.authentication.isIdTokenRequired() && oidcConfig.authentication.isUserInfoRequired()) {
+                if (!oidcConfig.authentication.isIdTokenRequired().orElse(true)
+                        && oidcConfig.authentication.isUserInfoRequired().orElse(false)) {
                     LOG.debugf("tenant %s supports only UserInfo", oidcConfig.tenantId.get());
                 } else {
                     throw new ConfigurationException(
@@ -189,7 +193,8 @@ public class OidcRecorder {
 
         if (oidcConfig.tokenStateManager.strategy != Strategy.KEEP_ALL_TOKENS) {
 
-            if (oidcConfig.authentication.isUserInfoRequired() || oidcConfig.roles.source.orElse(null) == Source.userinfo) {
+            if (oidcConfig.authentication.isUserInfoRequired().orElse(false)
+                    || oidcConfig.roles.source.orElse(null) == Source.userinfo) {
                 throw new ConfigurationException(
                         "UserInfo is required but DefaultTokenStateManager is configured to not keep the access token");
             }
@@ -250,7 +255,7 @@ public class OidcRecorder {
     }
 
     protected static Uni<JsonWebKeySet> getJsonWebSetUni(OidcProviderClient client, OidcTenantConfig oidcConfig) {
-        if (!oidcConfig.isDiscoveryEnabled()) {
+        if (!oidcConfig.isDiscoveryEnabled().orElse(true)) {
             final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
             return client.getJsonWebKeySet().onFailure(OidcCommonUtils.oidcEndpointNotAvailable())
                     .retry()
@@ -277,7 +282,7 @@ public class OidcRecorder {
         WebClient client = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
 
         Uni<OidcConfigurationMetadata> metadataUni = null;
-        if (!oidcConfig.discoveryEnabled) {
+        if (!oidcConfig.discoveryEnabled.orElse(true)) {
             metadataUni = Uni.createFrom().item(createLocalMetadata(oidcConfig, authServerUriString));
         } else {
             final long connectionDelayInMillisecs = OidcCommonUtils.getConnectionDelayInMillis(oidcConfig);
@@ -327,7 +332,7 @@ public class OidcRecorder {
     }
 
     private static boolean isServiceApp(OidcTenantConfig oidcConfig) {
-        return ApplicationType.SERVICE.equals(oidcConfig.applicationType);
+        return ApplicationType.SERVICE.equals(oidcConfig.applicationType.orElse(ApplicationType.SERVICE));
     }
 
     private static void verifyAuthServerUrl(OidcCommonConfig oidcConfig) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -1,0 +1,86 @@
+package io.quarkus.oidc.runtime.providers;
+
+import java.util.HashMap;
+import java.util.List;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret.Method;
+import io.smallrye.jwt.algorithm.SignatureAlgorithm;
+
+public class KnownOidcProviders {
+
+    public static OidcTenantConfig provider(OidcTenantConfig.Provider provider) {
+        if (OidcTenantConfig.Provider.GITHUB == provider) {
+            return github();
+        } else if (OidcTenantConfig.Provider.GOOGLE == provider) {
+            return google();
+        } else if (OidcTenantConfig.Provider.APPLE == provider) {
+            return apple();
+        } else if (OidcTenantConfig.Provider.MICROSOFT == provider) {
+            return microsoft();
+        } else if (OidcTenantConfig.Provider.FACEBOOK == provider) {
+            return facebook();
+        }
+        return null;
+    }
+
+    private static OidcTenantConfig github() {
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setAuthServerUrl("https://github.com/login/oauth");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.setDiscoveryEnabled(false);
+        ret.setAuthorizationPath("authorize");
+        ret.setTokenPath("access_token");
+        ret.setUserInfoPath("https://api.github.com/user");
+        ret.getAuthentication().setScopes(List.of("user:email"));
+        ret.getAuthentication().setUserInfoRequired(true);
+        ret.getAuthentication().setIdTokenRequired(false);
+        return ret;
+    }
+
+    private static OidcTenantConfig google() {
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setAuthServerUrl("https://accounts.google.com");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.getAuthentication().setScopes(List.of("openid", "email", "profile"));
+        return ret;
+    }
+
+    private static OidcTenantConfig microsoft() {
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setAuthServerUrl("https://login.microsoftonline.com/common/v2.0");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.getToken().setIssuer("any");
+        ret.getAuthentication().setScopes(List.of("openid", "email", "profile"));
+        return ret;
+    }
+
+    private static OidcTenantConfig facebook() {
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setAuthServerUrl("https://www.facebook.com");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.setDiscoveryEnabled(false);
+        ret.setAuthorizationPath("https://facebook.com/dialog/oauth/");
+        ret.setTokenPath("https://graph.facebook.com/v12.0/oauth/access_token");
+        ret.setJwksPath("https://www.facebook.com/.well-known/oauth/openid/jwks/");
+        ret.setUserInfoPath("https://graph.facebook.com/me/?fields=id,name,email,first_name,last_name");
+        ret.getAuthentication().setScopes(List.of("email", "public_profile"));
+        ret.getAuthentication().setUserInfoRequired(true);
+        ret.getAuthentication().setIdTokenRequired(false);
+        return ret;
+    }
+
+    private static OidcTenantConfig apple() {
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setAuthServerUrl("https://appleid.apple.com/");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.getAuthentication().setScopes(List.of("openid", "email", "name"));
+        ret.getAuthentication().setExtraParams(new HashMap<>());
+        ret.getAuthentication().getExtraParams().put("response_mode", "form_post");
+        ret.getAuthentication().setForceRedirectHttpsScheme(true);
+        ret.getCredentials().getClientSecret().setMethod(Method.POST_JWT);
+        ret.getCredentials().getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
+        ret.getCredentials().getJwt().setAudience("https://appleid.apple.com/");
+        return ret;
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -9,7 +9,7 @@ import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 
-@Path("/code-flow-user-info")
+@Path("/")
 @Authenticated
 public class CodeFlowUserInfoResource {
 
@@ -23,10 +23,23 @@ public class CodeFlowUserInfoResource {
     DefaultTokenIntrospectionUserInfoCache tokenCache;
 
     @GET
+    @Path("/code-flow-user-info-only")
     public String access() {
         int cacheSize = tokenCache.getCacheSize();
         tokenCache.clearCache();
         return identity.getPrincipal().getName() + ":" + userInfo.getString("preferred_username") + ", cache size: "
                 + cacheSize;
+    }
+
+    @GET
+    @Path("/code-flow-user-info-github")
+    public String accessGitHub() {
+        return access();
+    }
+
+    @GET
+    @Path("/code-flow-user-info-dynamic-github")
+    public String accessDynamicGitHub() {
+        return access();
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -18,7 +18,10 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
     @Override
     public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
         RoutingContext routingContext = identity.getAttribute(RoutingContext.class.getName());
-        if (routingContext != null && routingContext.normalizedPath().endsWith("code-flow-user-info")) {
+        if (routingContext != null &&
+                (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
+                        || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
+                        || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github"))) {
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
             UserInfo userInfo = identity.getAttribute("userinfo");
             builder.setPrincipal(new Principal() {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.keycloak;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.Provider;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Inject
+    @ConfigProperty(name = "keycloak.url")
+    String keycloakUrl;
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context,
+            OidcRequestContext<OidcTenantConfig> requestContext) {
+        String path = context.normalizedPath();
+        if (path.endsWith("code-flow-user-info-dynamic-github")) {
+
+            OidcTenantConfig config = new OidcTenantConfig();
+            config.setTenantId("code-flow-user-info-dynamic-github");
+
+            config.setProvider(Provider.GITHUB);
+
+            config.setAuthServerUrl(keycloakUrl + "/realms/quarkus/");
+            config.setAuthorizationPath("/");
+            config.setUserInfoPath("protocol/openid-connect/userinfo");
+            config.setClientId("quarkus-web-app");
+            config.getCredentials()
+                    .setSecret("AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
+
+            return Uni.createFrom().item(config);
+        }
+
+        return Uni.createFrom().nullItem();
+    }
+
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -17,8 +17,11 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow") || path.endsWith("code-flow/logout")) {
             return "code-flow";
         }
-        if (path.endsWith("code-flow-user-info")) {
+        if (path.endsWith("code-flow-user-info-only")) {
             return "code-flow-user-info-only";
+        }
+        if (path.endsWith("code-flow-user-info-github")) {
+            return "code-flow-user-info-github";
         }
         if (path.endsWith("bearer")) {
             return "bearer";

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -23,13 +23,20 @@ quarkus.oidc.code-flow.application-type=web-app
 quarkus.oidc.code-flow-user-info-only.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-only.discovery-enabled=false
 quarkus.oidc.code-flow-user-info-only.authorization-path=/
-quarkus.oidc.code-flow-user-info-only.token-path=oauth2-tokens
+quarkus.oidc.code-flow-user-info-only.token-path=access_token
 quarkus.oidc.code-flow-user-info-only.user-info-path=protocol/openid-connect/userinfo
 quarkus.oidc.code-flow-user-info-only.authentication.id-token-required=false
 quarkus.oidc.code-flow-user-info-only.authentication.user-info-required=true
 quarkus.oidc.code-flow-user-info-only.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-only.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 quarkus.oidc.code-flow-user-info-only.application-type=web-app
+
+quarkus.oidc.code-flow-user-info-github.provider=github
+quarkus.oidc.code-flow-user-info-github.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.code-flow-user-info-github.authorization-path=/
+quarkus.oidc.code-flow-user-info-github.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-user-info-github.client-id=quarkus-web-app
+quarkus.oidc.code-flow-user-info-github.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
 quarkus.oidc.token-cache.max-size=1
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -60,9 +60,15 @@ public class CodeFlowAuthorizationTest {
     @Test
     public void testCodeFlowUserInfo() throws IOException {
         defineCodeFlowAuthorizationOauth2TokenStub();
+        doTestCodeFlowUserInfo("code-flow-user-info-only");
+        doTestCodeFlowUserInfo("code-flow-user-info-github");
+        doTestCodeFlowUserInfo("code-flow-user-info-dynamic-github");
+    }
+
+    private void doTestCodeFlowUserInfo(String tenantId) throws IOException {
         try (final WebClient webClient = createWebClient()) {
             webClient.getOptions().setRedirectEnabled(true);
-            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-user-info");
+            HtmlPage page = webClient.getPage("http://localhost:8081/" + tenantId);
 
             HtmlForm form = page.getFormByName("form");
             form.getInputByName("username").type("alice");
@@ -72,7 +78,7 @@ public class CodeFlowAuthorizationTest {
 
             assertEquals("alice:alice, cache size: 1", page.getBody().asText());
 
-            assertNotNull(getSessionCookie(webClient, "code-flow-user-info-only"));
+            assertNotNull(getSessionCookie(webClient, tenantId));
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -84,7 +90,7 @@ public class CodeFlowAuthorizationTest {
     }
 
     private void defineCodeFlowAuthorizationOauth2TokenStub() {
-        wireMockServer.stubFor(WireMock.post("/auth/realms/quarkus/oauth2-tokens")
+        wireMockServer.stubFor(WireMock.post("/auth/realms/quarkus/access_token")
                 .withRequestBody(containing("authorization_code"))
                 .willReturn(WireMock.aResponse()
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Replaces #22176, Fixes #20783.

This PR builds on Stuart's idea but instead uses `OidcTenantConfig` references to well-known providers from the current `OidcTenantConfig`. Any of the statically or dynamically configured ODC tenants can refer to them and override as many properties as needed and add as many properties as needed in scope of the current tenant.

It will allow the following variations:
1. Default tenant:
```
quarkus.oidc.provider=github
quarkus.oidc.client-id=myclientid
//etc
```
2. Single custom tenant which may read better
```
quarkus.oidc.github.provider=github
quarkus.oidc.github.client-id=myclientid
//etc
```
3. More than one tenant
```
quarkus.oidc.github.provider=github
quarkus.oidc.github.client-id=myclientid

quarkus.oidc.apple.provider=apple
quarkus.oidc.apple.client-id=myclientid
```

4. In `TenantConfigResolver`:
```
OidcTenantConfig config = new OidcTenantConfig();
config.setProvider(Provider.GITHUB);
// more properties as needed
return Uni.createFrom().item(config);
```

This PR supports `GitHub` and `Apple` only in the beginning. Not sure about Microsoft - I believe some of its providers also have tenant specific `authServerUrl`. I think it makes sense to add them one by one - if we see all users dealing with a given provider have to set at least 2 identical properties including `authServerIUrl` then it would qualify.

PR is based on the idea of merging the current `OidcTenantConfig` with the referenced provider's `OidcTenantConfig`. At the moment the copying of properties is done selectively to handle the supported providers (GitHub for now) - it is safe as this merge operation can only happen if a recognized enum provider value is configured. I had to remove some default values for some properties and handle defaults directly in the code as otherwise it is not clear if it was the user who set this property or it was defaulted to some value.

Going forward it would be good to let the users provide arbitrary  `OidcTenantConfig` blocks, example, `myKeycloakWithHttpsAndProxyEtc` which can be referenced as `quarlus.oidc.provider`.

I've updated the current `GitHub` and `Apple` OIDC web-app doc fragments, but we'll have a proper doc dedicated to configuring various providers once we have a few more issues reported by Steph addressed...

CC @FroMage 