### PR TITLE
Support running the same application multiple times in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/WebJarUtil.java
@@ -44,7 +44,10 @@ import io.smallrye.common.io.jar.JarFiles;
 
 /**
  * Utility for Web resource related operations
+ * 
+ * @deprecated Use WebJarBuildItem and WebJarResultsBuildItem instead.
  */
+@Deprecated(forRemoval = true)
 public class WebJarUtil {
 
     private static final Logger LOG = Logger.getLogger(WebJarUtil.class);

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.smallrye.graphql.deployment;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -11,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,22 +35,17 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
-import io.quarkus.deployment.util.WebJarUtil;
-import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -60,7 +57,9 @@ import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
 import io.smallrye.graphql.api.Entry;
 import io.smallrye.graphql.cdi.config.ConfigKey;
 import io.smallrye.graphql.cdi.config.MicroProfileConfig;
@@ -95,10 +94,9 @@ public class SmallRyeGraphQLProcessor {
     private static final String FALSE = "false";
 
     // For the UI
-    private static final String GRAPHQL_UI_WEBJAR_GROUP_ID = "io.smallrye";
-    private static final String GRAPHQL_UI_WEBJAR_ARTIFACT_ID = "smallrye-graphql-ui-graphiql";
-    private static final String GRAPHQL_UI_WEBJAR_PREFIX = "META-INF/resources/graphql-ui/";
-    private static final String GRAPHQL_UI_FINAL_DESTINATION = "META-INF/graphql-ui-files";
+    private static final GACT GRAPHQL_UI_WEBJAR_ARTIFACT_KEY = new GACT("io.smallrye", "smallrye-graphql-ui-graphiql", null,
+            "jar");
+    private static final String GRAPHQL_UI_WEBJAR_STATIC_RESOURCES_PATH = "META-INF/resources/graphql-ui/";
     private static final String FILE_TO_UPDATE = "render.js";
     private static final String LINE_TO_UPDATE = "const api = '";
     private static final String LINE_FORMAT = LINE_TO_UPDATE + "%s';";
@@ -520,16 +518,11 @@ public class SmallRyeGraphQLProcessor {
 
     @BuildStep
     void getGraphqlUiFinalDestination(
-            BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer,
-            BuildProducer<NativeImageResourceBuildItem> nativeImageResourceProducer,
-            BuildProducer<NotFoundPageDisplayableEndpointBuildItem> notFoundPageDisplayableEndpointProducer,
-            BuildProducer<SmallRyeGraphQLBuildItem> smallRyeGraphQLBuildProducer,
             HttpRootPathBuildItem httpRootPath,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchMode,
             SmallRyeGraphQLConfig graphQLConfig,
-            LiveReloadBuildItem liveReloadBuildItem) throws Exception {
+            BuildProducer<WebJarBuildItem> webJarBuildProducer) {
 
         if (shouldInclude(launchMode, graphQLConfig)) {
 
@@ -542,58 +535,31 @@ public class SmallRyeGraphQLProcessor {
             String graphQLPath = httpRootPath.resolvePath(graphQLConfig.rootPath);
             String graphQLUiPath = nonApplicationRootPathBuildItem.resolvePath(graphQLConfig.ui.rootPath);
 
-            ResolvedDependency artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, GRAPHQL_UI_WEBJAR_GROUP_ID,
-                    GRAPHQL_UI_WEBJAR_ARTIFACT_ID);
-            if (launchMode.getLaunchMode().isDevOrTest()) {
-                Path tempPath = WebJarUtil.copyResourcesForDevOrTest(liveReloadBuildItem, curateOutcomeBuildItem, launchMode,
-                        artifact,
-                        GRAPHQL_UI_WEBJAR_PREFIX);
-                WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLPath, LINE_TO_UPDATE, LINE_FORMAT);
-                WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), graphQLUiPath,
-                        UI_LINE_TO_UPDATE, UI_LINE_FORMAT);
-                WebJarUtil.updateUrl(tempPath.resolve(FILE_TO_UPDATE), nonApplicationRootPathBuildItem.resolvePath("dev"),
-                        LOGO_LINE_TO_UPDATE, LOGO_LINE_FORMAT);
+            webJarBuildProducer.produce(
+                    WebJarBuildItem.builder().artifactKey(GRAPHQL_UI_WEBJAR_ARTIFACT_KEY) //
+                            .root(GRAPHQL_UI_WEBJAR_STATIC_RESOURCES_PATH) //
+                            .filter(new WebJarResourcesFilter() {
+                                @Override
+                                public FilterResult apply(String fileName, InputStream file) throws IOException {
+                                    if (fileName.endsWith(FILE_TO_UPDATE)) {
+                                        String content = new String(file.readAllBytes(), StandardCharsets.UTF_8);
+                                        content = updateUrl(content, graphQLPath, LINE_TO_UPDATE,
+                                                LINE_FORMAT);
+                                        content = updateUrl(content, graphQLUiPath,
+                                                UI_LINE_TO_UPDATE,
+                                                UI_LINE_FORMAT);
+                                        content = updateUrl(content, graphQLUiPath,
+                                                LOGO_LINE_TO_UPDATE,
+                                                LOGO_LINE_FORMAT);
 
-                smallRyeGraphQLBuildProducer
-                        .produce(new SmallRyeGraphQLBuildItem(tempPath.toAbsolutePath().toString(), graphQLUiPath));
+                                        return new FilterResult(
+                                                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), true);
+                                    }
 
-                // Handle live reload of branding files
-                if (liveReloadBuildItem.isLiveReload() && !liveReloadBuildItem.getChangedResources().isEmpty()) {
-                    WebJarUtil.hotReloadBrandingChanges(curateOutcomeBuildItem, launchMode, artifact,
-                            liveReloadBuildItem.getChangedResources());
-                }
-            } else {
-                Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(curateOutcomeBuildItem, artifact,
-                        GRAPHQL_UI_WEBJAR_PREFIX);
-
-                for (Map.Entry<String, byte[]> file : files.entrySet()) {
-
-                    String fileName = file.getKey();
-                    byte[] content = file.getValue();
-                    if (fileName.endsWith(FILE_TO_UPDATE)) {
-                        content = WebJarUtil
-                                .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLPath, LINE_TO_UPDATE,
-                                        LINE_FORMAT)
-                                .getBytes(StandardCharsets.UTF_8);
-                        content = WebJarUtil
-                                .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLUiPath,
-                                        UI_LINE_TO_UPDATE,
-                                        UI_LINE_FORMAT)
-                                .getBytes(StandardCharsets.UTF_8);
-                        content = WebJarUtil
-                                .updateUrl(new String(content, StandardCharsets.UTF_8), graphQLUiPath,
-                                        LOGO_LINE_TO_UPDATE,
-                                        LOGO_LINE_FORMAT)
-                                .getBytes(StandardCharsets.UTF_8);
-                    }
-                    fileName = GRAPHQL_UI_FINAL_DESTINATION + "/" + fileName;
-
-                    generatedResourceProducer.produce(new GeneratedResourceBuildItem(fileName, content));
-                    nativeImageResourceProducer.produce(new NativeImageResourceBuildItem(fileName));
-                }
-
-                smallRyeGraphQLBuildProducer.produce(new SmallRyeGraphQLBuildItem(GRAPHQL_UI_FINAL_DESTINATION, graphQLUiPath));
-            }
+                                    return new FilterResult(file, false);
+                                }
+                            })
+                            .build());
         }
     }
 
