### PR TITLE
Update to Vert.x 4.2.4 and Netty 4.1.73

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -110,7 +110,7 @@
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.18.2.Final</wildfly-elytron.version>
         <jboss-threads.version>3.4.2.Final</jboss-threads.version>
-        <vertx.version>4.2.2</vertx.version>
+        <vertx.version>4.2.4</vertx.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <httpasync.version>4.1.5</httpasync.version>
@@ -133,7 +133,7 @@
         <infinispan.version>13.0.5.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <netty.version>4.1.72.Final</netty.version>
+        <netty.version>4.1.73.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
         <mutiny.version>1.3.1</mutiny.version>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -52,7 +52,7 @@
         <jakarta.json.version>1.1.6</jakarta.json.version>
         <mutiny.version>1.3.1</mutiny.version>
         <smallrye-common.version>1.8.0</smallrye-common.version>
-        <vertx.version>4.2.2</vertx.version>
+        <vertx.version>4.2.4</vertx.version>
         <rest-assured.version>4.4.0</rest-assured.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.43.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
-        <grpc-jprotoc.version>1.2.0</grpc-jprotoc.version>
-        <protoc.version>3.19.2</protoc.version>
+        <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
+        <protoc.version>3.19.3</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
 
     </properties>


### PR DESCRIPTION
Vert.x 4.2.4 release notes are explained in https://github.com/vert-x3/wiki/wiki/4.2.4-Release-Notes.

Netty 4.1.73 release notes are explained in https://netty.io/news/2022/01/12/4-1-73-Final.html.
Noteworthy changes are:

- Make "pinned memory" from PooledByteBufAllocator reflect buffers in use
- Allow to disable duplicate native library check
- Allow same native libraries if the content is the same


This PR also aligns the gRPC dependencies with the vert.x gRPC dependencies (that we use underneath).


CC @jviet 