### PR TITLE
Qute - make sure to call Qute.clearCache() during app shutdown

### DIFF
--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 import javax.interceptor.Interceptor;
@@ -40,6 +41,7 @@ import io.quarkus.qute.Variant;
 import io.quarkus.qute.runtime.QuteRecorder.QuteContext;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
+import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.Startup;
 
 @Startup(Interceptor.Priority.PLATFORM_BEFORE)
@@ -196,6 +198,11 @@ public class EngineProducer {
     @ApplicationScoped
     Engine getEngine() {
         return engine;
+    }
+
+    void onShutdown(@Observes ShutdownEvent event) {
+        // Make sure to clear the Qute cache
+        Qute.clearCache();
     }
 
     String getBasePath() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
@@ -100,7 +100,7 @@ public final class Expressions {
                 }
                 // Non-separator char
                 if (!literal) {
-                    if (splitConfig.isInfixNotationSupported() && brackets == 0 && c == ' ') {
+                    if (brackets == 0 && c == ' ' && splitConfig.isInfixNotationSupported()) {
                         // Not inside a virtual method
                         if (infix == 1) {
                             // The second space after the infix method

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Qute.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Qute.java
@@ -67,11 +67,14 @@ public final class Qute {
      * <p>
      * Note that the engine should have a {@link IndexedArgumentsParserHook} registered so that the
      * {@link #fmt(String, Object...)} method works correcly.
+     * <p>
+     * The cache is always cleared when a new engine is set.
      * 
      * @param engine
      * @see #engine()
      */
     public static void setEngine(Engine engine) {
+        clearCache();
         Qute.engine = engine;
     }
 


### PR DESCRIPTION
- and when a new engine is set; this is necessary to avoid the leaks of
the Engine instance
- also fix immutability of SectionBlock.parameters and SectionBlock.expressions