### PR TITLE
Bump opentracing-jdbc.version from 0.2.4 to 0.2.11

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -25,7 +25,7 @@
         <opentracing-web-servlet-filter.version>0.4.1</opentracing-web-servlet-filter.version>
         <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.4.0</opentracing-concurrent.version>
-        <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
+        <opentracing-jdbc.version>0.2.11</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
         <opentelemetry.version>1.9.1</opentelemetry.version>


### PR DESCRIPTION
Bump opentracing-jdbc.version from 0.2.4 to 0.2.11 to avoid `java.lang.IllegalStateException: Timer already cancelled.` with tracing and Oracle database.

java-jdbc issue: https://github.com/opentracing-contrib/java-jdbc/issues/73
