### PR TITLE
Upgrade to Mutiny 1.3.1 and Mutiny Vert.x bindings 2.18.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -54,7 +54,7 @@
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
-        <smallrye-mutiny-vertx-binding.version>2.18.0</smallrye-mutiny-vertx-binding.version>
+        <smallrye-mutiny-vertx-binding.version>2.18.1</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>3.13.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.0.0</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
@@ -136,7 +136,7 @@
         <netty.version>4.1.72.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
-        <mutiny.version>1.3.0</mutiny.version>
+        <mutiny.version>1.3.1</mutiny.version>
         <kafka3.version>3.0.0</kafka3.version>
         <snappy.version>1.1.8.1</snappy.version>
         <zookeeper.version>3.5.7</zookeeper.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -42,7 +42,7 @@
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>1.3.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>1.3.1</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -50,7 +50,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>
-        <mutiny.version>1.3.0</mutiny.version>
+        <mutiny.version>1.3.1</mutiny.version>
         <smallrye-common.version>1.8.0</smallrye-common.version>
         <vertx.version>4.2.2</vertx.version>
         <rest-assured.version>4.4.0</rest-assured.version>
@@ -62,7 +62,7 @@
         <yasson.version>1.0.11</yasson.version>
         <jakarta.json.bind-api.version>1.0.2</jakarta.json.bind-api.version>
         <awaitility.version>4.1.1</awaitility.version>
-        <smallrye-mutiny-vertx-core.version>2.18.0</smallrye-mutiny-vertx-core.version>
+        <smallrye-mutiny-vertx-core.version>2.18.1</smallrye-mutiny-vertx-core.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Mutiny 1.3.1 contains an important bug fix.
