### PR TITLE
Minor cleanup to some tests that register custom config

### DIFF
--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigExpanderTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigExpanderTestCase.java
@@ -8,10 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.ExpressionConfigSourceInterceptor;
@@ -23,32 +19,11 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  */
 public class ConfigExpanderTestCase {
 
-    static ClassLoader classLoader;
-    static ConfigProviderResolver cpr;
-    Config config;
-
-    @BeforeAll
-    public static void initConfig() {
-        classLoader = Thread.currentThread().getContextClassLoader();
-        cpr = ConfigProviderResolver.instance();
-    }
-
-    @AfterEach
-    public void doAfter() {
-        try {
-            cpr.releaseConfig(cpr.getConfig());
-        } catch (IllegalStateException ignored) {
-            // just means no config was installed, which is fine
-        }
-    }
-
     private SmallRyeConfig buildConfig(Map<String, String> configMap) {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         builder.withInterceptors(new ExpressionConfigSourceInterceptor());
         builder.withSources(new PropertiesConfigSource(configMap, "test input", 500));
         final SmallRyeConfig config = (SmallRyeConfig) builder.build();
-        cpr.registerConfig(config, classLoader);
-        this.config = config;
         return config;
     }
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigProfileTestCase.java
@@ -11,9 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.ExpressionConfigSourceInterceptor;
@@ -24,24 +21,6 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 
 public class ConfigProfileTestCase {
 
-    static ClassLoader classLoader;
-    static ConfigProviderResolver cpr;
-
-    @BeforeAll
-    public static void initConfig() {
-        classLoader = Thread.currentThread().getContextClassLoader();
-        cpr = ConfigProviderResolver.instance();
-    }
-
-    @AfterEach
-    public void doAfter() {
-        try {
-            cpr.releaseConfig(cpr.getConfig());
-        } catch (IllegalStateException ignored) {
-            // just means no config was installed, which is fine
-        }
-    }
-
     private SmallRyeConfigBuilder configBuilder(String... keyValues) {
         return new SmallRyeConfigBuilder()
                 .addDefaultInterceptors()
@@ -51,7 +30,6 @@ public class ConfigProfileTestCase {
 
     private SmallRyeConfig buildConfig(String... keyValues) {
         final SmallRyeConfig config = configBuilder(keyValues).build();
-        cpr.registerConfig(config, classLoader);
         return config;
     }
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/DotEnvTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/DotEnvTestCase.java
@@ -15,9 +15,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.SmallRyeConfig;
@@ -27,24 +24,6 @@ import io.smallrye.config.SmallRyeConfigBuilder;
  *
  */
 public class DotEnvTestCase {
-
-    static ClassLoader classLoader;
-    static ConfigProviderResolver cpr;
-
-    @BeforeAll
-    public static void initConfig() {
-        classLoader = Thread.currentThread().getContextClassLoader();
-        cpr = ConfigProviderResolver.instance();
-    }
-
-    @AfterEach
-    public void doAfter() {
-        try {
-            cpr.releaseConfig(cpr.getConfig());
-        } catch (IllegalStateException ignored) {
-            // just means no config was installed, which is fine
-        }
-    }
 
     private SmallRyeConfig buildConfig(Map<String, String> configMap) throws IOException {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
@@ -62,10 +41,10 @@ public class DotEnvTestCase {
             }
         }
         builder.withSources(
-                new ConfigUtils.BuildTimeDotEnvConfigSourceProvider(dotEnv.toUri().toString()).getConfigSources(classLoader));
+                new ConfigUtils.BuildTimeDotEnvConfigSourceProvider(dotEnv.toUri().toString())
+                        .getConfigSources(Thread.currentThread().getContextClassLoader()));
         final SmallRyeConfig config = builder.build();
         Files.delete(dotEnv);
-        cpr.registerConfig(config, classLoader);
         return config;
     }
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/UUIDPropertyTest.java
@@ -4,9 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.runtime.LaunchMode;
@@ -16,29 +13,10 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 
 public class UUIDPropertyTest {
 
-    static ClassLoader classLoader;
-    static ConfigProviderResolver cpr;
-
-    @BeforeAll
-    public static void initConfig() {
-        classLoader = Thread.currentThread().getContextClassLoader();
-        cpr = ConfigProviderResolver.instance();
-    }
-
-    @AfterEach
-    public void doAfter() {
-        try {
-            cpr.releaseConfig(cpr.getConfig());
-        } catch (IllegalStateException ignored) {
-            // just means no config was installed, which is fine
-        }
-    }
-
     private SmallRyeConfig buildConfig() {
         final SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
         builder.withDefaultValue(ConfigUtils.UUID_KEY, UUID.randomUUID().toString());
         final SmallRyeConfig config = builder.build();
-        cpr.registerConfig(config, classLoader);
         return config;
     }
 


### PR DESCRIPTION
As discussed here: https://github.com/quarkusio/quarkus/pull/22821#issuecomment-1012280322

Btw, that superfluous catch also exists in some `main` classes (e.g. `ExtensionLoader`), but I didn't want to touch those.