### PR TITLE
Fix response truncation

### DIFF
--- a/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/LargeResource.java
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/LargeResource.java
@@ -1,0 +1,39 @@
+package io.quarkus.resteasy.jackson;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/large")
+public class LargeResource {
+
+    @GET
+    @Path("/bufmult")
+    public Map<String, String> hello() {
+        Map<String, String> ret = new HashMap<>();
+        for (int i = 0; i < 830; ++i) {
+            if (i == 0) {
+                //hack to make this exactly 2 * 8191 bytes long, as tested by trial and error
+                ret.put("key00", "value" + i);
+            } else {
+                ret.put("key" + i, "value" + i);
+            }
+        }
+        return ret;
+    }
+
+    @GET
+    @Path("/huge")
+    public Map<String, String> huge() {
+        Map<String, String> ret = new HashMap<>();
+        for (int i = 0; i < 1280; ++i) {
+            ret.put("key" + i, "value" + i);
+        }
+        return ret;
+    }
+}

--- a/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/LargeResponseTest.java
+++ b/extensions/resteasy-classic/resteasy-jackson/deployment/src/test/java/io/quarkus/resteasy/jackson/LargeResponseTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.resteasy.jackson;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class LargeResponseTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(LargeResource.class));
+
+    @Test
+    public void testLargeResponseMultipleOfBuffer() {
+        RestAssured.get("/large/bufmult").then()
+                .statusCode(200)
+                .body("key500", equalTo("value500"));
+    }
+
+    @Test
+    public void testLargeResponse() {
+        RestAssured.get("/large/huge").then()
+                .statusCode(200)
+                .body("key500", equalTo("value500"));
+    }
+
+}


### PR DESCRIPTION
If the response is an exact multiple of the buffer size it is being
truncated.

The existing code based on calculating the number of buffers has other issues as well, including:
- not handling already buffered data
- The remainder can be written out of order, as it is written to the buffer immediately

Fixes #22973