### PR TITLE
Fixed config locations to be URIs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -10,7 +10,9 @@ import static java.util.stream.Collectors.toSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -253,12 +255,13 @@ public class ConfigGenerationBuildStep {
         configWatchedFiles.add(
                 Paths.get(userDir, "config", String.format("application-%s.properties", profile)).toAbsolutePath().toString());
 
-        Optional<List<String>> optionalLocations = config.getOptionalValues(SMALLRYE_CONFIG_LOCATIONS, String.class);
+        Optional<List<URI>> optionalLocations = config.getOptionalValues(SMALLRYE_CONFIG_LOCATIONS, URI.class);
         optionalLocations.ifPresent(locations -> {
-            for (String location : locations) {
-                if (!Files.isDirectory(Paths.get(location))) {
-                    configWatchedFiles.add(location);
-                    configWatchedFiles.add(appendProfileToFilename(location, profile));
+            for (URI location : locations) {
+                Path path = location.getScheme() != null ? Paths.get(location) : Paths.get(location.getPath());
+                if (!Files.isDirectory(path)) {
+                    configWatchedFiles.add(location.toString());
+                    configWatchedFiles.add(appendProfileToFilename(location.toString(), profile));
                 }
             }
         });

--- a/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/ConfigConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.runtime;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,7 +22,7 @@ public class ConfigConfig {
      * separated by a comma and each must represent a valid {@link java.net.URI}.
      */
     @ConfigItem(name = "config.locations")
-    public Optional<List<String>> locations;
+    public Optional<List<URI>> locations;
 
     /**
      * Accepts a single configuration profile name. If a configuration property cannot be found in the current active


### PR DESCRIPTION
The [quarkus.config.locations](https://quarkus.io/guides/all-config#quarkus-core_quarkus.config.locations) configuration is specified as a `java.net.URI` in the documentation, but `ConfigGenerationBuildStep` was treating it as a file path

Fixes: https://github.com/quarkusio/quarkus/issues/22699

@radcortez @glefloch @gsmet 