### PR TITLE
Fix `RestClientBuilder` failed to instantiate provider message

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -251,7 +251,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             try {
                 registerMpSpecificProvider(componentClass.getDeclaredConstructor().newInstance());
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                throw new IllegalArgumentException("Failed to instantiate exception mapper " + componentClass
+                throw new IllegalArgumentException("Failed to instantiate provider " + componentClass
                         + ". Does it have a public no-arg constructor?", e);
             }
         }


### PR DESCRIPTION
It was always referring to the provide as an "exception mapper"; which is confusing to the end user. Repleced with the generic term "provider".