### PR TITLE
Enable recording of JAXBElement during static init

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -41,6 +41,8 @@ import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 import javax.transaction.TransactionManager;
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
 
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.boot.archive.scan.spi.ClassDescriptor;
@@ -124,6 +126,8 @@ import io.quarkus.hibernate.orm.runtime.RequestScopedSessionHolder;
 import io.quarkus.hibernate.orm.runtime.TransactionSessions;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDefinition;
 import io.quarkus.hibernate.orm.runtime.boot.scan.QuarkusScanner;
+import io.quarkus.hibernate.orm.runtime.boot.xml.JAXBElementSubstitution;
+import io.quarkus.hibernate.orm.runtime.boot.xml.QNameSubstitution;
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
 import io.quarkus.hibernate.orm.runtime.cdi.QuarkusArcBeanContainer;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleCreateDDLSupplier;
@@ -602,6 +606,16 @@ public final class HibernateOrmProcessor {
         recorderContext.registerSubstitution(QuarkusPersistenceUnitDefinition.class,
                 QuarkusPersistenceUnitDefinition.Serialized.class,
                 QuarkusPersistenceUnitDefinition.Substitution.class);
+
+        if (hasXmlMappings(persistenceUnitDescriptorBuildItems)) {
+            //Make it possible to record JAXBElement as bytecode:
+            recorderContext.registerSubstitution(JAXBElement.class,
+                    JAXBElementSubstitution.Serialized.class,
+                    JAXBElementSubstitution.class);
+            recorderContext.registerSubstitution(QName.class,
+                    QNameSubstitution.Serialized.class,
+                    QNameSubstitution.class);
+        }
 
         beanContainerListener
                 .produce(new BeanContainerListenerBuildItem(

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/hbm/HbmXmlFilterDefTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/hbm/HbmXmlFilterDefTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.hibernate.orm.xml.hbm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.SmokeTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class HbmXmlFilterDefTest {
+    @RegisterExtension
+    final static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar
+                    .addClass(SmokeTestUtils.class)
+                    .addClass(NonAnnotatedEntity.class)
+                    .addAsResource("META-INF/hbm-filterdef.xml", "my-hbm.xml"))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.mapping-files", "my-hbm.xml")
+            .overrideConfigKey("quarkus.hibernate-orm.log.sql", "true");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Inject
+    Session session;
+
+    @Test
+    @Transactional
+    public void hbmXmlTakenIntoAccount() {
+        assertThat(sessionFactory.getDefinedFilterNames())
+                .contains("idFilter");
+    }
+
+    @Test
+    @Transactional
+    public void smokeTest() {
+        NonAnnotatedEntity firstEntity = new NonAnnotatedEntity("first");
+        session.persist(firstEntity);
+        NonAnnotatedEntity secondEntity = new NonAnnotatedEntity("second");
+        session.persist(secondEntity);
+        session.flush();
+
+        assertThat(session.createQuery("select e from " + NonAnnotatedEntity.class.getName() + " e",
+                NonAnnotatedEntity.class).list())
+                        .hasSize(2);
+        session.enableFilter("idFilter")
+                .setParameterList("ids", Collections.singletonList(firstEntity.getId()));
+        assertThat(session.createQuery("select e from " + NonAnnotatedEntity.class.getName() + " e",
+                NonAnnotatedEntity.class).list())
+                        .hasSize(1);
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/resources/META-INF/hbm-filterdef.xml
+++ b/extensions/hibernate-orm/deployment/src/test/resources/META-INF/hbm-filterdef.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping>
+    <class name="io.quarkus.hibernate.orm.xml.hbm.NonAnnotatedEntity">
+        <id name="id">
+            <generator class="identity"/>
+        </id>
+        <property name="name" column="thename"/>
+        <filter name="idFilter" condition="id in (:ids)"/>
+    </class>
+    <filter-def name="idFilter">
+        <filter-param name="ids" type="long"/>
+    </filter-def>
+</hibernate-mapping>

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/xml/JAXBElementSubstitution.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/xml/JAXBElementSubstitution.java
@@ -1,0 +1,37 @@
+package io.quarkus.hibernate.orm.runtime.boot.xml;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+
+import io.quarkus.runtime.ObjectSubstitution;
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class JAXBElementSubstitution implements ObjectSubstitution<JAXBElement, JAXBElementSubstitution.Serialized> {
+
+    @Override
+    public Serialized serialize(JAXBElement obj) {
+        return new Serialized(obj.getName(), obj.getDeclaredType(), obj.getScope(), obj.getValue());
+    }
+
+    @Override
+    public JAXBElement deserialize(Serialized obj) {
+        return new JAXBElement(obj.name, obj.declaredType, obj.scope, obj.value);
+    }
+
+    public static class Serialized {
+        public final QName name;
+        public final Class<?> declaredType;
+        public final Class<?> scope;
+        public final Object value;
+
+        @RecordableConstructor
+        public Serialized(QName name, Class<?> declaredType, Class<?> scope, Object value) {
+            this.name = name;
+            this.declaredType = declaredType;
+            this.scope = scope;
+            this.value = value;
+        }
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/xml/QNameSubstitution.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/xml/QNameSubstitution.java
@@ -1,0 +1,33 @@
+package io.quarkus.hibernate.orm.runtime.boot.xml;
+
+import javax.xml.namespace.QName;
+
+import io.quarkus.runtime.ObjectSubstitution;
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
+public class QNameSubstitution implements ObjectSubstitution<QName, QNameSubstitution.Serialized> {
+
+    @Override
+    public Serialized serialize(QName obj) {
+        return new Serialized(obj.getNamespaceURI(), obj.getLocalPart(), obj.getPrefix());
+    }
+
+    @Override
+    public QName deserialize(Serialized obj) {
+        return new QName(obj.namespaceURI, obj.localPart, obj.prefix);
+    }
+
+    public static class Serialized {
+        public final String namespaceURI;
+        public final String localPart;
+        public final String prefix;
+
+        @RecordableConstructor
+        public Serialized(String namespaceURI, String localPart, String prefix) {
+            this.namespaceURI = namespaceURI;
+            this.localPart = localPart;
+            this.prefix = prefix;
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #22801

The actual problem is that some parts of the HBM model are not correctly mapped to POJOs in Hibernate ORM, and use the raw JAXBElement instead.

I gave up on fixing the problem upstream, because that involves customizing a very obscure edge case in JAXB, and I definitely lack the know-how.

Fortunately, it seems quite simple to sidestep the problem by ensuring JAXBElement can be "recorded" during static init. So I did that.