### PR TITLE
Auto-enable basic logging for non-Quarkus tests

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/test/java/io/quarkus/restclient/config/RestClientConfigTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.Config;
@@ -13,12 +11,31 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.config.ConfigLogging;
 import io.smallrye.config.PropertiesConfigSource;
 
 public class RestClientConfigTest {
+
+    private static ClassLoader classLoader;
+    private static ConfigProviderResolver configProviderResolver;
+
+    @BeforeAll
+    public static void initConfig() {
+        classLoader = Thread.currentThread().getContextClassLoader();
+        configProviderResolver = ConfigProviderResolver.instance();
+    }
+
+    @AfterEach
+    public void doAfter() {
+        try {
+            configProviderResolver.releaseConfig(configProviderResolver.getConfig());
+        } catch (IllegalStateException ignored) {
+            // just means no config was installed, which is fine
+        }
+    }
 
     @Test
     public void testLoadRestClientConfig() throws IOException {
@@ -62,27 +79,10 @@ public class RestClientConfigTest {
     }
 
     private static void setupMPConfig() throws IOException {
-        ConfigProviderResolver resolver = ConfigProviderResolver.instance();
-        ConfigBuilder configBuilder = resolver.getBuilder();
+        ConfigBuilder configBuilder = configProviderResolver.getBuilder();
         URL propertyFile = RestClientConfigTest.class.getClassLoader().getResource("application.properties");
         assertThat(propertyFile).isNotNull();
         configBuilder.withSources(new PropertiesConfigSource(propertyFile));
-        resolver.registerConfig(configBuilder.build(), getContextClassLoader());
-    }
-
-    static ClassLoader getContextClassLoader() {
-        if (System.getSecurityManager() == null) {
-            return Thread.currentThread().getContextClassLoader();
-        } else {
-            return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
-                ClassLoader tccl = null;
-                try {
-                    tccl = Thread.currentThread().getContextClassLoader();
-                } catch (SecurityException ex) {
-                    ConfigLogging.log.failedToRetrieveClassloader(ex);
-                }
-                return tccl;
-            });
-        }
+        configProviderResolver.registerConfig(configBuilder.build(), classLoader);
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PropertyTestUtil.java
@@ -13,6 +13,10 @@ public class PropertyTestUtil {
 
     private static final String LOG_FILE_PATH_PROPERTY = "quarkus.log.file.path";
 
+    // this property is only used by this class, so it doesn't follow the regular quarkus.* pattern 
+    private static final String LOGGING_SETUP_IS_IMMINENT_PROPERTY = PropertyTestUtil.class.getName()
+            + ".logging-setup-is-imminent";
+
     public static void setLogFileProperty() {
         System.setProperty(LOG_FILE_PATH_PROPERTY, getLogFileLocation());
     }
@@ -50,5 +54,13 @@ public class PropertyTestUtil {
             return Arrays.asList("build", logFileName);
         }
         return Arrays.asList("target", logFileName);
+    }
+
+    public static void setLoggingSetupIsImminent() {
+        System.setProperty(LOGGING_SETUP_IS_IMMINENT_PROPERTY, "true");
+    }
+
+    public static boolean isLoggingSetupImminent() {
+        return Boolean.getBoolean(LOGGING_SETUP_IS_IMMINENT_PROPERTY);
     }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -94,6 +94,7 @@ public class QuarkusDevModeTest
                     "QuarkusDevModeTest must be used with the the JBoss LogManager. See https://quarkus.io/guides/logging#how-to-configure-logging-for-quarkustest for an example of how to configure it in Maven.");
         }
         rootLogger = (org.jboss.logmanager.Logger) logger;
+        PropertyTestUtil.setLoggingSetupIsImminent();
     }
 
     private DevModeMain devModeMain;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusProdModeTest.java
@@ -60,6 +60,7 @@ import io.quarkus.builder.item.BuildItem;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.common.PathTestHelper;
+import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.RestAssuredURLManager;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.utilities.JavaBinFinder;
@@ -88,6 +89,7 @@ public class QuarkusProdModeTest
     static {
         System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
         rootLogger = (Logger) LogManager.getLogManager().getLogger("");
+        PropertyTestUtil.setLoggingSetupIsImminent();
     }
 
     private Path outputDir;

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -85,6 +85,7 @@ public class QuarkusUnitTest
     static {
         System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
         rootLogger = (Logger) LogManager.getLogManager().getLogger("");
+        PropertyTestUtil.setLoggingSetupIsImminent();
     }
 
     boolean started = false;

