### PR TITLE
Adjust Kogito guides to also import the resteasy-jackson extension

### DIFF
--- a/docs/src/main/asciidoc/kogito-dmn.adoc
+++ b/docs/src/main/asciidoc/kogito-dmn.adoc
@@ -78,7 +78,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-dmn-quickstart \
-    -Dextensions="dmn" \
+    -Dextensions="dmn,resteasy-jackson" \
     -DnoExamples
 cd kogito-dmn-quickstart
 ----
@@ -86,6 +86,7 @@ cd kogito-dmn-quickstart
 This command generates a Maven project, importing the `kogito-quarkus-decisions` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
+It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
 
 The `kogito-quarkus-decisions` is a specialized extension of the Kogito project focusing only on DMN support; if you want to 
 make use of the full capabilities offered by the Kogito platform, you can reference the generic Kogito extension of Quarkus.

--- a/docs/src/main/asciidoc/kogito-drl.adoc
+++ b/docs/src/main/asciidoc/kogito-drl.adoc
@@ -59,7 +59,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-drl-quickstart \
-    -Dextensions="kogito-quarkus-rules" \
+    -Dextensions="kogito-quarkus-rules,resteasy-jackson" \
     -DnoExamples
 cd kogito-drl-quickstart
 ----
@@ -67,6 +67,7 @@ cd kogito-drl-quickstart
 This command generates a Maven project, importing the `kogito-quarkus-rules` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
+It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito-quarkus-rules` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/kogito-pmml.adoc
+++ b/docs/src/main/asciidoc/kogito-pmml.adoc
@@ -62,7 +62,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-pmml-quickstart \
-    -Dextensions="kogito" \
+    -Dextensions="kogito,resteasy-jackson" \
     -DnoExamples
 cd kogito-pmml-quickstart
 ----
@@ -70,6 +70,7 @@ cd kogito-pmml-quickstart
 This command generates a Maven project, importing the `kogito` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
+It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/kogito.adoc
+++ b/docs/src/main/asciidoc/kogito.adoc
@@ -88,7 +88,7 @@ First, we need a new project. Create a new project with the following command:
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=kogito-quickstart \
-    -Dextensions="kogito" \
+    -Dextensions="kogito,resteasy-jackson" \
     -DnoExamples
 cd kogito-quickstart
 ----
@@ -96,6 +96,7 @@ cd kogito-quickstart
 This command generates a Maven project, importing the `kogito` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
+It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito` extension
 to your project by running the following command in your project base directory:


### PR DESCRIPTION
We will move them to RESTEasy Reactive when we do The Big Switch (tm).

This is now needed because they can work with both RESTEasy and RESTEasy Reactive depending on what's in the classpath but they need at least one of them.