### PR TITLE
Add example on how to use a specific CLI version with JBang

### DIFF
--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -80,6 +80,13 @@ If JBang has already been installed, you can directly use it:
 jbang app install --fresh --force quarkus@quarkusio
 ----
 
+If you want to use a specific version, you can directly target a version:
+[source,bash]
+----
+# Create an alias in order to use a specific version
+jbang app install --name qs2.2.5 io.quarkus:quarkus-cli:2.2.5.Final:runner
+----
+
 If you have built Quarkus locally, you can use that version:
 [source,bash]
 ----


### PR DESCRIPTION
Add the following example:
```
jbang app install --name qs2.2.5 io.quarkus:quarkus-cli:2.2.5.Final:runner
```