### PR TITLE
Resteasy Reactive: Handle null fields in multiparts

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputResource.java
@@ -49,4 +49,14 @@ public class MultipartOutputResource {
         return response;
     }
 
+    @GET
+    @Path("/with-null-fields")
+    @Produces(MediaType.MULTIPART_FORM_DATA)
+    public MultipartOutputFileResponse nullFields() {
+        MultipartOutputFileResponse response = new MultipartOutputFileResponse();
+        response.name = null;
+        response.file = null;
+        return response;
+    }
+
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingBlockingEndpointsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MultipartOutputUsingBlockingEndpointsTest.java
@@ -67,6 +67,17 @@ public class MultipartOutputUsingBlockingEndpointsTest extends AbstractMultipart
         assertContainsFile(response, "file", MediaType.APPLICATION_OCTET_STREAM, "lorem.txt");
     }
 
+    @Test
+    public void testWithNullFields() {
+        RestAssured
+                .given()
+                .get("/multipart/output/with-null-fields")
+                .then()
+                .contentType(ContentType.MULTIPART)
+                .log().all()
+                .statusCode(200); // should return 200 with no parts
+    }
+
     private void assertContainsFile(String response, String name, String contentType, String fileName) {
         String[] lines = response.split("--");
         assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_FILE_PART, name, fileName))

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
@@ -69,20 +69,22 @@ public class MultipartMessageBodyWriter extends ServerMessageBodyWriter.AllWrite
         Charset charset = requestContext.getDeployment().getRuntimeConfiguration().body().defaultCharset();
         String boundaryLine = "--" + boundary;
         for (PartItem part : parts) {
-            // write boundary: --...
-            writeLine(outputStream, boundaryLine, charset);
-            // write content disposition header
-            writeLine(outputStream, HttpHeaders.CONTENT_DISPOSITION + ": form-data; name=\"" + part.getName() + "\""
-                    + getFileNameIfFile(part.getValue()), charset);
-            // write content content type
-            writeLine(outputStream, HttpHeaders.CONTENT_TYPE + ": " + part.getType(), charset);
-            // extra line
-            writeLine(outputStream, charset);
+            if (part.getValue() != null) {
+                // write boundary: --...
+                writeLine(outputStream, boundaryLine, charset);
+                // write content disposition header
+                writeLine(outputStream, HttpHeaders.CONTENT_DISPOSITION + ": form-data; name=\"" + part.getName() + "\""
+                        + getFileNameIfFile(part.getValue()), charset);
+                // write content content type
+                writeLine(outputStream, HttpHeaders.CONTENT_TYPE + ": " + part.getType(), charset);
+                // extra line
+                writeLine(outputStream, charset);
 
-            // write content
-            write(outputStream, serialiseEntity(part.getValue(), part.getType(), requestContext));
-            // extra line
-            writeLine(outputStream, charset);
+                // write content
+                write(outputStream, serialiseEntity(part.getValue(), part.getType(), requestContext));
+                // extra line
+                writeLine(outputStream, charset);
+            }
         }
 
         // write boundary: -- ... --


### PR DESCRIPTION
When having null values in parts, these should be ignored. I confirmed that this behaviour is the same then in Resteasy Classic.

Fix https://github.com/quarkusio/quarkus/issues/22847