### PR TITLE
Use NumberFormat to write Jaeger configuration in the default locale

### DIFF
--- a/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/CommaParseJaegerConfigurationTest.java
+++ b/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/CommaParseJaegerConfigurationTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.jaeger.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.jaegertracing.Configuration.SamplerConfiguration;
+import io.quarkus.jaeger.runtime.JaegerConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Some Locales, like FRENCH use a different separator between the integer and the fraction part. The internal
+ * Jaeger configuration, read the value with the default locale, so we need the config to write the value to Jaeger in
+ * the same expected format.
+ */
+public class CommaParseJaegerConfigurationTest {
+    private static final Locale DEFAULT_LOCALE = Locale.getDefault();
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withEmptyApplication()
+            .setBeforeAllCustomizer(() -> Locale.setDefault(Locale.FRENCH))
+            .setAfterAllCustomizer(() -> Locale.setDefault(DEFAULT_LOCALE))
+            .overrideConfigKey("quarkus.jaeger.sampler-type", "probabilistic")
+            .overrideConfigKey("quarkus.jaeger.sampler-param", "0.5");
+
+    @Inject
+    JaegerConfig jaegerConfig;
+
+    @Test
+    void localeParse() {
+        assertEquals("0,5", NumberFormat.getInstance().format(jaegerConfig.samplerParam.get()));
+
+        SamplerConfiguration samplerConfiguration = SamplerConfiguration.fromEnv();
+        assertEquals(0.5d, samplerConfiguration.getParam().doubleValue());
+    }
+}

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkus.jaeger.runtime;
 
+import java.text.NumberFormat;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
@@ -79,7 +80,7 @@ public class JaegerDeploymentRecorder {
         initTracerProperty("JAEGER_REPORTER_FLUSH_INTERVAL", jaeger.reporterFlushInterval,
                 duration -> String.valueOf(duration.toMillis()));
         initTracerProperty("JAEGER_SAMPLER_TYPE", jaeger.samplerType, type -> type);
-        initTracerProperty("JAEGER_SAMPLER_PARAM", jaeger.samplerParam, param -> param.toString());
+        initTracerProperty("JAEGER_SAMPLER_PARAM", jaeger.samplerParam, param -> NumberFormat.getInstance().format(param));
         initTracerProperty("JAEGER_SAMPLER_MANAGER_HOST_PORT", jaeger.samplerManagerHostPort, hostPort -> hostPort.toString());
         initTracerProperty("JAEGER_SERVICE_NAME", jaeger.serviceName, name -> name);
         initTracerProperty("JAEGER_TAGS", jaeger.tags, tags -> tags.toString());


### PR DESCRIPTION
- Fixes #21002