@@ -603,14 +569,24 @@ public class SmallRyeGraphQLProcessor {
             BuildProducer<RouteBuildItem> routeProducer,
             SmallRyeGraphQLRecorder recorder,
             SmallRyeGraphQLRuntimeConfig runtimeConfig,
-            SmallRyeGraphQLBuildItem smallRyeGraphQLBuildItem,
             LaunchModeBuildItem launchMode,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            SmallRyeGraphQLConfig graphQLConfig) throws Exception {
+            SmallRyeGraphQLConfig graphQLConfig,
+            WebJarResultsBuildItem webJarResultsBuildItem,
+            BuildProducer<SmallRyeGraphQLBuildItem> smallRyeGraphQLBuildProducer) {
+
+        WebJarResultsBuildItem.WebJarResult result = webJarResultsBuildItem.byArtifactKey(GRAPHQL_UI_WEBJAR_ARTIFACT_KEY);
+        if (result == null) {
+            return;
+        }
 
         if (shouldInclude(launchMode, graphQLConfig)) {
-            Handler<RoutingContext> handler = recorder.uiHandler(smallRyeGraphQLBuildItem.getGraphqlUiFinalDestination(),
-                    smallRyeGraphQLBuildItem.getGraphqlUiPath(), runtimeConfig);
+            String graphQLUiPath = nonApplicationRootPathBuildItem.resolvePath(graphQLConfig.ui.rootPath);
+            smallRyeGraphQLBuildProducer
+                    .produce(new SmallRyeGraphQLBuildItem(result.getFinalDestination(), graphQLUiPath));
+
+            Handler<RoutingContext> handler = recorder.uiHandler(result.getFinalDestination(),
+                    graphQLUiPath, runtimeConfig);
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .route(graphQLConfig.ui.rootPath)
                     .displayOnNotFoundPage("GraphQL UI")
@@ -628,5 +604,19 @@ public class SmallRyeGraphQLProcessor {
 
     private static boolean shouldInclude(LaunchModeBuildItem launchMode, SmallRyeGraphQLConfig graphQLConfig) {
         return launchMode.getLaunchMode().isDevOrTest() || graphQLConfig.ui.alwaysInclude;
+    }
+
+    private String updateUrl(String original, String path, String lineStartsWith, String format) {
+        try (Scanner scanner = new Scanner(original)) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.trim().startsWith(lineStartsWith)) {
+                    String newLine = String.format(format, path);
+                    return original.replace(line.trim(), newLine);
+                }
+            }
+        }
+
+        return original;
     }
 }

--- a/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
+++ b/extensions/smallrye-health/deployment/src/main/java/io/quarkus/smallrye/health/deployment/SmallRyeHealthProcessor.java
@@ -3,15 +3,14 @@ package io.quarkus.smallrye.health.deployment;
 import static io.quarkus.arc.processor.Annotations.containsAny;
 import static io.quarkus.arc.processor.Annotations.getAnnotations;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
@@ -46,21 +45,15 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.ShutdownListenerBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
-import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.kubernetes.spi.KubernetesHealthLivenessPathBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesHealthReadinessPathBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesHealthStartupPathBuildItem;
-import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.runtime.LaunchMode;
+import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
@@ -77,6 +70,9 @@ import io.quarkus.smallrye.health.runtime.SmallRyeWellnessHandler;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
 import io.smallrye.health.SmallRyeHealthReporter;
 import io.smallrye.health.api.HealthGroup;
 import io.smallrye.health.api.HealthGroups;
