### PR TITLE
Fix remaining HV/RESTEasy warnings when Kotlin around

### DIFF
--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -54,6 +54,8 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.bootstrap.classloading.ClassPathElement;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -66,7 +68,7 @@ import io.quarkus.deployment.builditem.ConfigClassBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
@@ -345,29 +347,20 @@ class HibernateValidatorProcessor {
     }
 
     @BuildStep
-    NativeImageConfigBuildItem nativeImageConfig() {
-        List<String> potentialHibernateValidatorResourceBundles = List.of(
+    void optionalResouceBundles(BuildProducer<NativeImageResourceBundleBuildItem> resourceBundles) {
+        String[] potentialHibernateValidatorResourceBundles = {
                 AbstractMessageInterpolator.DEFAULT_VALIDATION_MESSAGES,
                 AbstractMessageInterpolator.USER_VALIDATION_MESSAGES,
-                AbstractMessageInterpolator.CONTRIBUTOR_VALIDATION_MESSAGES);
-        List<String> userDefinedHibernateValidatorResourceBundles = new ArrayList<>();
+                AbstractMessageInterpolator.CONTRIBUTOR_VALIDATION_MESSAGES };
 
         for (String potentialHibernateValidatorResourceBundle : potentialHibernateValidatorResourceBundles) {
-            if (Thread.currentThread().getContextClassLoader().getResource(potentialHibernateValidatorResourceBundle) != null) {
-                userDefinedHibernateValidatorResourceBundles.add(potentialHibernateValidatorResourceBundle);
+            for (ClassPathElement cpe : QuarkusClassLoader.getElements(potentialHibernateValidatorResourceBundle, false)) {
+                if (cpe.isRuntime()) {
+                    resourceBundles.produce(new NativeImageResourceBundleBuildItem(potentialHibernateValidatorResourceBundle));
+                    break;
+                }
             }
         }
-
-        if (userDefinedHibernateValidatorResourceBundles.isEmpty()) {
-            return null;
-        }
-
-        NativeImageConfigBuildItem.Builder builder = NativeImageConfigBuildItem.builder();
-        for (String hibernateValidatorResourceBundle : userDefinedHibernateValidatorResourceBundles) {
-            builder.addResourceBundle(hibernateValidatorResourceBundle);
-        }
-
-        return builder.build();
     }
 
     @BuildStep

--- a/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
+++ b/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java
@@ -56,12 +56,14 @@ import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BuiltinScope;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.arc.processor.Transformation;
+import io.quarkus.bootstrap.classloading.ClassPathElement;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
@@ -181,14 +183,14 @@ public class ResteasyServerCommonProcessor {
     }
 
     @BuildStep
-    NativeImageConfigBuildItem config() {
-        if (Thread.currentThread().getContextClassLoader().getResource(MESSAGES_RESOURCE_BUNDLE) == null) {
-            return null;
+    NativeImageResourceBundleBuildItem optionalResourceBundle() {
+        for (ClassPathElement cpe : QuarkusClassLoader.getElements(MESSAGES_RESOURCE_BUNDLE, false)) {
+            if (cpe.isRuntime()) {
+                return new NativeImageResourceBundleBuildItem(MESSAGES_RESOURCE_BUNDLE);
+            }
         }
 
-        return NativeImageConfigBuildItem.builder()
-                .addResourceBundle(MESSAGES_RESOURCE_BUNDLE)
-                .build();
+        return null;
     }
 
     @BuildStep


### PR DESCRIPTION
Instead of checking the CL, we check only the runtime elements so we are
sure the elements will be available at runtime.

Related to #21694