### PR TITLE
Fixed ignored escape sequence by explicitly defining it via maven

### DIFF
--- a/extensions/azure-functions-http/maven-archetype/pom.xml
+++ b/extensions/azure-functions-http/maven-archetype/pom.xml
@@ -21,5 +21,17 @@
                 <version>3.0.1</version>
             </extension>
         </extensions>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.1.0</version>
+                    <configuration>
+                        <escapeString>\</escapeString>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
Should fix https://github.com/quarkusio/quarkus/issues/20814

Without the explicit definition of an escapeString the generated pom.xml is actually broken (referencing absolute directories of the authors machine or containing wrong groupId, artifactId etc.)