--- a/test-framework/junit5-properties/src/main/resources/junit-platform.properties
+++ b/test-framework/junit5-properties/src/main/resources/junit-platform.properties
@@ -1,1 +1,2 @@
+junit.jupiter.extensions.autodetection.enabled=true
 junit.jupiter.testclass.order.default=io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -32,6 +32,7 @@ import io.quarkus.deployment.dev.testing.CurrentTestApplication;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.test.common.PathTestHelper;
+import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.RestorableSystemProperties;
 import io.quarkus.test.common.TestClassIndexer;
@@ -48,6 +49,10 @@ public class AbstractJvmQuarkusTestExtension {
     //needed for @Nested
     protected static final Deque<Class<?>> currentTestClassStack = new ArrayDeque<>();
     protected static Class<?> currentJUnitTestClass;
+
+    static {
+        PropertyTestUtil.setLoggingSetupIsImminent();
+    }
 
     protected PrepareResult createAugmentor(ExtensionContext context, Class<? extends QuarkusTestProfile> profile,
             Collection<Runnable> shutdownTasks) throws Exception {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NonQuarkusTestLoggingEnabler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NonQuarkusTestLoggingEnabler.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.junit;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.common.PropertyTestUtil;
+
+public class NonQuarkusTestLoggingEnabler implements BeforeAllCallback {
+
+    private static boolean initialized;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        if (!initialized) {
+            initialized = true;
+            if (!PropertyTestUtil.isLoggingSetupImminent()) {
+                System.err.println("!!! NonQuarkusTestLoggingEnabler");
+                try {
+                    IntegrationTestUtil.activateLogging();
+                } finally {
+                    // release the config that was retrieved by above call so that tests that try to register their own config
+                    // don't fail with:
+                    // IllegalStateException: SRCFG00017: Configuration already registered for the given class loader
+                    var configproviderResolver = ConfigProviderResolver.instance();
+                    var config = configproviderResolver.getConfig();
+                    if (config != null) { // probably never null, but be safe
+                        configproviderResolver.releaseConfig(config);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -59,6 +59,10 @@ public class QuarkusIntegrationTestExtension
     private static Map<String, String> devServicesProps;
     private static String containerNetworkId;
 
+    static {
+        PropertyTestUtil.setLoggingSetupIsImminent();
+    }
+
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         if (!failedBoot) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 import io.quarkus.test.common.ArtifactLauncher;
+import io.quarkus.test.common.PropertyTestUtil;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.junit.launcher.ArtifactLauncherProvider;
 import io.quarkus.test.junit.main.Launch;
@@ -44,6 +45,10 @@ public class QuarkusMainIntegrationTestExtension implements BeforeEachCallback, 
     Properties quarkusArtifactProperties;
 
     LaunchResult result;
+
+    static {
+        PropertyTestUtil.setLoggingSetupIsImminent();
+    }
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {

--- a/test-framework/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test-framework/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.NonQuarkusTestLoggingEnabler


### PR DESCRIPTION
This is what I had in mind here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/LoggingSetupRecorder.2EhandleFailedStart.28.29

It's not pretty with all that `static` stuff, but the challenge is to kinda "publish" the info early enough that regular Quarkus logging setup is imminent (about to happen), _before_ the globally enabled `NonQuarkusTestLoggingEnabler` is executed (which is _before_ extensions registered via `@ExtendWith`).
There is also the challenge to include `QuarkusUnitTest` and others from `junit5-internal` because the way this is all set up activates the `NonQuarkusTestLoggingEnabler` also in Quarkus modules (e.g. in CI) that depend on `quarkus-junit5-internal` _and_ `quarkus-junit5`.

The state handling in that enabler relies on "Quarkus tests first" test class ordering, as is our `QuarkusTestProfileAwareClassOrderer`'s default behavior.

I tested this successfully in `extensions/vertx-http/deployment` (and added a non-Quarkus test).

The registration setup has two "side effects" (which I think are bearable):
- `junit.jupiter.extensions.autodetection.enabled=true` will also enable other extensions that are on the classpath (via ServiceLoader)
- if users exclude `junit5-properties` (#22172), this enabler will still be picked up in case the custom `junit-platform.properties` contains `junit.jupiter.extensions.autodetection.enabled=true`

Draft until:
- [ ] code is cleaned up and some Javadoc is added
- [ ] I have tested this in my current project
- [ ] I have verified nothing strange happens in continuous testing (it shouldn't)

Do we need something in the testing docs? Like a hint that we activate `junit.jupiter.extensions.autodetection.enabled`? Not sure.

Btw, I don't think this can be tested automatically in a reasonable way but I'm open to suggestions!