### PR TITLE
Remove the MQTT codestart  declaration

### DIFF
--- a/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-reactive-messaging-mqtt/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,8 +11,3 @@ metadata:
   config:
   - "mp.messaging."
   - "quarkus.reactive-messaging."
-  codestart:
-    name: "reactive-messaging"
-    languages:
-      - "java"
-    artifact: "io.quarkus:quarkus-project-core-extension-codestarts"


### PR DESCRIPTION
Follow-up of #23029 (forgot to remove the codestart declaration in the MQTT extension).

Thanks @loicmathieu for reporting this very quickly!