### PR TITLE
Declare maven central as repository for gradle plugin resolution

### DIFF
--- a/devtools/gradle/settings.gradle
+++ b/devtools/gradle/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 plugins {
     id "com.gradle.enterprise" version "3.8"
 }


### PR DESCRIPTION
By default plugin are only resolved against the gradle plugin portal. this adds maven central as an other repository