### PR TITLE
Simplify getting-started-testing example documentation

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -199,7 +199,6 @@ We will create a simple test to ensure that this is being served correctly:
 ----
 package org.acme.getting.started.testing;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -218,21 +217,11 @@ public class StaticContentTest {
     URL url;
 
     @Test
-    public void testIndexHtml() throws Exception {
+    public void testIndexHtml() throws IOException {
         try (InputStream in = url.openStream()) {
-            String contents = readStream(in);
+            String contents = new String(in.readAllBytes(), StandardCharsets.UTF_8);
             Assertions.assertTrue(contents.contains("<title>Testing Guide</title>"));
         }
-    }
-
-    private static String readStream(InputStream in) throws IOException {
-        byte[] data = new byte[1024];
-        int r;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        while ((r = in.read(data)) > 0) {
-            out.write(data, 0, r);
-        }
-        return new String(out.toByteArray(), StandardCharsets.UTF_8);
     }
 }
 ----
@@ -274,7 +263,6 @@ be appended to the end of the endpoint path.
 ----
 package org.acme.getting.started.testing;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -295,21 +283,11 @@ public class StaticContentTest {
     URL url;
 
     @Test
-    public void testIndexHtml() throws Exception {
+    public void testIndexHtml() throws IOException {
         try (InputStream in = url.openStream()) {
-            String contents = readStream(in);
-            Assertions.assertTrue(contents.equals("hello"));
+            String contents = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            Assertions.assertEquals("hello", contents);
         }
-    }
-
-    private static String readStream(InputStream in) throws IOException {
-        byte[] data = new byte[1024];
-        int r;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        while ((r = in.read(data)) > 0) {
-            out.write(data, 0, r);
-        }
-        return new String(out.toByteArray(), StandardCharsets.UTF_8);
     }
 }
 ----


### PR DESCRIPTION
Remove the `readStream(InputStream in)` method and use the `InputStream.readAllBytes()` instead.