### PR TITLE
Make copying of Vertx context data conditional

### DIFF
--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -34,6 +34,7 @@ import io.quarkus.opentelemetry.runtime.tracing.restclient.OpenTelemetryClientFi
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
+import io.quarkus.vertx.deployment.CopyVertxContextDataBuildItem;
 
 public class OpenTelemetryProcessor {
     static class OpenTelemetryEnabled implements BooleanSupplier {
@@ -135,6 +136,11 @@ public class OpenTelemetryProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     void storeVertxOnContextStorage(OpenTelemetryRecorder recorder, CoreVertxBuildItem vertx) {
         recorder.storeVertxOnContextStorage(vertx.getVertx());
+    }
+
+    @BuildStep
+    CopyVertxContextDataBuildItem copyVertxContextData() {
+        return new CopyVertxContextDataBuildItem(QuarkusContextStorage.ACTIVE_CONTEXT);
     }
 
     public static boolean isClassPresent(String classname) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -151,6 +151,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.ForbiddenException;
+import io.quarkus.vertx.deployment.CopyVertxContextDataBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
@@ -643,7 +644,8 @@ public class ResteasyReactiveProcessor {
             ParamConverterProvidersBuildItem paramConverterProvidersBuildItem,
             ContextResolversBuildItem contextResolversBuildItem,
             ResteasyReactiveServerConfig serverConfig,
-            LaunchModeBuildItem launchModeBuildItem)
+            LaunchModeBuildItem launchModeBuildItem,
+            List<CopyVertxContextDataBuildItem> copyVertxContextDataBuildItems)
             throws NoSuchMethodException {
 
         if (!resourceScanningResultBuildItem.isPresent()) {
@@ -761,7 +763,8 @@ public class ResteasyReactiveProcessor {
         RuntimeValue<Deployment> deployment = recorder.createDeployment(deploymentInfo,
                 beanContainerBuildItem.getValue(), shutdownContext, vertxConfig,
                 requestContextFactoryBuildItem.map(RequestContextFactoryBuildItem::getFactory).orElse(null),
-                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent);
+                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent,
+                copyVertxContextDataBuildItems.stream().map(CopyVertxContextDataBuildItem::getProperty).collect(toList()));
 
         quarkusRestDeploymentBuildItemBuildProducer
                 .produce(new ResteasyReactiveDeploymentBuildItem(deployment, deploymentPath));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
+import java.util.List;
+
 import javax.enterprise.event.Event;
 import javax.ws.rs.core.SecurityContext;
 
@@ -23,8 +25,9 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
     public QuarkusResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
             RoutingContext context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
             ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl,
-            CurrentIdentityAssociation currentIdentityAssociation) {
-        super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
+            CurrentIdentityAssociation currentIdentityAssociation, List<String> vertxContextPropsToCopy) {
+        super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl,
+                vertxContextPropsToCopy);
         this.association = currentIdentityAssociation;
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -4,6 +4,7 @@ import static io.quarkus.resteasy.reactive.server.runtime.NotFoundExceptionMappe
 
 import java.io.Closeable;
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -73,7 +74,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
             ShutdownContext shutdownContext, HttpBuildTimeConfig vertxConfig,
             RequestContextFactory contextFactory,
             BeanFactory<ResteasyReactiveInitialiser> initClassFactory,
-            LaunchMode launchMode, boolean servletPresent) {
+            LaunchMode launchMode, boolean servletPresent, List<String> vertxContextPropsToCopy) {
 
         if (servletPresent) {
             info.setResumeOn404(true);
@@ -107,7 +108,8 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
                     return new QuarkusResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
                             requestContext,
                             handlerChain,
-                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation);
+                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation,
+                            vertxContextPropsToCopy);
                 }
 
             };

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/CopyVertxContextDataBuildItem.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/CopyVertxContextDataBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkus.vertx.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Build item which indicates that the current Vertx request context data needs
+ * to be copied into the connection context
+ */
+public final class CopyVertxContextDataBuildItem extends MultiBuildItem {
+
+    private final String property;
+
+    public CopyVertxContextDataBuildItem(String property) {
+        this.property = property;
+    }
+
+    public String getProperty() {
+        return property;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.server.vertx;
 
 import io.vertx.ext.web.RoutingContext;
+import java.util.Collections;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.RequestContextFactory;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -14,6 +15,6 @@ public class VertxRequestContextFactory implements RequestContextFactory {
             ProvidersImpl providers, Object context, ThreadSetupAction requestContext,
             ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
         return new VertxResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
-                requestContext, handlerChain, abortHandlerChain, null);
+                requestContext, handlerChain, abortHandlerChain, null, Collections.emptyList());
     }
 }


### PR DESCRIPTION
In order to avoid negatively affecting RESTEasy Reactive performance
just to serve very specific use cases, we introduce a way to
conditionally control when the current Vertx request context data needs
to be copied into the connection context

Follow up of: #22671