### PR TITLE
Support for assisted project updates

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeExtensionDepsTest.java
@@ -79,7 +79,7 @@ public class ExcludeExtensionDepsTest extends ExecutableOutputOutcomeTestBase {
         final Set<Dependency> expectedRuntimeDeps = new HashSet<>();
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b", "1"), "compile",
                 DependencyFlags.DIRECT, DependencyFlags.RUNTIME_EXTENSION_ARTIFACT, DependencyFlags.RUNTIME_CP,
-                DependencyFlags.DEPLOYMENT_CP));
+                DependencyFlags.DEPLOYMENT_CP, DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT));
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b-dep-1", "1"), "compile",
                 DependencyFlags.RUNTIME_CP, DependencyFlags.DEPLOYMENT_CP));
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b-dep-2", "1"), "compile",

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ExcludeLibDepsTest.java
@@ -71,7 +71,7 @@ public class ExcludeLibDepsTest extends ExecutableOutputOutcomeTestBase {
         final Set<Dependency> expectedRuntimeDeps = new HashSet<>();
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a", "1"), "compile",
                 DependencyFlags.DIRECT, DependencyFlags.RUNTIME_EXTENSION_ARTIFACT, DependencyFlags.RUNTIME_CP,
-                DependencyFlags.DEPLOYMENT_CP));
+                DependencyFlags.DEPLOYMENT_CP, DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT));
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-dep-1", "1"), "compile",
                 DependencyFlags.RUNTIME_CP, DependencyFlags.DEPLOYMENT_CP));
         expectedRuntimeDeps.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-dep-2", "1"), "compile",

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -43,6 +43,7 @@ import io.quarkus.gradle.tasks.QuarkusBuild;
 import io.quarkus.gradle.tasks.QuarkusDev;
 import io.quarkus.gradle.tasks.QuarkusGenerateCode;
 import io.quarkus.gradle.tasks.QuarkusGoOffline;
+import io.quarkus.gradle.tasks.QuarkusInfo;
 import io.quarkus.gradle.tasks.QuarkusListCategories;
 import io.quarkus.gradle.tasks.QuarkusListExtensions;
 import io.quarkus.gradle.tasks.QuarkusListPlatforms;
@@ -51,6 +52,7 @@ import io.quarkus.gradle.tasks.QuarkusRemoveExtension;
 import io.quarkus.gradle.tasks.QuarkusTest;
 import io.quarkus.gradle.tasks.QuarkusTestConfig;
 import io.quarkus.gradle.tasks.QuarkusTestNative;
+import io.quarkus.gradle.tasks.QuarkusUpdate;
 import io.quarkus.gradle.tooling.GradleApplicationModelBuilder;
 import io.quarkus.gradle.tooling.dependency.ExtensionDependency;
 
