### PR TITLE
Bump kubernetes-client-bom from 5.10.1 to 5.10.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -162,7 +162,7 @@
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.10.1</kubernetes-client.version>
+        <kubernetes-client.version>5.10.2</kubernetes-client.version>
         <flapdoodle.mongo.version>3.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Back-port equivalent of #22660 (+ #22664)

Kubernetes Client 5.10.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.10.2

This release patches the following issues:
- https://github.com/fabric8io/kubernetes-client/issues/3653

/cc @gsmet 
