### PR TITLE
Do not handle print-data-fetcher-exception as a config relocation

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -417,7 +417,7 @@ public class SmallRyeGraphQLProcessor {
             LaunchModeBuildItem launchMode,
             BuildProducer<SystemPropertyBuildItem> systemProperties) {
 
-        // User did not set this explisitly 
+        // User did not set this explicitly
         if (!graphQLConfig.printDataFetcherException.isPresent()) {
             if (launchMode.getLaunchMode().isDevOrTest()) {
                 systemProperties.produce(new SystemPropertyBuildItem(ConfigKey.PRINT_DATAFETCHER_EXCEPTION, TRUE));

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfigMapping.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfigMapping.java
@@ -42,7 +42,6 @@ public class SmallRyeGraphQLConfigMapping extends RelocateConfigSourceIntercepto
         mapKey(relocations, ConfigKey.ALLOW_POST_WITH_QUERY_PARAMETERS, QUARKUS_HTTP_POST_QUERYPARAMETERS_ENABLED);
         mapKey(relocations, ConfigKey.ERROR_EXTENSION_FIELDS, QUARKUS_ERROR_EXTENSION_FIELDS);
         mapKey(relocations, ConfigKey.DEFAULT_ERROR_MESSAGE, QUARKUS_DEFAULT_ERROR_MESSAGE);
-        mapKey(relocations, ConfigKey.PRINT_DATAFETCHER_EXCEPTION, QUARKUS_PRINT_DATAFETCHER_EXCEPTION);
         mapKey(relocations, ConfigKey.SCHEMA_INCLUDE_SCALARS, QUARKUS_SCHEMA_INCLUDE_SCALARS);
         mapKey(relocations, ConfigKey.SCHEMA_INCLUDE_DEFINITION, QUARKUS_SCHEMA_INCLUDE_DEFINITION);
         mapKey(relocations, ConfigKey.SCHEMA_INCLUDE_DIRECTIVES, QUARKUS_SCHEMA_INCLUDE_DIRECTIVES);


### PR DESCRIPTION
It is manually handled in SmallRyeGraphQLProcessor.
Fixes #21030

See https://github.com/quarkusio/quarkus/blob/main/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java#L421