### PR TITLE
Adjustments for the info and update commands

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusInfo.java
@@ -34,6 +34,9 @@ public class QuarkusInfo extends QuarkusPlatformTask {
 
     @TaskAction
     public void logInfo() {
+
+        getProject().getLogger().warn(getName() + " is experimental, its options and output might change in future versions");
+
         final QuarkusProject quarkusProject = getQuarkusProject(false);
         final Map<String, Object> params = new HashMap<>();
         params.put(UpdateCommandHandler.APP_MODEL, extension().getApplicationModel());

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusUpdate.java
@@ -55,6 +55,9 @@ public class QuarkusUpdate extends QuarkusPlatformTask {
 
     @TaskAction
     public void logUpdates() {
+
+        getProject().getLogger().warn(getName() + " is experimental, its options and output might change in future versions");
+
         final QuarkusProject quarkusProject = getQuarkusProject(false);
         final Map<String, Object> params = new HashMap<>();
         try {

--- a/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/InfoMojo.java
@@ -21,6 +21,12 @@ import io.quarkus.devtools.project.QuarkusProject;
 public class InfoMojo extends QuarkusProjectStateMojoBase {
 
     @Override
+    protected void validateParameters() throws MojoExecutionException {
+        getLog().warn("quarkus:info goal is experimental, its options and output may change in future versions");
+        super.validateParameters();
+    }
+
+    @Override
     protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
 
         final Map<String, Object> params = new HashMap<>();

--- a/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/UpdateMojo.java
@@ -35,6 +35,12 @@ public class UpdateMojo extends QuarkusProjectStateMojoBase {
     boolean rectify;
 
     @Override
+    protected void validateParameters() throws MojoExecutionException {
+        getLog().warn("quarkus:update goal is experimental, its options and output might change in future versions");
+        super.validateParameters();
+    }
+
+    @Override
     protected void processProjectState(QuarkusProject quarkusProject) throws MojoExecutionException {
 
         final Map<String, Object> params = new HashMap<>();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -66,14 +66,17 @@ public class MavenProjectBuildFile extends BuildFile {
     }
 
     public static QuarkusProject getProject(Artifact projectPom, Model projectModel, Path projectDir,
-            Properties projectProps, MavenArtifactResolver mvnResolver, MessageWriter log,
+            Properties projectProps, MavenArtifactResolver artifactResolver, MessageWriter log,
             Supplier<String> defaultQuarkusVersion) throws RegistryResolutionException {
-        return getProject(projectPom, projectModel, projectDir, projectProps, mvnResolver, mvnResolver, log,
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                ? QuarkusProjectHelper.getCatalogResolver(artifactResolver, log)
+                : ExtensionCatalogResolver.empty();
+        return getProject(projectPom, projectModel, projectDir, projectProps, artifactResolver, catalogResolver, log,
                 defaultQuarkusVersion);
     }
 
     public static QuarkusProject getProject(Artifact projectPom, Model projectModel, Path projectDir,
-            Properties projectProps, MavenArtifactResolver artifactResolver, MavenArtifactResolver catalogArtifactResolver,
+            Properties projectProps, MavenArtifactResolver artifactResolver, ExtensionCatalogResolver catalogResolver,
             MessageWriter log, Supplier<String> defaultQuarkusVersion) throws RegistryResolutionException {
         final List<ArtifactCoords> managedDeps;
         final Supplier<List<ArtifactCoords>> deps;
@@ -94,9 +97,6 @@ public class MavenProjectBuildFile extends BuildFile {
         }
 
         final ExtensionCatalog extensionCatalog;
-        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
-                ? QuarkusProjectHelper.getCatalogResolver(catalogArtifactResolver, log)
-                : ExtensionCatalogResolver.empty();
         if (catalogResolver.hasRegistries()) {
             try {
                 if (!importedPlatforms.isEmpty()) {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ModuleState.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/state/ModuleState.java
@@ -82,4 +82,8 @@ public class ModuleState {
     public Collection<TopExtensionDependency> getExtensions() {
         return directExtDeps.values();
     }
+
+    public boolean hasExtension(ArtifactKey key) {
+        return directExtDeps.containsKey(key);
+    }
 }


### PR DESCRIPTION
Adjustments following feedback on https://github.com/quarkusio/quarkus/pull/22979

* Add 'experimental' warning to the info and update commands
* use a single instance of the catalog resolver for the update (fixes `Looking for the newly published extensions in registry.quarkus.io` logged twice)
* make sure update to the current platform version isn't suggested (e.g `Update: io.quarkus.platform:quarkus-bom:pom:2.6.2.Final -> 2.6.2.Final`)