### PR TITLE
Remove detailed documentation about AWS signing in Hibernate Search

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -814,47 +814,15 @@ for more information.
 ====
 
 [[aws-request-signing]]
-== AWS request signing
+== [[configuration-reference-aws]] AWS request signing
 
 If you need to use https://docs.aws.amazon.com/elasticsearch-service/[Amazon’s managed Elasticsearch service],
 you will find it requires a proprietary authentication method involving request signing.
 
-To enable AWS request signing, an additional extension is required:
+You can enable AWS request signing in Hibernate Search by adding a dedicated extension to your project and configuring it.
 
-[source,bash]
-----
-./mvnw quarkus:add-extension -Dextensions="hibernate-search-orm-elasticsearch-aws"
-----
-
-Once the extension is there, you will need some more configuration:
-
-* Configure the AWS region with
-link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[`quarkus.hibernate-search-orm.elasticsearch.aws.region`].
-* Enable request signing with
-link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[`quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled`].
-* Optionally, configure how credentials are retrieved with
-link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[`quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type`].
-The default gets the credentials from the application environment (AWS instance role, ...),
-but several more options are available.
-
-For example:
-
-[source,properties]
-----
-quarkus.hibernate-search-orm.elasticsearch.aws.region=us-east-1
-quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled=true
-----
-
-Or, if credentials are not available in the application environment (AWS instance role, ...):
-
-[source,properties]
-----
-quarkus.hibernate-search-orm.elasticsearch.aws.region=us-east-1
-quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled=true
-quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type=static
-quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id=AKIDEXAMPLE
-quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY
-----
+See link:{hibernate-search-orm-elasticsearch-aws-guide}#aws-configuration-reference[the documentation for the Hibernate Search ORM + Elasticsearch AWS extension]
+for more information.
 
 == Further reading
 
@@ -904,8 +872,3 @@ for more information.
 ====
 
 :no-duration-note: true
-
-[[configuration-reference-aws]]
-=== AWS Integration Configuration
-
-Please see link:{hibernate-search-orm-elasticsearch-aws-guide}#aws-configuration-reference[the documentation for the Hibernate Search ORM + Elasticsearch AWS extension].


### PR DESCRIPTION
The content has moved, in particular the list of configuration
properties, leading to dead links all over the place.

We're probably better off just linking to the extension documentation in
the Quarkiverse.