### PR TITLE
Rest client - better error message when a rest client is injected into Filters

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/deployment/pom.xml
+++ b/extensions/resteasy-classic/rest-client-config/deployment/pom.xml
@@ -22,6 +22,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/resteasy-classic/rest-client-config/runtime/pom.xml
+++ b/extensions/resteasy-classic/rest-client-config/runtime/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -4,6 +4,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.enterprise.inject.CreationException;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -75,4 +79,21 @@ public class RestClientsConfig {
         configs.put(clientInterface.getName(), clientConfig);
     }
 
+    public static RestClientsConfig getInstance() {
+        InstanceHandle<RestClientsConfig> configHandle;
+        try {
+            configHandle = Arc.container().instance(RestClientsConfig.class);
+        } catch (CreationException e) {
+            String message = "The Rest Client configuration cannot be initialized at this stage. "
+                    + "Try to wrap your Rest Client injection in the Provider<> interface:\n\n"
+                    + "  @Inject\n"
+                    + "  @RestClient\n"
+                    + "  Provider<MyRestClientInterface> myRestClient;\n";
+            throw new RuntimeException(message, e);
+        }
+        if (!configHandle.isAvailable()) {
+            throw new IllegalStateException("Unable to find the RestClientConfigs");
+        }
+        return configHandle.get();
+    }
 }

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -41,7 +41,7 @@ public class RestClientBase {
     public RestClientBase(Class<?> proxyType, String baseUriFromAnnotation, String configKey,
             Class<?>[] annotationProviders) {
         this(proxyType, baseUriFromAnnotation, configKey, annotationProviders,
-                getConfigRoot());
+                RestClientsConfig.getInstance());
     }
 
     RestClientBase(Class<?> proxyType, String baseUriFromAnnotation, String configKey,
@@ -312,15 +312,6 @@ public class RestClientBase {
             }
             throw e;
         }
-    }
-
-    private static RestClientsConfig getConfigRoot() {
-        InstanceHandle<RestClientsConfig> configHandle = Arc.container()
-                .instance(RestClientsConfig.class);
-        if (!configHandle.isAvailable()) {
-            throw new IllegalStateException("Unable to find the RestClientConfigs");
-        }
-        return configHandle.get();
     }
 
     private RestClientConfig clientConfigByConfigKey() {

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -24,8 +24,6 @@ import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties;
 
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
-import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.restclient.config.RestClientConfig;
 import io.quarkus.restclient.config.RestClientsConfig;
 
@@ -44,7 +42,7 @@ public class RestClientCDIDelegateBuilder<T> {
     }
 
     private RestClientCDIDelegateBuilder(Class<T> jaxrsInterface, String baseUriFromAnnotation, String configKey) {
-        this(jaxrsInterface, baseUriFromAnnotation, configKey, getConfigRoot());
+        this(jaxrsInterface, baseUriFromAnnotation, configKey, RestClientsConfig.getInstance());
     }
 
     RestClientCDIDelegateBuilder(Class<T> jaxrsInterface, String baseUriFromAnnotation, String configKey,
@@ -330,15 +328,6 @@ public class RestClientCDIDelegateBuilder<T> {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("The value of URL was invalid " + baseUrl, e);
         }
-    }
-
-    private static RestClientsConfig getConfigRoot() {
-        InstanceHandle<RestClientsConfig> configHandle = Arc.container()
-                .instance(RestClientsConfig.class);
-        if (!configHandle.isAvailable()) {
-            throw new IllegalStateException("Unable to find the RestClientsConfig");
-        }
-        return configHandle.get();
     }
 
     private RestClientConfig clientConfigByConfigKey() {


### PR DESCRIPTION
WebFilters and reactive resteasy filters are initialized at static
init phase, but the rest client Config Root is only available at
runtime. This makes it impossible to inject rest clients into filters,
unless they are wrapped in the Provider interface (effectively
postponing the rest client creation until the runtime).

The improved error message suggests to wrap the rest client injection
type into Provider, when CreationException is encountered during rest
client init.

This resolves https://github.com/quarkusio/quarkus/issues/22684