### PR TITLE
Make sure REST methods can be called without an active CDI context

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MetricDescriptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/MetricDescriptor.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.metrics.annotation.Metric;
 
 import io.micrometer.core.instrument.Tags;
 
-class MetricDescriptor {
+public class MetricDescriptor {
     final String name;
     final Tags tags;
     ExtendedMetricID metricId = null;

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/QuarkusRestPathTemplateInterceptor.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import javax.annotation.Priority;
+import javax.enterprise.context.ContextNotActiveException;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -12,6 +13,7 @@ import javax.interceptor.InvocationContext;
 import io.quarkus.arc.ArcInvocationContext;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.ext.web.RoutingContext;
 
 @SuppressWarnings("unused")
 @QuarkusRestPathTemplate
@@ -24,7 +26,13 @@ public class QuarkusRestPathTemplateInterceptor {
     @AroundInvoke
     Object restMethodInvoke(InvocationContext context) throws Exception {
         QuarkusRestPathTemplate annotation = getAnnotation(context);
-        if ((annotation != null) && (request.getCurrent() != null)) {
+        RoutingContext routingContext = null;
+        try {
+            routingContext = request.getCurrent();
+        } catch (ContextNotActiveException ex) {
+            // just leave routingContext as null
+        }
+        if ((annotation != null) && (routingContext != null)) {
             ((HttpServerRequestInternal) request.getCurrent().request()).context().putLocal("UrlPathTemplate",
                     annotation.value());
         }

--- a/integration-tests/micrometer-mp-metrics/src/main/java/io/quarkus/it/micrometer/mpmetrics/PrimeResource.java
+++ b/integration-tests/micrometer-mp-metrics/src/main/java/io/quarkus/it/micrometer/mpmetrics/PrimeResource.java
@@ -70,6 +70,8 @@ public class PrimeResource {
     }
 
     @Gauge(name = "highestPrimeNumberSoFar", unit = MetricUnits.NONE, description = "Highest prime number so far.")
+    @GET
+    @Path("/blabla") // make this a REST method just to verify that a gauge will still work on it
     public Long highestPrimeNumberSoFar() {
         return highestPrimeSoFar.get();
     }


### PR DESCRIPTION
Fixes #22662 - the problem is that if there's a gauge on a REST method and its `GaugeAdapterImpl` calls that REST method during scraping, it is called without an attached CDI and routing context, and `CurrentVertxRequest.getCurrent()` throws an exception in this case, rather than returns null.