### PR TITLE
Fix schemaLocation problem in LiquibaseFunctionalityNativeIT

### DIFF
--- a/integration-tests/liquibase/src/main/resources/db/xml/create-views.xml
+++ b/integration-tests/liquibase/src/main/resources/db/xml/create-views.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
 
     <preConditions>
         <dbms type="h2"/>


### PR DESCRIPTION
Fixes:
```
Caused by: org.xml.sax.SAXParseException; systemId: http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.2.xsd; lineNumber: 2; columnNumber: 35; s4s-elt-character: Non-whitespace characters are not allowed in schema elements other than 'xs:appinfo' and 'xs:documentation'. Saw '301 Moved Permanently'.
```

The Liquibase guys must have switched to https today.