### PR TITLE
Avoid treating IdTokens issued by providers as internal IdTokens

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -53,6 +53,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     static final Uni<Void> VOID_UNI = Uni.createFrom().voidItem();
     static final Integer MAX_COOKIE_VALUE_LENGTH = 4096;
 
+    private static final String INTERNAL_IDTOKEN_HEADER = "internal";
     private static final Logger LOG = Logger.getLogger(CodeAuthenticationMechanism.class);
 
     private final BlockingTaskRunner<String> createTokenStateRequestContext = new BlockingTaskRunner<String>();
@@ -106,7 +107,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         context.put(AuthorizationCodeTokens.class.getName(), session);
                         return authenticate(identityProviderManager, context,
                                 new IdTokenCredential(session.getIdToken(),
-                                        !configContext.oidcConfig.authentication.isIdTokenRequired().orElse(true)))
+                                        isInternalIdToken(session.getIdToken(), configContext)))
                                                 .call(new Function<SecurityIdentity, Uni<?>>() {
                                                     @Override
                                                     public Uni<Void> apply(SecurityIdentity identity) {
@@ -153,7 +154,18 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                                     }
                                                 });
                     }
+
                 });
+    }
+
+    private boolean isInternalIdToken(String idToken, TenantConfigContext configContext) {
+        if (!configContext.oidcConfig.authentication.idTokenRequired.orElse(true)) {
+            JsonObject headers = OidcUtils.decodeJwtHeaders(idToken);
+            if (headers != null) {
+                return headers.getBoolean(INTERNAL_IDTOKEN_HEADER, false);
+            }
+        }
+        return false;
     }
 
     private boolean isJavaScript(RoutingContext context) {
@@ -361,7 +373,8 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     }
 
     private String generateInternalIdToken(OidcTenantConfig oidcConfig) {
-        return Jwt.claims().sign(KeyUtils.createSecretKeyFromSecret(oidcConfig.credentials.secret.get()));
+        return Jwt.claims().jws().header(INTERNAL_IDTOKEN_HEADER, true)
+                .sign(KeyUtils.createSecretKeyFromSecret(oidcConfig.credentials.secret.get()));
     }
 
     private Uni<Void> processSuccessfulAuthentication(RoutingContext context,

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -80,11 +80,20 @@ public final class OidcUtils {
         if (tokens.countTokens() != 1) {
             return null;
         }
+        return decodeAsJsonObject(encodedContent);
+    }
+
+    private static JsonObject decodeAsJsonObject(String encodedContent) {
         try {
             return new JsonObject(new String(Base64.getUrlDecoder().decode(encodedContent), StandardCharsets.UTF_8));
         } catch (IllegalArgumentException ex) {
             return null;
         }
+    }
+
+    public static JsonObject decodeJwtHeaders(String jwt) {
+        StringTokenizer tokens = new StringTokenizer(jwt, ".");
+        return decodeAsJsonObject(tokens.nextToken());
     }
 
     public static List<String> findRoles(String clientId, OidcTenantConfig.Roles rolesConfig, JsonObject json) {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -59,6 +59,7 @@ quarkus.oidc.tenant-web-app-no-discovery.client-id=quarkus-app-webapp
 quarkus.oidc.tenant-web-app-no-discovery.credentials.secret=secret
 quarkus.oidc.tenant-web-app-no-discovery.application-type=web-app
 quarkus.oidc.tenant-web-app-no-discovery.authentication.user-info-required=true
+quarkus.oidc.tenant-web-app-no-discovery.authentication.id-token-required=false
 quarkus.oidc.tenant-web-app-no-discovery.roles.source=userinfo
 quarkus.oidc.tenant-web-app-no-discovery.allow-user-info-cache=false
 


### PR DESCRIPTION
Fixes #23007.

I just added an `internal` header qualifier when generating an internal token to prevent treating the ID tokens issued by the providers as the internal ones when `quarkus.oidc.authentication.id-token-required=false`. (in theory, they might also have an `internal` header - but it is probably close to 0 then I can do `internal_something_random` but I don't think it will be necessary).
Tested it by updating one of Keycloak tests (yes, it was failing before I applied a fix :-)).