### PR TITLE
Update GraphQLClientConfig javadoc

### DIFF
--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -18,7 +18,6 @@ public class GraphQLClientConfig {
 
     /**
      * HTTP headers to add when communicating with the target GraphQL service.
-     * Right now, this only works for the dynamic client.
      */
     @ConfigItem(name = "header")
     public Map<String, String> headers;


### PR DESCRIPTION
The `headers` setting map now works with both client types.