### PR TITLE
Add option to exclude generated resources from the dev mode classloader

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/GeneratedResourceBuildItem.java
@@ -6,9 +6,21 @@ public final class GeneratedResourceBuildItem extends MultiBuildItem {
     final String name;
     final byte[] classData;
 
+    // This option is only meant to be set by extensions that also generated the resource on the file system
+    // and must rely on Quarkus not getting in the way of loading that resource.
+    // It is currently used by Kogito to get serving of static resources in Dev Mode by Vert.x
+    final boolean excludeFromDevCL;
+
     public GeneratedResourceBuildItem(String name, byte[] classData) {
         this.name = name;
         this.classData = classData;
+        this.excludeFromDevCL = false;
+    }
+
+    public GeneratedResourceBuildItem(String name, byte[] classData, boolean excludeFromDevCL) {
+        this.name = name;
+        this.classData = classData;
+        this.excludeFromDevCL = excludeFromDevCL;
     }
 
     public String getName() {
@@ -17,5 +29,9 @@ public final class GeneratedResourceBuildItem extends MultiBuildItem {
 
     public byte[] getClassData() {
         return classData;
+    }
+
+    public boolean isExcludeFromDevCL() {
+        return excludeFromDevCL;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/runner/bootstrap/StartupActionImpl.java
@@ -357,6 +357,9 @@ public class StartupActionImpl implements StartupAction {
         }
         if (applicationClasses) {
             for (GeneratedResourceBuildItem i : buildResult.consumeMulti(GeneratedResourceBuildItem.class)) {
+                if (i.isExcludeFromDevCL()) {
+                    continue;
+                }
                 data.put(i.getName(), i.getClassData());
             }
         }


### PR DESCRIPTION
This is needed be Kogito in order to support serving their generated
resources (which also reside on the filesystem) from Vertx in dev-mode

See also https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Kogito.20and.20RESTEasy.20Reactive/near/267874078