### PR TITLE
Provide configuration for RESTEasy Reactive response buffer size

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -332,6 +332,7 @@ public class JaxrsClientReactiveProcessor {
 
         return new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(
                 getEffectivePropertyValue("input-buffer-size", config.inputBufferSize.asLongValue(), Long.class, mpConfig),
+                getEffectivePropertyValue("output-buffer-size", config.outputBufferSize, Integer.class, mpConfig),
                 getEffectivePropertyValue("single-default-produces", config.singleDefaultProduces, Boolean.class, mpConfig),
                 getEffectivePropertyValue("default-produces", config.defaultProduces, Boolean.class, mpConfig));
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ResteasyReactiveConfig.java
@@ -19,6 +19,15 @@ public class ResteasyReactiveConfig {
     public MemorySize inputBufferSize;
 
     /**
+     * The size of the output stream response buffer. If a response is larger than this and no content-length
+     * is provided then the request will be chunked.
+     *
+     * Larger values may give slight performance increases for large responses, at the expense of more memory usage.
+     */
+    @ConfigItem(defaultValue = "8191")
+    public int outputBufferSize;
+
+    /**
      * By default we assume a default produced media type of "text/plain"
      * for String endpoint return types. If this is disabled, the default
      * produced media type will be "[text/plain, *&sol;*]" which is more

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -726,7 +726,7 @@ public class ResteasyReactiveProcessor {
         Class<? extends Application> applicationClass = application == null ? Application.class : application.getClass();
         DeploymentInfo deploymentInfo = new DeploymentInfo()
                 .setInterceptors(interceptors.sort())
-                .setConfig(createRestReactiveConfig(config))
+                .setResteasyReactiveConfig(createRestReactiveConfig(config))
                 .setExceptionMapping(exceptionMapping)
                 .setCtxResolvers(contextResolvers)
                 .setFeatures(feats)
@@ -784,6 +784,7 @@ public class ResteasyReactiveProcessor {
 
         return new org.jboss.resteasy.reactive.common.ResteasyReactiveConfig(
                 getEffectivePropertyValue("input-buffer-size", config.inputBufferSize.asLongValue(), Long.class, mpConfig),
+                getEffectivePropertyValue("output-buffer-size", config.outputBufferSize, Integer.class, mpConfig),
                 getEffectivePropertyValue("single-default-produces", config.singleDefaultProduces, Boolean.class, mpConfig),
                 getEffectivePropertyValue("default-produces", config.defaultProduces, Boolean.class, mpConfig));
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/ChunkedResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/ChunkedResponseTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.reactive.server.test.response;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.server.providers.serialisers.ServerStringMessageBodyHandler;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ChunkedResponseTest {
+
+    private static final String LARGE_HELLO_STRING = "h" + "e".repeat(256) + "llo";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class)
+                    .addAsResource(new StringAsset("quarkus.rest.output-buffer-size = 256"),
+                            "application.properties"));
+
+    @Test
+    void chunked() {
+        when()
+                .get("/hello/big")
+                .then().statusCode(200)
+                .body(equalTo(LARGE_HELLO_STRING))
+                .header("Transfer-encoding", "chunked");
+    }
+
+    @Test
+    void notChunked() {
+        when()
+                .get("/hello/small")
+                .then().statusCode(200)
+                .body(equalTo("hello"))
+                .header("Transfer-encoding", nullValue());
+    }
+
+    @Path("hello")
+    public static final class HelloResource {
+
+        @GET
+        @Path("big")
+        public String helloBig() {
+            return LARGE_HELLO_STRING;
+        }
+
+        @GET
+        @Path("small")
+        public String helloSmall() {
+            return "hello";
+        }
+    }
+
+    @Provider
+    public static final class CustomStringMessageBodyWriter extends ServerStringMessageBodyHandler {
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException {
+
+            try (OutputStream stream = context.getOrCreateOutputStream()) {
+                stream.write(((String) o).getBytes());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/ResteasyReactiveConfig.java
@@ -9,7 +9,15 @@ public class ResteasyReactiveConfig {
     private long inputBufferSize;
 
     /**
-     * By default we assume a default produced media type of "text/plain"
+     * The size of the output stream response buffer. If a response is larger than this and no content-length
+     * is provided then the request will be chunked.
+     *
+     * Larger values may give slight performance increases for large responses, at the expense of more memory usage.
+     */
+    private int outputBufferSize = 8192;
+
+    /**
+     * By default, we assume a default produced media type of "text/plain"
      * for String endpoint return types. If this is disabled, the default
      * produced media type will be "[text/plain, *&sol;*]" which is more
      * expensive due to negotiation.
@@ -27,8 +35,10 @@ public class ResteasyReactiveConfig {
     public ResteasyReactiveConfig() {
     }
 
-    public ResteasyReactiveConfig(long inputBufferSize, boolean singleDefaultProduces, boolean defaultProduces) {
+    public ResteasyReactiveConfig(long inputBufferSize, int outputBufferSize, boolean singleDefaultProduces,
+            boolean defaultProduces) {
         this.inputBufferSize = inputBufferSize;
+        this.outputBufferSize = outputBufferSize;
         this.singleDefaultProduces = singleDefaultProduces;
         this.defaultProduces = defaultProduces;
     }
@@ -39,6 +49,14 @@ public class ResteasyReactiveConfig {
 
     public void setInputBufferSize(long inputBufferSize) {
         this.inputBufferSize = inputBufferSize;
+    }
+
+    public int getOutputBufferSize() {
+        return outputBufferSize;
+    }
+
+    public void setOutputBufferSize(int outputBufferSize) {
+        this.outputBufferSize = outputBufferSize;
     }
 
     public boolean isSingleDefaultProduces() {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/ResteasyReactiveDeploymentManager.java
@@ -79,8 +79,9 @@ public class ResteasyReactiveDeploymentManager {
     public static class ScanStep {
         final IndexView index;
         int inputBufferSize = 10000;
+        int outputBufferSize = 8192;
         /**
-         * By default we assume a default produced media type of "text/plain"
+         * By default, we assume a default produced media type of "text/plain"
          * for String endpoint return types. If this is disabled, the default
          * produced media type will be "[text/plain, *&sol;*]" which is more
          * expensive due to negotiation.
@@ -207,7 +208,8 @@ public class ResteasyReactiveDeploymentManager {
                     .setAdditionalReaders(readers)
                     .setAdditionalWriters(writers)
                     .setInjectableBeans(new HashMap<>())
-                    .setConfig(new ResteasyReactiveConfig(inputBufferSize, singleDefaultProduces, defaultProduces))
+                    .setConfig(new ResteasyReactiveConfig(inputBufferSize, outputBufferSize, singleDefaultProduces,
+                            defaultProduces))
                     .setHttpAnnotationToMethod(resources.getHttpAnnotationToMethod())
                     .setApplicationScanningResult(applicationScanningResult);
             for (MethodScanner scanner : methodScanners) {
@@ -376,7 +378,7 @@ public class ResteasyReactiveDeploymentManager {
             }
 
             DeploymentInfo info = new DeploymentInfo()
-                    .setConfig(new ResteasyReactiveConfig())
+                    .setResteasyReactiveConfig(new ResteasyReactiveConfig())
                     .setFeatures(sa.scannedFeatures)
                     .setInterceptors(sa.resourceInterceptors)
                     .setDynamicFeatures(sa.dynamicFeatures)

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
+import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.model.ResourceParamConverterProvider;
 import org.jboss.resteasy.reactive.common.util.types.Types;
@@ -43,6 +44,7 @@ public class Deployment {
     private final List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers;
     private final RuntimeExceptionMapper exceptionMapper;
     private final boolean resumeOn404;
+    private final ResteasyReactiveConfig resteasyReactiveConfig;
     //this is not final, as it is set after startup
     private RuntimeConfiguration runtimeConfiguration;
 
@@ -56,7 +58,8 @@ public class Deployment {
             List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers,
             List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers,
             RuntimeExceptionMapper exceptionMapper,
-            boolean resumeOn404) {
+            boolean resumeOn404,
+            ResteasyReactiveConfig resteasyReactiveConfig) {
         this.exceptionMapping = exceptionMapping;
         this.contextResolvers = contextResolvers;
         this.serialisers = serialisers;
@@ -73,6 +76,7 @@ public class Deployment {
         this.runtimeConfigurableServerRestHandlers = runtimeConfigurableServerRestHandlers;
         this.exceptionMapper = exceptionMapper;
         this.resumeOn404 = resumeOn404;
+        this.resteasyReactiveConfig = resteasyReactiveConfig;
     }
 
     public RuntimeExceptionMapper getExceptionMapper() {
@@ -85,6 +89,10 @@ public class Deployment {
 
     public ConfigurationImpl getConfiguration() {
         return configuration;
+    }
+
+    public ResteasyReactiveConfig getResteasyReactiveConfig() {
+        return resteasyReactiveConfig;
     }
 
     public ExceptionMapping getExceptionMapping() {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/DeploymentInfo.java
@@ -28,7 +28,7 @@ public class DeploymentInfo {
     private ParamConverterProviders paramConverterProviders;
     private Supplier<Application> applicationSupplier;
     private Function<Class<?>, BeanFactory<?>> factoryCreator;
-    private ResteasyReactiveConfig config;
+    private ResteasyReactiveConfig resteasyReactiveConfig;
     private Function<Object, Object> clientProxyUnwrapper;
     private String applicationPath;
     private List<HandlerChainCustomizer> globalHandlerCustomizers = new ArrayList<>();
@@ -143,12 +143,12 @@ public class DeploymentInfo {
         return this;
     }
 
-    public ResteasyReactiveConfig getConfig() {
-        return config;
+    public ResteasyReactiveConfig getResteasyReactiveConfig() {
+        return resteasyReactiveConfig;
     }
 
-    public DeploymentInfo setConfig(ResteasyReactiveConfig config) {
-        this.config = config;
+    public DeploymentInfo setResteasyReactiveConfig(ResteasyReactiveConfig resteasyReactiveConfig) {
+        this.resteasyReactiveConfig = resteasyReactiveConfig;
         return this;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -192,7 +192,7 @@ public class RuntimeDeploymentManager {
                 abortHandlingChain.toArray(EMPTY_REST_HANDLER_ARRAY), dynamicEntityWriter,
                 prefix, paramConverterProviders, configurationImpl, applicationSupplier,
                 threadSetupAction, requestContextFactory, preMatchHandlers, classMappers,
-                runtimeConfigurableServerRestHandlers, exceptionMapper, info.isResumeOn404());
+                runtimeConfigurableServerRestHandlers, exceptionMapper, info.isResumeOn404(), info.getResteasyReactiveConfig());
     }
 
     private void forEachMapperEntry(URITemplate path,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -101,7 +101,7 @@ public class RuntimeResourceDeployment {
 
     private final DeploymentInfo info;
     private final ServerSerialisers serialisers;
-    private final ResteasyReactiveConfig quarkusRestConfig;
+    private final ResteasyReactiveConfig resteasyReactiveConfig;
     private final Supplier<Executor> executorSupplier;
     private final RuntimeInterceptorDeployment runtimeInterceptorDeployment;
     private final DynamicEntityWriter dynamicEntityWriter;
@@ -118,7 +118,7 @@ public class RuntimeResourceDeployment {
             ResourceLocatorHandler resourceLocatorHandler, boolean defaultBlocking) {
         this.info = info;
         this.serialisers = info.getSerialisers();
-        this.quarkusRestConfig = info.getConfig();
+        this.resteasyReactiveConfig = info.getResteasyReactiveConfig();
         this.executorSupplier = executorSupplier;
         this.runtimeInterceptorDeployment = runtimeInterceptorDeployment;
         this.dynamicEntityWriter = dynamicEntityWriter;
@@ -265,7 +265,7 @@ public class RuntimeResourceDeployment {
             if (!defaultBlocking) {
                 if (!method.isBlocking()) {
                     // allow the body to be read by chunks
-                    handlers.add(new InputHandler(quarkusRestConfig.getInputBufferSize(), executorSupplier));
+                    handlers.add(new InputHandler(resteasyReactiveConfig.getInputBufferSize(), executorSupplier));
                     checkReadBodyRequestFilters = true;
                 }
             }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
@@ -20,11 +20,9 @@ public class ResteasyReactiveOutputStream extends OutputStream {
     private final ResteasyReactiveRequestContext context;
     protected final HttpServerRequest request;
     private ByteBuf pooledBuffer;
-    private long written;
     private boolean committed;
 
     private boolean closed;
-    private boolean finished;
     protected boolean waitingForDrain;
     protected boolean drainHandlerRegistered;
     protected boolean first = true;
@@ -217,7 +215,6 @@ public class ResteasyReactiveOutputStream extends OutputStream {
             }
             throw new IOException(e);
         }
-        updateWritten(len);
     }
 
     public void writeBlocking(ByteBuf buffer, boolean finished) throws IOException {
@@ -238,13 +235,6 @@ public class ResteasyReactiveOutputStream extends OutputStream {
                 request.response().setChunked(true);
             }
         }
-        if (finished) {
-            this.finished = true;
-        }
-    }
-
-    void updateWritten(final long len) throws IOException {
-        this.written += len;
     }
 
     /**


### PR DESCRIPTION
This also changes the default which was `256` bytes to `8192` bytes which is the default used in RESTEasy Classic

Resolves: #22585