### PR TITLE
OIDC providers fixes

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -274,7 +274,7 @@ public class OidcCommonUtils {
                     key = ks.getKey(creds.jwt.keyId.get(), creds.jwt.keyPassword.toCharArray());
                 }
             } catch (Exception ex) {
-                throw new ConfigurationException("Key can not be loaded");
+                throw new ConfigurationException("Key can not be loaded", ex);
             }
             if (key == null) {
                 throw new ConfigurationException("Key is null");

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -481,8 +481,8 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Force 'https' as the 'redirect_uri' parameter scheme when running behind an SSL terminating reverse proxy.
          * This property, if enabled, will also affect the logout `post_logout_redirect_uri` and the local redirect requests.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean forceRedirectHttpsScheme;
+        @ConfigItem(defaultValueDocumentation = "false")
+        public Optional<Boolean> forceRedirectHttpsScheme = Optional.empty();
 
         /**
          * List of scopes
@@ -603,12 +603,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
             this.extraParams = extraParams;
         }
 
-        public boolean isForceRedirectHttpsScheme() {
+        public Optional<Boolean> isForceRedirectHttpsScheme() {
             return forceRedirectHttpsScheme;
         }
 
         public void setForceRedirectHttpsScheme(boolean forceRedirectHttpsScheme) {
-            this.forceRedirectHttpsScheme = forceRedirectHttpsScheme;
+            this.forceRedirectHttpsScheme = Optional.of(forceRedirectHttpsScheme);
         }
 
         public boolean isRestorePathAfterRedirect() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -612,7 +612,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private boolean isForceHttps(TenantConfigContext configContext) {
-        return configContext.oidcConfig.authentication.forceRedirectHttpsScheme;
+        return configContext.oidcConfig.authentication.forceRedirectHttpsScheme.orElse(false);
     }
 
     private Uni<Void> buildLogoutRedirectUriUni(RoutingContext context, TenantConfigContext configContext,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -335,6 +335,9 @@ public final class OidcUtils {
         if (tenant.authentication.scopes.isEmpty()) {
             tenant.authentication.scopes = provider.authentication.scopes;
         }
+        if (tenant.authentication.forceRedirectHttpsScheme.isEmpty()) {
+            tenant.authentication.forceRedirectHttpsScheme = provider.authentication.forceRedirectHttpsScheme;
+        }
 
         // credentials
         if (tenant.credentials.clientSecret.method.isEmpty()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.runtime.providers;
 
-import java.util.HashMap;
 import java.util.List;
 
 import io.quarkus.oidc.OidcTenantConfig;
@@ -63,10 +62,8 @@ public class KnownOidcProviders {
         ret.setAuthorizationPath("https://facebook.com/dialog/oauth/");
         ret.setTokenPath("https://graph.facebook.com/v12.0/oauth/access_token");
         ret.setJwksPath("https://www.facebook.com/.well-known/oauth/openid/jwks/");
-        ret.setUserInfoPath("https://graph.facebook.com/me/?fields=id,name,email,first_name,last_name");
         ret.getAuthentication().setScopes(List.of("email", "public_profile"));
-        ret.getAuthentication().setUserInfoRequired(true);
-        ret.getAuthentication().setIdTokenRequired(false);
+        ret.getAuthentication().setForceRedirectHttpsScheme(true);
         return ret;
     }
 
@@ -75,8 +72,6 @@ public class KnownOidcProviders {
         ret.setAuthServerUrl("https://appleid.apple.com/");
         ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.getAuthentication().setScopes(List.of("openid", "email", "name"));
-        ret.getAuthentication().setExtraParams(new HashMap<>());
-        ret.getAuthentication().getExtraParams().put("response_mode", "form_post");
         ret.getAuthentication().setForceRedirectHttpsScheme(true);
         ret.getCredentials().getClientSecret().setMethod(Method.POST_JWT);
         ret.getCredentials().getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -94,12 +94,9 @@ public class OidcUtilsTest {
         assertEquals("https://facebook.com/dialog/oauth/", config.getAuthorizationPath().get());
         assertEquals("https://www.facebook.com/.well-known/oauth/openid/jwks/", config.getJwksPath().get());
         assertEquals("https://graph.facebook.com/v12.0/oauth/access_token", config.getTokenPath().get());
-        assertEquals("https://graph.facebook.com/me/?fields=id,name,email,first_name,last_name",
-                config.getUserInfoPath().get());
 
-        assertFalse(config.authentication.idTokenRequired.get());
-        assertTrue(config.authentication.userInfoRequired.get());
         assertEquals(List.of("email", "public_profile"), config.authentication.scopes.get());
+        assertTrue(config.authentication.forceRedirectHttpsScheme.get());
     }
 
     @Test
@@ -113,11 +110,9 @@ public class OidcUtilsTest {
         tenant.setAuthorizationPath("authorization");
         tenant.setJwksPath("jwks");
         tenant.setTokenPath("tokens");
-        tenant.setUserInfoPath("userinfo");
 
-        tenant.authentication.setIdTokenRequired(true);
-        tenant.authentication.setUserInfoRequired(false);
         tenant.authentication.setScopes(List.of("write"));
+        tenant.authentication.setForceRedirectHttpsScheme(false);
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.FACEBOOK));
 
@@ -126,12 +121,10 @@ public class OidcUtilsTest {
         assertTrue(config.isDiscoveryEnabled().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals("authorization", config.getAuthorizationPath().get());
+        assertFalse(config.getAuthentication().isForceRedirectHttpsScheme().get());
         assertEquals("jwks", config.getJwksPath().get());
         assertEquals("tokens", config.getTokenPath().get());
-        assertEquals("userinfo", config.getUserInfoPath().get());
 
-        assertTrue(config.authentication.idTokenRequired.get());
-        assertFalse(config.authentication.userInfoRequired.get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
     }
 
@@ -186,6 +179,7 @@ public class OidcUtilsTest {
         tenant.setAuthServerUrl("http://localhost/wiremock");
         tenant.getToken().setIssuer("http://localhost/wiremock");
         tenant.authentication.setScopes(List.of("write"));
+        tenant.authentication.setForceRedirectHttpsScheme(false);
 
         OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.MICROSOFT));
 
@@ -194,6 +188,7 @@ public class OidcUtilsTest {
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
         assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
+        assertFalse(config.authentication.forceRedirectHttpsScheme.get());
     }
 
     @Test
@@ -209,6 +204,7 @@ public class OidcUtilsTest {
         assertEquals(Method.POST_JWT, config.credentials.clientSecret.method.get());
         assertEquals("https://appleid.apple.com/", config.credentials.jwt.audience.get());
         assertEquals(SignatureAlgorithm.ES256.getAlgorithm(), config.credentials.jwt.signatureAlgorithm.get());
+        assertTrue(config.authentication.forceRedirectHttpsScheme.get());
     }
 
     @Test


### PR DESCRIPTION
Updates the facebook provider now that it supports an id token. Also for free, a missing exception cause.