@@ -74,6 +76,8 @@ public class QuarkusPlugin implements Plugin<Project> {
     public static final String QUARKUS_TEST_TASK_NAME = "quarkusTest";
     public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
     public static final String QUARKUS_GO_OFFLINE_TASK_NAME = "quarkusGoOffline";
+    public static final String QUARKUS_INFO_TASK_NAME = "quarkusInfo";
+    public static final String QUARKUS_UPDATE_TASK_NAME = "quarkusUpdate";
 
     @Deprecated
     public static final String BUILD_NATIVE_TASK_NAME = "buildNative";
@@ -112,6 +116,8 @@ public class QuarkusPlugin implements Plugin<Project> {
         tasks.register(LIST_PLATFORMS_TASK_NAME, QuarkusListPlatforms.class);
         tasks.register(ADD_EXTENSION_TASK_NAME, QuarkusAddExtension.class);
         tasks.register(REMOVE_EXTENSION_TASK_NAME, QuarkusRemoveExtension.class);
+        tasks.register(QUARKUS_INFO_TASK_NAME, QuarkusInfo.class);
+        tasks.register(QUARKUS_UPDATE_TASK_NAME, QuarkusUpdate.class);
         tasks.register(QUARKUS_GO_OFFLINE_TASK_NAME, QuarkusGoOffline.class, task -> {
             task.setCompileClasspath(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
             task.setTestCompileClasspath(

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
@@ -1,0 +1,53 @@
+package io.quarkus.gradle.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.commands.handlers.InfoCommandHandler;
+import io.quarkus.devtools.commands.handlers.UpdateCommandHandler;
+import io.quarkus.devtools.project.QuarkusProject;
+
+public class QuarkusInfo extends QuarkusPlatformTask {
+
+    private boolean perModule = false;
+
+    @Input
+    public boolean getPerModule() {
+        return perModule;
+    }
+
+    @Option(description = "Log project's state per module.", option = "perModule")
+    public void setPerModule(boolean perModule) {
+        this.perModule = perModule;
+    }
+
+    public QuarkusInfo() {
+        super("Log Quarkus-specific project information, such as imported Quarkus platform BOMs, Quarkus extensions found among the project dependencies, etc.");
+    }
+
+    @TaskAction
+    public void logInfo() {
+        final QuarkusProject quarkusProject = getQuarkusProject(false);
+        final Map<String, Object> params = new HashMap<>();
+        params.put(UpdateCommandHandler.APP_MODEL, extension().getApplicationModel());
+        params.put(UpdateCommandHandler.LOG_STATE_PER_MODULE, perModule);
+        final QuarkusCommandInvocation invocation = new QuarkusCommandInvocation(quarkusProject, params);
+        final QuarkusCommandOutcome outcome;
+        try {
+            outcome = new InfoCommandHandler().execute(invocation);
+        } catch (Exception e) {
+            throw new GradleException("Failed to collect Quarkus project information", e);
+        }
+        if (outcome.getValue(InfoCommandHandler.RECOMMENDATIONS_AVAILABLE, false)) {
+            this.getProject().getLogger().warn(
+                    "Non-recommended Quarkus platform BOM and/or extension versions were found. For more details, please, execute 'gradle quarkusUpdate --rectify'");
+        }
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -1,0 +1,78 @@
+package io.quarkus.gradle.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.handlers.UpdateCommandHandler;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.registry.RegistryResolutionException;
+
+public class QuarkusUpdate extends QuarkusPlatformTask {
+
+    private boolean perModule = false;
+    private boolean recommendedState = false;
+    private boolean rectify = false;
+
+    @Input
+    public boolean getPerModule() {
+        return perModule;
+    }
+
+    @Option(description = "Log project's state per module.", option = "perModule")
+    public void setPerModule(boolean perModule) {
+        this.perModule = perModule;
+    }
+
+    @Input
+    public boolean getRecommendedState() {
+        return recommendedState;
+    }
+
+    @Option(description = "Log the new recommended project state.", option = "recommendedState")
+    public void setRecommendedState(boolean recommendedState) {
+        this.recommendedState = recommendedState;
+    }
+
+    @Input
+    public boolean getRectify() {
+        return rectify;
+    }
+
+    @Option(description = "Log the rectified state of the current project according to the recommendations based on the currently enforced Quarkus platforms.", option = "rectify")
+    public void setRectify(boolean rectify) {
+        this.rectify = rectify;
+    }
+
+    public QuarkusUpdate() {
+        super("Log Quarkus-specific recommended project updates, such as the new Quarkus platform BOM versions, new versions of Quarkus extensions that aren't managed by the Quarkus BOMs, etc");
+    }
+
+    @TaskAction
+    public void logUpdates() {
+        final QuarkusProject quarkusProject = getQuarkusProject(false);
+        final Map<String, Object> params = new HashMap<>();
+        try {
+            params.put(UpdateCommandHandler.LATEST_CATALOG,
+                    getExtensionCatalogResolver(quarkusProject.log()).resolveExtensionCatalog());
+        } catch (RegistryResolutionException e) {
+            throw new GradleException(
+                    "Failed to resolve the latest Quarkus extension catalog from the configured extension registries", e);
+        }
+        params.put(UpdateCommandHandler.APP_MODEL, extension().getApplicationModel());
+        params.put(UpdateCommandHandler.LOG_STATE_PER_MODULE, perModule);
+        params.put(UpdateCommandHandler.LOG_RECOMMENDED_STATE, recommendedState);
+        params.put(UpdateCommandHandler.RECTIFY, rectify);
+        final QuarkusCommandInvocation invocation = new QuarkusCommandInvocation(quarkusProject, params);
+        try {
+            new UpdateCommandHandler().execute(invocation);
+        } catch (Exception e) {
+            throw new GradleException("Failed to resolve recommended updates", e);
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
@@ -1,0 +1,43 @@
+package io.quarkus.maven;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.commands.handlers.InfoCommandHandler;
+import io.quarkus.devtools.commands.handlers.UpdateCommandHandler;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * Log Quarkus-specific project information, such as imported Quarkus platform BOMs,
+ * Quarkus extensions found among the project dependencies, etc.
+ */
+@Mojo(name = "info", requiresProject = true)
+public class InfoMojo extends QuarkusProjectStateMojoBase {
+
+    @Override
+    protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
+
+        final Map<String, Object> params = new HashMap<>();
+        params.put(UpdateCommandHandler.APP_MODEL, resolveApplicationModel());
+        params.put(UpdateCommandHandler.LOG_STATE_PER_MODULE, perModule);
+
+        final QuarkusCommandInvocation invocation = new QuarkusCommandInvocation(quarkusProject, params);
+        QuarkusCommandOutcome outcome;
+        try {
+            outcome = new InfoCommandHandler().execute(invocation);
+        } catch (QuarkusCommandException e) {
+            throw new MojoExecutionException("Failed to resolve the available updates", e);
+        }
+
+        if (outcome.getValue(InfoCommandHandler.RECOMMENDATIONS_AVAILABLE, false)) {
+            getLog().warn(
+                    "Non-recommended Quarkus platform BOM and/or extension versions were found. For more details, please, execute 'mvn quarkus:update -Drectify'");
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectStateMojoBase.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusProjectStateMojoBase.java
@@ -1,0 +1,155 @@
+package io.quarkus.maven;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.cli.transfer.QuietMavenTransferListener;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DependencyNode;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.GACTV;
+
+public abstract class QuarkusProjectStateMojoBase extends QuarkusProjectMojoBase {
+
+    /**
+     * If true, the information will be logged per each relevant module of the project
+     * instead of an overall summary
+     */
+    @Parameter(property = "perModule", required = false)
+    boolean perModule;
+
+    @Override
+    public void doExecute(QuarkusProject quarkusProject, MessageWriter log) throws MojoExecutionException {
+        if (project.getFile() == null) {
+            throw new MojoExecutionException("This goal requires a project");
+        }
+
+        if (!QuarkusProjectHelper.isRegistryClientEnabled()) {
+            throw new MojoExecutionException("This goal requires a Quarkus extension registry client to be enabled");
+        }
+
+        final Collection<Path> createdDirs = ensureResolvable(new DefaultArtifact(project.getGroupId(),
+                project.getArtifactId(), ArtifactCoords.TYPE_POM, project.getVersion()));
+        try {
+            processProjectState(quarkusProject);
+        } finally {
+            for (Path p : createdDirs) {
+                IoUtils.recursiveDelete(p);
+            }
+        }
+    }
+
+    protected abstract void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException;
+
+    protected ApplicationModel resolveApplicationModel() throws MojoExecutionException {
+        try {
+            return new BootstrapAppModelResolver(artifactResolver())
+                    .resolveModel(GACTV.pom(project.getGroupId(), project.getArtifactId(), project.getVersion()));
+        } catch (AppModelResolverException e) {
+            throw new MojoExecutionException("Failed to resolve the Quarkus application model for project "
+                    + GACTV.pom(project.getGroupId(), project.getArtifactId(), project.getVersion()), e);
+        }
+    }
+
+    private Collection<Path> ensureResolvable(Artifact a) throws MojoExecutionException {
+        final DependencyNode root;
+        try {
+            root = artifactResolver().collectDependencies(a, Collections.emptyList()).getRoot();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to collect dependencies of " + a, e);
+        }
+        final List<Path> createdDirs = new ArrayList<>();
+        ensureResolvableModule(root, artifactResolver().getMavenContext().getWorkspace(), createdDirs);
+        return createdDirs;
+    }
+
+    private void ensureResolvableModule(DependencyNode node, LocalWorkspace workspace, List<Path> createdDirs)
+            throws MojoExecutionException {
+        Artifact artifact = node.getArtifact();
+        if (artifact != null) {
+            final LocalProject module = workspace.getProject(artifact.getGroupId(), artifact.getArtifactId());
+            if (module != null && !module.getRawModel().getPackaging().equals(ArtifactCoords.TYPE_POM)) {
+                final Path classesDir = module.getClassesDir();
+                if (!Files.exists(classesDir)) {
+                    Path topDirToCreate = classesDir;
+                    while (!Files.exists(topDirToCreate.getParent())) {
+                        topDirToCreate = topDirToCreate.getParent();
+                    }
+                    try {
+                        Files.createDirectories(classesDir);
+                        createdDirs.add(topDirToCreate);
+                    } catch (IOException e) {
+                        throw new MojoExecutionException("Failed to create " + classesDir, e);
+                    }
+                }
+            }
+        }
+        for (DependencyNode c : node.getChildren()) {
+            ensureResolvableModule(c, workspace, createdDirs);
+        }
+    }
+
+    @Override
+    protected MavenArtifactResolver catalogArtifactResolver() throws MojoExecutionException {
+        if (getLog().isDebugEnabled()) {
+            return artifactResolver();
+        } else {
+            try {
+                final MavenArtifactResolver baseResolver = artifactResolver();
+                final DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(
+                        baseResolver.getSession());
+                session.setTransferListener(new QuietMavenTransferListener());
+                final BootstrapMavenContext ctx = new BootstrapMavenContext(BootstrapMavenContext.config()
+                        .setRepositorySystem(baseResolver.getSystem())
+                        .setRemoteRepositoryManager(baseResolver.getRemoteRepositoryManager())
+                        .setRemoteRepositories(baseResolver.getRepositories())
+                        .setWorkspaceDiscovery(false)
+                        .setRepositorySystemSession(session));
+                return new MavenArtifactResolver(ctx);
+            } catch (BootstrapMavenException e) {
+                throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+            }
+        }
+    }
+
+    @Override
+    protected MavenArtifactResolver initArtifactResolver() throws MojoExecutionException {
+        try {
+            return MavenArtifactResolver.builder()
+                    .setRemoteRepositoryManager(remoteRepositoryManager)
+                    // The system needs to be initialized with the bootstrap model builder to properly interpolate system properties set on the command line
+                    // e.g. -Dquarkus.platform.version=xxx
+                    //.setRepositorySystem(bootstrapProvider.repositorySystem())
+                    // The session should be initialized with the loaded workspace
+                    //.setRepositorySystemSession(repoSession)
+                    .setRemoteRepositories(repos)
+                    // To support multimodule projects that haven't been installed
+                    .setPreferPomsFromWorkspace(true)
+                    .build();
+        } catch (BootstrapMavenException e) {
+            throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+        }
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -1,0 +1,59 @@
+package io.quarkus.maven;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.handlers.UpdateCommandHandler;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.registry.RegistryResolutionException;
+
+/**
+ * Log Quarkus-related recommended updates, such as new Quarkus platform BOM versions and
+ * Quarkus extensions versions that aren't managed by the Quarkus platform BOMs.
+ */
+@Mojo(name = "update", requiresProject = true)
+public class UpdateMojo extends QuarkusProjectStateMojoBase {
+
+    /**
+     * If true, the state of the project will be logged as if the recommended updates
+     * were applied
+     */
+    @Parameter(property = "recommendedState")
+    boolean recommendedState;
+
+    /**
+     * If true, instead of checking and recommending the latest available Quarkus platform version,
+     * recommendations to properly align the current project configuration will be logged (if any)
+     */
+    @Parameter(property = "rectify")
+    boolean rectify;
+
+    @Override
+    protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
+
+        final Map<String, Object> params = new HashMap<>();
+        try {
+            params.put(UpdateCommandHandler.LATEST_CATALOG, getExtensionCatalogResolver().resolveExtensionCatalog());
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException(
+                    "Failed to resolve the latest Quarkus extension catalog from the configured extension registries", e);
+        }
+        params.put(UpdateCommandHandler.APP_MODEL, resolveApplicationModel());
+        params.put(UpdateCommandHandler.LOG_RECOMMENDED_STATE, recommendedState);
+        params.put(UpdateCommandHandler.LOG_STATE_PER_MODULE, perModule);
+        params.put(UpdateCommandHandler.RECTIFY, rectify);
+
+        final QuarkusCommandInvocation invocation = new QuarkusCommandInvocation(quarkusProject, params);
+        try {
+            new UpdateCommandHandler().execute(invocation);
+        } catch (QuarkusCommandException e) {
+            throw new MojoExecutionException("Failed to resolve the available updates", e);
+        }
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
@@ -1,13 +1,13 @@
 package io.quarkus.bootstrap.model;
 
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,13 +49,13 @@ public interface ApplicationModel {
     }
 
     default Collection<WorkspaceModule> getWorkspaceModules() {
-        final List<WorkspaceModule> modules = new ArrayList<>();
+        final Map<WorkspaceModuleId, WorkspaceModule> modules = new HashMap<>();
         for (ResolvedDependency d : getDependencies()) {
             final WorkspaceModule module = d.getWorkspaceModule();
             if (module != null) {
-                modules.add(module);
+                modules.putIfAbsent(module.getId(), module);
             }
         }
-        return modules;
+        return modules.values();
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
@@ -1,11 +1,15 @@
 package io.quarkus.bootstrap.workspace;
 
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathList;
 import java.io.File;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
@@ -18,6 +22,8 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
     private final File buildDir;
     private PathCollection buildFiles;
     private final Map<String, ArtifactSources> sourcesSets = new HashMap<>();
+    private List<Dependency> directDepConstraints = Collections.emptyList();
+    private List<Dependency> directDeps = Collections.emptyList();
 
     public DefaultWorkspaceModule(WorkspaceModuleId id, File moduleDir, File buildDir) {
         super();
@@ -67,6 +73,31 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
     @Override
     public PathCollection getBuildFiles() {
         return buildFiles == null ? PathList.empty() : buildFiles;
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencyConstraints() {
+        return directDepConstraints;
+    }
+
+    public void setDirectDependencyConstraints(List<Dependency> directDepConstraints) {
+        this.directDepConstraints = directDepConstraints;
+    }
+
+    @Override
+    public Collection<Dependency> getDirectDependencies() {
+        return directDeps;
+    }
+
+    public void setDirectDependencies(List<Dependency> directDeps) {
+        this.directDeps = directDeps;
+    }
+
+    public void addDirectDependency(Dependency directDep) {
+        if (directDeps.isEmpty()) {
+            directDeps = new ArrayList<>();
+        }
+        this.directDeps.add(directDep);
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/WorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/WorkspaceModule.java
@@ -1,5 +1,6 @@
 package io.quarkus.bootstrap.workspace;
 
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.paths.EmptyPathTree;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathTree;
@@ -43,4 +44,8 @@ public interface WorkspaceModule {
         return artifactSources == null || !artifactSources.isOutputAvailable() ? EmptyPathTree.getInstance()
                 : artifactSources.getOutputTree();
     }
+
+    Collection<Dependency> getDirectDependencyConstraints();
+
+    Collection<Dependency> getDirectDependencies();
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
@@ -20,4 +20,17 @@ public interface ArtifactCoords {
     default String toGACTVString() {
         return getGroupId() + ":" + getArtifactId() + ":" + getClassifier() + ":" + getType() + ":" + getVersion();
     }
+
+    default String toCompactCoords() {
+        final StringBuilder b = new StringBuilder();
+        b.append(getGroupId()).append(':').append(getArtifactId()).append(':');
+        if (!getClassifier().isEmpty()) {
+            b.append(getClassifier()).append(':');
+        }
+        if (!TYPE_JAR.equals(getType())) {
+            b.append(getType()).append(':');
+        }
+        b.append(getVersion());
+        return b.toString();
+    }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
@@ -14,8 +14,15 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
 
     public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version) {
         super(groupId, artifactId, classifier, type, version);
-        this.scope = "copmpile";
+        this.scope = "compile";
         flags = 0;
+    }
+
+    public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version, String scope,
+            boolean optional) {
+        super(groupId, artifactId, classifier, type, version);
+        this.scope = scope;
+        flags = optional ? DependencyFlags.OPTIONAL : 0;
     }
 
     public ArtifactDependency(ArtifactCoords coords, int... flags) {
@@ -79,7 +86,7 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
             return true;
         if (!super.equals(obj))
             return false;
-        if (getClass() != obj.getClass())
+        if (!(obj instanceof ArtifactDependency))
             return false;
         ArtifactDependency other = (ArtifactDependency) obj;
         return flags == other.flags && Objects.equals(scope, other.scope);
@@ -87,6 +94,6 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
 
     @Override
     public String toString() {
-        return "[" + toGACTVString() + " " + scope + "]";
+        return "[" + toGACTVString() + " " + scope + " " + flags + "]";
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
@@ -3,13 +3,17 @@ package io.quarkus.maven.dependency;
 public interface DependencyFlags {
 
     /* @formatter:off */
-    public static final int OPTIONAL =                   0b0000001;
-    public static final int DIRECT =                     0b0000010;
-    public static final int RUNTIME_CP =                 0b0000100;
-    public static final int DEPLOYMENT_CP =              0b0001000;
-    public static final int RUNTIME_EXTENSION_ARTIFACT = 0b0010000;
-    public static final int WORKSPACE_MODULE =           0b0100000;
-    public static final int RELOADABLE =                 0b1000000;
+    public static final int OPTIONAL =                             0b00000001;
+    public static final int DIRECT =                               0b00000010;
+    public static final int RUNTIME_CP =                           0b00000100;
+    public static final int DEPLOYMENT_CP =                        0b00001000;
+    public static final int RUNTIME_EXTENSION_ARTIFACT =           0b00010000;
+    public static final int WORKSPACE_MODULE =                     0b00100000;
+    public static final int RELOADABLE =                           0b01000000;
+    // A top-level runtime extension artifact is either a direct
+    // dependency or a first extension dependency on the branch
+    // navigating from the root to leaves
+    public static final int TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT = 0b10000000;
     /* @formatter:on */
 
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
@@ -105,12 +105,13 @@ public class GACTV implements ArtifactCoords, Serializable {
             return true;
         if (obj == null)
             return false;
-        if (getClass() != obj.getClass())
+        if (!(obj instanceof ArtifactCoords)) {
             return false;
-        GACTV other = (GACTV) obj;
-        return Objects.equals(artifactId, other.artifactId) && Objects.equals(classifier, other.classifier)
-                && Objects.equals(groupId, other.groupId) && Objects.equals(type, other.type)
-                && Objects.equals(version, other.version);
+        }
+        ArtifactCoords other = (ArtifactCoords) obj;
+        return Objects.equals(artifactId, other.getArtifactId()) && Objects.equals(groupId, other.getGroupId())
+                && Objects.equals(version, other.getVersion()) && Objects.equals(type, other.getType())
+                && Objects.equals(classifier, other.getClassifier());
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -77,10 +77,10 @@ public class ResolvedArtifactDependency extends ArtifactDependency implements Re
             return true;
         if (!super.equals(obj))
             return false;
-        if (getClass() != obj.getClass())
+        if (!(obj instanceof ResolvableDependency))
             return false;
-        ResolvedArtifactDependency other = (ResolvedArtifactDependency) obj;
-        return Objects.equals(module, other.module) && Objects.equals(paths, other.paths);
+        ResolvableDependency other = (ResolvableDependency) obj;
+        return Objects.equals(module, other.getWorkspaceModule()) && Objects.equals(paths, other.getResolvedPaths());
     }
 
     @Override

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/CollectDependenciesBase.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.DependencyFlags;
-import io.quarkus.maven.dependency.ResolvedArtifactDependency;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -103,7 +102,8 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
         ext.install(repo);
         root.addDependency(ext);
         addCollectedDep(ext.getRuntime(), "compile", false,
-                DependencyFlags.DIRECT | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
+                DependencyFlags.DIRECT | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
+                        | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
         addCollectedDeploymentDep(ext.getDeployment());
     }
 
@@ -160,7 +160,7 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
         if (expectedResult.isEmpty()) {
             expectedResult = new ArrayList<>();
         }
-        expectedResult.add(new ArtifactDependency(new ResolvedArtifactDependency(artifact.toArtifact()), scope, allFlags));
+        expectedResult.add(new ArtifactDependency(artifact.toArtifact(), scope, allFlags));
     }
 
     protected void addCollectedDeploymentDep(TsArtifact ext) {
@@ -168,7 +168,7 @@ public abstract class CollectDependenciesBase extends ResolverSetupCleanup {
             deploymentDeps = new ArrayList<>();
         }
         deploymentDeps
-                .add(new ArtifactDependency(new ResolvedArtifactDependency(ext.toArtifact()), "compile",
+                .add(new ArtifactDependency(ext.toArtifact(), "compile",
                         DependencyFlags.DEPLOYMENT_CP));
     }
 

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/replace/test/ManagedReplacedDependencyTestCase.java
@@ -52,7 +52,8 @@ public class ManagedReplacedDependencyTestCase extends CollectDependenciesBase {
         addManagedDep(ext201);
         addManagedDep(ext301);
 
-        addCollectedDep(ext301.getRuntime(), DependencyFlags.DIRECT | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT);
+        addCollectedDep(ext301.getRuntime(), DependencyFlags.DIRECT | DependencyFlags.RUNTIME_EXTENSION_ARTIFACT
+                | DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
         addCollectedDeploymentDep(ext301.getDeployment());
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -208,6 +208,9 @@ public class DeploymentInjectingDependencyVisitor {
                 }
                 if (extDep != null) {
                     newRtDep.setRuntimeExtensionArtifact();
+                    if (collectingTopExtensionRuntimeNodes) {
+                        newRtDep.setFlags(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT);
+                    }
                 }
                 appBuilder.addDependency(newRtDep.build());
             }

--- a/independent-projects/tools/artifact-api/pom.xml
+++ b/independent-projects/tools/artifact-api/pom.xml
@@ -13,6 +13,13 @@
     <artifactId>quarkus-devtools-artifact-api</artifactId>
     <name>Quarkus - Dev tools - Maven Artifact API</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-bootstrap-app-model</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactCoords.java
+++ b/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactCoords.java
@@ -3,10 +3,7 @@ package io.quarkus.maven;
 import java.io.Serializable;
 import java.util.Objects;
 
-public class ArtifactCoords implements Serializable {
-
-    public static final String TYPE_JAR = "jar";
-    public static final String TYPE_POM = "pom";
+public class ArtifactCoords implements io.quarkus.maven.dependency.ArtifactCoords, Serializable {
 
     public static ArtifactCoords fromString(String str) {
         return new ArtifactCoords(split(str, new String[5]));
@@ -96,15 +93,15 @@ public class ArtifactCoords implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || !(o instanceof io.quarkus.maven.dependency.ArtifactCoords)) {
             return false;
         }
-        ArtifactCoords that = (ArtifactCoords) o;
-        return Objects.equals(groupId, that.groupId) &&
-                Objects.equals(artifactId, that.artifactId) &&
-                Objects.equals(classifier, that.classifier) &&
-                Objects.equals(type, that.type) &&
-                Objects.equals(version, that.version);
+        io.quarkus.maven.dependency.ArtifactCoords that = (io.quarkus.maven.dependency.ArtifactCoords) o;
+        return Objects.equals(groupId, that.getGroupId()) &&
+                Objects.equals(artifactId, that.getArtifactId()) &&
+                Objects.equals(classifier, that.getClassifier()) &&
+                Objects.equals(type, that.getType()) &&
+                Objects.equals(version, that.getVersion());
     }
 
     @Override
@@ -125,5 +122,18 @@ public class ArtifactCoords implements Serializable {
             buf.append(classifier);
         }
         return buf.append(':').append(type).append(':').append(version);
+    }
+
+    public String toCompactCoords() {
+        final StringBuilder b = new StringBuilder();
+        b.append(getGroupId()).append(':').append(getArtifactId()).append(':');
+        if (!getClassifier().isEmpty()) {
+            b.append(getClassifier()).append(':');
+        }
+        if (!TYPE_JAR.equals(getType())) {
+            b.append(getType()).append(':');
+        }
+        b.append(getVersion());
+        return b.toString();
     }
 }

--- a/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
+++ b/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
@@ -1,8 +1,9 @@
 package io.quarkus.maven;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-public class ArtifactKey implements Serializable {
+public class ArtifactKey implements io.quarkus.maven.dependency.ArtifactKey, Serializable {
 
     public static ArtifactKey fromString(String str) {
         return new ArtifactKey(split(str, new String[4], str.length()));
@@ -113,13 +114,7 @@ public class ArtifactKey implements Serializable {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((artifactId == null) ? 0 : artifactId.hashCode());
-        result = prime * result + ((classifier == null) ? 0 : classifier.hashCode());
-        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        return result;
+        return Objects.hash(artifactId, classifier, groupId, type);
     }
 
     @Override
@@ -128,30 +123,11 @@ public class ArtifactKey implements Serializable {
             return true;
         if (obj == null)
             return false;
-        if (getClass() != obj.getClass())
+        if (!(obj instanceof io.quarkus.maven.dependency.ArtifactKey))
             return false;
-        ArtifactKey other = (ArtifactKey) obj;
-        if (artifactId == null) {
-            if (other.artifactId != null)
-                return false;
-        } else if (!artifactId.equals(other.artifactId))
-            return false;
-        if (classifier == null) {
-            if (other.classifier != null)
-                return false;
-        } else if (!classifier.equals(other.classifier))
-            return false;
-        if (groupId == null) {
-            if (other.groupId != null)
-                return false;
-        } else if (!groupId.equals(other.groupId))
-            return false;
-        if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+        io.quarkus.maven.dependency.ArtifactKey other = (io.quarkus.maven.dependency.ArtifactKey) obj;
+        return Objects.equals(artifactId, other.getArtifactId()) && Objects.equals(classifier, other.getClassifier())
+                && Objects.equals(groupId, other.getGroupId()) && Objects.equals(type, other.getType());
     }
 
     @Override
@@ -165,15 +141,6 @@ public class ArtifactKey implements Serializable {
         }
         if (type != null) {
             buf.append(':').append(type);
-        }
-        return buf.toString();
-    }
-
-    public String toGacString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append(groupId).append(':').append(artifactId);
-        if (!classifier.isEmpty()) {
-            buf.append(':').append(classifier);
         }
         return buf.toString();
     }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/InfoCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/InfoCommandHandler.java
@@ -1,0 +1,399 @@
+package io.quarkus.devtools.commands.handlers;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.state.ExtensionProvider;
+import io.quarkus.devtools.project.state.ModuleState;
+import io.quarkus.devtools.project.state.ProjectState;
+import io.quarkus.devtools.project.state.TopExtensionDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InfoCommandHandler implements QuarkusCommandHandler {
+
+    public static final String APP_MODEL = "app-model";
+    public static final String LOG_STATE_PER_MODULE = "log-state-per-module";
+    public static final String RECOMMENDATIONS_AVAILABLE = "recommendations-available";
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+
+        final ApplicationModel appModel = invocation.getValue(APP_MODEL);
+        final boolean logStatePerModule = invocation.getValue(UpdateCommandHandler.LOG_STATE_PER_MODULE, false);
+
+        final boolean recommendationsAvailable = logState(
+                resolveProjectState(appModel, invocation.getExtensionsCatalog()), logStatePerModule, false,
+                invocation.log());
+        return QuarkusCommandOutcome.success().setValue(RECOMMENDATIONS_AVAILABLE, recommendationsAvailable);
+    }
+
+    // TODO: instead of returning a boolean, the info about available
+    // recommendations should be reflected in ProjectState
+    protected static boolean logState(ProjectState projectState, boolean perModule, boolean rectify,
+            MessageWriter log) {
+
+        boolean recommendationsAvailable = false;
+
+        final Map<ArtifactKey, PlatformInfo> providerInfo = new LinkedHashMap<>();
+        for (ArtifactCoords bom : projectState.getPlatformBoms()) {
+            providerInfo.computeIfAbsent(bom.getKey(), k -> new PlatformInfo()).imported = bom;
+        }
+        for (TopExtensionDependency dep : projectState.getExtensions()) {
+            final ExtensionOrigin origin = dep.getOrigin();
+            if (origin != null && origin.isPlatform()) {
+                providerInfo.computeIfAbsent(origin.getBom().getKey(), k -> new PlatformInfo()).recommended = origin
+                        .getBom();
+            }
+        }
+
+        if (providerInfo.isEmpty()) {
+            log.info("No Quarkus platform BOMs found");
+        } else {
+            log.info("Quarkus platform BOMs:");
+            boolean recommendExtraImports = false;
+            for (PlatformInfo platform : providerInfo.values()) {
+                if (platform.imported == null) {
+                    recommendExtraImports = true;
+                    continue;
+                }
+                final StringBuilder sb = new StringBuilder();
+                if (platform.recommended == null) {
+                    if (rectify) {
+                        sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                                UpdateCommandHandler.REMOVE, platform.imported.toCompactCoords()));
+                    } else {
+                        sb.append("  ");
+                        sb.append(platform.imported.toCompactCoords()).append(" | unnecessary");
+                    }
+                    recommendationsAvailable = true;
+                } else if (platform.isVersionUpdateRecommended()) {
+                    if (rectify) {
+                        sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                                UpdateCommandHandler.UPDATE, platform.imported.toCompactCoords()));
+                        sb.append(platform.imported.toCompactCoords()).append(" -> ")
+                                .append(platform.getRecommendedVersion());
+                    } else {
+                        sb.append("  ");
+                        sb.append(platform.imported.toCompactCoords()).append(" | misaligned");
+                    }
+                    recommendationsAvailable = true;
+                } else {
+                    if (rectify) {
+                        sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT, "",
+                                platform.imported.toCompactCoords()));
+                    } else {
+                        sb.append("  ").append(platform.imported.toCompactCoords());
+                    }
+                }
+                log.info(sb.toString());
+            }
+            if (rectify && recommendExtraImports) {
+                for (PlatformInfo platform : providerInfo.values()) {
+                    if (platform.imported == null) {
+                        log.info(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT, UpdateCommandHandler.ADD,
+                                platform.recommended.toCompactCoords()));
+                    }
+                }
+                recommendationsAvailable = true;
+            }
+        }
+
+        if (projectState.getExtensions().isEmpty()) {
+            log.info("No Quarkus extensions found among the project dependencies");
+            return recommendationsAvailable;
+        }
+
+        log.info("");
+
+        if (perModule) {
+            final ModuleState mainModule = projectState.getMainModule();
+            final Path baseDir = mainModule.getModuleDir();
+            recommendationsAvailable |= logModuleInfo(mainModule, baseDir, log, rectify);
+            for (ModuleState module : projectState.getModules()) {
+                if (!module.isMain()) {
+                    recommendationsAvailable |= logModuleInfo(module, baseDir, log, rectify);
+                }
+            }
+        } else {
+            for (ExtensionProvider provider : projectState.getExtensionProviders()) {
+                if (provider.getExtensions().isEmpty()) {
+                    continue;
+                }
+                log.info("Extensions from " + provider.getKey() + ":");
+                for (TopExtensionDependency dep : provider.getExtensions()) {
+                    final StringBuilder sb = new StringBuilder();
+                    if (dep.isPlatformExtension()) {
+                        if (rectify) {
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                                        UpdateCommandHandler.UPDATE, ""));
+                            } else {
+                                sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT, "", ""));
+                            }
+                            sb.append(dep.getArtifact().getGroupId()).append(':')
+                                    .append(dep.getArtifact().getArtifactId());
+                            if (!dep.getArtifact().getClassifier().isEmpty()) {
+                                sb.append(':').append(dep.getArtifact().getClassifier());
+                            }
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(':').append(dep.getArtifact().getVersion());
+                                if (rectify) {
+                                    sb.append(" -> remove version (managed)");
+                                }
+                                recommendationsAvailable = true;
+                            }
+                        } else {
+                            sb.append("  ").append(dep.getArtifact().getGroupId()).append(':')
+                                    .append(dep.getArtifact().getArtifactId());
+                            if (!dep.getArtifact().getClassifier().isEmpty()) {
+                                sb.append(':').append(dep.getArtifact().getClassifier());
+                            }
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(':').append(dep.getArtifact().getVersion());
+                                sb.append(" | misaligned");
+                                recommendationsAvailable = true;
+                            }
+                        }
+                    } else {
+                        sb.append("  ").append(dep.getArtifact().getGroupId()).append(':')
+                                .append(dep.getArtifact().getArtifactId());
+                        if (!dep.getArtifact().getClassifier().isEmpty()) {
+                            sb.append(':').append(dep.getArtifact().getClassifier());
+                        }
+                        sb.append(':').append(dep.getArtifact().getVersion());
+                    }
+                    if (dep.isTransitive()) {
+                        sb.append(" | transitive");
+                    }
+                    log.info(sb.toString());
+                }
+                log.info("");
+            }
+        }
+        return recommendationsAvailable;
+    }
+
+    private static boolean logModuleInfo(ModuleState module, Path baseDir, MessageWriter log, boolean rectify) {
+        if (module.getExtensions().isEmpty() && module.getPlatformBoms().isEmpty() && !module.isMain()) {
+            return false;
+        }
+        boolean recommendationsAvailable = false;
+
+        final StringBuilder sb = new StringBuilder();
+        if (module.isMain()) {
+            sb.append("Main application module ");
+        } else {
+            sb.append("Module ");
+        }
+        sb.append(module.getId().getGroupId()).append(':').append(module.getId().getArtifactId()).append(':');
+        log.info(sb.toString());
+
+        final Iterator<Path> i = module.getWorkspaceModule().getBuildFiles().iterator();
+        if (i.hasNext()) {
+            sb.setLength(0);
+            sb.append("  Build file: ");
+            sb.append(baseDir.relativize(i.next()));
+            while (i.hasNext()) {
+                sb.append(", ").append(baseDir.relativize(i.next()));
+            }
+            log.info(sb.toString());
+        }
+
+        if (!module.getPlatformBoms().isEmpty()) {
+            log.info("  Platform BOMs:");
+            for (ArtifactCoords bom : module.getPlatformBoms()) {
+                log.info("    " + bom.toCompactCoords());
+            }
+        }
+
+        if (!module.getExtensions().isEmpty()) {
+            final Map<String, List<TopExtensionDependency>> extDepsByProvider = new LinkedHashMap<>();
+            for (TopExtensionDependency dep : module.getExtensions()) {
+                extDepsByProvider.computeIfAbsent(dep.getProviderKey(), k -> new ArrayList<>()).add(dep);
+            }
+            for (Map.Entry<String, List<TopExtensionDependency>> provider : extDepsByProvider.entrySet()) {
+                log.info("  Extensions from " + provider.getKey() + ":");
+                for (TopExtensionDependency dep : provider.getValue()) {
+                    sb.setLength(0);
+                    sb.append("  ");
+                    if (dep.isPlatformExtension()) {
+                        if (rectify) {
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                                        UpdateCommandHandler.UPDATE, ""));
+                            } else {
+                                sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT, "", ""));
+                            }
+                            sb.append(dep.getArtifact().getGroupId()).append(':')
+                                    .append(dep.getArtifact().getArtifactId());
+                            if (!dep.getArtifact().getClassifier().isEmpty()) {
+                                sb.append(':').append(dep.getArtifact().getClassifier());
+                            }
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(':').append(dep.getArtifact().getVersion());
+                                if (rectify) {
+                                    sb.append(" -> remove version (managed)");
+                                }
+                                recommendationsAvailable = true;
+                            }
+                        } else {
+                            sb.append("  ").append(dep.getArtifact().getGroupId()).append(':')
+                                    .append(dep.getArtifact().getArtifactId());
+                            if (!dep.getArtifact().getClassifier().isEmpty()) {
+                                sb.append(':').append(dep.getArtifact().getClassifier());
+                            }
+                            if (dep.isNonRecommendedVersion()) {
+                                sb.append(':').append(dep.getArtifact().getVersion());
+                                sb.append(" | misaligned");
+                                recommendationsAvailable = true;
+                            }
+                        }
+                    } else {
+                        if (rectify) {
+                            sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT, "", ""));
+                        } else {
+                            sb.append("  ");
+                        }
+                        sb.append(dep.getArtifact().toCompactCoords());
+                    }
+                    if (dep.isTransitive()) {
+                        sb.append(" | transitive");
+                    }
+                    log.info(sb.toString());
+                }
+                log.info("");
+            }
+        }
+        return recommendationsAvailable;
+    }
+
+    protected static ProjectState resolveProjectState(ApplicationModel appModel, ExtensionCatalog currentCatalog) {
+        final ProjectState.Builder projectBuilder = ProjectState.builder();
+
+        final Collection<ArtifactCoords> importedPlatformBoms = appModel.getPlatforms().getImportedPlatformBoms();
+        if (importedPlatformBoms.isEmpty()) {
+            return projectBuilder.build();
+        }
+
+        final Map<String, ExtensionProvider.Builder> extProviderBuilders = new HashMap<>(importedPlatformBoms.size());
+        importedPlatformBoms.forEach(bom -> {
+            projectBuilder.addPlatformBom(bom);
+            extProviderBuilders.put(ExtensionProvider.key(bom, true),
+                    ExtensionProvider.builder().setArtifact(bom).setPlatform(true));
+        });
+
+        final Map<WorkspaceModuleId, ModuleState.Builder> projectModuleBuilders = new HashMap<>();
+        final Map<ArtifactKey, List<ModuleState.Builder>> directModuleDeps = new HashMap<>();
+
+        final WorkspaceModule appModule = appModel.getAppArtifact().getWorkspaceModule();
+        if (appModule != null) {
+            final ModuleState.Builder module = ModuleState.builder().setWorkspaceModule(appModule).setMainModule(true);
+            projectModuleBuilders.put(appModule.getId(), module);
+            appModule.getDirectDependencies()
+                    .forEach(d -> directModuleDeps.computeIfAbsent(d.getKey(), dk -> new ArrayList<>()).add(module));
+
+            for (Dependency constraint : appModule.getDirectDependencyConstraints()) {
+                if (extProviderBuilders.containsKey(constraint.toCompactCoords())) {
+                    module.addPlatformBom(constraint);
+                }
+            }
+
+        }
+        for (ResolvedDependency dep : appModel.getDependencies()) {
+            if (dep.getWorkspaceModule() != null) {
+                projectModuleBuilders.computeIfAbsent(dep.getWorkspaceModule().getId(), k -> {
+                    final ModuleState.Builder module = ModuleState.builder()
+                            .setWorkspaceModule(dep.getWorkspaceModule());
+                    dep.getWorkspaceModule().getDirectDependencies().forEach(
+                            d -> directModuleDeps.computeIfAbsent(d.getKey(), dk -> new ArrayList<>()).add(module));
+                    return module;
+                });
+            }
+        }
+
+        final Map<ArtifactKey, TopExtensionDependency.Builder> directExtDeps = new HashMap<>();
+        for (ResolvedDependency dep : appModel.getDependencies()) {
+            if (dep.isFlagSet(DependencyFlags.TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT)) {
+                directExtDeps.put(dep.getKey(), TopExtensionDependency.builder().setResolvedDependency(dep)
+                        .setTransitive(!directModuleDeps.containsKey(dep.getKey())));
+            } else if (dep.isRuntimeExtensionArtifact() && directModuleDeps.containsKey(dep.getKey())) {
+                directExtDeps.put(dep.getKey(), TopExtensionDependency.builder().setResolvedDependency(dep));
+            }
+        }
+
+        if (directExtDeps.isEmpty()) {
+            return projectBuilder.build();
+        }
+
+        currentCatalog.getExtensions().forEach(e -> {
+            final ArtifactKey key = e.getArtifact().getKey();
+            final TopExtensionDependency.Builder dep = directExtDeps.get(key);
+            if (dep != null) {
+                dep.setCatalogMetadata(e);
+            }
+        });
+
+        for (TopExtensionDependency.Builder extBuilder : directExtDeps.values()) {
+            final List<ModuleState.Builder> modules = directModuleDeps.getOrDefault(extBuilder.getKey(),
+                    Collections.emptyList());
+            final TopExtensionDependency dep = extBuilder.setTransitive(modules.isEmpty()).build();
+            projectBuilder.addExtensionDependency(dep);
+            for (ModuleState.Builder module : modules) {
+                module.addExtensionDependency(dep);
+            }
+            final ExtensionProvider.Builder provider = extProviderBuilders.computeIfAbsent(dep.getProviderKey(),
+                    k -> ExtensionProvider.builder().setOrigin(dep.getOrigin()));
+            provider.addExtension(dep);
+        }
+
+        for (ExtensionProvider.Builder builder : extProviderBuilders.values()) {
+            projectBuilder.addExtensionProvider(builder.build());
+        }
+
+        for (ModuleState.Builder builder : projectModuleBuilders.values()) {
+            projectBuilder.addModule(builder.build());
+        }
+
+        return projectBuilder.build();
+    }
+
+    static class PlatformInfo {
+        ArtifactCoords imported;
+        ArtifactCoords recommended;
+
+        boolean isVersionUpdateRecommended() {
+            return imported != null && recommended != null && !imported.getVersion().equals(recommended.getVersion());
+        }
+
+        String getRecommendedVersion() {
+            return recommended == null ? null : recommended.getVersion();
+        }
+
+        boolean isImported() {
+            return imported != null;
+        }
+
+        boolean isToBeImported() {
+            return recommended != null;
+        }
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/UpdateCommandHandler.java
@@ -1,0 +1,368 @@
+package io.quarkus.devtools.commands.handlers;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.commands.data.QuarkusCommandInvocation;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.commands.handlers.InfoCommandHandler.PlatformInfo;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.state.ExtensionProvider;
+import io.quarkus.devtools.project.state.ModuleState;
+import io.quarkus.devtools.project.state.ProjectState;
+import io.quarkus.devtools.project.state.TopExtensionDependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import io.quarkus.registry.catalog.selection.ExtensionOrigins;
+import io.quarkus.registry.catalog.selection.OriginCombination;
+import io.quarkus.registry.catalog.selection.OriginPreference;
+import io.quarkus.registry.catalog.selection.OriginSelector;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class UpdateCommandHandler implements QuarkusCommandHandler {
+
+    public static final String APP_MODEL = "app-model";
+    public static final String LATEST_CATALOG = "latest-catalog";
+    public static final String LOG_RECOMMENDED_STATE = "log-recommended-state";
+    public static final String LOG_STATE_PER_MODULE = "log-state-per-module";
+    public static final String RECTIFY = "rectify";
+
+    public static final String ADD = "Add:";
+    public static final String REMOVE = "Remove:";
+    public static final String UPDATE = "Update:";
+
+    public static final String PLATFORM_RECTIFY_FORMAT = "%-7s %s";
+
+    @Override
+    public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
+
+        final ApplicationModel appModel = invocation.getValue(APP_MODEL);
+        final ExtensionCatalog latestCatalog = invocation.getValue(UpdateCommandHandler.LATEST_CATALOG);
+        final boolean logRecommendedState = invocation.getValue(UpdateCommandHandler.LOG_RECOMMENDED_STATE, false);
+        final boolean logStatePerModule = invocation.getValue(UpdateCommandHandler.LOG_STATE_PER_MODULE, false);
+        final boolean rectify = invocation.getValue(UpdateCommandHandler.RECTIFY, false);
+
+        if (logStatePerModule && !rectify) {
+            throw new QuarkusCommandException("Update per module isn't supported yet!");
+        }
+
+        final ProjectState currentState = InfoCommandHandler.resolveProjectState(appModel,
+                invocation.getQuarkusProject().getExtensionsCatalog());
+
+        if (rectify) {
+            InfoCommandHandler.logState(currentState, logStatePerModule, rectify, invocation.getQuarkusProject().log());
+        } else {
+            logUpdates(currentState, latestCatalog, logRecommendedState, logStatePerModule,
+                    invocation.getQuarkusProject().log());
+        }
+
+        return QuarkusCommandOutcome.success();
+    }
+
+    private static void logUpdates(ProjectState currentState, ExtensionCatalog recommendedCatalog, boolean recommendState,
+            boolean perModule, MessageWriter log) {
+        if (currentState.getPlatformBoms().isEmpty()) {
+            log.info("The project does not import any Quarkus platform BOM");
+            return;
+        }
+        if (currentState.getExtensions().isEmpty()) {
+            log.info("Quarkus extension were not found among the project dependencies");
+            return;
+        }
+        final ProjectState recommendedState = resolveRecommendedState(currentState, recommendedCatalog, log);
+        if (currentState == recommendedState) {
+            log.info("No recommended updates found");
+            return;
+        }
+
+        if (recommendState) {
+            InfoCommandHandler.logState(recommendedState, perModule, false, log);
+            return;
+        }
+
+        // log instructions
+        final Map<ArtifactKey, PlatformInfo> platformImports = new LinkedHashMap<>();
+        for (ArtifactCoords c : currentState.getPlatformBoms()) {
+            final PlatformInfo info = new PlatformInfo();
+            info.imported = c;
+            platformImports.put(c.getKey(), info);
+        }
+        List<PlatformInfo> importVersionUpdates = new ArrayList<>();
+        List<PlatformInfo> newImports = new ArrayList<>(0);
+        for (ArtifactCoords c : recommendedState.getPlatformBoms()) {
+            final PlatformInfo importInfo = platformImports.computeIfAbsent(c.getKey(), k -> new PlatformInfo());
+            importInfo.recommended = c;
+            if (importInfo.isImported()) {
+                importVersionUpdates.add(importInfo);
+            } else {
+                newImports.add(importInfo);
+            }
+        }
+
+        log.info("");
+        final boolean importsToBeRemoved = importVersionUpdates.size() + newImports.size() < platformImports.size();
+        if (!importVersionUpdates.isEmpty() || !newImports.isEmpty() || importsToBeRemoved) {
+            log.info("Recommended Quarkus platform BOM updates:");
+            if (!importVersionUpdates.isEmpty()) {
+                for (PlatformInfo importInfo : importVersionUpdates) {
+                    log.info(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                            UpdateCommandHandler.UPDATE, importInfo.imported.toCompactCoords()) + " -> "
+                            + importInfo.getRecommendedVersion());
+                }
+            }
+            if (!newImports.isEmpty()) {
+                for (PlatformInfo importInfo : newImports) {
+                    log.info(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                            UpdateCommandHandler.ADD, importInfo.recommended.toCompactCoords()));
+                }
+            }
+            if (importsToBeRemoved) {
+                for (PlatformInfo importInfo : platformImports.values()) {
+                    if (importInfo.recommended == null) {
+                        log.info(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                                UpdateCommandHandler.REMOVE, importInfo.imported.toCompactCoords()));
+                    }
+                }
+            }
+            log.info("");
+        }
+
+        final Map<ArtifactKey, ExtensionInfo> extensionInfo = new LinkedHashMap<>(currentState.getExtensions().size());
+        for (TopExtensionDependency dep : currentState.getExtensions()) {
+            extensionInfo.put(dep.getKey(), new ExtensionInfo(dep));
+        }
+        for (TopExtensionDependency dep : recommendedState.getExtensions()) {
+            final ExtensionInfo info = extensionInfo.get(dep.getKey());
+            if (info != null) {
+                info.recommendedDep = dep;
+            }
+        }
+        final Map<ArtifactCoords, List<ArtifactCoords>> versionedManagedExtensions = new LinkedHashMap<>(0);
+        final Map<String, List<ExtensionInfo>> nonPlatformExtensionUpdates = new LinkedHashMap<>();
+        for (ExtensionInfo info : extensionInfo.values()) {
+            if (info.getRecommendedDependency() == null) {
+                continue;
+            }
+            if (info.getRecommendedDependency().isPlatformExtension()) {
+                if (info.currentDep.isNonRecommendedVersion()) {
+                    versionedManagedExtensions
+                            .computeIfAbsent(info.getRecommendedDependency().getOrigin().getBom(), k -> new ArrayList<>())
+                            .add(info.currentDep.getArtifact());
+                }
+            } else if (!info.currentDep.getVersion().equals(info.getRecommendedDependency().getVersion())) {
+                nonPlatformExtensionUpdates.computeIfAbsent(info.currentDep.getProviderKey(), k -> new ArrayList<>()).add(info);
+            }
+        }
+
+        if (!versionedManagedExtensions.isEmpty()) {
+            for (Map.Entry<ArtifactCoords, List<ArtifactCoords>> origin : versionedManagedExtensions.entrySet()) {
+                log.info("Extensions from " + origin.getKey().toCompactCoords() + ":");
+                for (ArtifactCoords c : origin.getValue()) {
+                    final StringBuilder sb = new StringBuilder();
+                    sb.append(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                            UpdateCommandHandler.UPDATE, c.toCompactCoords()));
+                    sb.append(" -> remove version (managed)");
+                    log.info(sb.toString());
+                }
+                log.info("");
+            }
+        }
+
+        if (!nonPlatformExtensionUpdates.isEmpty()) {
+            for (Map.Entry<String, List<ExtensionInfo>> provider : nonPlatformExtensionUpdates.entrySet()) {
+                log.info("Extensions from " + provider.getKey() + ":");
+                for (ExtensionInfo info : provider.getValue()) {
+                    log.info(String.format(UpdateCommandHandler.PLATFORM_RECTIFY_FORMAT,
+                            UpdateCommandHandler.UPDATE, info.currentDep.getArtifact().toCompactCoords() + " -> "
+                                    + info.getRecommendedDependency().getVersion()));
+                }
+                log.info("");
+            }
+        }
+    }
+
+    private static ProjectState resolveRecommendedState(ProjectState currentState, ExtensionCatalog latestCatalog,
+            MessageWriter log) {
+        if (currentState.getPlatformBoms().isEmpty()) {
+            return currentState;
+        }
+        if (currentState.getExtensions().isEmpty()) {
+            return currentState;
+        }
+
+        final Map<ArtifactKey, ExtensionInfo> extensionInfo = new HashMap<>();
+        for (TopExtensionDependency dep : currentState.getExtensions()) {
+            extensionInfo.put(dep.getKey(), new ExtensionInfo(dep));
+        }
+
+        for (Extension e : latestCatalog.getExtensions()) {
+            final ExtensionInfo candidate = extensionInfo.get(e.getArtifact().getKey());
+            if (candidate != null) {
+                candidate.latestMetadata = e;
+            }
+        }
+
+        final List<ArtifactCoords> unknownExtensions = new ArrayList<>(0);
+        final List<Extension> updateCandidates = new ArrayList<>(extensionInfo.size());
+        final Map<String, Map<ArtifactKey, ExtensionInfo>> updateCandidatesByOrigin = new HashMap<>();
+        for (ExtensionInfo i : extensionInfo.values()) {
+            if (i.latestMetadata == null) {
+                unknownExtensions.add(i.currentDep.getArtifact());
+            } else {
+                updateCandidates.add(i.latestMetadata);
+                for (ExtensionOrigin o : i.latestMetadata.getOrigins()) {
+                    updateCandidatesByOrigin.computeIfAbsent(o.getId(), k -> new HashMap<>()).put(i.currentDep.getKey(), i);
+                }
+            }
+        }
+
+        if (extensionInfo.isEmpty()) {
+            return currentState;
+        }
+
+        if (!unknownExtensions.isEmpty()) {
+            log.warn(
+                    "The following extensions may be incompatible with the recommended updates because the configured Quarkus registries did not provide any compatibility information for them in the context of the currently recommended Quarkus platforms:");
+            unknownExtensions.forEach(e -> log.warn(" " + e.getKey().toGacString()));
+        }
+
+        final List<ExtensionCatalog> recommendedOrigins;
+        try {
+            recommendedOrigins = getRecommendedOrigins(latestCatalog, updateCandidates);
+        } catch (QuarkusCommandException e) {
+            log.info("Failed to find a compatible configuration update for the project");
+            return currentState;
+        }
+
+        int collectedUpdates = 0;
+        for (ExtensionCatalog recommendedOrigin : recommendedOrigins) {
+            final Map<ArtifactKey, ExtensionInfo> candidates = updateCandidatesByOrigin.get(recommendedOrigin.getId());
+            for (Extension e : recommendedOrigin.getExtensions()) {
+                final ExtensionInfo info = candidates.get(e.getArtifact().getKey());
+                if (info != null && info.recommendedMetadata == null) {
+                    info.recommendedMetadata = e;
+                    if (++collectedUpdates == updateCandidates.size()) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        final ProjectState.Builder stateBuilder = ProjectState.builder();
+        for (ExtensionCatalog c : recommendedOrigins) {
+            if (c.isPlatform()) {
+                stateBuilder.addPlatformBom(c.getBom());
+            }
+        }
+
+        final Map<String, ExtensionProvider.Builder> extProviders = new LinkedHashMap<>(recommendedOrigins.size());
+        for (ExtensionInfo info : extensionInfo.values()) {
+            final TopExtensionDependency ext = info.getRecommendedDependency();
+            stateBuilder.addExtensionDependency(ext);
+            extProviders.computeIfAbsent(ext.getProviderKey(), k -> ExtensionProvider.builder().setOrigin(ext.getOrigin()))
+                    .addExtension(ext);
+        }
+
+        extProviders.values().forEach(b -> stateBuilder.addExtensionProvider(b.build()));
+
+        for (ModuleState module : currentState.getModules()) {
+            final ModuleState.Builder moduleBuilder = ModuleState.builder()
+                    .setMainModule(module.isMain())
+                    .setWorkspaceModule(module.getWorkspaceModule());
+            for (TopExtensionDependency dep : module.getExtensions()) {
+                final TopExtensionDependency recommendedDep = extensionInfo.get(dep.getKey()).getRecommendedDependency();
+                moduleBuilder.addExtensionDependency(recommendedDep);
+                final ExtensionOrigin origin = recommendedDep.getOrigin();
+                if (origin != null && origin.isPlatform()) {
+                    moduleBuilder.addPlatformBom(origin.getBom());
+                }
+            }
+            stateBuilder.addModule(moduleBuilder.build());
+        }
+
+        return stateBuilder.build();
+    }
+
+    private static class ExtensionInfo {
+        final TopExtensionDependency currentDep;
+        Extension latestMetadata;
+        Extension recommendedMetadata;
+        TopExtensionDependency recommendedDep;
+
+        ExtensionInfo(TopExtensionDependency currentDep) {
+            this.currentDep = currentDep;
+        }
+
+        Extension getRecommendedMetadata() {
+            if (recommendedMetadata != null) {
+                return recommendedMetadata;
+            }
+            if (recommendedDep == null) {
+                return currentDep.getCatalogMetadata();
+            }
+            return recommendedMetadata = currentDep.getCatalogMetadata();
+        }
+
+        TopExtensionDependency getRecommendedDependency() {
+            if (recommendedDep != null) {
+                return recommendedDep;
+            }
+            if (recommendedMetadata == null) {
+                return currentDep;
+            }
+            return recommendedDep = TopExtensionDependency.builder()
+                    .setArtifact(recommendedMetadata.getArtifact())
+                    .setCatalogMetadata(recommendedMetadata)
+                    .setTransitive(currentDep.isTransitive())
+                    .build();
+        }
+    }
+
+    private static List<ExtensionCatalog> getRecommendedOrigins(ExtensionCatalog extensionCatalog, List<Extension> extensions)
+            throws QuarkusCommandException {
+        final List<ExtensionOrigins> extOrigins = new ArrayList<>(extensions.size());
+        for (Extension e : extensions) {
+            addOrigins(extOrigins, e);
+        }
+
+        final OriginCombination recommendedCombination = OriginSelector.of(extOrigins).calculateRecommendedCombination();
+        if (recommendedCombination == null) {
+            final StringBuilder buf = new StringBuilder();
+            buf.append("Failed to determine a compatible Quarkus version for the requested extensions: ");
+            buf.append(extensions.get(0).getArtifact().getKey().toGacString());
+            for (int i = 1; i < extensions.size(); ++i) {
+                buf.append(", ").append(extensions.get(i).getArtifact().getKey().toGacString());
+            }
+            throw new QuarkusCommandException(buf.toString());
+        }
+        return recommendedCombination.getUniqueSortedOrigins().stream().map(o -> o.getCatalog()).collect(Collectors.toList());
+    }
+
+    private static void addOrigins(final List<ExtensionOrigins> extOrigins, Extension e) {
+        ExtensionOrigins.Builder eoBuilder = null;
+        for (ExtensionOrigin o : e.getOrigins()) {
+            if (!(o instanceof ExtensionCatalog)) {
+                continue;
+            }
+            final ExtensionCatalog c = (ExtensionCatalog) o;
+            final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
+            if (op == null) {
+                continue;
+            }
+            if (eoBuilder == null) {
+                eoBuilder = ExtensionOrigins.builder(e.getArtifact().getKey());
+            }
+            eoBuilder.addOrigin(c, op);
+        }
+        if (eoBuilder != null) {
+            extOrigins.add(eoBuilder.build());
+        }
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ExtensionProvider.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ExtensionProvider.java
@@ -1,0 +1,129 @@
+package io.quarkus.devtools.project.state;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ExtensionProvider {
+
+    static String key(ExtensionOrigin origin) {
+        if (origin == null) {
+            return "unknown origin";
+        }
+        if (origin.isPlatform()) {
+            return origin.getBom().getGroupId() + ':' + origin.getBom().getArtifactId();
+        }
+        return groupIdToHost(GACTV.fromString(origin.getId()).getGroupId());
+    }
+
+    public static String key(ArtifactCoords coords, boolean platform) {
+        if (coords == null) {
+            return "unknown origin";
+        }
+        if (platform) {
+            return coords.getGroupId() + ':' + coords.getArtifactId();
+        }
+        return groupIdToHost(coords.getGroupId());
+    }
+
+    private static String groupIdToHost(final String groupId) {
+        final StringBuilder buf = new StringBuilder();
+        int i = groupId.lastIndexOf('.');
+        int end = groupId.length();
+        while (i > 0) {
+            if (buf.length() > 0) {
+                buf.append('.');
+            }
+            buf.append(groupId.substring(i + 1, end));
+            end = i;
+            i = groupId.lastIndexOf('.', i - 1);
+        }
+        if (buf.length() > 0) {
+            buf.append('.');
+        }
+        buf.append(groupId.substring(0, end));
+        return buf.toString();
+    }
+
+    public static class Builder {
+
+        private ArtifactCoords coords;
+        private Boolean platform;
+        private ExtensionOrigin origin;
+        private final Map<ArtifactKey, TopExtensionDependency> providedExtensions = new LinkedHashMap<>();
+
+        private Builder() {
+        }
+
+        public Builder setArtifact(ArtifactCoords coords) {
+            this.coords = coords;
+            return this;
+        }
+
+        public Builder setPlatform(boolean platform) {
+            this.platform = platform;
+            return this;
+        }
+
+        public Builder setOrigin(ExtensionOrigin origin) {
+            this.origin = origin;
+            return this;
+        }
+
+        public Builder addExtension(TopExtensionDependency e) {
+            providedExtensions.put(e.getKey(), e);
+            return this;
+        }
+
+        public ExtensionProvider build() {
+            if (coords == null && origin != null) {
+                coords = origin.isPlatform() ? origin.getBom() : GACTV.fromString(origin.getId());
+            }
+            if (platform == null) {
+                platform = origin == null ? false : origin.isPlatform();
+            }
+            return new ExtensionProvider(coords, platform, providedExtensions);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final String key;
+    private final ArtifactCoords coords;
+    private final boolean platform;
+    private final Map<ArtifactKey, TopExtensionDependency> providedExtensions;
+
+    private ExtensionProvider(ArtifactCoords coords, boolean platform,
+            Map<ArtifactKey, TopExtensionDependency> providedExtensions) {
+        this.key = key(coords, platform);
+        this.coords = coords;
+        this.platform = platform;
+        this.providedExtensions = providedExtensions;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public ArtifactCoords getArtifact() {
+        return coords;
+    }
+
+    public Collection<TopExtensionDependency> getExtensions() {
+        return providedExtensions.values();
+    }
+
+    public boolean isPlatform() {
+        return platform;
+    }
+
+    public boolean isUnknown() {
+        return coords == null;
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ModuleState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ModuleState.java
@@ -1,0 +1,85 @@
+package io.quarkus.devtools.project.state;
+
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a state of a module of a Quarkus project focusing primarily on Quarkus-specific information, such as
+ * imported Quarkus platform BOMs, extensions and their origins.
+ */
+public class ModuleState {
+
+    public class Builder {
+
+        private Builder() {
+        }
+
+        public Builder setWorkspaceModule(WorkspaceModule module) {
+            ModuleState.this.module = module;
+            return this;
+        }
+
+        public Builder setMainModule(boolean main) {
+            ModuleState.this.main = main;
+            return this;
+        }
+
+        public Builder addPlatformBom(ArtifactCoords coords) {
+            ModuleState.this.platformBomImports.add(coords);
+            return this;
+        }
+
+        public Builder addExtensionDependency(TopExtensionDependency dep) {
+            ModuleState.this.directExtDeps.put(dep.getKey(), dep);
+            return this;
+        }
+
+        public ModuleState build() {
+            return ModuleState.this;
+        }
+    }
+
+    public static Builder builder() {
+        return new ModuleState().new Builder();
+    }
+
+    private WorkspaceModule module;
+    private final Set<ArtifactCoords> platformBomImports = new LinkedHashSet<>(1);
+    private final Map<ArtifactKey, TopExtensionDependency> directExtDeps = new LinkedHashMap<>();
+    private boolean main;
+
+    private ModuleState() {
+    }
+
+    public WorkspaceModuleId getId() {
+        return module.getId();
+    }
+
+    public WorkspaceModule getWorkspaceModule() {
+        return module;
+    }
+
+    public Path getModuleDir() {
+        return module.getModuleDir().toPath();
+    }
+
+    public boolean isMain() {
+        return main;
+    }
+
+    public Collection<ArtifactCoords> getPlatformBoms() {
+        return platformBomImports;
+    }
+
+    public Collection<TopExtensionDependency> getExtensions() {
+        return directExtDeps.values();
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ProjectState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ProjectState.java
@@ -1,0 +1,88 @@
+package io.quarkus.devtools.project.state;
+
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a Quarkus project state focusing primarily on Quarkus-specific information, such as
+ * imported Quarkus platform BOMs, extensions and their origins.
+ */
+public class ProjectState {
+
+    public class Builder {
+
+        private Builder() {
+        }
+
+        public Builder addPlatformBom(ArtifactCoords coords) {
+            ProjectState.this.importedPlatformBoms.add(coords);
+            return this;
+        }
+
+        public Builder addExtensionDependency(TopExtensionDependency dep) {
+            ProjectState.this.topExtensions.put(dep.getKey(), dep);
+            return this;
+        }
+
+        public Builder addModule(ModuleState state) {
+            ProjectState.this.modules.put(state.getId(), state);
+            if (state.isMain()) {
+                ProjectState.this.mainModule = state;
+            }
+            return this;
+        }
+
+        public Builder addExtensionProvider(ExtensionProvider provider) {
+            providers.put(provider.getKey(), provider);
+            return this;
+        }
+
+        public ProjectState build() {
+            return ProjectState.this;
+        }
+    }
+
+    public static Builder builder() {
+        return new ProjectState().new Builder();
+    }
+
+    private final List<ArtifactCoords> importedPlatformBoms = new ArrayList<>();
+    private final Map<ArtifactKey, TopExtensionDependency> topExtensions = new LinkedHashMap<>();
+    private ModuleState mainModule;
+    private final Map<WorkspaceModuleId, ModuleState> modules = new LinkedHashMap<>();
+    private final Map<String, ExtensionProvider> providers = new LinkedHashMap<>();
+
+    public Collection<ArtifactCoords> getPlatformBoms() {
+        return importedPlatformBoms;
+    }
+
+    public Collection<TopExtensionDependency> getExtensions() {
+        return topExtensions.values();
+    }
+
+    public TopExtensionDependency getExtension(ArtifactKey key) {
+        return topExtensions.get(key);
+    }
+
+    public Collection<ModuleState> getModules() {
+        return modules.values();
+    }
+
+    public ModuleState getMainModule() {
+        return mainModule;
+    }
+
+    public ModuleState getModule(WorkspaceModuleId id) {
+        return modules.get(id);
+    }
+
+    public Collection<ExtensionProvider> getExtensionProviders() {
+        return providers.values();
+    }
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/TopExtensionDependency.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/TopExtensionDependency.java
@@ -1,0 +1,164 @@
+package io.quarkus.devtools.project.state;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class TopExtensionDependency {
+
+    public static class Builder {
+
+        private ArtifactCoords coords;
+        private ResolvedDependency resolvedDep;
+        private Extension catalogMetadata;
+        private boolean transitive;
+
+        private Builder() {
+        }
+
+        public Builder setResolvedDependency(ResolvedDependency resolvedDep) {
+            this.resolvedDep = resolvedDep;
+            return setArtifact(new GACTV(resolvedDep.getGroupId(), resolvedDep.getArtifactId(), resolvedDep.getClassifier(),
+                    resolvedDep.getType(), resolvedDep.getVersion()));
+        }
+
+        public Builder setArtifact(ArtifactCoords coords) {
+            this.coords = coords;
+            return this;
+        }
+
+        public Builder setCatalogMetadata(Extension metadata) {
+            this.catalogMetadata = metadata;
+            return this;
+        }
+
+        public Builder setTransitive(boolean transitive) {
+            this.transitive = transitive;
+            return this;
+        }
+
+        public TopExtensionDependency build() {
+            if (catalogMetadata == null) {
+                catalogMetadata = resolvedDep.getContentTree()
+                        .apply("META-INF/" + BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME, visit -> {
+                            if (visit == null) {
+                                return null;
+                            }
+                            try {
+                                return Extension.fromFile(visit.getPath());
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(
+                                        "Failed to deserialize extension metadata from " + visit.getUrl(), e);
+                            }
+                        });
+            }
+            return new TopExtensionDependency(coords, catalogMetadata, ExtensionProvider.key(getOrigin(catalogMetadata)),
+                    transitive);
+        }
+
+        public ArtifactKey getKey() {
+            return resolvedDep == null ? null : resolvedDep.getKey();
+        }
+
+        private static ExtensionOrigin getOrigin(Extension metadata) {
+            if (metadata == null || metadata.getOrigins().isEmpty()) {
+                return null;
+            }
+            ExtensionOrigin origin = metadata.getOrigins().get(0);
+            if (origin.isPlatform()) {
+                return origin;
+            }
+            if (metadata.getOrigins().size() > 1) {
+                for (int i = 1; i < metadata.getOrigins().size(); ++i) {
+                    final ExtensionOrigin o = metadata.getOrigins().get(i);
+                    if (o.isPlatform()) {
+                        origin = o;
+                        break;
+                    }
+                }
+            }
+            return origin;
+        }
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final ArtifactCoords coords;
+    private final Extension catalogMetadata;
+    private final boolean transitive;
+    private final String providerKey;
+
+    private TopExtensionDependency(ArtifactCoords coords, Extension metadata, String providerKey, boolean transitive) {
+        this.coords = coords;
+        this.catalogMetadata = metadata;
+        this.providerKey = providerKey;
+        this.transitive = transitive;
+    }
+
+    public ArtifactKey getKey() {
+        return coords.getKey();
+    }
+
+    public ArtifactCoords getArtifact() {
+        return coords;
+    }
+
+    public ExtensionOrigin getOrigin() {
+        if (catalogMetadata == null || catalogMetadata.getOrigins().isEmpty()) {
+            return null;
+        }
+        ExtensionOrigin origin = catalogMetadata.getOrigins().get(0);
+        if (origin.isPlatform()) {
+            return origin;
+        }
+        if (catalogMetadata.getOrigins().size() > 1) {
+            for (int i = 1; i < catalogMetadata.getOrigins().size(); ++i) {
+                final ExtensionOrigin o = catalogMetadata.getOrigins().get(i);
+                if (o.isPlatform()) {
+                    origin = o;
+                    break;
+                }
+            }
+        }
+        return origin;
+    }
+
+    public boolean isTransitive() {
+        return transitive;
+    }
+
+    public String getVersion() {
+        return coords.getVersion();
+    }
+
+    public String getCatalogVersion() {
+        return catalogMetadata == null ? null : catalogMetadata.getArtifact().getVersion();
+    }
+
+    public boolean isNonRecommendedVersion() {
+        final String catalogVersion = getCatalogVersion();
+        return catalogVersion == null ? false : !catalogVersion.equals(getVersion());
+    }
+
+    public boolean isPlatformExtension() {
+        final ExtensionOrigin origin = getOrigin();
+        return origin == null ? false : origin.isPlatform();
+    }
+
+    public Extension getCatalogMetadata() {
+        return catalogMetadata;
+    }
+
+    public String getProviderKey() {
+        return providerKey;
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -43,6 +43,7 @@ public class ExtensionCatalogResolver {
     public static ExtensionCatalogResolver empty() {
         final ExtensionCatalogResolver resolver = new ExtensionCatalogResolver();
         resolver.registries = Collections.emptyList();
+        resolver.log = MessageWriter.info();
         return resolver;
     }
 


### PR DESCRIPTION
Introduces two dev tools commands:
* info - logging the current project Quarkus-related info such as imported platform BOMs, and direct (and top-level transitive) extension dependencies, possibly indicating version misalignment;
* update - queries enabled registries, calculates recommended updates and logs the recommendations.

For example
````
[aloubyansky@localhost code-with-quarkus]$ mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:info
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< org.acme:code-with-quarkus >---------------------
[INFO] Building code-with-quarkus 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:info (default-cli) @ code-with-quarkus ---
[INFO] Quarkus platform BOMs:
[INFO]   io.quarkus.platform:quarkus-bom:pom:2.5.2.Final
[INFO]   io.quarkus.platform:quarkus-camel-bom:pom:2.4.1.Final | unnecessary
[INFO] 
[INFO] Extensions from registry.quarkus.io:
[INFO]   io.quarkiverse.prettytime:quarkus-prettytime:0.2.1
[INFO] 
[INFO] Extensions from io.quarkus.platform:quarkus-kogito-bom:
[INFO]   org.kie.kogito:kogito-quarkus-rules:2.0.0-SNAPSHOT | misaligned
[INFO] 
[INFO] Extensions from io.quarkus.platform:quarkus-bom:
[INFO]   io.quarkus:quarkus-hibernate-orm:2.6.2.Final | misaligned
[INFO]   io.quarkus:quarkus-openshift
[INFO]   io.quarkus:quarkus-arc
[INFO] 
[WARNING] Non-recommended Quarkus platform BOM and/or extension versions were found. For more details, please, execute 'mvn quarkus:update -Drectify'
````
````
[aloubyansky@localhost code-with-quarkus]$ mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:update -Drectify
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< org.acme:code-with-quarkus >---------------------
[INFO] Building code-with-quarkus 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:update (default-cli) @ code-with-quarkus ---
[INFO] Looking for the newly published extensions in registry.quarkus.redhat.com
[INFO] Quarkus platform BOMs:
[INFO]         io.quarkus.platform:quarkus-bom:pom:2.5.2.Final
[INFO] Remove: io.quarkus.platform:quarkus-camel-bom:pom:2.4.1.Final
[INFO] Add:    io.quarkus.platform:quarkus-kogito-bom:pom:2.5.2.Final
[INFO] 
[INFO] Extensions from registry.quarkus.io:
[INFO]   io.quarkiverse.prettytime:quarkus-prettytime:0.2.1
[INFO] 
[INFO] Extensions from io.quarkus.platform:quarkus-kogito-bom:
[INFO] Update: org.kie.kogito:kogito-quarkus-rules:2.0.0-SNAPSHOT -> org.kie.kogito:kogito-quarkus-rules
[INFO] 
[INFO] Extensions from io.quarkus.platform:quarkus-bom:
[INFO] Update: io.quarkus:quarkus-hibernate-orm:2.6.2.Final -> io.quarkus:quarkus-hibernate-orm
[INFO]         io.quarkus:quarkus-openshift
[INFO]         io.quarkus:quarkus-arc
````
With the `code.quarkus.redhat.com` registry enabled:
````
[aloubyansky@localhost code-with-quarkus]$ mvn io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:update
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< org.acme:code-with-quarkus >---------------------
[INFO] Building code-with-quarkus 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:update (default-cli) @ code-with-quarkus ---
[INFO] Looking for the newly published extensions in registry.quarkus.redhat.com
[INFO] 
[INFO] Recommended Quarkus platform BOM updates:
[INFO] Add:    com.redhat.quarkus.platform:quarkus-bom:pom:2.2.3.SP1-redhat-00002
[INFO] Add:    io.quarkus.platform:quarkus-kogito-bom:pom:2.2.3.Final
[INFO] Remove: io.quarkus.platform:quarkus-bom:pom:2.5.2.Final
[INFO] Remove: io.quarkus.platform:quarkus-camel-bom:pom:2.4.1.Final
[INFO] 
[INFO] Extensions from com.redhat.quarkus.platform:quarkus-bom:pom:2.2.3.SP1-redhat-00002:
[INFO] Update: io.quarkus:quarkus-hibernate-orm:2.6.2.Final -> io.quarkus:quarkus-hibernate-orm
[INFO] 
[INFO] Extensions from io.quarkus.platform:quarkus-kogito-bom:pom:2.2.3.Final:
[INFO] Update: org.kie.kogito:kogito-quarkus-rules:2.0.0-SNAPSHOT -> org.kie.kogito:kogito-quarkus-rules
[INFO] 
[INFO] Extensions from registry.quarkus.io:
[INFO] Update: io.quarkiverse.prettytime:quarkus-prettytime:0.2.1 -> 0.1.2
````
Equivalent `quarkusInfo` and `quarkusUpdate` Gradle commands are included.