### PR TITLE
Make sure (basic) logging is set up before each test class

### DIFF
--- a/test-framework/junit5-properties/src/main/resources/junit-platform.properties
+++ b/test-framework/junit5-properties/src/main/resources/junit-platform.properties
@@ -1,1 +1,2 @@
+junit.jupiter.extensions.autodetection.enabled=true
 junit.jupiter.testclass.order.default=io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/BasicLoggingEnabler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/BasicLoggingEnabler.java
@@ -1,0 +1,54 @@
+package io.quarkus.test.junit;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+
+/**
+ * A (global) JUnit callback that enables/sets up basic logging if logging has not already been set up.
+ * <p/>
+ * This is useful for getting log output from non-Quarkus tests (if executed separately or before the first Quarkus test),
+ * but also for getting instant log output from {@code QuarkusTestResourceLifecycleManagers} etc.
+ * <p/>
+ * This callback can be disabled via {@link #CFGKEY_ENABLED} in {@code junit-platform.properties} or via system property.
+ */
+public class BasicLoggingEnabler implements BeforeAllCallback {
+
+    private static final String CFGKEY_ENABLED = "junit.quarkus.enable-basic-logging";
+    private static Boolean enabled;
+
+    // to speed things up a little, eager async loading of the config that will be looked up in LoggingSetupRecorder
+    // downside: doesn't obey CFGKEY_ENABLED, but that should be bearable
+    static {
+        // e.g. continuous testing has everything set up already (DELAYED_HANDLER is active)
+        if (!InitialConfigurator.DELAYED_HANDLER.isActivated()) {
+            new Thread(() -> ConfigProvider.getConfig()).start();
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        if (enabled == null) {
+            enabled = context.getConfigurationParameter(CFGKEY_ENABLED).map(Boolean::valueOf).orElse(Boolean.TRUE);
+        }
+        if (!enabled || InitialConfigurator.DELAYED_HANDLER.isActivated()) {
+            return;
+        }
+        try {
+            IntegrationTestUtil.activateLogging();
+        } finally {
+            // release the config that was retrieved by above call so that tests that try to register their own config
+            // don't fail with:
+            // "IllegalStateException: SRCFG00017: Configuration already registered for the given class loader"
+            // also, a possible recreation of basically the same config for a later test class will consume far less time
+            var configProviderResolver = ConfigProviderResolver.instance();
+            var config = configProviderResolver.getConfig();
+            if (config != null) { // probably never null, but be safe
+                configProviderResolver.releaseConfig(config);
+            }
+        }
+    }
+}

--- a/test-framework/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/test-framework/junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.quarkus.test.junit.BasicLoggingEnabler

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/util/QuarkusTestProfileAwareClassOrdererTest.java
@@ -2,6 +2,7 @@ package io.quarkus.test.junit.util;
 
 import static io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer.CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST;
 import static io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer.CFGKEY_SECONDARY_ORDERER;
+import static io.quarkus.test.junit.util.QuarkusTestProfileAwareClassOrderer._CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -98,6 +99,23 @@ class QuarkusTestProfileAwareClassOrdererTest {
         when(contextMock.getConfigurationParameter(anyString())).thenReturn(Optional.empty()); // for strict stubbing
         // prioritize unit tests
         when(contextMock.getConfigurationParameter(CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST)).thenReturn(Optional.of("01_"));
+
+        underTest.orderClasses(contextMock);
+
+        assertThat(input).containsExactly(nonQuarkusTestDesc, quarkusTestDesc);
+    }
+
+    @Test
+    @Deprecated
+    void configuredPrefix_deprecated() {
+        ClassDescriptor quarkusTestDesc = quarkusDescriptorMock(Test01.class, null);
+        ClassDescriptor nonQuarkusTestDesc = descriptorMock(Test03.class);
+        List<ClassDescriptor> input = Arrays.asList(quarkusTestDesc, nonQuarkusTestDesc);
+        doReturn(input).when(contextMock).getClassDescriptors();
+
+        when(contextMock.getConfigurationParameter(anyString())).thenReturn(Optional.empty()); // for strict stubbing
+        // prioritize unit tests
+        when(contextMock.getConfigurationParameter(_CFGKEY_ORDER_PREFIX_NON_QUARKUS_TEST)).thenReturn(Optional.of("01_"));
 
         underTest.orderClasses(contextMock);
 


### PR DESCRIPTION
Alternative, actually much simpler approach to #22821 (which had this irritating flaw: https://github.com/quarkusio/quarkus/pull/22821#issuecomment-1012614080).

This makes sure that basic logging is available for _all_ kinds of (Junit) tests, Quarkus or not, right from the start!

This not only achieves the main goal of getting log output from non-Quarkus tests (in whichever order they are executed), but it has also the nice effect that all very early log output is "instant", instead of being delayed to regular log setup. E.g. a log statement from `io.quarkus.test.junit.QuarkusTestProfile.getConfigOverrides()` appears right away and will be there even if the following log activation is removed:
https://github.com/quarkusio/quarkus/blob/f133a1bb8a32989b0a1d68da0679d51d1ea98c82/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java#L309-L312

In fact, I think most such calls can be removed with this very early running, global JUnit callback.
I could do that in a follow-up PR which could then also include the renaming from `handleFailedStart()` to `initializeBasicLogging()` (as discussed here: https://github.com/quarkusio/quarkus/pull/22821#discussion_r782611380).

~~PS: If this is merged, I will also follow up with a PR making `RestClientConfigTest` more robust and removing that catch from some core tests (see https://github.com/quarkusio/quarkus/pull/22821#issuecomment-1012280322).~~ #22921 

PPS: There is at least one issue that I believe this PR will fix. I'll look it up later.