### PR TITLE
Update the output of list extensions

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -64,8 +64,6 @@ public class ProjectExtensionsList extends BaseBuildCommand implements Callable<
                 installable = false;
                 // check if any format was specified
                 boolean formatSpecified = format.isSpecified();
-                // show origins by default
-                format.useOriginsUnlessSpecified();
 
                 if (runMode.isDryRun()) {
                     return dryRunList(spec.commandLine().getHelp(), null);

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/ListFormatOptions.java
@@ -10,27 +10,16 @@ public class ListFormatOptions {
     @CommandLine.Option(names = { "--name" }, hidden = true, description = "Display extension artifactId only. (deprecated)")
     boolean name = false;
 
-    @CommandLine.Option(names = { "--concise" }, order = 5, description = "Display extension name and artifactId.")
+    @CommandLine.Option(names = { "--concise" }, order = 5, description = "Display extension artifactId and name.")
     boolean concise = false;
 
     @CommandLine.Option(names = {
-            "--full" }, order = 6, description = "Display concise format and version related columns.")
+            "--full" }, order = 6, description = "Display extension artifactId, name, version, platform origin, and other information.")
     boolean full = false;
 
     @CommandLine.Option(names = {
-            "--origins" }, order = 7, description = "Display extensions including their platform origins.")
+            "--origins" }, order = 7, description = "Display extension artifactId, name, version, and platform origins.")
     boolean origins = false;
-
-    /**
-     * If a value was not specified via options (all false),
-     * make origins true. Used with specific platform list.
-     */
-    public void useOriginsUnlessSpecified() {
-        if (id || name || concise || full || origins) {
-            return;
-        }
-        origins = true;
-    }
 
     /**
      * Check if any format has been specified on the command line.
@@ -40,7 +29,9 @@ public class ListFormatOptions {
     }
 
     public String getFormatString() {
-        String formatString = "id";
+        String formatString = "concise";
+        if (id)
+            formatString = "id";
         if (concise)
             formatString = "concise";
         else if (full)

--- a/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/common/OutputOptionMixin.java
@@ -125,13 +125,13 @@ public class OutputOptionMixin implements MessageWriter {
     @Override
     public void debug(String msg) {
         if (isVerbose()) {
-            out().println(colorScheme().ansi().new Text("[DEBUG] " + msg, colorScheme()));
+            out().println(colorScheme().ansi().new Text("@|faint [DEBUG] " + msg + "|@", colorScheme()));
         }
     }
 
     @Override
     public void warn(String msg) {
-        out().println(colorScheme().ansi().new Text(WARN_ICON + " " + msg, colorScheme()));
+        out().println(colorScheme().ansi().new Text("@|yellow " + WARN_ICON + " " + msg + "|@", colorScheme()));
     }
 
     // CommandLine must be passed in (forwarded commands)

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliNonProjectTest.java
@@ -61,7 +61,8 @@ public class CliNonProjectTest {
     @Test
     public void testListPlatformExtensions() throws Exception {
         // List extensions of a specified platform version
-        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-P=io.quarkus:quarkus-bom:2.0.0.CR3", "-e");
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "list", "-P=io.quarkus:quarkus-bom:2.0.0.CR3", "-e",
+                "--origins");
         Assertions.assertEquals(CommandLine.ExitCode.OK, result.exitCode,
                 "Expected OK return code." + result);
         Assertions.assertTrue(result.stdout.contains("Jackson"),

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/AddExtensionsCommandHandler.java
@@ -76,7 +76,7 @@ public class AddExtensionsCommandHandler implements QuarkusCommandHandler {
             StringBuilder sb = new StringBuilder();
             sb.append(ERROR_ICON + " Multiple extensions matching '").append(m.getKeyword()).append("'");
             m.getExtensions()
-                    .forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
+                    .forEach(extension -> sb.append(System.lineSeparator()).append("     - ")
                             .append(extension.managementKey()));
             sb.append(System.lineSeparator())
                     .append("     Be more specific e.g using the exact name or the full GAV.");

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/ListExtensionsCommandHandler.java
@@ -16,6 +16,8 @@ import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionOrigin;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Instances of this class are thread-safe. It lists extensions according to the options passed in as properties of
@@ -30,10 +33,14 @@ import java.util.function.Predicate;
  */
 public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
 