@@ -96,10 +92,8 @@ class SmallRyeHealthProcessor {
     private static final DotName JAX_RS_PATH = DotName.createSimple("javax.ws.rs.Path");
 
     // For the UI
-    private static final String HEALTH_UI_WEBJAR_GROUP_ID = "io.smallrye";
-    private static final String HEALTH_UI_WEBJAR_ARTIFACT_ID = "smallrye-health-ui";
-    private static final String HEALTH_UI_WEBJAR_PREFIX = "META-INF/resources/health-ui/";
-    private static final String HEALTH_UI_FINAL_DESTINATION = "META-INF/health-ui-files";
+    private static final GACT HEALTH_UI_WEBJAR_ARTIFACT_KEY = new GACT("io.smallrye", "smallrye-health-ui", null, "jar");
+    private static final String HEALTH_UI_WEBJAR_STATIC_RESOURCES_PATH = "META-INF/resources/health-ui/";
     private static final String JS_FILE_TO_UPDATE = "healthui.js";
     private static final String INDEX_FILE_TO_UPDATE = "index.html";
 
@@ -408,14 +402,10 @@ class SmallRyeHealthProcessor {
     // UI
     @BuildStep
     void registerUiExtension(
-            BuildProducer<GeneratedResourceBuildItem> generatedResourceProducer,
-            BuildProducer<NativeImageResourceBuildItem> nativeImageResourceProducer,
-            BuildProducer<SmallRyeHealthBuildItem> smallRyeHealthBuildProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             SmallRyeHealthConfig healthConfig,
-            CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchModeBuildItem,
-            LiveReloadBuildItem liveReloadBuildItem) throws Exception {
+            BuildProducer<WebJarBuildItem> webJarBuildProducer) {
 
         if (shouldInclude(launchModeBuildItem, healthConfig)) {
 
@@ -426,49 +416,26 @@ class SmallRyeHealthProcessor {
             }
 
             String healthPath = nonApplicationRootPathBuildItem.resolvePath(healthConfig.rootPath);
-            String healthUiPath = nonApplicationRootPathBuildItem.resolvePath(healthConfig.ui.rootPath);
 
-            ResolvedDependency artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, HEALTH_UI_WEBJAR_GROUP_ID,
-                    HEALTH_UI_WEBJAR_ARTIFACT_ID);
+            webJarBuildProducer.produce(
+                    WebJarBuildItem.builder().artifactKey(HEALTH_UI_WEBJAR_ARTIFACT_KEY) //
+                            .root(HEALTH_UI_WEBJAR_STATIC_RESOURCES_PATH) //
+                            .filter(new WebJarResourcesFilter() {
+                                @Override
+                                public FilterResult apply(String fileName, InputStream file) throws IOException {
+                                    if (fileName.endsWith(JS_FILE_TO_UPDATE) || fileName.endsWith(INDEX_FILE_TO_UPDATE)) {
+                                        byte[] content = SmallRyeHealthProcessor.this
+                                                .updateApiUrl(new String(file.readAllBytes(), StandardCharsets.UTF_8),
+                                                        healthPath)
+                                                .getBytes(StandardCharsets.UTF_8);
 
-            if (launchModeBuildItem.getLaunchMode().isDevOrTest()) {
-                Path tempPath = WebJarUtil.copyResourcesForDevOrTest(liveReloadBuildItem, curateOutcomeBuildItem,
-                        launchModeBuildItem,
-                        artifact,
-                        HEALTH_UI_WEBJAR_PREFIX);
-                if (launchModeBuildItem.getLaunchMode().equals(LaunchMode.DEVELOPMENT)) {
-                    updateApiUrl(tempPath.resolve(JS_FILE_TO_UPDATE), healthPath);
-                    updateApiUrl(tempPath.resolve(INDEX_FILE_TO_UPDATE), healthPath);
-                }
+                                        return new FilterResult(new ByteArrayInputStream(content), true);
+                                    }
 
-                smallRyeHealthBuildProducer
-                        .produce(new SmallRyeHealthBuildItem(tempPath.toAbsolutePath().toString(), healthUiPath));
-
-                // Handle live reload of branding files
-                if (liveReloadBuildItem.isLiveReload() && !liveReloadBuildItem.getChangedResources().isEmpty()) {
-                    WebJarUtil.hotReloadBrandingChanges(curateOutcomeBuildItem, launchModeBuildItem, artifact,
-                            liveReloadBuildItem.getChangedResources());
-                }
-            } else {
-                Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(curateOutcomeBuildItem, artifact,
-                        HEALTH_UI_WEBJAR_PREFIX);
-
-                for (Map.Entry<String, byte[]> file : files.entrySet()) {
-
-                    String fileName = file.getKey();
-                    byte[] content = file.getValue();
-                    if (fileName.endsWith(JS_FILE_TO_UPDATE) || fileName.endsWith(INDEX_FILE_TO_UPDATE)) {
-                        content = updateApiUrl(new String(content, StandardCharsets.UTF_8), healthPath)
-                                .getBytes(StandardCharsets.UTF_8);
-                    }
-                    fileName = HEALTH_UI_FINAL_DESTINATION + "/" + fileName;
-
-                    generatedResourceProducer.produce(new GeneratedResourceBuildItem(fileName, content));
-                    nativeImageResourceProducer.produce(new NativeImageResourceBuildItem(fileName));
-                }
-
-                smallRyeHealthBuildProducer.produce(new SmallRyeHealthBuildItem(HEALTH_UI_FINAL_DESTINATION, healthUiPath));
-            }
+                                    return new FilterResult(file, false);
+                                }
+                            })
+                            .build());
         }
     }
 
@@ -478,14 +445,24 @@ class SmallRyeHealthProcessor {
             BuildProducer<RouteBuildItem> routeProducer,
             SmallRyeHealthRecorder recorder,
             SmallRyeHealthRuntimeConfig runtimeConfig,
-            SmallRyeHealthBuildItem smallRyeHealthBuildItem,
+            WebJarResultsBuildItem webJarResultsBuildItem,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
             LaunchModeBuildItem launchMode,
-            SmallRyeHealthConfig healthConfig) {
+            SmallRyeHealthConfig healthConfig,
+            BuildProducer<SmallRyeHealthBuildItem> smallryeHealthBuildProducer) {
+
+        WebJarResultsBuildItem.WebJarResult result = webJarResultsBuildItem.byArtifactKey(HEALTH_UI_WEBJAR_ARTIFACT_KEY);
+        if (result == null) {
+            return;
+        }
 
         if (shouldInclude(launchMode, healthConfig)) {
-            Handler<RoutingContext> handler = recorder.uiHandler(smallRyeHealthBuildItem.getHealthUiFinalDestination(),
-                    smallRyeHealthBuildItem.getHealthUiPath(), runtimeConfig);
+            String healthUiPath = nonApplicationRootPathBuildItem.resolvePath(healthConfig.ui.rootPath);
+            smallryeHealthBuildProducer
+                    .produce(new SmallRyeHealthBuildItem(result.getFinalDestination(), healthUiPath));
+
+            Handler<RoutingContext> handler = recorder.uiHandler(result.getFinalDestination(),
+                    healthUiPath, runtimeConfig);
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .route(healthConfig.ui.rootPath)
                     .displayOnNotFoundPage("Health UI")
@@ -497,15 +474,6 @@ class SmallRyeHealthProcessor {
                     .route(healthConfig.ui.rootPath + "*")
                     .handler(handler)
                     .build());
-
-        }
-    }
-
-    private void updateApiUrl(Path fileToUpdate, String healthPath) throws IOException {
-        String content = Files.readString(fileToUpdate);
-        String result = updateApiUrl(content, healthPath);
-        if (result != null) {
-            Files.write(fileToUpdate, result.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
+++ b/extensions/swagger-ui/deployment/src/main/java/io/quarkus/swaggerui/deployment/SwaggerUiProcessor.java
@@ -1,7 +1,8 @@
 package io.quarkus.swaggerui.deployment;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,20 +24,18 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.deployment.builditem.LiveReloadBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
-import io.quarkus.deployment.util.WebJarUtil;
-import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.maven.dependency.GACT;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.common.deployment.SmallRyeOpenApiConfig;
 import io.quarkus.swaggerui.runtime.SwaggerUiRecorder;
 import io.quarkus.swaggerui.runtime.SwaggerUiRuntimeConfig;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
+import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
 import io.smallrye.openapi.ui.IndexHtmlCreator;
 import io.smallrye.openapi.ui.Option;
 import io.smallrye.openapi.ui.ThemeHref;
@@ -46,10 +45,8 @@ import io.vertx.ext.web.RoutingContext;
 public class SwaggerUiProcessor {
     private static final Logger LOG = Logger.getLogger(SwaggerUiProcessor.class);
 
-    private static final String SWAGGER_UI_WEBJAR_GROUP_ID = "io.smallrye";
-    private static final String SWAGGER_UI_WEBJAR_ARTIFACT_ID = "smallrye-open-api-ui";
-    private static final String SWAGGER_UI_WEBJAR_PREFIX = "META-INF/resources/openapi-ui/";
-    private static final String SWAGGER_UI_FINAL_DESTINATION = "META-INF/swagger-ui-files";
+    private static final GACT SWAGGER_UI_WEBJAR_ARTIFACT_KEY = new GACT("io.smallrye", "smallrye-open-api-ui", null, "jar");
+    private static final String SWAGGER_UI_WEBJAR_STATIC_RESOURCES_PATH = "META-INF/resources/openapi-ui/";
 
     // Branding files to monitor for changes
     private static final String BRANDING_DIR = "META-INF/branding/";
@@ -87,16 +84,12 @@ public class SwaggerUiProcessor {
 
     @BuildStep
     public void getSwaggerUiFinalDestination(
-            BuildProducer<GeneratedResourceBuildItem> generatedResources,
-            BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
-            BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            CurateOutcomeBuildItem curateOutcomeBuildItem,
             LaunchModeBuildItem launchMode,
             SwaggerUiConfig swaggerUiConfig,
             SmallRyeOpenApiConfig openapi,
-            LiveReloadBuildItem liveReloadBuildItem,
-            Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig) throws Exception {
+            Optional<DevServicesLauncherConfigResultBuildItem> devServicesLauncherConfig,
+            BuildProducer<WebJarBuildItem> webJarBuildProducer) throws Exception {
 
         if (shouldInclude(launchMode, swaggerUiConfig)) {
             if ("/".equals(swaggerUiConfig.path)) {
@@ -127,52 +120,36 @@ public class SwaggerUiProcessor {
 
             String openApiPath = nonApplicationRootPathBuildItem.resolvePath(openapi.path);
             String swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path);
+            ThemeHref theme = swaggerUiConfig.theme.orElse(ThemeHref.feeling_blue);
 
-            ResolvedDependency artifact = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, SWAGGER_UI_WEBJAR_GROUP_ID,
-                    SWAGGER_UI_WEBJAR_ARTIFACT_ID);
+            NonApplicationRootPathBuildItem indexRootPathBuildItem = null;
 
             if (launchMode.getLaunchMode().isDevOrTest()) {
+                indexRootPathBuildItem = nonApplicationRootPathBuildItem;
 
                 // In dev mode, default to persist Authorization true
                 if (!swaggerUiConfig.persistAuthorization.isPresent()) {
                     swaggerUiConfig.persistAuthorization = Optional.of(true);
                 }
-
-                Path tempPath = WebJarUtil.copyResourcesForDevOrTest(liveReloadBuildItem, curateOutcomeBuildItem, launchMode,
-                        artifact,
-                        SWAGGER_UI_WEBJAR_PREFIX);
-                // Update index.html
-                WebJarUtil.updateFile(tempPath.resolve("index.html"),
-                        generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig, nonApplicationRootPathBuildItem));
-
-                swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(tempPath.toAbsolutePath().toString(), swaggerUiPath));
-
-                // Handle live reload of branding files
-                if (liveReloadBuildItem.isLiveReload() && !liveReloadBuildItem.getChangedResources().isEmpty()) {
-                    WebJarUtil.hotReloadBrandingChanges(curateOutcomeBuildItem, launchMode, artifact,
-                            liveReloadBuildItem.getChangedResources());
-                }
-            } else {
-                Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(curateOutcomeBuildItem, artifact,
-                        SWAGGER_UI_WEBJAR_PREFIX);
-                ThemeHref theme = swaggerUiConfig.theme.orElse(ThemeHref.feeling_blue);
-                for (Map.Entry<String, byte[]> file : files.entrySet()) {
-                    String fileName = file.getKey();
-                    // Make sure to only include the selected theme
-                    if (fileName.equals(theme.toString()) || !fileName.startsWith("theme-")) {
-                        byte[] content;
-                        if (fileName.endsWith("index.html")) {
-                            content = generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig, null);
-                        } else {
-                            content = file.getValue();
-                        }
-                        fileName = SWAGGER_UI_FINAL_DESTINATION + "/" + fileName;
-                        generatedResources.produce(new GeneratedResourceBuildItem(fileName, content));
-                        nativeImageResourceBuildItemBuildProducer.produce(new NativeImageResourceBuildItem(fileName));
-                    }
-                }
-                swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(SWAGGER_UI_FINAL_DESTINATION, swaggerUiPath));
             }
+
+            byte[] indexHtmlContent = generateIndexHtml(openApiPath, swaggerUiPath, swaggerUiConfig, indexRootPathBuildItem);
+            webJarBuildProducer.produce(
+                    WebJarBuildItem.builder().artifactKey(SWAGGER_UI_WEBJAR_ARTIFACT_KEY) //
+                            .root(SWAGGER_UI_WEBJAR_STATIC_RESOURCES_PATH) //
+                            .filter(new WebJarResourcesFilter() {
+                                @Override
+                                public FilterResult apply(String fileName, InputStream file) throws IOException {
+                                    if (!fileName.equals(theme.toString()) && fileName.startsWith("theme-")) {
+                                        return new FilterResult(null, true);
+                                    }
+                                    if (fileName.endsWith("index.html")) {
+                                        return new FilterResult(new ByteArrayInputStream(indexHtmlContent), true);
+                                    }
+                                    return new FilterResult(file, false);
+                                }
+                            })
+                            .build());
         }
     }
 
@@ -181,14 +158,23 @@ public class SwaggerUiProcessor {
     public void registerSwaggerUiHandler(SwaggerUiRecorder recorder,
             BuildProducer<RouteBuildItem> routes,
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem,
-            SwaggerUiBuildItem finalDestinationBuildItem,
+            WebJarResultsBuildItem webJarResultsBuildItem,
             SwaggerUiRuntimeConfig runtimeConfig,
             LaunchModeBuildItem launchMode,
-            SwaggerUiConfig swaggerUiConfig) throws Exception {
+            SwaggerUiConfig swaggerUiConfig,
+            BuildProducer<SwaggerUiBuildItem> swaggerUiBuildProducer) {
+
+        WebJarResultsBuildItem.WebJarResult result = webJarResultsBuildItem.byArtifactKey(SWAGGER_UI_WEBJAR_ARTIFACT_KEY);
+        if (result == null) {
+            return;
+        }
 
         if (shouldInclude(launchMode, swaggerUiConfig)) {
-            Handler<RoutingContext> handler = recorder.handler(finalDestinationBuildItem.getSwaggerUiFinalDestination(),
-                    finalDestinationBuildItem.getSwaggerUiPath(),
+            String swaggerUiPath = nonApplicationRootPathBuildItem.resolvePath(swaggerUiConfig.path);
+            swaggerUiBuildProducer.produce(new SwaggerUiBuildItem(result.getFinalDestination(), swaggerUiPath));
+
+            Handler<RoutingContext> handler = recorder.handler(result.getFinalDestination(),
+                    swaggerUiPath,
                     runtimeConfig);
 
             routes.produce(nonApplicationRootPathBuildItem.routeBuilder()

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/CombinedWebJarResourcesFilter.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/CombinedWebJarResourcesFilter.java
@@ -1,0 +1,37 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * WebJarResourcesFilter which combines several other filters. Each filter gets called with the inputstream of the previous
+ * filter, or the original one if it is the first filter. Filters are processed in order.
+ */
+public class CombinedWebJarResourcesFilter implements WebJarResourcesFilter {
+    private final List<WebJarResourcesFilter> filters;
+
+    public CombinedWebJarResourcesFilter(List<WebJarResourcesFilter> filters) {
+        this.filters = filters;
+    }
+
+    @Override
+    public FilterResult apply(String fileName, InputStream stream) throws IOException {
+        FilterResult lastResult = null;
+        boolean changed = false;
+        for (WebJarResourcesFilter filter : filters) {
+
+            if (lastResult != null) {
+                lastResult = filter.apply(fileName, lastResult.getStream());
+            } else {
+                lastResult = filter.apply(fileName, stream);
+            }
+
+            if (lastResult.isChanged() && !changed) {
+                changed = true;
+            }
+        }
+
+        return new FilterResult(lastResult.getStream(), changed);
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/InMemoryTargetVisitor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/InMemoryTargetVisitor.java
@@ -1,0 +1,22 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Visitor which holds all web jar resources in memory.
+ */
+public class InMemoryTargetVisitor implements WebJarResourcesTargetVisitor {
+    private Map<String, byte[]> content = new HashMap<>();
+
+    public Map<String, byte[]> getContent() {
+        return content;
+    }
+
+    @Override
+    public void visitFile(String path, InputStream stream) throws IOException {
+        content.put(path, stream.readAllBytes());
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/InsertVariablesResourcesFilter.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/InsertVariablesResourcesFilter.java
@@ -1,0 +1,69 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.runtime.ApplicationConfig;
+
+/**
+ * Filter for inserting variables into an InputStream.
+ * Supported placeholders are:
+ * <ul>
+ * <li>{applicationName}</li>
+ * <li>{applicationVersion}</li>
+ * <li>{quarkusVersion}</li>
+ * </ul>
+ */
+public class InsertVariablesResourcesFilter implements WebJarResourcesFilter {
+
+    private static final String CSS = ".css";
+
+    private final ApplicationConfig applicationConfig;
+    private final ResolvedDependency appArtifact;
+
+    public InsertVariablesResourcesFilter(ApplicationConfig applicationConfig, ResolvedDependency appArtifact) {
+        this.applicationConfig = applicationConfig;
+        this.appArtifact = appArtifact;
+    }
+
+    @Override
+    public FilterResult apply(String fileName, InputStream stream) throws IOException {
+        if (stream == null) {
+            return new FilterResult(null, false);
+        }
+
+        // Allow replacement of certain values in css
+        if (fileName.endsWith(CSS)) {
+            String applicationName = applicationConfig.name
+                    .orElse(appArtifact.getArtifactId());
+
+            String applicationVersion = applicationConfig.version.orElse(appArtifact.getVersion());
+
+            byte[] oldContentBytes = stream.readAllBytes();
+            String oldContents = new String(oldContentBytes);
+            String contents = replaceHeaderVars(oldContents, applicationName, applicationVersion);
+
+            String header = replaceHeaderVars(applicationConfig.uiHeader.orElse(""), applicationName, applicationVersion);
+            contents = contents.replace("{applicationHeader}", header);
+
+            boolean changed = contents.length() != oldContents.length() || !contents.equals(oldContents);
+            if (changed) {
+                return new FilterResult(new ByteArrayInputStream(contents.getBytes()), true);
+            } else {
+                return new FilterResult(new ByteArrayInputStream(oldContentBytes), false);
+            }
+        }
+
+        return new FilterResult(stream, false);
+    }
+
+    private static String replaceHeaderVars(String contents, String applicationName, String applicationVersion) {
+        contents = contents.replace("{applicationName}", applicationName);
+        contents = contents.replace("{applicationVersion}", applicationVersion);
+        contents = contents.replace("{quarkusVersion}", Version.getVersion());
+        return contents;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/PathTargetVisitor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/PathTargetVisitor.java
@@ -1,0 +1,47 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Visitor which copies resources of the web jar to a given path.
+ */
+public class PathTargetVisitor implements WebJarResourcesTargetVisitor {
+    private final Path deploymentPath;
+
+    public PathTargetVisitor(Path deploymentPath) {
+        this.deploymentPath = deploymentPath;
+    }
+
+    @Override
+    public void visitDirectory(String path) throws IOException {
+        Files.createDirectories(deploymentPath.resolve(path));
+    }
+
+    @Override
+    public void visitFile(String path, InputStream stream) throws IOException {
+        Path targetFilePath = deploymentPath.resolve(path);
+        createFile(stream, targetFilePath);
+    }
+
+    @Override
+    public boolean supportsOnlyCopyingNonArtifactFiles() {
+        return true;
+    }
+
+    private static void createFile(InputStream source, Path targetFile) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(targetFile.toString())) {
+            FileChannel channel = fos.getChannel();
+            try (FileLock lock = channel.tryLock()) {
+                if (lock != null) {
+                    source.transferTo(fos);
+                }
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarBuildItem.java
@@ -1,0 +1,105 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.maven.dependency.GACT;
+
+/**
+ * BuildItem for deploying a webjar.
+ */
+public final class WebJarBuildItem extends MultiBuildItem {
+    /**
+     * ArtifactKey pointing to the web jar. Has to be one of the applications dependencies.
+     */
+    private final GACT artifactKey;
+
+    /**
+     * Root inside the webJar starting from which resources are unpacked.
+     */
+    private final String root;
+
+    /**
+     * Only copy resources of the webjar which are either user overridden, or contain variables.
+     */
+    private final boolean onlyCopyNonArtifactFiles;
+
+    /**
+     * Defines whether Quarkus can override resources of the webjar with Quarkus internal files.
+     */
+    private final boolean useDefaultQuarkusBranding;
+
+    private final WebJarResourcesFilter filter;
+
+    private WebJarBuildItem(Builder builder) {
+        this.artifactKey = builder.artifactKey;
+        this.root = builder.root;
+        this.useDefaultQuarkusBranding = builder.useDefaultQuarkusBranding;
+        this.onlyCopyNonArtifactFiles = builder.onlyCopyNonArtifactFiles;
+        this.filter = builder.filter;
+    }
+
+    public GACT getArtifactKey() {
+        return artifactKey;
+    }
+
+    public String getRoot() {
+        return root;
+    }
+
+    public boolean getUseDefaultQuarkusBranding() {
+        return useDefaultQuarkusBranding;
+    }
+
+    public boolean getOnlyCopyNonArtifactFiles() {
+        return onlyCopyNonArtifactFiles;
+    }
+
+    public WebJarResourcesFilter getFilter() {
+        return filter;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private GACT artifactKey;
+        private String root;
+        private WebJarResourcesFilter filter;
+        private boolean useDefaultQuarkusBranding = true;
+        private boolean onlyCopyNonArtifactFiles;
+
+        public Builder artifactKey(GACT artifactKey) {
+            this.artifactKey = artifactKey;
+            return this;
+        }
+
+        public Builder root(String root) {
+            this.root = root;
+
+            if (this.root != null && this.root.startsWith("/")) {
+                this.root = this.root.substring(1);
+            }
+
+            return this;
+        }
+
+        public Builder filter(WebJarResourcesFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder useDefaultQuarkusBranding(boolean useDefaultQuarkusBranding) {
+            this.useDefaultQuarkusBranding = useDefaultQuarkusBranding;
+            return this;
+        }
+
+        public Builder onlyCopyNonArtifactFiles(boolean onlyCopyNonArtifactFiles) {
+            this.onlyCopyNonArtifactFiles = onlyCopyNonArtifactFiles;
+            return this;
+        }
+
+        public WebJarBuildItem build() {
+            return new WebJarBuildItem(this);
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarProcessor.java
@@ -1,0 +1,94 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.vertx.http.runtime.webjar.WebJarRecorder;
+
+public class WebJarProcessor {
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep(onlyIfNot = IsNormal.class)
+    WebJarResultsBuildItem processWebJarDevMode(WebJarRecorder recorder, List<WebJarBuildItem> webJars,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            ShutdownContextBuildItem shutdownContext,
+            ApplicationConfig applicationConfig) throws IOException {
+
+        Map<GACT, WebJarResultsBuildItem.WebJarResult> results = new HashMap<>();
+
+        Path deploymentBasePath = Files.createTempDirectory("quarkus-webjar");
+        recorder.shutdownTask(shutdownContext, deploymentBasePath.toString());
+
+        for (WebJarBuildItem webJar : webJars) {
+            Path resourcesDirectory = deploymentBasePath
+                    .resolve(buildFinalDestination(webJar.getArtifactKey(), webJar.getRoot()));
+            ResolvedDependency dependency = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, webJar.getArtifactKey());
+
+            Path staticResourcesPath = WebJarUtil.copyResourcesForDevOrTest(curateOutcomeBuildItem, applicationConfig, webJar,
+                    dependency, resourcesDirectory);
+
+            results.put(webJar.getArtifactKey(),
+                    new WebJarResultsBuildItem.WebJarResult(dependency, staticResourcesPath.toAbsolutePath().toString()));
+        }
+
+        return new WebJarResultsBuildItem(results);
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    WebJarResultsBuildItem processWebJarProdMode(List<WebJarBuildItem> webJars,
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer,
+            ApplicationConfig applicationConfig) {
+
+        Map<GACT, WebJarResultsBuildItem.WebJarResult> results = new HashMap<>();
+
+        for (WebJarBuildItem webJar : webJars) {
+
+            ResolvedDependency dependency = WebJarUtil.getAppArtifact(curateOutcomeBuildItem, webJar.getArtifactKey());
+
+            Map<String, byte[]> files = WebJarUtil.copyResourcesForProduction(
+                    curateOutcomeBuildItem, applicationConfig, webJar, dependency);
+
+            String finalDestination = buildFinalDestination(webJar.getArtifactKey(), webJar.getRoot());
+            for (Map.Entry<String, byte[]> file : files.entrySet()) {
+                String fileName = finalDestination + "/" + file.getKey();
+                byte[] fileContent = file.getValue();
+
+                generatedResources
+                        .produce(new GeneratedResourceBuildItem(fileName, fileContent));
+                nativeImageResourceBuildItemBuildProducer.produce(new NativeImageResourceBuildItem(fileName));
+            }
+
+            results.put(webJar.getArtifactKey(),
+                    new WebJarResultsBuildItem.WebJarResult(dependency, finalDestination));
+        }
+
+        return new WebJarResultsBuildItem(results);
+    }
+
+    private String buildFinalDestination(GACT artifactKey, String webRoot) {
+        String finalDestination = "META-INF/" + artifactKey.toString().replace(":", "_") + "/" + webRoot;
+
+        if (finalDestination.endsWith("/")) {
+            finalDestination = finalDestination.substring(0, finalDestination.length() - 1);
+        }
+
+        return finalDestination;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResourcesFilter.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResourcesFilter.java
@@ -1,0 +1,48 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+@FunctionalInterface
+public interface WebJarResourcesFilter {
+
+    /**
+     * Filter web jar resources. Can either update or not update the content of a web jars resource, or not include a resource
+     * at all.
+     *
+     * @param fileName path and name of the resource inside the webjar, starting from the webJarRoot.
+     * @param stream current resource content, might be null
+     * @return a FilterResult, never null
+     */
+    FilterResult apply(String fileName, InputStream stream) throws IOException;
+
+    class FilterResult implements Closeable {
+        private final InputStream stream;
+        private final boolean changed;
+
+        public FilterResult(InputStream stream, boolean changed) {
+            this.stream = stream;
+            this.changed = changed;
+        }
+
+        public InputStream getStream() {
+            return stream;
+        }
+
+        public boolean isChanged() {
+            return changed;
+        }
+
+        public boolean hasStream() {
+            return stream != null;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (hasStream()) {
+                stream.close();
+            }
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResourcesTargetVisitor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResourcesTargetVisitor.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface WebJarResourcesTargetVisitor {
+    default void visitDirectory(String path) throws IOException {
+    }
+
+    default void visitFile(String path, InputStream stream) throws IOException {
+
+    }
+
+    default boolean supportsOnlyCopyingNonArtifactFiles() {
+        return false;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResultsBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarResultsBuildItem.java
@@ -1,0 +1,48 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+/**
+ * Holds the complete result after applying every {@link WebJarBuildItem}.
+ */
+public final class WebJarResultsBuildItem extends SimpleBuildItem {
+    private final Map<GACT, WebJarResult> results;
+
+    public WebJarResultsBuildItem(Map<GACT, WebJarResult> results) {
+        this.results = results;
+    }
+
+    public WebJarResult byArtifactKey(GACT artifactKey) {
+        return results.get(artifactKey);
+    }
+
+    public static class WebJarResult {
+        /**
+         * Resolved dependency of the webjar
+         */
+        private ResolvedDependency dependency;
+
+        /**
+         * Path to where the webjar content was unpacked to. For dev and test mode, the files while be unpacked to a temp
+         * directory on disk. In Prod Mode, the files will be available as generated resources inside this path.
+         */
+        private String finalDestination;
+
+        public WebJarResult(ResolvedDependency dependency, String finalDestination) {
+            this.dependency = dependency;
+            this.finalDestination = finalDestination;
+        }
+
+        public ResolvedDependency getDependency() {
+            return dependency;
+        }
+
+        public String getFinalDestination() {
+            return finalDestination;
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarUtil.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/webjar/WebJarUtil.java
@@ -1,0 +1,224 @@
+package io.quarkus.vertx.http.deployment.webjar;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.paths.PathTree;
+import io.quarkus.paths.PathVisit;
+import io.quarkus.runtime.ApplicationConfig;
+
+/**
+ * Utility for Web resource related operations
+ */
+public class WebJarUtil {
+
+    private static final Logger LOG = Logger.getLogger(WebJarUtil.class);
+
+    private static final String CUSTOM_MEDIA_FOLDER = "META-INF/branding/";
+    private static final List<String> OVERRIDABLE_RESOURCES = Arrays.asList("logo.png", "favicon.ico", "style.css");
+
+    private WebJarUtil() {
+    }
+
+    static Path copyResourcesForDevOrTest(CurateOutcomeBuildItem curateOutcomeBuildItem, ApplicationConfig config,
+            WebJarBuildItem webJar,
+            ResolvedDependency resourcesArtifact,
+            Path deploymentBasePath)
+            throws IOException {
+
+        Path deploymentPath = Files.createDirectories(deploymentBasePath);
+
+        PathTargetVisitor visitor = new PathTargetVisitor(deploymentPath);
+        copyResources(curateOutcomeBuildItem, config, webJar, resourcesArtifact, visitor);
+
+        return deploymentPath;
+    }
+
+    static Map<String, byte[]> copyResourcesForProduction(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            ApplicationConfig config, WebJarBuildItem webJar,
+            ResolvedDependency resourcesArtifact) {
+
+        InMemoryTargetVisitor visitor = new InMemoryTargetVisitor();
+        copyResources(curateOutcomeBuildItem, config, webJar, resourcesArtifact, visitor);
+
+        return visitor.getContent();
+    }
+
+    private static void copyResources(CurateOutcomeBuildItem curateOutcomeBuildItem, ApplicationConfig config,
+            WebJarBuildItem webJar,
+            ResolvedDependency resourcesArtifact, WebJarResourcesTargetVisitor visitor) {
+        final ResolvedDependency userApplication = curateOutcomeBuildItem.getApplicationModel().getAppArtifact();
+
+        ClassLoader classLoader = WebJarUtil.class.getClassLoader();
+
+        resourcesArtifact.getContentTree().accept(webJar.getRoot(), new Consumer<PathVisit>() {
+            @Override
+            public void accept(PathVisit pathVisit) {
+                if (pathVisit == null || !Files.isDirectory(pathVisit.getPath())) {
+                    return;
+                }
+
+                List<WebJarResourcesFilter> filters = new ArrayList<>();
+                if (webJar.getFilter() != null) {
+                    filters.add(webJar.getFilter());
+                }
+                filters.add(new InsertVariablesResourcesFilter(config, userApplication));
+
+                try {
+                    Files.walkFileTree(pathVisit.getPath(),
+                            new ResourcesFileVisitor(visitor, pathVisit.getPath(), resourcesArtifact,
+                                    userApplication, new CombinedWebJarResourcesFilter(filters), classLoader, webJar));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        });
+    }
+
+    static ResolvedDependency getAppArtifact(CurateOutcomeBuildItem curateOutcomeBuildItem, GACT artifactKey) {
+        for (ResolvedDependency dep : curateOutcomeBuildItem.getApplicationModel().getDependencies()) {
+            if (dep.getKey().equals(artifactKey)) {
+                return dep;
+            }
+        }
+        throw new RuntimeException("Could not find artifact " + artifactKey
+                + " among the application dependencies");
+    }
+
+    private static String getModuleOverrideName(ResolvedDependency artifact, String filename) {
+        String type = filename.substring(filename.lastIndexOf("."));
+        return artifact.getArtifactId() + type;
+    }
+
+    private static InputStream getOverride(ResolvedDependency userApplication, ClassLoader classLoader, String filename,
+            String moduleName,
+            boolean useDefaultQuarkusBranding) {
+
+        // First check if the developer supplied the files
+        InputStream overrideStream = getCustomOverride(userApplication, filename, moduleName);
+        if (overrideStream == null && useDefaultQuarkusBranding) {
+            // Else check if Quarkus has a default branding
+            overrideStream = getQuarkusOverride(classLoader, filename, moduleName);
+        }
+        return overrideStream;
+    }
+
+    private static InputStream getCustomOverride(ResolvedDependency userApplication, String filename, String moduleName) {
+        // Check if the developer supplied the files
+        byte[] content = readFromPathTree(userApplication.getContentTree(), CUSTOM_MEDIA_FOLDER + moduleName);
+        if (content != null) {
+            return new ByteArrayInputStream(content);
+        }
+
+        content = readFromPathTree(userApplication.getContentTree(), CUSTOM_MEDIA_FOLDER + filename);
+        if (content != null) {
+            return new ByteArrayInputStream(content);
+        }
+
+        return null;
+    }
+
+    private static byte[] readFromPathTree(PathTree tree, String relativePath) {
+        return tree.apply(relativePath, (visit) -> {
+            if (visit == null) {
+                return null;
+            }
+
+            try {
+                return Files.readAllBytes(visit.getPath());
+            } catch (IOException e) {
+                LOG.error("Could not read file content " + visit.getPath(), e);
+            }
+            return null;
+        });
+    }
+
+    private static InputStream getQuarkusOverride(ClassLoader classLoader, String filename, String moduleName) {
+        // Allow quarkus per module override
+        InputStream stream = classLoader.getResourceAsStream(CUSTOM_MEDIA_FOLDER + moduleName);
+        if (stream != null) {
+            return stream;
+        }
+
+        return classLoader.getResourceAsStream(CUSTOM_MEDIA_FOLDER + filename);
+    }
+
+    private static class ResourcesFileVisitor extends SimpleFileVisitor<Path> {
+        private final WebJarResourcesTargetVisitor visitor;
+        private final Path rootFolderToCopy;
+        private final ResolvedDependency resourcesArtifact;
+        private final ResolvedDependency userApplication;
+        private final WebJarResourcesFilter filter;
+        private final ClassLoader classLoader;
+        private final WebJarBuildItem webJar;
+
+        public ResourcesFileVisitor(WebJarResourcesTargetVisitor visitor, Path rootFolderToCopy,
+                ResolvedDependency resourcesArtifact, ResolvedDependency userApplication, WebJarResourcesFilter filter,
+                ClassLoader classLoader, WebJarBuildItem webJar) {
+            this.visitor = visitor;
+            this.rootFolderToCopy = rootFolderToCopy;
+            this.resourcesArtifact = resourcesArtifact;
+            this.userApplication = userApplication;
+            this.filter = filter;
+            this.classLoader = classLoader;
+            this.webJar = webJar;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(final Path dir,
+                final BasicFileAttributes attrs) throws IOException {
+            visitor.visitDirectory(rootFolderToCopy.relativize(dir).toString());
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(final Path file,
+                final BasicFileAttributes attrs) throws IOException {
+            String fileName = rootFolderToCopy.relativize(file).toString();
+
+            String moduleName = getModuleOverrideName(resourcesArtifact, fileName);
+            boolean overrideFileCreated = false;
+            if (OVERRIDABLE_RESOURCES.contains(fileName)) {
+                try (WebJarResourcesFilter.FilterResult filterResult = filter.apply(fileName,
+                        getOverride(userApplication, classLoader,
+                                fileName, moduleName, webJar.getUseDefaultQuarkusBranding()))) {
+                    if (filterResult.hasStream()) {
+                        overrideFileCreated = true;
+                        // Override (either developer supplied or Quarkus)
+                        visitor.visitFile(fileName, filterResult.getStream());
+                    }
+                }
+            }
+
+            if (!overrideFileCreated) {
+                try (WebJarResourcesFilter.FilterResult filterResult = filter.apply(fileName, Files.newInputStream(file))) {
+                    if (!visitor.supportsOnlyCopyingNonArtifactFiles() || !webJar.getOnlyCopyNonArtifactFiles()
+                            || filterResult.isChanged()) {
+                        if (filterResult.hasStream()) {
+                            visitor.visitFile(fileName, filterResult.getStream());
+                        }
+                    }
+                }
+            }
+
+            return FileVisitResult.CONTINUE;
+        }
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/webjar/WebJarRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/webjar/WebJarRecorder.java
@@ -1,0 +1,56 @@
+package io.quarkus.vertx.http.runtime.webjar;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.ShutdownContext;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class WebJarRecorder {
+
+    private static final Logger LOG = Logger.getLogger(WebJarRecorder.class);
+
+    public void shutdownTask(ShutdownContext shutdownContext, String deploymentBasePath) {
+
+        shutdownContext.addShutdownTask(new DeleteDirectoryRunnable(deploymentBasePath));
+    }
+
+    private static final class DeleteDirectoryRunnable implements Runnable {
+
+        private final Path directory;
+
+        private DeleteDirectoryRunnable(String directory) {
+            this.directory = Paths.get(directory);
+        }
+
+        @Override
+        public void run() {
+            try {
+                Files.walkFileTree(directory,
+                        new SimpleFileVisitor<Path>() {
+                            @Override
+                            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                                Files.delete(dir);
+                                return FileVisitResult.CONTINUE;
+                            }
+
+                            @Override
+                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                                Files.delete(file);
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
+            } catch (IOException e) {
+                LOG.error("Error cleaning up webjar temporary directory: " + directory, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for running the same application multiple times in dev mode on the same machine.
Problem was, that resources of webjars (like devui) where unpacked to %TEMP%/quarkus/applicationName/libraryName/libraryVersion.
On windows, this worked fine. %TEMP% points to a path inside the user directory (e.g. c:/users/martin/appdata/local/temp/).
On linux however, this caused AccessDeniedException, since %TEMP% points to a global temp directory, e.g. /temp.

This branch changes the location where webjars are unpacked to.
Now, every quarkus dev mode isntace creates a new temp directory, e.g. C:\Users\Martin\AppData\Local\Temp\quarkus-webjar10464518099488497426.
These temp directories are removed on shutdown.


The directory layout inside the temp directory is changed. It is now flatter, and the same as in the generated resource. e.g. quarkus-webjar10464518099488497426\META-INF\swagger-ui-files\index.html

I also deprecated io.quarkus.deployment.util.WebJarUtil (forRemoval) in favor of two new BuildItems - WebJarBuildItem and WebJarResultBuildItem.
WebJarBuildItem contains the instructions on which artifact should be unpacked and to which final destination (e.g. META-INF/swagger-ui-files). The webjar is either unpacked to disk (dev mode), or resources are generated (prod).
WebJarResultBuildItem contains the path where the webjar was unpacked to.

dev-ui, swagger-ui, smallrye-health and graphql already use these new builditems - in quarkus, no place uses the deprecated WebJarUtil anymore.

fixes #22515

Related zulip discussion: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Refactoring.20WebJarUtil