### PR TITLE
Set current project file when initializing the Maven resolver in the bootstrap provider

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -955,7 +955,9 @@ public class DevMojo extends AbstractMojo {
                     .setRepositorySystem(repoSystem)
                     .setRemoteRepositories(repos)
                     .setRemoteRepositoryManager(remoteRepositoryManager)
-                    .setWorkspaceDiscovery(true);
+                    .setWorkspaceDiscovery(true)
+                    .setPreferPomsFromWorkspace(true)
+                    .setCurrentProject(project.getFile().toString());
 
             // if it already exists, it may be a reload triggered by a change in a POM
             // in which case we should not be using the original Maven session

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -120,6 +120,7 @@ public class QuarkusBootstrapProvider implements Closeable {
             try {
                 return MavenArtifactResolver.builder()
                         .setWorkspaceDiscovery(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST)
+                        .setCurrentProject(mojo.mavenProject().getFile().toString())
                         .setPreferPomsFromWorkspace(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST)
                         .setRepositorySystem(repoSystem)
                         .setRepositorySystemSession(mojo.repositorySystemSession())


### PR DESCRIPTION
This helps when for example dev mode is launched for a module targeted with `-pl` and the parent POM enables that module in a profile. Although in such a case the workspace discovery might not be including all the modules enabled in the profile. To enable all the modules, `quarkus.bootstrap.effective-model-builder` still has to be enabled.

This little change also may appear as a slight optimization resolving the current project path.