### PR TITLE
Use code.quarkus instead of the stage in rest-client-codestart

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/java/src/main/java/org/acme/MyRemoteService.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/java/src/main/java/org/acme/MyRemoteService.java
@@ -8,7 +8,7 @@ import javax.ws.rs.QueryParam;
 import java.util.List;
 import java.util.Set;
 
-@RegisterRestClient(baseUri = "https://stage.code.quarkus.io/api")
+@RegisterRestClient(baseUri = "https://code.quarkus.io/api")
 public interface MyRemoteService {
 
     @GET

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/kotlin/src/main/kotlin/org/acme/MyRemoteService.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/rest-client-codestart/kotlin/src/main/kotlin/org/acme/MyRemoteService.kt
@@ -5,7 +5,7 @@ import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 
-@RegisterRestClient(baseUri = "https://stage.code.quarkus.io/api")
+@RegisterRestClient(baseUri = "https://code.quarkus.io/api")
 interface MyRemoteService {
 
     @GET

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_java_ilove_quark_us_MyRemoteService.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_java_ilove_quark_us_MyRemoteService.java
@@ -8,7 +8,7 @@ import javax.ws.rs.QueryParam;
 import java.util.List;
 import java.util.Set;
 
-@RegisterRestClient(baseUri = "https://stage.code.quarkus.io/api")
+@RegisterRestClient(baseUri = "https://code.quarkus.io/api")
 public interface MyRemoteService {
 
     @GET

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_kotlin_ilove_quark_us_MyRemoteService.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTClientCodestartTest/testContent/src_main_kotlin_ilove_quark_us_MyRemoteService.kt
@@ -5,7 +5,7 @@ import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 
-@RegisterRestClient(baseUri = "https://stage.code.quarkus.io/api")
+@RegisterRestClient(baseUri = "https://code.quarkus.io/api")
 interface MyRemoteService {
 
     @GET


### PR DESCRIPTION
Use code.quarkus instead of the stage in rest-client-codestart

This example is end user-facing and thus I think code.quarkus.io address should be used instead of the stage which is internal detail.