-    private static final String FULL_FORMAT = "%-8s %-50s %-50s %-25s%s";
-    private static final String CONCISE_FORMAT = "%-50s %-50s";
-    private static final String NAME_FORMAT = "%-50s";
-    private static final String ORIGINS_FORMAT = "%-50s %-60s %s";
+    // private static final String NAME_FORMAT = "%-50s";
+    // private static final String CONCISE_FORMAT = "%-50s %-50s";
+    // private static final String FULL_FORMAT = "%-8s %-50s %-50s %-25s%s";
+    // private static final String ORIGINS_FORMAT = "%-50s %-60s %s";
+    private static final String ID_FORMAT = "%-1s %s";
+    private static final String CONCISE_FORMAT = "%-1s %-50s %s";
+    private static final String ORIGINS_FORMAT = "%-1s %-50s %-50s %-25s %s";
+    private static final String FULL_FORMAT = "%-1s %-50s %-60s %-25s %s";
 
     @Override
     public QuarkusCommandOutcome execute(QuarkusCommandInvocation invocation) throws QuarkusCommandException {
@@ -65,21 +72,25 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
             log.info("");
         }
 
-        BiConsumer<MessageWriter, Object[]> currentFormatter;
+        BiConsumer<MessageWriter, DisplayData> currentFormatter;
         switch (format.toLowerCase()) {
-            case "full":
-                currentFormatter = this::fullFormatter;
-                log.info(String.format(FULL_FORMAT, "Status", "Extension", "ArtifactId", "Updated Version", "Guide"));
+            case "id":
+            case "name":
+                currentFormatter = this::idFormatter;
+                log.info(String.format(ID_FORMAT, "✬", "ArtifactId"));
+                break;
+            default:
+            case "concise":
+                currentFormatter = this::conciseFormatter;
+                log.info(String.format(CONCISE_FORMAT, "✬", "ArtifactId", "Extension Name"));
                 break;
             case "origins":
                 currentFormatter = this::originsFormatter;
+                log.info(String.format(ORIGINS_FORMAT, "✬", "ArtifactId", "Extension Name", "Version", "Origin"));
                 break;
-            case "concise":
-                currentFormatter = this::conciseFormatter;
-                break;
-            case "id":
-            default:
-                currentFormatter = this::nameFormatter;
+            case "full":
+                currentFormatter = this::fullFormatter;
+                log.info(String.format(FULL_FORMAT, "✬", "ArtifactId", "Extension", "Version", "Guide"));
                 break;
         }
 
@@ -107,47 +118,53 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
         return QuarkusCommandOutcome.success();
     }
 
