### PR TITLE
Bump kubernetes-client-bom from 5.11.1 to 5.11.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -166,7 +166,7 @@
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.11.1</kubernetes-client.version>
+        <kubernetes-client.version>5.11.2</kubernetes-client.version>
         <flapdoodle.mongo.version>3.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Kubernetes Client 5.11.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.11.2

This release patches the following issues:
- https://github.com/fabric8io/kubernetes-client/issues/3653
- https://github.com/fabric8io/kubernetes-client/issues/3697

Regarding `#3653`, we've also released patches for other 5.x minor version. It might be a good idea to patch the Quarkus LTS branches with the appropriate Kubernetes Client version (let me know if you want me to do this).

/cc @metacosm
