### PR TITLE
Fixed NPE for OpenTelemetry tracing requests without remoteAddress

### DIFF
--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/VertxUtil.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/VertxUtil.java
@@ -36,7 +36,8 @@ public final class VertxUtil {
         // If none is found resorts to the remote address from the http request
         return getForwardedHeaderValue(httpServerRequest)
                 .orElseGet(() -> getXForwardedHeaderValue(httpServerRequest)
-                        .orElseGet(() -> httpServerRequest.remoteAddress().host()));
+                        .orElseGet(() -> httpServerRequest.remoteAddress() != null ? httpServerRequest.remoteAddress().host()
+                                : null));
 
     }
 }


### PR DESCRIPTION
This PR contains a small fix for a NPE I've seen today using 2.6.1.

```
[io.net.cha.AbstractChannelHandlerContext] (vert.x-eventloop-thread-1) An exception 'java.lang.NullPointerException' [enable DEBUG level for full stacktrace] was thrown by a user handler's exceptionCaught() method while handling the following exception:: java.lang.NullPointerException
	at io.quarkus.opentelemetry.runtime.tracing.vertx.VertxUtil.lambda$extractClientIP$2(VertxUtil.java:39)
	at java.base/java.util.Optional.orElseGet(Optional.java:369)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.VertxUtil.lambda$extractClientIP$3(VertxUtil.java:39)
	at java.base/java.util.Optional.orElseGet(Optional.java:369)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.VertxUtil.extractClientIP(VertxUtil.java:38)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.OpenTelemetryVertxTracer$AdditionalServerAttributesExtractor.onStart(OpenTelemetryVertxTracer.java:388)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.OpenTelemetryVertxTracer$AdditionalServerAttributesExtractor.onStart(OpenTelemetryVertxTracer.java:381)
	at io.opentelemetry.instrumentation.api.instrumenter.Instrumenter.start(Instrumenter.java:176)
	at io.opentelemetry.instrumentation.api.instrumenter.ServerInstrumenter.start(ServerInstrumenter.java:30)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.OpenTelemetryVertxTracer.receiveRequest(OpenTelemetryVertxTracer.java:90)
	at io.quarkus.opentelemetry.runtime.tracing.vertx.OpenTelemetryVertxTracer.receiveRequest(OpenTelemetryVertxTracer.java:42)
	at io.vertx.core.http.impl.Http1xServerRequest.reportRequestBegin(Http1xServerRequest.java:580)
	at io.vertx.core.http.impl.Http1xServerRequest.handleBegin(Http1xServerRequest.java:153)
	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:143)
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:156)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.quarkus.netty.runtime.virtual.VirtualChannel.readInbound(VirtualChannel.java:251)
	at io.quarkus.netty.runtime.virtual.VirtualChannel.doBeginRead(VirtualChannel.java:274)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.beginRead(AbstractChannel.java:852)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.read(DefaultChannelPipeline.java:1362)
	at io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:686)
	at io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:671)
	at io.netty.channel.DefaultChannelPipeline.read(DefaultChannelPipeline.java:1004)
	at io.netty.channel.AbstractChannel.read(AbstractChannel.java:290)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.readIfIsAutoRead(DefaultChannelPipeline.java:1422)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelActive(DefaultChannelPipeline.java:1400)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelActive(AbstractChannelHandlerContext.java:230)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelActive(AbstractChannelHandlerContext.java:216)
	at io.netty.channel.DefaultChannelPipeline.fireChannelActive(DefaultChannelPipeline.java:895)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:522)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```