### PR TITLE
Get rid of useless JBoss Threads version in build logs

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/GradleLogger.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/GradleLogger.java
@@ -56,7 +56,9 @@ public class GradleLogger implements LoggerProvider {
                         } catch (Exception e) {
                             text = invalidFormat(format, parameters);
                         }
-                    doActualLog(log, level, text, thrown);
+                    if (!text.startsWith("JBoss Threads version")) {
+                        doActualLog(log, level, text, thrown);
+                    }
                 }
             }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/MojoLogger.java
@@ -62,8 +62,10 @@ public class MojoLogger implements LoggerProvider {
                             text = invalidFormat(format, parameters);
                         }
                     }
-                    synchronized (MojoLogger.class) {
-                        doActualLog(log, level, text, thrown);
+                    if (!text.startsWith("JBoss Threads version")) {
+                        synchronized (MojoLogger.class) {
+                            doActualLog(log, level, text, thrown);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The way this is done is hideous, however it's done
like this because this message is logged extremely early,
before any of the build time logging has had a chance to be
setup from Quarkus itself.

P.S. Ideally we would just change [this](https://github.com/jbossas/jboss-threads/blob/3.4.2.Final/src/main/java/org/jboss/threads/Messages.java#L42) to `DEBUG`, but this might not be possible since other projects depend on JBoss Threads as well (see https://github.com/jbossas/jboss-threads/pull/102 for more details)