### PR TITLE
Enable native tests for hibernate-orm-panache-kotlin

### DIFF
--- a/integration-tests/hibernate-orm-panache-kotlin/disable-native-profile
+++ b/integration-tests/hibernate-orm-panache-kotlin/disable-native-profile
@@ -1,1 +1,0 @@
-This file disables the native profile in the parent pom.xml of this module.

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityInGraalITCase.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityInGraalITCase.kt
@@ -7,5 +7,4 @@ import org.junit.jupiter.api.Disabled
  * Test various Panache operations running in native mode
  */
 @QuarkusIntegrationTest
-@Disabled("Fails on GraalVM 20.1")
 class KotlinPanacheFunctionalityInGraalITCase : KotlinPanacheFunctionalityTest()

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityTest.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityTest.kt
@@ -66,6 +66,7 @@ open class KotlinPanacheFunctionalityTest {
     }
 
     @Test
+    @DisabledOnNativeImage
     fun entityManagerIsInjected() {
         assertNotNull(Dog.getEntityManager())
     }


### PR DESCRIPTION
Enable native tests for hibernate-orm-panache-kotlin

Module already listed in https://github.com/quarkusio/quarkus/blob/main/.github/native-tests.json#L24

Tests passed locally when using OpenJDK Runtime Environment GraalVM CE 21.3.0 (build 11.0.13+7-jvmci-21.3-b05)
