### PR TITLE
Ensure that UTF8 is used as the default encoding in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/ResponseStringNonAsciiTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/response/ResponseStringNonAsciiTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.response;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ResponseStringNonAsciiTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(HelloResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        RestAssured.get("/hello")
+                .then().statusCode(200)
+                .and().body(Matchers.equalTo("{\"message\": \"Καλημέρα κόσμε\"}"))
+                .and().contentType("application/json");
+    }
+
+    @Path("hello")
+    public static class HelloResource {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response hello() {
+            return Response.ok("{\"message\": \"Καλημέρα κόσμε\"}").build();
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -35,7 +36,7 @@ public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter
         setContentTypeIfNecessary(context);
         OutputStream stream = context.getOrCreateOutputStream();
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
-            stream.write(((String) o).getBytes());
+            stream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             defaultWriter.writeValue(stream, o);
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
@@ -46,7 +47,7 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
         setContentTypeIfNecessary(context);
         OutputStream stream = context.getOrCreateOutputStream();
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
-            stream.write(((String) o).getBytes());
+            stream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             // First test the names to see if JsonView is used. We do this to avoid doing reflection for the common case
             // where JsonView is not used

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/kotlin/serialization/KotlinSerializationMessageBodyWriter.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/kotlin/serialization/KotlinSerializationMessageBodyWriter.kt
@@ -1,7 +1,6 @@
 package io.quarkus.kotlin.serialization
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToStream
 import kotlinx.serialization.serializer
@@ -11,6 +10,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter.AllWriteab
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext
 import java.io.OutputStream
 import java.lang.reflect.Type
+import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
@@ -25,7 +25,7 @@ class KotlinSerializationMessageBodyWriter(@Inject var json: Json) : AllWriteabl
     ) {
         JsonMessageBodyWriterUtil.setContentTypeIfNecessary(httpHeaders)
         if (o is String) { // YUK: done in order to avoid adding extra quotes...
-            entityStream.write(o.toByteArray())
+            entityStream.write(o.toByteArray(StandardCharsets.UTF_8))
         } else {
             json.encodeToStream(o, entityStream)
         }
@@ -37,7 +37,7 @@ class KotlinSerializationMessageBodyWriter(@Inject var json: Json) : AllWriteabl
         val stream: OutputStream = NoopCloseAndFlushOutputStream(originalStream)
 
         if (o is String) { // YUK: done in order to avoid adding extra quotes...
-            stream.write(o.toByteArray())
+            stream.write(o.toByteArray(StandardCharsets.UTF_8))
         } else {
             json.encodeToStream(serializer(genericType), o, stream)
         }

--- a/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
+++ b/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
 import javax.ws.rs.core.MultivaluedMap;
 
 public final class JacksonMessageBodyWriterUtil {
@@ -43,7 +44,7 @@ public final class JacksonMessageBodyWriterUtil {
             OutputStream entityStream, ObjectWriter defaultWriter) throws IOException {
         setContentTypeIfNecessary(httpHeaders);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
-            entityStream.write(((String) o).getBytes());
+            entityStream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             if (annotations != null) {
                 for (Annotation annotation : annotations) {

--- a/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 import javax.ws.rs.WebApplicationException;
@@ -28,7 +29,7 @@ public class JsonbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteable
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         JsonMessageBodyWriterUtil.setContentTypeIfNecessary(httpHeaders);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
-            entityStream.write(((String) o).getBytes());
+            entityStream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             json.toJson(o, type, entityStream);
         }
@@ -41,7 +42,7 @@ public class JsonbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteable
         OutputStream originalStream = context.getOrCreateOutputStream();
         OutputStream stream = new NoopCloseAndFlushOutputStream(originalStream);
         if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
-            stream.write(((String) o).getBytes());
+            stream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             json.toJson(o, stream);
         }


### PR DESCRIPTION
This was already being done when producing `text/plain`, but in cases
where `application/json` was being used and the actual entity was a String,
the encoding was not being specified

Fixes: #21700