### PR TITLE
Ιmprove k8s deployment errors related to target platform

### DIFF
--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesDeploymentClusterBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/KubernetesDeploymentClusterBuildItem.java
@@ -1,0 +1,17 @@
+
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class KubernetesDeploymentClusterBuildItem extends MultiBuildItem {
+
+    private final String kind;
+
+    public KubernetesDeploymentClusterBuildItem(String kind) {
+        this.kind = kind;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
@@ -1,0 +1,35 @@
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.fabric8.knative.client.KnativeClient;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
+import io.quarkus.kubernetes.spi.GeneratedKubernetesResourceBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesDeploymentClusterBuildItem;
+
+public class KnativeDeployer {
+
+    @BuildStep
+    public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
+            List<GeneratedKubernetesResourceBuildItem> resources,
+            KubernetesClientBuildItem client, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+        selectedDeploymentTarget.ifPresent(target -> {
+            if (!KubernetesDeploy.INSTANCE.checkSilently()) {
+                return;
+            }
+            if (target.getEntry().getName().equals(KNATIVE)) {
+                if (client.getClient().isAdaptable(KnativeClient.class)) {
+                    deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(KNATIVE));
+                } else {
+                    throw new IllegalStateException(
+                            "Knative was requested as a deployment, but the target cluster is not a Knative cluster!");
+                }
+            }
+        });
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
@@ -1,0 +1,36 @@
+
+package io.quarkus.kubernetes.deployment;
+
+import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
+import io.quarkus.kubernetes.spi.GeneratedKubernetesResourceBuildItem;
+import io.quarkus.kubernetes.spi.KubernetesDeploymentClusterBuildItem;
+
+public class OpenshiftDeployer {
+
+    @BuildStep
+    public void checkEnvironment(Optional<SelectedKubernetesDeploymentTargetBuildItem> selectedDeploymentTarget,
+            List<GeneratedKubernetesResourceBuildItem> resources,
+            KubernetesClientBuildItem client, BuildProducer<KubernetesDeploymentClusterBuildItem> deploymentCluster) {
+        selectedDeploymentTarget.ifPresent(target -> {
+            if (!KubernetesDeploy.INSTANCE.checkSilently()) {
+                return;
+            }
+            if (target.getEntry().getName().equals(OPENSHIFT)) {
+                if (client.getClient().isAdaptable(OpenShiftClient.class)) {
+                    deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(OPENSHIFT));
+                } else {
+                    throw new IllegalStateException(
+                            "Openshift was requested as a deployment, but the target cluster is not an Openshift cluster!");
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Resolves: #21311

This pull requests adds the following checks:
- connection to the target cluster is possible before attempting to deploy
- the selected deployment target can be satisfied by the selected cluster (e.g. openshift or knative apis are available).