### PR TITLE
Make sure quarkusDev configuration is resolved before quarkusTest task runs

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -167,7 +167,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                     ConfigurationContainer configurations = project.getConfigurations();
 
                     // create a custom configuration for devmode
-                    Configuration configuration = configurations.create(DEV_MODE_CONFIGURATION_NAME)
+                    Configuration devModeConfiguration = configurations.create(DEV_MODE_CONFIGURATION_NAME)
                             .extendsFrom(configurations.findByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
 
                     tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile.class,
@@ -197,12 +197,15 @@ public class QuarkusPlugin implements Plugin<Project> {
                         task.dependsOn(classesTask, resourcesTask, testClassesTask, testResourcesTask,
                                 quarkusGenerateCodeDev,
                                 quarkusGenerateCodeTests);
-                        task.setQuarkusDevConfiguration(configuration);
+                        task.setQuarkusDevConfiguration(devModeConfiguration);
                     });
                     quarkusRemoteDev.configure(task -> task.dependsOn(classesTask, resourcesTask));
-                    quarkusTest.configure(task -> task.dependsOn(classesTask, resourcesTask, testClassesTask, testResourcesTask,
-                            quarkusGenerateCode,
-                            quarkusGenerateCodeTests));
+                    quarkusTest.configure(task -> {
+                        task.dependsOn(classesTask, resourcesTask, testClassesTask, testResourcesTask,
+                                quarkusGenerateCode,
+                                quarkusGenerateCodeTests);
+                        task.setQuarkusDevConfiguration(devModeConfiguration);
+                    });
                     quarkusBuild.configure(
                             task -> task.dependsOn(classesTask, resourcesTask, tasks.named(JavaPlugin.JAR_TASK_NAME)));
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -51,7 +51,7 @@ public class QuarkusDev extends QuarkusTask {
 
     public static final String IO_QUARKUS_DEVMODE_ARGS = "io.quarkus.devmode-args";
     private Set<File> filesIncludedInClasspath = new HashSet<>();
-    private Configuration quarkusDevConfiguration;
+    protected Configuration quarkusDevConfiguration;
 
     private File buildDir;
 


### PR DESCRIPTION
Sets the quarkusDev configuration reference to the `QuarkusTest` task. 

close #22663 