### PR TITLE
Improve GRPC server blocked performance

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingExecutionHandler.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingExecutionHandler.java
@@ -15,34 +15,45 @@ class BlockingExecutionHandler<ReqT> implements Handler<Promise<Object>> {
     private final Consumer<ServerCall.Listener<ReqT>> consumer;
     private final InjectableContext.ContextState state;
     private final ManagedContext requestContext;
+    private final Object lock;
 
     public BlockingExecutionHandler(Consumer<ServerCall.Listener<ReqT>> consumer, Context grpcContext,
             ServerCall.Listener<ReqT> delegate, InjectableContext.ContextState state,
-            ManagedContext requestContext) {
+            ManagedContext requestContext,
+            Object lock) {
         this.consumer = consumer;
         this.grpcContext = grpcContext;
         this.delegate = delegate;
         this.state = state;
         this.requestContext = requestContext;
+        this.lock = lock;
     }
 
     @Override
     public void handle(Promise<Object> event) {
-        final Context previous = Context.current();
-        grpcContext.attach();
-        try {
-            requestContext.activate(state);
+        /*
+         * We lock here because with client side streaming different messages from the same request
+         * might be served by different worker threads. This guarantees memory consistency.
+         * The lock object is assumed to be the request's listener
+         */
+        synchronized (lock) {
+            final Context previous = Context.current();
+            grpcContext.attach();
             try {
-                consumer.accept(delegate);
-            } catch (Throwable any) {
-                event.fail(any);
-                return;
+                requestContext.activate(state);
+                try {
+                    consumer.accept(delegate);
+                } catch (Throwable any) {
+                    event.fail(any);
+                    return;
+                } finally {
+                    requestContext.deactivate();
+                }
+                event.complete();
             } finally {
-                requestContext.deactivate();
+                grpcContext.detach(previous);
             }
-            event.complete();
-        } finally {
-            grpcContext.detach(previous);
         }
     }
+
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/blocking/BlockingServerInterceptor.java
@@ -2,8 +2,10 @@ package io.quarkus.grpc.runtime.supports.blocking;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -13,8 +15,10 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InjectableContext.ContextState;
 import io.quarkus.arc.ManagedContext;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -70,9 +74,9 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
             // that should always be called before this interceptor
             ContextState state = requestContext.getState();
             ReplayListener<ReqT> replay = new ReplayListener<>(state);
-            vertx.executeBlocking(new Handler<Promise<Object>>() {
+            vertx.executeBlocking(new Handler<Promise<ServerCall.Listener<ReqT>>>() {
                 @Override
-                public void handle(Promise<Object> f) {
+                public void handle(Promise<ServerCall.Listener<ReqT>> f) {
                     ServerCall.Listener<ReqT> listener;
                     try {
                         requestContext.activate(state);
@@ -80,10 +84,14 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
                     } finally {
                         requestContext.deactivate();
                     }
-                    replay.setDelegate(listener, requestContext);
-                    f.complete(null);
+                    f.complete(listener);
                 }
-            }, null);
+            }, false, new Handler<AsyncResult<ServerCall.Listener<ReqT>>>() {
+                @Override
+                public void handle(AsyncResult<ServerCall.Listener<ReqT>> event) {
+                    replay.setDelegate(event.result());
+                }
+            });
 
             return replay;
         } else {
@@ -95,48 +103,69 @@ public class BlockingServerInterceptor implements ServerInterceptor, Function<St
      * Stores the incoming events until the listener is injected.
      * When injected, replay the events.
      *
-     * Note that event must be executed in order, explaining the `ordered:true`.
+     * Note that event must be executed in order, explaining why incomingEvents
+     * are executed sequentially
      */
     private class ReplayListener<ReqT> extends ServerCall.Listener<ReqT> {
-        private ServerCall.Listener<ReqT> delegate;
-        private final List<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new ArrayList<>();
-        private final ContextState requestContextState;
+        private final InjectableContext.ContextState requestContextState;
 
-        private ReplayListener(ContextState requestContextState) {
+        // exclusive to event loop context
+        private ServerCall.Listener<ReqT> delegate;
+        private final Queue<Consumer<ServerCall.Listener<ReqT>>> incomingEvents = new LinkedList<>();
+        private boolean isConsumingFromIncomingEvents = false;
+
+        private ReplayListener(InjectableContext.ContextState requestContextState) {
             this.requestContextState = requestContextState;
         }
 
-        synchronized void setDelegate(ServerCall.Listener<ReqT> delegate,
-                ManagedContext requestContext) {
+        /**
+         * Must be called from within the event loop context
+         * If there are deferred events will start executing them in the shared worker context
+         * 
+         * @param delegate
+         */
+        void setDelegate(ServerCall.Listener<ReqT> delegate) {
             this.delegate = delegate;
-            requestContext.activate(requestContextState);
-            try {
-                for (Consumer<ServerCall.Listener<ReqT>> event : incomingEvents) {
-                    event.accept(delegate);
+            if (!this.isConsumingFromIncomingEvents) {
+                Consumer<ServerCall.Listener<ReqT>> consumer = incomingEvents.poll();
+                if (consumer != null) {
+                    executeBlockingWithRequestContext(consumer);
                 }
-            } finally {
-                requestContext.deactivate();
             }
-            incomingEvents.clear();
         }
 
-        private synchronized void executeOnContextOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
-            if (this.delegate != null) {
+        private void executeOnContextOrEnqueue(Consumer<ServerCall.Listener<ReqT>> consumer) {
+            if (this.delegate != null && !this.isConsumingFromIncomingEvents) {
                 executeBlockingWithRequestContext(consumer);
             } else {
                 incomingEvents.add(consumer);
             }
         }
 
+        /**
+         * Will execute the consumer in a worker context
+         * Once complete will enqueue the next consumer for execution.
+         * This guarantees ordered execution per request.
+         *
+         * @param consumer
+         */
         private void executeBlockingWithRequestContext(Consumer<ServerCall.Listener<ReqT>> consumer) {
             final Context grpcContext = Context.current();
             Handler<Promise<Object>> blockingHandler = new BlockingExecutionHandler<>(consumer, grpcContext, delegate,
-                    requestContextState, getRequestContext());
+                    requestContextState, getRequestContext(), this);
             if (devMode) {
                 blockingHandler = new DevModeBlockingExecutionHandler(Thread.currentThread().getContextClassLoader(),
                         blockingHandler);
             }
-            vertx.executeBlocking(blockingHandler, true, null);
+            this.isConsumingFromIncomingEvents = true;
+            vertx.executeBlocking(blockingHandler, false, p -> {
+                Consumer<ServerCall.Listener<ReqT>> next = incomingEvents.poll();
+                if (next != null) {
+                    executeBlockingWithRequestContext(next);
+                } else {
+                    this.isConsumingFromIncomingEvents = false;
+                }
+            });
         }
 
         @Override


### PR DESCRIPTION
During load tests with a GRPC server that executes blocking code as described [here](https://quarkus.io/guides/grpc-getting-started#implementing-a-service) we noticed very high latency.

During inspection we noticed that the issue lied with how _BlockingServerInterceptor_ is handling order guarantees of events. It adds event consumers to the shared blocking context in order, all from the same event loop. For a request, consuming the events in order is a requirement but that should not be true for events between different requests. With the implementation as is there is no parallel execution of blocking requests.

We performed a test where we enqueued 100 concurrent requests

```bash
for i in {1..100}
do
   ./grpcurl -connect-timeout 300 -import-path ~/grpc-server-box/src/main/proto -proto hello.proto -d '{"name": "hello"}' -plaintext localhost:9000 hello.HelloGrpc/SayHello &
done
```

The code in question sleeps for 1 second

```java
    @Override
    @Blocking
    public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
        try {
            try {
                Thread.sleep(1000); // SLEEP FOR 1 SECOND
            } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
            }

            responseObserver.onNext(HelloReply.newBuilder().setMessage("Hello " + request.getName() + "!").build());
            responseObserver.onCompleted();
        } catch (RuntimeException ex) {
            responseObserver.onError(new StatusRuntimeException(Status.INTERNAL));
        }
    }
```

The following chart shows latency using the current code from Quarkus 2.6.1. Latency gets progressively higher as all calls are executed sequentially:
![Screen Shot 2022-01-10 at 15 18 20](https://user-images.githubusercontent.com/1569429/148826564-48f2b8f8-cc4f-471d-aeda-e4d388fcc4b6.png)

The following chart shows latency using the code from this PR. Latency stays stable at ~1 second as all calls are executed in parallel:
![Screen Shot 2022-01-10 at 15 18 47](https://user-images.githubusercontent.com/1569429/148827030-5bdcd65b-b5ed-4725-b674-afcb01f89874.png)

The PR change is simple. We add events to the worker context with _ordered=false_, but from a request's listener it handles the order guarantee by only executing the next event once the previous completes. With this approach we maintain the requirement of ordered execution of event per request, but allow requests to run in parallel.