### PR TITLE
Qute - relax infix notation syntax

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Expressions.java
@@ -100,10 +100,20 @@ public final class Expressions {
                 }
                 // Non-separator char
                 if (!literal) {
+                    // Not inside a string/type literal
                     if (brackets == 0 && c == ' ' && splitConfig.isInfixNotationSupported()) {
-                        // Not inside a virtual method
-                        if (infix == 1) {
-                            // The second space after the infix method
+                        // Infix supported, blank space and not inside a virtual method
+                        if (separator == 0
+                                && (buffer.length() == 0 || buffer.charAt(buffer.length() - 1) == '(')) {
+                            // Skip redundant blank space:
+                            // 1. before the infix method
+                            // foo  or bar
+                            // ----^
+                            // 2. before an infix method parameter
+                            // foo or  bar
+                            // -------^
+                        } else if (infix == 1) {
+                            // The space after the infix method
                             // foo or bar
                             // ------^
                             buffer.append(LEFT_BRACKET);

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ExpressionTest.java
@@ -69,6 +69,17 @@ public class ExpressionTest {
     }
 
     @Test
+    public void testInfixNotationRedundantSpace() throws InterruptedException, ExecutionException {
+        verify("name   or 'John'", null, null, name("name"), virtualMethod("or", ExpressionImpl.from("'John'")));
+        verify("name or    'John'", null, null, name("name"), virtualMethod("or", ExpressionImpl.from("'John'")));
+        verify("name  or   'John'", null, null, name("name"), virtualMethod("or", ExpressionImpl.from("'John'")));
+        verify("name  or  'John' or 1", null, null, name("name"), virtualMethod("or", ExpressionImpl.from("'John'")),
+                virtualMethod("or", ExpressionImpl.literalFrom(-1, "1")));
+        verify("name  or  'John'  or  1", null, null, name("name"), virtualMethod("or", ExpressionImpl.from("'John'")),
+                virtualMethod("or", ExpressionImpl.literalFrom(-1, "1")));
+    }
+
+    @Test
     public void testNestedVirtualMethods() {
         assertNestedVirtualMethod(ExpressionImpl.from("movie.findServices(movie.name,movie.toNumber(movie.getName))"));
         assertNestedVirtualMethod(ExpressionImpl.from("movie.findServices(movie.name, movie.toNumber(movie.getName) )"));

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SimpleTest.java
@@ -83,6 +83,7 @@ public class SimpleTest {
         data.put("nameOptional", Optional.of("BUG"));
         assertEquals("John Bug", engine.parse("{name.or('John')} {surname.or('John')}").render(data));
         assertEquals("John Bug", engine.parse("{name ?: 'John'} {surname or 'John'}").render(data));
+        assertEquals("John Bug", engine.parse("{name ?:  'John'} {surname  or   'John'}").render(data));
         assertEquals("John Bug", engine.parse("{name ?: \"John Bug\"}").render(data));
         assertEquals("Is null", engine.parse("{foo ?: 'Is null'}").render(data));
         assertEquals("10", engine.parse("{foo.age.limit ?: 10}").render(data));


### PR DESCRIPTION
- ignore redundant blank space before infix method and before infix
method param