### PR TITLE
Copy RestClient interface annotations to generated class

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveCDIWrapperBase.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveCDIWrapperBase.java
@@ -7,6 +7,8 @@ import javax.annotation.PreDestroy;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.NoClassInterceptors;
+
 public abstract class RestClientReactiveCDIWrapperBase<T extends Closeable> implements Closeable {
     private static final Logger log = Logger.getLogger(RestClientReactiveCDIWrapperBase.class);
 
@@ -17,11 +19,13 @@ public abstract class RestClientReactiveCDIWrapperBase<T extends Closeable> impl
     }
 
     @Override
+    @NoClassInterceptors
     public void close() throws IOException {
         delegate.close();
     }
 
     @PreDestroy
+    @NoClassInterceptors
     public void destroy() {
         try {
             close();
@@ -32,6 +36,7 @@ public abstract class RestClientReactiveCDIWrapperBase<T extends Closeable> impl
 
     // used by generated code
     @SuppressWarnings("unused")
+    @NoClassInterceptors
     public Object getDelegate() {
         return delegate;
     }

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/FaultToleranceScanner.java
@@ -84,6 +84,11 @@ final class FaultToleranceScanner {
                 // synthetic methods can't be intercepted
                 continue;
             }
+            if (annotationStore.hasAnnotation(method, io.quarkus.arc.processor.DotNames.NO_CLASS_INTERCEPTORS)
+                    && !annotationStore.hasAnyAnnotation(method, DotNames.FT_ANNOTATIONS)) {
+                // methods annotated @NoClassInterceptors and not annotated with an interceptor binding are not intercepted
+                continue;
+            }
 
             action.accept(method);
         }

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
@@ -41,6 +41,9 @@ public class ClientCallingResource {
     @RestClient
     FaultToleranceClient faultToleranceClient;
 
+    @RestClient
+    FaultToleranceOnInterfaceClient faultToleranceOnInterfaceClient;
+
     @Inject
     InMemorySpanExporter inMemorySpanExporter;
 
@@ -138,6 +141,16 @@ public class ClientCallingResource {
 
         router.route("/call-with-fault-tolerance").blockingHandler(rc -> {
             rc.end(faultToleranceClient.helloWithFallback());
+        });
+
+        router.route("/call-with-fault-tolerance-on-interface").blockingHandler(rc -> {
+            String exception = "";
+            try {
+                faultToleranceOnInterfaceClient.hello();
+            } catch (Exception e) {
+                exception = e.getClass().getSimpleName();
+            }
+            rc.end(exception);
         });
     }
 

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/FaultToleranceOnInterfaceClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/FaultToleranceOnInterfaceClient.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.rest.client.main;
+
+import java.time.temporal.ChronoUnit;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/unprocessable")
+@RegisterRestClient(configKey = "w-fault-tolerance")
+@CircuitBreaker(requestVolumeThreshold = 2, delay = 1, delayUnit = ChronoUnit.MINUTES)
+public interface FaultToleranceOnInterfaceClient {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    String hello();
+}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -93,6 +93,21 @@ public class BasicTest {
     }
 
     @Test
+    void shouldApplyInterfaceLevelInterceptorBinding() {
+        for (int i = 0; i < 2; i++) {
+            RestAssured.with().body(baseUrl).post("/call-with-fault-tolerance-on-interface")
+                    .then()
+                    .statusCode(200)
+                    .body(equalTo("ClientWebApplicationException"));
+        }
+
+        RestAssured.with().body(baseUrl).post("/call-with-fault-tolerance-on-interface")
+                .then()
+                .statusCode(200)
+                .body(equalTo("CircuitBreakerOpenException"));
+    }
+
+    @Test
     void shouldCreateClientSpans() {
         // Reset captured traces
         RestAssured.given().when().get("/export-clear").then().statusCode(200);


### PR DESCRIPTION
When RestClient Reactive generates the implementation class, it does
not copy interface-level annotations to the generated class (though
it does copy annotations from RestClient methods). This means that
interceptor bindings declared on the interface itself don't work.

With this commit, RestClient Reactive will copy all annotations
declared on the RestClient interface (with the exception of
a scope annotation and some MicroProfile RestClient annotations)
to the generated class. This includes interceptor bindings, too.

Fixes #22764