### PR TITLE
fix/mutiny deprecated in 1.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -136,7 +136,7 @@
         <netty.version>4.1.72.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.2.Final</jboss-logging.version>
-        <mutiny.version>1.2.0</mutiny.version>
+        <mutiny.version>999-SNAPSHOT</mutiny.version>
         <kafka3.version>3.0.0</kafka3.version>
         <snappy.version>1.1.8.1</snappy.version>
         <zookeeper.version>3.5.7</zookeeper.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -42,7 +42,7 @@
         <version.jboss-logging>3.4.2.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>1.2.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>999-SNAPSHOT</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -50,7 +50,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>
-        <mutiny.version>1.2.0</mutiny.version>
+        <mutiny.version>999-SNAPSHOT</mutiny.version>
         <smallrye-common.version>1.8.0</smallrye-common.version>
         <vertx.version>4.2.2</vertx.version>
         <rest-assured.version>4.4.0</rest-assured.version>

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
@@ -32,7 +32,7 @@ public class SomeService {
 
     Multi<String> greetingAsMulti() {
         return Multi.createFrom().items("h", "e", "l", "l", "o")
-                .groupItems().intoMultis().of(2)
+                .group().intoMultis().of(2)
                 .onItem().transformToUniAndConcatenate(g -> g.collect().in(StringBuffer::new, StringBuffer::append))
                 .emitOn(executor)
                 .onItem().transform(StringBuffer::toString);


### PR DESCRIPTION
- Use Mutiny 999-SNAPSHOT
- Do not use deprecated APIs from the upcoming Mutiny 1.3.0 release
