### PR TITLE
Fully disable JNDI services in Hibernate ORM extension

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJndiService.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJndiService.java
@@ -1,0 +1,39 @@
+package io.quarkus.hibernate.orm.runtime.customized;
+
+import javax.naming.event.NamespaceChangeListener;
+
+import org.hibernate.engine.jndi.spi.JndiService;
+
+/**
+ * Intentionally implementing these methods as no-op:
+ * some Hibernate ORM internal components currently require
+ * being able to attempt a lookup even when JNDI is not being used.
+ * Since we don't use JNDI in Quarkus we might as well short-circuit these
+ * as an additional precaution.
+ * In future versions of Hibernate ORM we might be able to throw an
+ * exception instead.
+ */
+final class QuarkusJndiService implements JndiService {
+
+    @Override
+    public Object locate(String jndiName) {
+        // no-op
+        return null;
+    }
+
+    @Override
+    public void bind(String jndiName, Object value) {
+        // no-op
+    }
+
+    @Override
+    public void unbind(String jndiName) {
+        // no-op
+    }
+
+    @Override
+    public void addListener(String jndiName, NamespaceChangeListener listener) {
+        // no-op
+    }
+
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJndiServiceInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusJndiServiceInitiator.java
@@ -2,15 +2,14 @@ package io.quarkus.hibernate.orm.runtime.customized;
 
 import java.util.Map;
 
-import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.StandardServiceInitiator;
-import org.hibernate.engine.jndi.internal.JndiServiceInitiator;
 import org.hibernate.engine.jndi.spi.JndiService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 public final class QuarkusJndiServiceInitiator implements StandardServiceInitiator<JndiService> {
 
-    public static final JndiServiceInitiator INSTANCE = new JndiServiceInitiator();
+    public static final QuarkusJndiServiceInitiator INSTANCE = new QuarkusJndiServiceInitiator();
+    private static final QuarkusJndiService SERVICE_INSTANCE = new QuarkusJndiService();
 
     @Override
     public Class<JndiService> getServiceInitiated() {
@@ -19,6 +18,6 @@ public final class QuarkusJndiServiceInitiator implements StandardServiceInitiat
 
     @Override
     public JndiService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
-        throw new HibernateException("JNDI is not available in Quarkus - please setup integrations in some different way");
+        return SERVICE_INSTANCE;
     }
 }


### PR DESCRIPTION
Let's apply some additional hardening as JNDI really lost popularity recently :)