### PR TITLE
[2.2] Protobuf Java and gRPC version updates (CVE-2021-22569)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -188,9 +188,9 @@
         <google-http-client.version>1.38.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.38.1</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc.version>1.41.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <grpc-jprotoc.version>1.2.0</grpc-jprotoc.version>
-        <protobuf-java.version>3.17.3</protobuf-java.version>
+        <protobuf-java.version>3.18.2</protobuf-java.version>
         <protoc.version>${protobuf-java.version}</protoc.version>
         <picocli.version>4.6.1</picocli.version>
         <google-cloud-functions.version>1.0.1</google-cloud-functions.version>


### PR DESCRIPTION
Update Protobuf Java to 3.18.2 and gRPC Java to 1.41.2

Upgraded Protobuf Java to 3.18.2 to avoid CVE-2021-22569 - https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-wrvw-hg22-4m67