### PR TITLE
Propagate reason phrase of aborted request in JAX-RS Client

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSetResponseEntityRestHandler.java
@@ -7,38 +7,44 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.StatusType;
 import org.jboss.resteasy.reactive.client.api.WebClientApplicationException;
 import org.jboss.resteasy.reactive.client.impl.ClientRequestContextImpl;
 import org.jboss.resteasy.reactive.client.impl.ClientResponseContextImpl;
 import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
 import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.common.jaxrs.StatusTypeImpl;
 
 public class ClientSetResponseEntityRestHandler implements ClientRestHandler {
 
     @Override
     public void handle(RestClientRequestContext context) throws Exception {
         ClientRequestContextImpl requestContext = context.getClientRequestContext();
-        ClientResponseContextImpl responseContext = new ClientResponseContextImpl(context);
         if (context.isCheckSuccessfulFamily()) {
-            int effectiveResponseStatus = determineEffectiveResponseStatus(context, requestContext);
-            if (Response.Status.Family.familyOf(effectiveResponseStatus) != Response.Status.Family.SUCCESSFUL) {
-                throw new WebClientApplicationException(effectiveResponseStatus, context.getResponseReasonPhrase());
+            StatusType effectiveResponseStatus = determineEffectiveResponseStatus(context, requestContext);
+            if (Response.Status.Family.familyOf(effectiveResponseStatus.getStatusCode()) != Response.Status.Family.SUCCESSFUL) {
+                throw new WebClientApplicationException(effectiveResponseStatus.getStatusCode(),
+                        effectiveResponseStatus.getReasonPhrase());
             }
         }
 
         // the spec doesn't really say this, but the TCK checks that the abortWith entity ends up read
         // so we have to write it, but without filters/interceptors
         if (isAbortedWith(requestContext)) {
-            setExistingEntity(requestContext.getAbortedWith(), responseContext, context);
+            propagateAbortedWithEntityToResponse(context);
         }
     }
 
-    private int determineEffectiveResponseStatus(RestClientRequestContext context, ClientRequestContextImpl requestContext) {
-        int effectiveResponseStatus = context.getResponseStatus();
-        if (effectiveResponseStatus == 0) {
+    private StatusType determineEffectiveResponseStatus(RestClientRequestContext context,
+            ClientRequestContextImpl requestContext) {
+        StatusType effectiveResponseStatus = new StatusTypeImpl(context.getResponseStatus(), context.getResponseReasonPhrase());
+        if (effectiveResponseStatus.getStatusCode() == 0) {
             if (isAbortedWith(requestContext)) {
-                effectiveResponseStatus = requestContext.getAbortedWith().getStatus();
+                Response abortedWith = requestContext.getAbortedWith();
+                if (abortedWith.getStatusInfo() != null) {
+                    effectiveResponseStatus = abortedWith.getStatusInfo();
+                }
             }
         }
         return effectiveResponseStatus;
@@ -48,27 +54,32 @@ public class ClientSetResponseEntityRestHandler implements ClientRestHandler {
         return requestContext != null && requestContext.getAbortedWith() != null;
     }
 
-    private void setExistingEntity(Response abortedWith, ClientResponseContextImpl responseContext,
-            RestClientRequestContext restClientRequestContext) throws IOException {
-        Object value = abortedWith.getEntity();
-        if (value == null) {
-            responseContext.setEntityStream(null);
-            return;
+    private void propagateAbortedWithEntityToResponse(RestClientRequestContext restClientRequestContext) throws IOException {
+        new ClientResponseContextImpl(restClientRequestContext)
+                .setEntityStream(entityStreamOfAbortedResponseOf(restClientRequestContext));
+    }
+
+    private ByteArrayInputStream entityStreamOfAbortedResponseOf(RestClientRequestContext context) throws IOException {
+        Response abortedWith = context.getAbortedWith();
+        Object untypedEntity = abortedWith.getEntity();
+        if (untypedEntity == null) {
+            return null;
         }
+
         Entity entity;
-        if (value instanceof Entity) {
-            entity = (Entity) value;
+        if (untypedEntity instanceof Entity) {
+            entity = (Entity) untypedEntity;
         } else {
             MediaType mediaType = abortedWith.getMediaType();
             if (mediaType == null) {
                 // FIXME: surely this is wrong, perhaps we can use the expected response type?
                 mediaType = MediaType.TEXT_PLAIN_TYPE;
             }
-            entity = Entity.entity(value, mediaType);
+            entity = Entity.entity(untypedEntity, mediaType);
         }
         // FIXME: pass headers?
-        Buffer buffer = restClientRequestContext.writeEntity(entity, (MultivaluedMap) Serialisers.EMPTY_MULTI_MAP,
+        Buffer buffer = context.writeEntity(entity, (MultivaluedMap) Serialisers.EMPTY_MULTI_MAP,
                 Serialisers.NO_WRITER_INTERCEPTOR);
-        responseContext.setEntityStream(new ByteArrayInputStream(buffer.getBytes()));
+        return new ByteArrayInputStream(buffer.getBytes());
     }
 }


### PR DESCRIPTION
This PR complements https://github.com/quarkusio/quarkus/pull/22859 by providing the reason phrase of aborted requests in addition to their status code.

@geoand I hope you don't mind that I renamed method `setExistingEntity` to `propagateAbortedWithEntityToResponse` (I can undo that change otherwise, no problem). Please note, that the previous test in `ClientRequestFilterAbortWithTestCase` didn't check the code part where `RestClientRequestContext.isCheckSuccessfulFamily == true`. I added such a test so that we now cover both cases. 