### PR TITLE
Fix logging with panache in entities

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/QuarkusClassVisitor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/QuarkusClassVisitor.java
@@ -1,0 +1,32 @@
+package io.quarkus.deployment;
+
+import org.objectweb.asm.ClassVisitor;
+
+/**
+ * A subclass of {@link ClassVisitor} that allows carrying around data
+ * that are useful in the context of Quarkus bytecode transformations.
+ * Class visitors that require access to these data should extend this class.
+ */
+public abstract class QuarkusClassVisitor extends ClassVisitor {
+    public QuarkusClassVisitor(int api) {
+        super(api);
+    }
+
+    public QuarkusClassVisitor(int api, ClassVisitor classVisitor) {
+        super(api, classVisitor);
+    }
+
+    // ---
+
+    // this could possibly be a Map<String, Object> or something like that,
+    // but there's no need at the moment
+    private int originalClassReaderOptions;
+
+    public int getOriginalClassReaderOptions() {
+        return originalClassReaderOptions;
+    }
+
+    public void setOriginalClassReaderOptions(int originalClassReaderOptions) {
+        this.originalClassReaderOptions = originalClassReaderOptions;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ClassTransformingBuildStep.java
@@ -32,6 +32,7 @@ import org.objectweb.asm.ClassWriter;
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.bootstrap.classloading.ClassPathElement;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.QuarkusClassVisitor;
 import io.quarkus.deployment.QuarkusClassWriter;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -313,6 +314,9 @@ public class ClassTransformingBuildStep {
             ClassVisitor visitor = writer;
             for (BiFunction<String, ClassVisitor, ClassVisitor> i : visitors) {
                 visitor = i.apply(className, visitor);
+                if (visitor instanceof QuarkusClassVisitor) {
+                    ((QuarkusClassVisitor) visitor).setOriginalClassReaderOptions(classReaderOptions);
+                }
             }
             cr.accept(visitor, classReaderOptions);
             data = writer.toByteArray();

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateEntityEnhancer.java
@@ -10,6 +10,7 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
+import io.quarkus.deployment.QuarkusClassVisitor;
 import io.quarkus.deployment.QuarkusClassWriter;
 import io.quarkus.gizmo.Gizmo;
 import net.bytebuddy.ClassFileVersion;
@@ -36,7 +37,7 @@ public final class HibernateEntityEnhancer implements BiFunction<String, ClassVi
         return new HibernateEnhancingClassVisitor(className, outputClassVisitor);
     }
 
-    private static class HibernateEnhancingClassVisitor extends ClassVisitor {
+    private static class HibernateEnhancingClassVisitor extends QuarkusClassVisitor {
 
         private final String className;
         private final ClassVisitor outputClassVisitor;
@@ -78,7 +79,7 @@ public final class HibernateEntityEnhancer implements BiFunction<String, ClassVi
             final byte[] transformedBytes = hibernateEnhancement(className, inputBytes);
             //Then re-convert the transformed bytecode to not interrupt the visitor chain:
             ClassReader cr = new ClassReader(transformedBytes);
-            cr.accept(outputClassVisitor, 0);
+            cr.accept(outputClassVisitor, super.getOriginalClassReaderOptions());
         }
 
         private byte[] hibernateEnhancement(final String className, final byte[] originalBytes) {

--- a/integration-tests/logging-panache/pom.xml
+++ b/integration-tests/logging-panache/pom.xml
@@ -20,14 +20,14 @@
             <artifactId>quarkus-arc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--
-          - this dependency is enough to test that the Logging with Panache
-          - and Hibernate ORM with Panache class transformations do not collide
-          - on setting the class reader options (issue #20569)
-          -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,6 +56,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingEntity.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.logging;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class LoggingEntity extends PanacheEntity {
+    public void something() {
+        Log.info("Hi!");
+    }
+}

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
@@ -18,10 +18,10 @@ public class LoggingWithPanacheTest {
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(LoggingBean.class, NoStackTraceTestException.class))
+                    .addClasses(LoggingBean.class, LoggingEntity.class, NoStackTraceTestException.class))
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.logging\".min-level", "TRACE")
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.logging\".level", "TRACE")
-            .setLogRecordPredicate(record -> "io.quarkus.logging.LoggingBean".equals(record.getLoggerName()))
+            .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus.logging.Logging"))
             .assertLogRecords(records -> {
                 Formatter formatter = new PatternFormatter("[%p] %m");
                 List<String> lines = records.stream().map(formatter::format).map(String::trim).collect(Collectors.toList());
@@ -38,7 +38,8 @@ public class LoggingWithPanacheTest {
                         "[WARN] three: foo | bar | baz",
                         "[ERROR] four: foo | bar | baz | quux",
                         "[WARN] foo | bar | baz | quux: io.quarkus.logging.NoStackTraceTestException",
-                        "[ERROR] Hello Error: io.quarkus.logging.NoStackTraceTestException");
+                        "[ERROR] Hello Error: io.quarkus.logging.NoStackTraceTestException",
+                        "[INFO] Hi!");
             });
 
     @Inject
@@ -47,5 +48,6 @@ public class LoggingWithPanacheTest {
     @Test
     public void test() {
         bean.doSomething();
+        new LoggingEntity().something();
     }
 }


### PR DESCRIPTION
In case an entity class uses `io.quarkus.logging.Log`, it requires
two bytecode transformations: the Hibernate transformation, and
the logging transformation. Unfortunately, `HibernateEntityEnhancer`
needs to break the chain of class visitors to be able to call into
the Hibernate Enhancer API. To be able to pretend that it's still
a regular `ClassVisitor`, it serializes the intermediate state
to a `byte[]`, runs the Hibernate enhancer, and then builds a whole
new `ClassReader` to continue in the original chain. This new
`ClassReader` is missing the options set on the original `ClassReader`,
which causes a failure in the logging transformation, because that
uses `LocalVariablesSorter`.

This commit introduces `QuarkusClassVisitor`, a new superclass
for class visitors that require access to some contextual data.
The bytecode transformation machinery puts the `ClassReader`
options into each `QuarkusClassVisitor` instance before
the bytecode transformation process begins. Finally,
`HibernateEntityEnhancer` extends this new class, so that when
it creates the new `ClassReader`, it can pass the correct options.

Fixes #22157