### PR TITLE
Create file when adding a registry to default config

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
@@ -30,16 +30,13 @@ public class RegistryAddCommand extends BaseRegistryCommand {
             existingConfig = Files.exists(configYaml);
         }
 
+        registryClient.refreshRegistryCache(output);
         final RegistriesConfig.Mutable config;
-        if (existingConfig) {
-            registryClient.refreshRegistryCache(output);
-            config = registryClient.resolveConfig().mutable();
-            if (config.getSource().getFilePath() == null) {
-                output.error("Can only modify file-based configuration. Config source is " + config.getSource().describe());
-                return CommandLine.ExitCode.SOFTWARE;
-            }
-        } else {
+        if (configYaml != null && !existingConfig) {
+            // we're creating a new configuration for a new file
             config = RegistriesConfig.builder();
+        } else {
+            config = registryClient.resolveConfig().mutable();
         }
 
         boolean persist = false;
@@ -48,10 +45,10 @@ public class RegistryAddCommand extends BaseRegistryCommand {
         }
 
         if (persist) {
-            if (existingConfig) {
-                config.persist();
-            } else {
+            if (configYaml != null) {
                 config.persist(configYaml);
+            } else {
+                config.persist();
             }
         }
         return CommandLine.ExitCode.OK;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigImpl.java
@@ -217,7 +217,9 @@ public class RegistriesConfigImpl implements RegistriesConfig {
 
     static void persistConfigSource(RegistriesConfigImpl config) throws IOException {
         Path targetFile = config.configSource.getFilePath();
-        if (targetFile == null) {
+        if (config.configSource == ConfigSource.DEFAULT) {
+            targetFile = RegistriesConfigLocator.getDefaultConfigYamlLocation();
+        } else if (targetFile == null) {
             throw new UnsupportedOperationException(
                     String.format("Can not write configuration as it was read from an alternate source: %s",
                             config.configSource.describe()));

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistriesConfigLocator.java
@@ -159,8 +159,6 @@ public class RegistriesConfigLocator {
     }
 
     /**
-     * TODO: compare set *.json.RegistriesConfigLocator#initFromEnvironmentOrNull
-     * 
      * @param map A Map containing environment variables, e.g. {@link System#getenv()}
      * @return A RegistriesConfig object initialized from environment variables.
      */


### PR DESCRIPTION
Rely more on persist capability built into the registry client.
If this is a default config being persisted, use the default config path.
Fixes #22731
