### PR TITLE
Fix cache clear from dev UI

### DIFF
--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/devconsole/CacheDevConsoleRecorder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/devconsole/CacheDevConsoleRecorder.java
@@ -1,5 +1,9 @@
 package io.quarkus.cache.runtime.devconsole;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
 import java.util.Optional;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -18,11 +22,9 @@ import io.vertx.ext.web.RoutingContext;
 public class CacheDevConsoleRecorder {
     public Handler<RoutingContext> clearCacheHandler() {
         return new DevConsolePostHandler() {
-            int code;
-            String message = "";
 
             @Override
-            protected void handlePost(RoutingContext event, MultiMap form) throws Exception {
+            protected void handlePost(RoutingContext event, MultiMap form) {
                 String cacheName = form.get("name");
                 Optional<Cache> cache = CaffeineCacheSupplier.cacheManager().getCache(cacheName);
                 if (cache.isPresent() && cache.get() instanceof CaffeineCache) {
@@ -30,22 +32,28 @@ public class CacheDevConsoleRecorder {
 
                     String action = form.get("action");
                     if (action.equalsIgnoreCase("clearCache")) {
-                        caffeineCache.invalidateAll();
+                        caffeineCache.invalidateAll().subscribe().with(ignored -> {
+                            endResponse(event, OK, createResponseMessage(caffeineCache));
+                        });
+                    } else if (action.equalsIgnoreCase("refresh")) {
+                        endResponse(event, OK, createResponseMessage(caffeineCache));
+                    } else {
+                        String errorMessage = "Invalid action: " + action;
+                        endResponse(event, INTERNAL_SERVER_ERROR, createResponseError(cacheName, errorMessage));
                     }
-                    this.code = HttpResponseStatus.OK.code();
-                    this.message = createResponseMessage(caffeineCache);
-                    return;
                 } else {
                     String errorMessage = "Cache for " + cacheName + " not found";
-                    this.code = HttpResponseStatus.NOT_FOUND.code();
-                    this.message = createResponseError(cacheName, errorMessage);
+                    endResponse(event, NOT_FOUND, createResponseError(cacheName, errorMessage));
                 }
+            }
+
+            private void endResponse(RoutingContext event, HttpResponseStatus status, String message) {
+                event.response().setStatusCode(status.code());
+                event.response().end(message);
             }
 
             @Override
             protected void actionSuccess(RoutingContext event) {
-                event.response().setStatusCode(this.code);
-                event.response().end(this.message);
             }
 
             private String createResponseMessage(CaffeineCacheImpl cache) {


### PR DESCRIPTION
I just noticed that clearing a cache no longer worked from the dev UI. This PR fixes that bug.

⚠️ I'm not sure calling `await().indefinitely()` is a good practice in a `Handler` called by the dev UI so please confirm it before merging.