### PR TITLE
Move RESTEasy provider registration as unremovable beans to common module

### DIFF
--- a/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-common/deployment/src/main/java/io/quarkus/resteasy/common/deployment/ResteasyCommonProcessor.java
@@ -175,6 +175,7 @@ public class ResteasyCommonProcessor {
     JaxrsProvidersToRegisterBuildItem setupProviders(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             CombinedIndexBuildItem indexBuildItem,
             BeanArchiveIndexBuildItem beanArchiveIndexBuildItem,
+            BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
             List<ResteasyJaxrsProviderBuildItem> contributedProviderBuildItems,
             List<RestClientBuildItem> restClients,
             ResteasyConfigBuildItem resteasyConfig,
@@ -260,8 +261,14 @@ public class ResteasyCommonProcessor {
                     "org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider"));
         }
 
-        return new JaxrsProvidersToRegisterBuildItem(
+        JaxrsProvidersToRegisterBuildItem result = new JaxrsProvidersToRegisterBuildItem(
                 providersToRegister, contributedProviders, annotatedProviders, useBuiltinProviders);
+
+        // Providers that are also beans are unremovable
+        unremovableBeans.produce(new UnremovableBeanBuildItem(
+                b -> result.getProviders().contains(b.getBeanClass().toString())));
+
+        return result;
     }
 
     private String mutinySupportNeeded(CombinedIndexBuildItem indexBuildItem) {

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -648,10 +648,6 @@ public class ResteasyServerCommonProcessor {
                 ServletConfigSource.class,
                 ServletContextConfigSource.class,
                 FilterConfigSource.class));
-
-        // Providers that are also beans are unremovable
-        unremovableBeans.produce(new UnremovableBeanBuildItem(
-                b -> jaxrsProvidersToRegisterBuildItem.getProviders().contains(b.getBeanClass().toString())));
     }
 
     private static void generateDefaultConstructors(BuildProducer<BytecodeTransformerBuildItem> transformers,

--- a/integration-tests/smallrye-opentracing/pom.xml
+++ b/integration-tests/smallrye-opentracing/pom.xml
@@ -25,7 +25,7 @@
         <!-- Server dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -43,15 +43,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
-        </dependency>
 
         <!-- Client dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-mutiny</artifactId>
         </dependency>
 
         <!-- In-memory tracer -->
@@ -121,7 +117,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -134,20 +130,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/smallrye-opentracing/src/main/resources/application.properties
+++ b/integration-tests/smallrye-opentracing/src/main/resources/application.properties
@@ -3,5 +3,6 @@ quarkus.datasource.jdbc.url=jdbc:tracing:postgresql://localhost:5432/mydatabase
 quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
+quarkus.rest.single-default-produces=false
 
 pingpong/mp-rest/url=${test.url}


### PR DESCRIPTION
This is needed because without this change, applications that only
include the rest-client without including the server component,
result in the providers not being registered as unremovable beans.

Fixes: #22605
Fixes: #20498