-    private void conciseFormatter(MessageWriter writer, Object[] cols) {
-        Extension e = (Extension) cols[1];
-        writer.info(String.format(CONCISE_FORMAT, e.getName(), e.getArtifact().getArtifactId()));
+    private void idFormatter(MessageWriter writer, DisplayData data) {
+        writer.info(String.format(ID_FORMAT,
+                data.isPlatform(),
+                data.getExtensionArtifactId()));
     }
 
-    private void fullFormatter(MessageWriter writer, Object[] cols) {
-        Extension e = (Extension) cols[1];
-        final String guide = getGuide(e);
-        writer.info(String.format(FULL_FORMAT, cols[0], e.getName(), e.getArtifact().getArtifactId(), cols[2],
-                guide == null ? "" : guide));
+    private void conciseFormatter(MessageWriter writer, DisplayData data) {
+        writer.info(String.format(CONCISE_FORMAT,
+                data.isPlatform(),
+                data.trimToFit(50, data.getExtensionArtifactId()),
+                data.getExtensionName()));
     }
 
-    private void nameFormatter(MessageWriter writer, Object[] cols) {
-        Extension e = (Extension) cols[1];
-        writer.info(String.format(NAME_FORMAT, e.getArtifact().getArtifactId()));
-    }
+    private void originsFormatter(MessageWriter writer, DisplayData data) {
+        List<String> origins = data.getOrigins();
+        writer.info(String.format(ORIGINS_FORMAT,
+                data.isPlatform(),
+                data.trimToFit(50, data.getExtensionArtifactId()),
+                data.trimToFit(50, data.getExtensionName()),
+                data.getVersion(),
+                origins.isEmpty() ? "" : origins.get(0)));
 
-    private void originsFormatter(MessageWriter writer, Object[] cols) {
-        Extension e = (Extension) cols[1];
-        String origin = null;
-        int i = 0;
-        final List<ExtensionOrigin> origins = e.getOrigins();
-        while (i < origins.size() && origin == null) {
-            final ExtensionOrigin o = origins.get(i++);
-            if (o.isPlatform()) {
-                origin = o.getBom().toString();
-            }
+        // If there is more than one platform origin, list the others
+        for (int i = 1; i < origins.size(); i++) {
+            writer.info(String.format(ORIGINS_FORMAT,
+                    "",
+                    "",
+                    "",
+                    "",
+                    origins.get(i)));
         }
-        writer.info(String.format(ORIGINS_FORMAT, e.getName(), e.getArtifact().getVersion(), origin == null ? "" : origin));
-        while (i < origins.size()) {
-            final ExtensionOrigin o = origins.get(i++);
-            if (o.isPlatform()) {
-                writer.info(String.format(ORIGINS_FORMAT, "", "", o.getBom().toString()));
-            }
-        }
+    }
+
+    private void fullFormatter(MessageWriter writer, DisplayData data) {
+        final String guide = getGuide(data.e);
+        writer.info(String.format(FULL_FORMAT,
+                data.isPlatform(),
+                data.trimToFit(50, data.getExtensionArtifactId()),
+                data.trimToFit(60, data.getExtensionName()),
+                data.getVersion(),
+                guide != null ? guide : ""));
     }
 
     private void display(MessageWriter messageWriter, final Extension e, final ArtifactCoords installed,
             boolean all,
             boolean installedOnly,
-            BiConsumer<MessageWriter, Object[]> formatter) {
+            BiConsumer<MessageWriter, DisplayData> formatter) {
         if (installedOnly && installed == null) {
             return;
         }
@@ -155,20 +172,72 @@ public class ListExtensionsCommandHandler implements QuarkusCommandHandler {
             return;
         }
 
-        String label = "";
-        String version = "";
-
-        if (installed != null) {
-            if (e.getArtifact().getVersion().equals(installed.getVersion()) || installed.getVersion() == null) {
-                label = "default";
-                version = e.getArtifact().getVersion();
-            } else {
-                label = "custom*";
-                version = String.format("%s* <> %s", installed.getVersion(), e.getArtifact().getVersion());
-            }
-        }
-
-        formatter.accept(messageWriter, new Object[] { label, e, version });
+        formatter.accept(messageWriter, new DisplayData(e, installed));
     }
 
+    class DisplayData {
+        Extension e;
+        ArtifactCoords installed;
+
+        DisplayData(Extension e, ArtifactCoords installed) {
+            this.e = e;
+            this.installed = installed;
+        }
+
+        String getExtensionName() {
+            return e.getName();
+        }
+
+        String getExtensionArtifactId() {
+            return e.getArtifact().getArtifactId();
+        }
+
+        List<String> getOrigins() {
+            ExtensionOrigin origin = null;
+            int i = 0;
+            final List<ExtensionOrigin> origins = e.getOrigins();
+            while (i < origins.size() && origin == null) {
+                final ExtensionOrigin o = origins.get(i++);
+                if (o.isPlatform()) {
+                    origin = o;
+                }
+            }
+            if (origins.isEmpty() || origin == null) {
+                return Arrays.asList("");
+            }
+
+            // Add the discovered origin first
+            final List<String> result = new ArrayList<>();
+            result.add(origin.getBom().toString().replace("::pom", ""));
+
+            // Append any other platform origins
+            final ExtensionOrigin o = origin;
+            origins.stream()
+                    .filter(e -> e.isPlatform())
+                    .filter(e -> e != o)
+                    .map(e -> e.getBom().toString().replace("::pom", ""))
+                    .collect(Collectors.toCollection(() -> result));
+            return result;
+        }
+
+        String getVersion() {
+            if (installed == null || installed.getVersion() == null) {
+                return e.getArtifact().getVersion();
+            }
+
+            return installed.getVersion();
+        }
+
+        String isPlatform() {
+            return e.hasPlatformOrigin() ? "✬" : "";
+        }
+
+        String trimToFit(int max, String s) {
+            if (s.length() >= max) {
+                return s.substring(0, max - 4) + "...";
+            } else {
+                return s;
+            }
+        }
+    }
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/handlers/QuarkusCommandHandlers.java
@@ -74,7 +74,7 @@ final class QuarkusCommandHandlers {
                     return null;
                 }
                 sb.append(ERROR_ICON + " Multiple extensions matching '").append(query).append("'");
-                candidates.forEach(extension -> sb.append(System.lineSeparator()).append("     * ")
+                candidates.forEach(extension -> sb.append(System.lineSeparator()).append("     - ")
                         .append(extension.managementKey()));
                 sb.append(System.lineSeparator())
                         .append("     try using the exact name or the full GAV (group id, artifact id, and version).");

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
@@ -97,27 +97,20 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
             boolean hibernateValidator = false;
             for (String line : output.split("\r?\n")) {
                 if (line.contains("agroal")) {
-                    assertTrue(line.startsWith("default"), "Agroal should list as being default: " + line);
+                    assertTrue(line.startsWith("✬"), "Agroal is a platform extension: " + line);
                     agroal = true;
                 } else if (line.contains("quarkus-resteasy ")) {
-                    assertTrue(line.startsWith("custom*"), "RESTEasy should list as being custom*: " + line);
-                    assertTrue(
-                            line.contains(
-                                    String.format("%-15s", getMavenPluginVersion())),
-                            "RESTEasy should list as being custom*: " + line);
+                    assertTrue(line.startsWith("✬"), "Resteasy is a platform extension: " + line);
                     resteasy = true;
                     assertTrue(
                             line.endsWith(
                                     String.format("%s", "https://quarkus.io/guides/rest-json")),
                             "RESTEasy should list as having an guide: " + line);
                 } else if (line.contains("quarkus-hibernate-orm-panache ")) {
-                    assertTrue(line.startsWith("default"), "Panache should list as being custom: " + line);
-                    assertTrue(
-                            line.contains(String.format("%-25s", getMavenPluginVersion())),
-                            "Panache should list as being custom*: " + line);
+                    assertTrue(line.startsWith("✬"), "Panache is a platform extension: " + line);
                     panache = true;
                 } else if (line.contains("hibernate-validator")) {
-                    assertTrue(line.startsWith("   "), "Hibernate Validator should not list as anything: " + line);
+                    assertTrue(line.startsWith("✬"), "Hibernate validator is a platform extension: " + line);
                     hibernateValidator = true;
                 }
             }


### PR DESCRIPTION
Resolves #18062 
Resolves #22812 

Human feedback needed (use `quarkus list ext` inside and outside a project with no arguments, with `--id`, `--concise`, `--full` or `--origin`).

