### PR TITLE
Use proper return type when indexing suspend functions

### DIFF
--- a/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/GreetingResource.kt
+++ b/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/GreetingResource.kt
@@ -17,6 +17,18 @@ class GreetingResource {
         return Person("Jim Halpert")
     }
 
+    @Path("suspend")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    suspend fun suspendHello(): Person {
+        return Person("Jim Halpert")
+    }
+
+    @Path("suspendList")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    suspend fun suspendHelloList() = listOf(Person("Jim Halpert"))
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/integration-tests/kotlin-serialization/src/test/kotlin/io/quarkus/it/kotser/ResourceTest.kt
+++ b/integration-tests/kotlin-serialization/src/test/kotlin/io/quarkus/it/kotser/ResourceTest.kt
@@ -24,6 +24,39 @@ open class ResourceTest {
     }
 
     @Test
+    fun testSuspendGet() {
+        given()
+            .`when`().get("/suspend")
+            .then()
+            .statusCode(200)
+            .body(`is`(
+                """
+                    {
+                      "name": "Jim Halpert",
+                      "defaulted": "hi there!"
+                    }""".trimIndent()
+            ))
+    }
+
+    @Test
+    fun testSuspendGetList() {
+        given()
+            .`when`().get("/suspendList")
+            .then()
+            .statusCode(200)
+            .body(`is`(
+                """
+[
+  {
+    "name": "Jim Halpert",
+    "defaulted": "hi there!"
+  }
+]
+""".trimIndent()
+            ))
+    }
+
+    @Test
     fun testPost() {
         given()
             .body("{\"name\":\"Pam Beasley\"}")


### PR DESCRIPTION
This was not a problem with Jackson or Jsonb, because they
used the object class to determine the type of serializer,
but it is needed for Kotlin serialization which actually
used the generic type provided in the MessageBodyWriter
params to determine the serializer

Addresses: https://github.com/quarkusio/quarkus/issues/9003#issuecomment-1017301945