### PR TITLE
Define global timeout attributes for REST Clients

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -95,6 +95,20 @@ public class RestClientsConfig {
 
     public RestClientLoggingConfig logging;
 
+    /**
+     * Global default connect timeout for automatically generated REST Clients. The attribute specifies a timeout
+     * in milliseconds that a client should wait to connect to the remote endpoint.
+     */
+    @ConfigItem(defaultValue = "15000", defaultValueDocumentation = "15000 ms")
+    public Long connectTimeout;
+
+    /**
+     * Global default read timeout for automatically generated REST Clients. The attribute specifies a timeout
+     * in milliseconds that a client should wait for a response from the remote endpoint.
+     */
+    @ConfigItem(defaultValue = "30000", defaultValueDocumentation = "30000 ms")
+    public Long readTimeout;
+
     public RestClientConfig getClientConfig(String configKey) {
         if (configKey == null) {
             return RestClientConfig.EMPTY;

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -269,16 +269,16 @@ public class RestClientBase {
     }
 
     void configureTimeouts(RestClientBuilder builder) {
-        Optional<Long> connectTimeout = oneOf(clientConfigByClassName().connectTimeout,
-                clientConfigByConfigKey().connectTimeout);
-        if (connectTimeout.isPresent()) {
-            builder.connectTimeout(connectTimeout.get(), TimeUnit.MILLISECONDS);
+        Long connectTimeout = oneOf(clientConfigByClassName().connectTimeout,
+                clientConfigByConfigKey().connectTimeout).orElse(this.configRoot.connectTimeout);
+        if (connectTimeout != null) {
+            builder.connectTimeout(connectTimeout, TimeUnit.MILLISECONDS);
         }
 
-        Optional<Long> readTimeout = oneOf(clientConfigByClassName().readTimeout,
-                clientConfigByConfigKey().readTimeout);
-        if (readTimeout.isPresent()) {
-            builder.readTimeout(readTimeout.get(), TimeUnit.MILLISECONDS);
+        Long readTimeout = oneOf(clientConfigByClassName().readTimeout,
+                clientConfigByConfigKey().readTimeout).orElse(this.configRoot.readTimeout);
+        if (readTimeout != null) {
+            builder.readTimeout(readTimeout, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -322,10 +322,13 @@ public class RestClientBase {
         return this.configRoot.getClientConfig(this.proxyType);
     }
 
-    private static <T> Optional<T> oneOf(Optional<T> o1, Optional<T> o2) {
-        if (o1.isPresent()) {
-            return o1;
+    @SafeVarargs
+    private static <T> Optional<T> oneOf(Optional<T>... optionals) {
+        for (Optional<T> o : optionals) {
+            if (o.isPresent()) {
+                return o;
+            }
         }
-        return o2;
+        return Optional.empty();
     }
 }

--- a/extensions/resteasy-classic/rest-client/runtime/src/test/java/io/quarkus/restclient/runtime/RestClientBaseTest.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/test/java/io/quarkus/restclient/runtime/RestClientBaseTest.java
@@ -99,6 +99,23 @@ public class RestClientBaseTest {
         Mockito.verify(restClientBuilderMock).property("resteasy.connectionPoolSize", 103);
     }
 
+    @Test
+    public void testGlobalTimeouts() {
+        RestClientsConfig configRoot = new RestClientsConfig();
+        configRoot.connectTimeout = 5000L;
+        configRoot.readTimeout = 10000L;
+        RestClientBuilder restClientBuilderMock = Mockito.mock(RestClientBuilder.class);
+        RestClientBase restClientBase = new RestClientBase(TestClient.class,
+                "http://localhost:8080",
+                "test-client",
+                null,
+                configRoot);
+        restClientBase.configureTimeouts(restClientBuilderMock);
+
+        Mockito.verify(restClientBuilderMock).connectTimeout(5000, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).readTimeout(10000, TimeUnit.MILLISECONDS);
+    }
+
     /**
      * This method creates a Quarkus style configuration object (which would normally be created based on the MP config
      * properties, but it's easier to instantiate it directly here).

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -310,16 +310,16 @@ public class RestClientCDIDelegateBuilder<T> {
     }
 
     private void configureTimeouts(RestClientBuilder builder) {
-        Optional<Long> connectTimeout = oneOf(clientConfigByClassName().connectTimeout,
-                clientConfigByConfigKey().connectTimeout);
-        if (connectTimeout.isPresent()) {
-            builder.connectTimeout(connectTimeout.get(), TimeUnit.MILLISECONDS);
+        Long connectTimeout = oneOf(clientConfigByClassName().connectTimeout,
+                clientConfigByConfigKey().connectTimeout).orElse(this.configRoot.connectTimeout);
+        if (connectTimeout != null) {
+            builder.connectTimeout(connectTimeout, TimeUnit.MILLISECONDS);
         }
 
-        Optional<Long> readTimeout = oneOf(clientConfigByClassName().readTimeout,
-                clientConfigByConfigKey().readTimeout);
-        if (readTimeout.isPresent()) {
-            builder.readTimeout(readTimeout.get(), TimeUnit.MILLISECONDS);
+        Long readTimeout = oneOf(clientConfigByClassName().readTimeout,
+                clientConfigByConfigKey().readTimeout).orElse(this.configRoot.readTimeout);
+        if (readTimeout != null) {
+            builder.readTimeout(readTimeout, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -359,10 +359,13 @@ public class RestClientCDIDelegateBuilder<T> {
         return this.configRoot.getClientConfig(jaxrsInterface);
     }
 
-    private static <T> Optional<T> oneOf(Optional<T> o1, Optional<T> o2) {
-        if (o1.isPresent()) {
-            return o1;
+    @SafeVarargs
+    private static <T> Optional<T> oneOf(Optional<T>... optionals) {
+        for (Optional<T> o : optionals) {
+            if (o.isPresent()) {
+                return o;
+            }
         }
-        return o2;
+        return Optional.empty();
     }
 }

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -97,6 +97,22 @@ public class RestClientCDIDelegateBuilderTest {
                 HttpPostRequestEncoder.EncoderMode.HTML5);
     }
 
+    @Test
+    public void testGlobalTimeouts() {
+        RestClientsConfig configRoot = new RestClientsConfig();
+        configRoot.connectTimeout = 5000L;
+        configRoot.readTimeout = 10000L;
+        configRoot.multipartPostEncoderMode = Optional.empty();
+        RestClientBuilderImpl restClientBuilderMock = Mockito.mock(RestClientBuilderImpl.class);
+        new RestClientCDIDelegateBuilder<>(TestClient.class,
+                "http://localhost:8080",
+                "test-client",
+                configRoot).build(restClientBuilderMock);
+
+        Mockito.verify(restClientBuilderMock).connectTimeout(5000, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).readTimeout(10000, TimeUnit.MILLISECONDS);
+    }
+
     private static RestClientsConfig createSampleConfiguration() {
         RestClientConfig clientConfig = new RestClientConfig();
         clientConfig.url = Optional.of("http://localhost");


### PR DESCRIPTION
Added global timeout attributes for rest clients:

quarkus.rest-client.connect-timeout
quarkus.rest-client.read-timeout

The default values are 15000 and 30000 ms respectively.

This resolves https://github.com/quarkusio/quarkus/issues/22862