### PR TITLE
Index classes using jandex plugin before starting devmode if configured

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -116,9 +116,9 @@ public class DevMojo extends AbstractMojo {
 
     /**
      * running any one of these phases means the compile phase will have been run, if these have
-     * not been run we manually run compile
+     * not been run we manually run compile.
      */
-    private static final Set<String> POST_COMPILE_PHASES = Set.of(
+    private static final List<String> POST_COMPILE_PHASES = List.of(
             "compile",
             "process-classes",
             "generate-test-sources",
@@ -141,7 +141,7 @@ public class DevMojo extends AbstractMojo {
      * running any one of these phases means the test-compile phase will have been run, if these have
      * not been run we manually run test-compile
      */
-    private static final Set<String> POST_TEST_COMPILE_PHASES = Set.of(
+    private static final List<String> POST_TEST_COMPILE_PHASES = List.of(
             "test-compile",
             "process-test-classes",
             "test",
@@ -153,6 +153,7 @@ public class DevMojo extends AbstractMojo {
             "verify",
             "install",
             "deploy");
+
     private static final String QUARKUS_GENERATE_CODE_GOAL = "generate-code";
     private static final String QUARKUS_GENERATE_CODE_TESTS_GOAL = "generate-code-tests";
 
@@ -163,6 +164,9 @@ public class DevMojo extends AbstractMojo {
 
     private static final String ORG_JETBRAINS_KOTLIN = "org.jetbrains.kotlin";
     private static final String KOTLIN_MAVEN_PLUGIN = "kotlin-maven-plugin";
+
+    private static final String ORG_JBOSS_JANDEX = "org.jboss.jandex";
+    private static final String JANDEX_MAVEN_PLUGIN = "jandex-maven-plugin";
 
     /**
      * The directory for compiled classes.
@@ -363,7 +367,7 @@ public class DevMojo extends AbstractMojo {
 
         initToolchain();
 
-        //we always want to compile if needed, so if it is run from the parent it will compile dependent projects
+        // we always want to compile if needed, so if it is run from the parent it will compile dependent projects
         handleAutoCompile();
 
         if (enforceBuildGoal) {
@@ -492,6 +496,10 @@ public class DevMojo extends AbstractMojo {
         boolean testCompileNeeded = true;
         boolean prepareNeeded = true;
         boolean prepareTestsNeeded = true;
+
+        String jandexGoalPhase = getGoalPhaseOrNull(ORG_JBOSS_JANDEX, JANDEX_MAVEN_PLUGIN, "jandex", "process-classes");
+        boolean indexClassNeeded = jandexGoalPhase != null;
+
         for (String goal : session.getGoals()) {
             if (goal.endsWith("quarkus:generate-code")) {
                 prepareNeeded = false;
@@ -502,11 +510,15 @@ public class DevMojo extends AbstractMojo {
 
             if (POST_COMPILE_PHASES.contains(goal)) {
                 compileNeeded = false;
-                break;
             }
+
+            if (jandexGoalPhase != null
+                    && POST_COMPILE_PHASES.indexOf(goal) >= POST_COMPILE_PHASES.indexOf(jandexGoalPhase)) {
+                indexClassNeeded = false;
+            }
+
             if (POST_TEST_COMPILE_PHASES.contains(goal)) {
                 testCompileNeeded = false;
-                break;
             }
             if (goal.endsWith("quarkus:dev")) {
                 break;
@@ -516,6 +528,9 @@ public class DevMojo extends AbstractMojo {
         //if the user did not compile we run it for them
         if (compileNeeded) {
             triggerCompile(false, prepareNeeded);
+        }
+        if (indexClassNeeded) {
+            initClassIndexes();
         }
         if (testCompileNeeded) {
             try {
@@ -535,6 +550,10 @@ public class DevMojo extends AbstractMojo {
         executeIfConfigured(pluginDescr.getGroupId(), pluginDescr.getArtifactId(),
                 test ? QUARKUS_GENERATE_CODE_TESTS_GOAL : QUARKUS_GENERATE_CODE_GOAL,
                 Collections.singletonMap("mode", LaunchMode.DEVELOPMENT.name()));
+    }
+
+    private void initClassIndexes() throws MojoExecutionException {
+        executeIfConfigured(ORG_JBOSS_JANDEX, JANDEX_MAVEN_PLUGIN, "jandex", Collections.emptyMap());
     }
 
     private PluginDescriptor getPluginDescriptor() {
@@ -589,6 +608,21 @@ public class DevMojo extends AbstractMojo {
                         project,
                         session,
                         pluginManager));
+    }
+
+    private String getGoalPhaseOrNull(String groupId, String artifactId, String goal, String defaultPhase) {
+        Plugin plugin = getConfiguredPluginOrNull(groupId, artifactId);
+
+        if (plugin == null) {
+            return null;
+        }
+        for (PluginExecution pluginExecution : plugin.getExecutions()) {
+            if (pluginExecution.getGoals().contains(goal)) {
+                var configuredPhase = pluginExecution.getPhase();
+                return configuredPhase != null ? configuredPhase : defaultPhase;
+            }
+        }
+        return null;
     }
 
     public boolean isGoalConfigured(Plugin plugin, String goal) {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
@@ -1,0 +1,21 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class JandexMultiModuleTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void testBasicMultiModuleBuild() throws Exception {
+
+        final File projectDir = getProjectDir("jandex-basic-multi-module-project");
+
+        BuildResult build = runGradleWrapper(projectDir, "clean", ":application:quarkusBuild");
+        assertThat(build.getTasks().get(":common:jandex")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(build.getTasks().get(":application:quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
+}


### PR DESCRIPTION
This branch tries to executes the `jandex-maven-plugin:jandex` goal after compilation if the plugin is applied to the project. 

close #22807 