### PR TITLE
MongoDB - Add an experimental resolver for mongo+srv:// urls in native mode

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -676,9 +676,39 @@ This means that the `org.acme.MyVariable` class is not known to GraalVM, the rem
 More details about the `@RegisterForReflection` annotation can be found on the xref:writing-native-applications-tips.adoc#registerForReflection[native application tips] page.
 ====
 
-== Conclusion
+== Using mongo+srv:// urls
 
-Accessing a MongoDB database from a MongoDB Client is easy with Quarkus as it provides configuration and native support for it.
+`mongo+srv://` urls are supported out of the box in JVM mode.
+However, in native, the default DNS resolver, provided by the MongoDB client, uses JNDI and does not work in native mode.
+
+If you need to use `mongo+srv://` in native mode, you can configure an alternative DNS resolver.
+This feature is **experimental** and may introduce a difference between JVM applications and native applications.
+
+To enable the alternative DNS resolver, use:
+
+[source, properties]
+----
+quarkus.mongodb.native.dns.use-vertx-dns-resolver=true
+----
+
+As indicated in the property name, it uses Vert.x to retrieve the DNS records.
+By default, it tries to read the first `nameserver` from `/etc/resolv.conf`, if this file exists.
+You can also configure your DNS server:
+
+[source properties]
+----
+quarkus.mongodb.native.dns.use-vertx-dns-resolver=true
+quarkus.mongodb.native.dns.server-host=10.0.0.1
+quarkus.mongodb.native.dns.server-port=53 # 53 is the default port
+----
+
+Also, you can configure the lookup timeout using:
+
+[source properties]
+----
+quarkus.mongodb.native.dns.use-vertx-dns-resolver=true
+quarkus.mongodb.native.dns.lookup-timeout=10s # the default is 5s
+----
 
 == Configuration Reference
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongodbConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongodbConfig.java
@@ -1,6 +1,9 @@
 package io.quarkus.mongodb.runtime;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -42,4 +45,37 @@ public class MongodbConfig {
      */
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, MongoClientConfig> mongoClientConfigs;
+
+    /**
+     * The default DNS resolver used to handle {@code mongo+srv://} urls cannot be used in a native executable.
+     * This option enables a fallback to use Vert.x to resolve the server names instead of JNDI.
+     *
+     * <strong>IMPORTANT:</strong> The resolution may be different in JVM mode (using the default (JNDI-based) DNS resolver,
+     * and in native mode. This feature is experimental.
+     */
+    @ConfigItem(name = "native.dns.use-vertx-dns-resolver", defaultValue = "false")
+    public boolean useVertxDnsResolverInNativeMode;
+
+    /**
+     * If {@code native.dns.use-vertx-dns-resolver} is set to {@code true}, this property configures the DNS server.
+     * If the server is not set, it tries to read the first {@code nameserver} from {@code /etc/resolv.conf} (if the
+     * file exists), otherwise fallback to the default.
+     */
+    @ConfigItem(name = "native.dns.server-host")
+    public Optional<String> dnsServerInNativeMode;
+
+    /**
+     * If {@code native.dns.use-vertx-dns-resolver} is set to {@code true}, this property configures the DNS server port.
+     * If not set, uses the system DNS resolver.
+     */
+    @ConfigItem(name = "native.dns.server-port", defaultValue = "53")
+    public OptionalInt dnsServerPortInNativeMode;
+
+    // mongo.dns.lookup-timeout
+    /**
+     * If {@code native.dns.use-vertx-dns-resolver} is set to {@code true}, this property configures the DNS lookup timeout
+     * duration.
+     */
+    @ConfigItem(name = "native.dns.lookup-timeout", defaultValue = "5s")
+    public Duration dnsLookupTimeoutInNativeMode;
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/DnsClientProducer.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/DnsClientProducer.java
@@ -1,0 +1,83 @@
+package io.quarkus.mongodb.runtime.dns;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.arc.Arc;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.dns.DnsClient;
+
+/**
+ * This class is used in native mode when {@code quarkus.mongodb.native.dns.use-vertx-dns-resolver} is set to {@code true}.
+ * By default, the MongoDB driver uses JNDI to retrieve the SRV and TXT DNS Records, which is not supported in native.
+ */
+public abstract class DnsClientProducer {
+
+    public static final String FLAG = "quarkus.mongodb.native.dns.use-vertx-dns-resolver";
+
+    private static final String DNS_SERVER = "quarkus.mongodb.native.dns.server-host";
+    private static final String DNS_SERVER_PORT = "quarkus.mongodb.native.dns.server-port";
+
+    public static final String LOOKUP_TIMEOUT = "quarkus.mongodb.native.dns.lookup-timeout";
+
+    private static DnsClient client;
+
+    public static synchronized io.vertx.mutiny.core.dns.DnsClient createDnsClient() {
+        Config config = ConfigProvider.getConfig();
+        if (client == null) {
+            Vertx vertx = Arc.container().instance(Vertx.class).get();
+
+            // If the server is not set, we attempt to read the /etc/resolv.conf. If it does not exist, we use the default
+            // configuration.
+            String server = config.getOptionalValue(DNS_SERVER, String.class).orElseGet(() -> {
+                List<String> list = nameServers();
+                if (!list.isEmpty()) {
+                    return list.get(0);
+                }
+                return null;
+            });
+            if (server != null) {
+                int port = config.getOptionalValue(DNS_SERVER_PORT, Integer.class).orElse(53);
+                client = vertx.createDnsClient(port, server);
+            } else {
+                client = vertx.createDnsClient();
+            }
+        }
+
+        return client;
+    }
+
+    public static List<String> nameServers() {
+        String file = "/etc/resolv.conf";
+        if (!new File(file).isFile()) {
+            return Collections.emptyList();
+        }
+
+        Path p = Paths.get(file);
+        List<String> nameServers = new ArrayList<>();
+        String line;
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(p)))) {
+            while ((line = br.readLine()) != null) {
+                StringTokenizer st = new StringTokenizer(line);
+                if (st.nextToken().startsWith("nameserver")) {
+                    nameServers.add(st.nextToken());
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return nameServers;
+    }
+}

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
@@ -1,14 +1,19 @@
 package io.quarkus.mongodb.runtime.graal;
 
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import com.mongodb.*;
 import com.mongodb.connection.*;
@@ -22,6 +27,10 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.mongodb.runtime.dns.DnsClientProducer;
+import io.vertx.mutiny.core.dns.DnsClient;
+import io.vertx.mutiny.core.dns.SrvRecord;
 
 public final class MongoClientSubstitutions {
 }
@@ -136,6 +145,7 @@ final class ServerAddressHelperSubstitution {
 
 @TargetClass(DefaultDnsResolver.class)
 final class DefaultDnsResolverSubstitution {
+
     /*
      * The format of SRV record is
      * priority weight port target.
@@ -149,7 +159,44 @@ final class DefaultDnsResolverSubstitution {
      */
     @Substitute
     public List<String> resolveHostFromSrvRecords(final String srvHost) {
-        throw new UnsupportedOperationException("mongo+srv:// not supported in native mode");
+        Config config = ConfigProvider.getConfig();
+        if (!config.getOptionalValue(DnsClientProducer.FLAG, Boolean.class).orElse(false)) {
+            throw new MongoConfigurationException(
+                    "'mongo+srv://' is not supported in native. You can set 'quarkus.mongodb.native.dns.use-vertx-dns-resolver' "
+                            +
+                            "to `true` to use an alternative DNS resolver.");
+        }
+        DnsClient dnsClient = DnsClientProducer.createDnsClient();
+        String srvHostDomain = srvHost.substring(srvHost.indexOf('.') + 1);
+        List<String> srvHostDomainParts = asList(srvHostDomain.split("\\."));
+        List<String> hosts = new ArrayList<>();
+        Duration timeout = config.getOptionalValue(DnsClientProducer.LOOKUP_TIMEOUT, Duration.class)
+                .orElse(Duration.ofSeconds(5));
+
+        try {
+            List<SrvRecord> srvRecords = dnsClient.resolveSRV("_mongodb._tcp." + srvHost).await().atMost(timeout);
+
+            if (srvRecords.isEmpty()) {
+                throw new MongoConfigurationException("No SRV records available for host " + "_mongodb._tcp." + srvHost);
+            }
+
+            for (SrvRecord srvRecord : srvRecords) {
+                String resolvedHost = srvRecord.target().endsWith(".")
+                        ? srvRecord.target().substring(0, srvRecord.target().length() - 1)
+                        : srvRecord.target();
+                String resolvedHostDomain = resolvedHost.substring(resolvedHost.indexOf('.') + 1);
+                if (!sameParentDomain(srvHostDomainParts, resolvedHostDomain)) {
+                    throw new MongoConfigurationException(
+                            format("The SRV host name '%s' resolved to a host '%s 'that is not in a sub-domain of the SRV host.",
+                                    srvHost, resolvedHost));
+                }
+                hosts.add(resolvedHost + ":" + srvRecord.port());
+            }
+        } catch (Throwable e) {
+            throw new MongoConfigurationException("Unable to look up SRV record for host " + srvHost, e);
+        }
+
+        return hosts;
     }
 
     @Substitute
@@ -170,7 +217,38 @@ final class DefaultDnsResolverSubstitution {
      */
     @Substitute
     public String resolveAdditionalQueryParametersFromTxtRecords(final String host) {
-        throw new UnsupportedOperationException("mongo+srv:// not supported in native mode");
+        Config config = ConfigProvider.getConfig();
+        if (!config.getOptionalValue(DnsClientProducer.FLAG, Boolean.class).orElse(false)) {
+            throw new MongoConfigurationException(
+                    "'mongo+srv://' is not supported in native. You can set 'quarkus.mongodb.native.dns.use-vertx-dns-resolver' "
+                            +
+                            "to `true` to use an alternative DNS resolver.");
+        }
+        DnsClient dnsClient = DnsClientProducer.createDnsClient();
+        List<String> txtRecordEnumeration;
+        String additionalQueryParameters = "";
+
+        try {
+            Duration timeout = config.getOptionalValue(DnsClientProducer.LOOKUP_TIMEOUT, Duration.class)
+                    .orElse(Duration.ofSeconds(5));
+            txtRecordEnumeration = dnsClient.resolveTXT(host).await().atMost(timeout);
+
+            for (String txtRecord : txtRecordEnumeration) {
+                // Remove all space characters, as the DNS resolver for TXT records inserts a space character
+                // between each character-string in a single TXT record.  That whitespace is spurious in
+                // this context and must be removed
+                additionalQueryParameters = txtRecord.replaceAll("\\s", "");
+
+                if (txtRecordEnumeration.size() > 1) {
+                    throw new MongoConfigurationException(format(
+                            "Multiple TXT records found for host '%s'.  Only one is permitted",
+                            host));
+                }
+            }
+            return additionalQueryParameters;
+        } catch (Throwable e) {
+            throw new MongoConfigurationException("Unable to look up TXT record for host " + host, e);
+        }
     }
 }
 


### PR DESCRIPTION
This PR provides an alternative DNS resolver in native mode.
In the DefaultDnsResolver substitution, this PR provides a way to switch to a Vert.x-based resolver which work in native.
See https://github.com/quarkusio/quarkus/discussions/22613.
