### PR TITLE
SmallRye GraphQL 1.4.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -47,7 +47,7 @@
         <smallrye-health.version>3.1.2</smallrye-health.version>
         <smallrye-metrics.version>3.0.4</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.17</smallrye-open-api.version>
-        <smallrye-graphql.version>1.4.1</smallrye-graphql.version>
+        <smallrye-graphql.version>1.4.2</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.3.2</smallrye-jwt.version>

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.graphql.client.runtime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -21,5 +22,18 @@ public class GraphQLClientConfig {
      */
     @ConfigItem(name = "header")
     public Map<String, String> headers;
+
+    /**
+     * WebSocket subprotocols that should be supported by this client for running subscriptions over websockets.
+     * Allowed values are:
+     * - `graphql-ws` for the deprecated Apollo protocol
+     * - `graphql-transport-ws` for the newer GraphQL over WebSocket protocol
+     * If multiple protocols are provided, the actual protocol to be used will be subject to negotiation with
+     * the server.
+     * To make the client work with the dummy protocol implemented by SmallRye GraphQL 1.4 server-side,
+     * leave this empty.
+     */
+    @ConfigItem
+    public Optional<List<String>> subprotocols;
 
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfigurationMergerBean.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfigurationMergerBean.java
@@ -1,5 +1,6 @@
 package io.quarkus.smallrye.graphql.client.runtime;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -47,6 +48,7 @@ public class GraphQLClientConfigurationMergerBean {
                 GraphQLClientConfiguration transformed = new GraphQLClientConfiguration();
                 transformed.setHeaders(quarkusConfig.headers);
                 quarkusConfig.url.ifPresent(transformed::setUrl);
+                transformed.setWebsocketSubprotocols(quarkusConfig.subprotocols.orElse(new ArrayList<>()));
                 upstreamConfiguration.addClient(configKey, transformed);
             } else {
                 // if SmallRye configuration already contains this client, override it with the Quarkus configuration
@@ -55,6 +57,13 @@ public class GraphQLClientConfigurationMergerBean {
                 // merge the headers
                 if (quarkusConfig.headers != null) {
                     upstreamConfig.getHeaders().putAll(quarkusConfig.headers);
+                }
+                if (quarkusConfig.subprotocols.isPresent()) {
+                    if (upstreamConfig.getWebsocketSubprotocols() != null) {
+                        upstreamConfig.getWebsocketSubprotocols().addAll(quarkusConfig.subprotocols.get());
+                    } else {
+                        upstreamConfig.setWebsocketSubprotocols(quarkusConfig.subprotocols.get());
+                    }
                 }
             }
         }


### PR DESCRIPTION
+  allow configuring websocket subprotocols for graphql clients