### PR TITLE
Clarified the Docker Compose instructions

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -159,7 +159,7 @@ service:
 
 ----
 
-Start the OpenTelemetry Collector and Jaeger system via the following docker-compose file that you can launch via `docker-compose run -d`:
+Start the OpenTelemetry Collector and Jaeger system via the following `docker-compose.yml` file that you can launch via `docker-compose up -d`:
 
 [source,yaml,subs="attributes"]
 ----


### PR DESCRIPTION
I don't think "docker-compose run" is the right command to use in this scenario. Instead, I changed it to tell the user to use `docker-compose up -d` so as to start the Jaeger service running in the background.

I also clarified what filename to use for the `docker-compose.yml` file. Otherwise the user might name it incorrectly, resulting in the `docker-compose up -d` command failing.