### PR TITLE
Do not use deprecated APIs from the upcoming Mutiny 1.3.0 release

### DIFF
--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/SomeService.java
@@ -32,7 +32,7 @@ public class SomeService {
 
     Multi<String> greetingAsMulti() {
         return Multi.createFrom().items("h", "e", "l", "l", "o")
-                .groupItems().intoMultis().of(2)
+                .group().intoMultis().of(2)
                 .onItem().transformToUniAndConcatenate(g -> g.collect().in(StringBuffer::new, StringBuffer::append))
                 .emitOn(executor)
                 .onItem().transform(StringBuffer::toString);


### PR DESCRIPTION
Year old deprecations will be removed in Mutiny 1.3.0, see https://github.com/smallrye/smallrye-mutiny/pull/796
