### PR TITLE
Declare com.microsoft.azure:adal4j dependency as optional

### DIFF
--- a/extensions/jdbc/jdbc-mssql/runtime/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/runtime/pom.xml
@@ -30,11 +30,13 @@
         <!--
             adal4j isn't used directly but you need to have it around for compilation to succeed.
             Since that's the only reason, doesn't seem necessary to require the specific version in the shared bom.
+            Newer versions of mssql-jdbc use msal4j rather than adal4j; thus declare dependency as optional.
             -->
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
             <version>1.6.6</version>
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
@@ -46,6 +46,8 @@ final class QuarkusSQLServerConnection {
 
 }
 
-class SQLServerJDBCSubstitutions {
+@TargetClass(className = "com.microsoft.aad.adal4j.AuthenticationException")
+@Substitute
+final class AuthenticationExceptionSubstitutions {
 
 }


### PR DESCRIPTION
The  `quarkus-jdbc-mssql` extension has a dependency on `com.microsoft.azure:adal4j`, which apparently is required for compilation to succeed.

To allow Quarkus applications to work with newer versions of `com.microsoft.sqlserver:mssql-jdbc` (currently not possible in Quarkus, because newer versions have issues with native mode), this dependency is declared as optional, since the newer versions have replaced this dependency with `com.azure:azure-identity` to support Active AD based authentication.

Also note that this dependency is also declared as optional by the `mssql-jdbc` module and that a Quarkus application unfortunately cannot work with Maven exclusions to exclude the dependency when imported via the Quarkus BOM.