### PR TITLE
Enable JNDI for MongoDB extension

### DIFF
--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -240,6 +240,9 @@ quarkus.mongodb.connection-string = mongodb://localhost:27017
 
 If you need more configuration properties, there is a full list at the end of this guide.
 
+WARNING: By default Quarkus will restrict the use of JNDI within an application, as a precaution to try and mitigate any future vulnerabilities similar to log4shell.
+Because the `mongo+srv` protocol often used to connect to MongoDB requires JNDI, this protection is automatically disabled when using the MongoDB client extension.
+
 [[dev-services]]
 === Dev Services (Configuration Free Databases)
 
@@ -663,9 +666,7 @@ You can then point your browser to `http://localhost:8080/fruits.html` and use y
 
 [WARNING]
 ====
-Currently, Quarkus doesn't support the `mongodb+srv` protocol in native mode.
-
-link:https://docs.mongodb.com/manual/core/security-client-side-encryption/[Client-Side Field Level Encryption] is also not supported in native mode.
+Currently, Quarkus doesn't support link:https://docs.mongodb.com/manual/core/security-client-side-encryption/[Client-Side Field Level Encryption] in native mode.
 ====
 
 [TIP]

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -45,6 +45,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.annotations.Weak;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.AllowJNDIBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -71,6 +72,12 @@ public class MongoClientProcessor {
     private static final DotName REACTIVE_MONGO_CLIENT = DotName.createSimple(ReactiveMongoClient.class.getName());
 
     private static final String SERVICE_BINDING_INTERFACE_NAME = "io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter";
+
+    @BuildStep
+    AllowJNDIBuildItem enableJndi() {
+        //unfortunately mongo+srv protocol needs JNDI
+        return new AllowJNDIBuildItem();
+    }
 
     @BuildStep
     AdditionalIndexedClassesBuildItem includeBsonTypesToIndex() {


### PR DESCRIPTION
Enable JNDI for MongoDB extension as mongo+srv protocol needs it.

@stuartwdouglas `AllowJNDIBuildItem` is a build time so I cannot only enable it when needed as the MongoDB connection string is set at runtime.

Would it be possible to move the JNDI disabling stuff at runtime ?