### PR TITLE
ResteasyReactive @Context param from CDI.  AWS objects CDI injectable

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -302,7 +302,7 @@ HTTP response messages and the `sam.yaml` file must configure the API Gateway to
 == Injectable AWS Context Variables
 
 If you are using RESTEasy and JAX-RS, you can inject various AWS Context variables into your JAX-RS resource classes
-using the JAX-RS `@Context` annotation.
+using the JAX-RS `@Context` annotation or anywhere else with the CDI `@Inject` annotation.
 
 For the AWS HTTP API you can inject the AWS variables `com.amazonaws.services.lambda.runtime.Context` and
 `com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent`.  Here is an example:

--- a/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-http/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 
 import io.quarkus.amazon.lambda.deployment.LambdaUtil;
 import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
+import io.quarkus.amazon.lambda.http.AwsHttpContextProducers;
 import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
 import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
@@ -27,15 +28,22 @@ public class AmazonLambdaHttpProcessor {
     private static final Logger log = Logger.getLogger(AmazonLambdaHttpProcessor.class);
 
     @BuildStep
+    public void setupCDI(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
+        builder.addBeanClasses(AwsHttpContextProducers.class);
+        additionalBeans.produce(builder.build());
+    }
+
+    @BuildStep
     public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             LambdaHttpBuildTimeConfig config) {
         if (!config.enableSecurity)
             return;
 
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();
-
-        builder.addBeanClass(LambdaHttpAuthenticationMechanism.class)
-                .addBeanClass(DefaultLambdaIdentityProvider.class);
+        builder.addBeanClasses(LambdaHttpAuthenticationMechanism.class,
+                DefaultLambdaIdentityProvider.class,
+                AwsHttpContextProducers.class);
         additionalBeans.produce(builder.build());
     }
 

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/AwsHttpContextProducers.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/AwsHttpContextProducers.java
@@ -1,0 +1,67 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+@Singleton
+public class AwsHttpContextProducers {
+
+    @RequestScoped
+    @Produces
+    public Context getAwsContext() {
+        return (Context) getContextObjects().get(Context.class);
+    }
+
+    @RequestScoped
+    @Produces
+    public APIGatewayV2HTTPEvent getHttpEvent() {
+        return (APIGatewayV2HTTPEvent) getContextObjects().get(APIGatewayV2HTTPEvent.class);
+    }
+
+    @RequestScoped
+    @Produces
+    public APIGatewayV2HTTPEvent.RequestContext getHttpRequestContext() {
+        return (APIGatewayV2HTTPEvent.RequestContext) getContextObjects().get(APIGatewayV2HTTPEvent.RequestContext.class);
+    }
+
+    @Inject
+    Instance<CurrentVertxRequest> current;
+
+    private Map<Class<?>, Object> getContextObjects() {
+        if (current == null) {
+            return Collections.EMPTY_MAP;
+        }
+        CurrentVertxRequest currentVertxRequest = current.get();
+        if (currentVertxRequest == null) {
+            return Collections.EMPTY_MAP;
+        }
+        RoutingContext routingContext = currentVertxRequest.getCurrent();
+        if (routingContext == null) {
+            return Collections.EMPTY_MAP;
+        }
+        MultiMap qheaders = routingContext.request().headers();
+        if (qheaders == null) {
+            return Collections.EMPTY_MAP;
+        }
+        if (qheaders instanceof QuarkusHttpHeaders) {
+            return ((QuarkusHttpHeaders) qheaders).getContextObjects();
+        } else {
+            return Collections.EMPTY_MAP;
+        }
+    }
+
+}

--- a/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
+++ b/extensions/amazon-lambda-rest/deployment/src/main/java/io/quarkus/amazon/lambda/http/deployment/AmazonLambdaHttpProcessor.java
@@ -6,6 +6,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.amazon.lambda.deployment.LambdaUtil;
 import io.quarkus.amazon.lambda.deployment.ProvidedAmazonLambdaHandlerBuildItem;
+import io.quarkus.amazon.lambda.http.AwsHttpContextProducers;
 import io.quarkus.amazon.lambda.http.DefaultLambdaIdentityProvider;
 import io.quarkus.amazon.lambda.http.LambdaHttpAuthenticationMechanism;
 import io.quarkus.amazon.lambda.http.LambdaHttpHandler;
@@ -30,6 +31,13 @@ import io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem;
 
 public class AmazonLambdaHttpProcessor {
     private static final Logger log = Logger.getLogger(AmazonLambdaHttpProcessor.class);
+
+    @BuildStep
+    public void setupCDI(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder();
+        builder.addBeanClasses(AwsHttpContextProducers.class);
+        additionalBeans.produce(builder.build());
+    }
 
     @BuildStep
     public void setupSecurity(BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/AwsHttpContextProducers.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/AwsHttpContextProducers.java
@@ -1,0 +1,68 @@
+package io.quarkus.amazon.lambda.http;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.quarkus.vertx.http.runtime.QuarkusHttpHeaders;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.web.RoutingContext;
+
+@Singleton
+public class AwsHttpContextProducers {
+
+    @RequestScoped
+    @Produces
+    public Context getAwsContext() {
+        return (Context) getContextObjects().get(Context.class);
+    }
+
+    @RequestScoped
+    @Produces
+    public AwsProxyRequestContext getHttpEvent() {
+        return (AwsProxyRequestContext) getContextObjects().get(AwsProxyRequestContext.class);
+    }
+
+    @RequestScoped
+    @Produces
+    public AwsProxyRequest getHttpRequestContext() {
+        return (AwsProxyRequest) getContextObjects().get(AwsProxyRequest.class);
+    }
+
+    @Inject
+    Instance<CurrentVertxRequest> current;
+
+    private Map<Class<?>, Object> getContextObjects() {
+        if (current == null) {
+            return Collections.EMPTY_MAP;
+        }
+        CurrentVertxRequest currentVertxRequest = current.get();
+        if (currentVertxRequest == null) {
+            return Collections.EMPTY_MAP;
+        }
+        RoutingContext routingContext = currentVertxRequest.getCurrent();
+        if (routingContext == null) {
+            return Collections.EMPTY_MAP;
+        }
+        MultiMap qheaders = routingContext.request().headers();
+        if (qheaders == null) {
+            return Collections.EMPTY_MAP;
+        }
+        if (qheaders instanceof QuarkusHttpHeaders) {
+            return ((QuarkusHttpHeaders) qheaders).getContextObjects();
+        } else {
+            return Collections.EMPTY_MAP;
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ContextParamFromCdiTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/ContextParamFromCdiTest.java
@@ -1,0 +1,50 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ContextParamFromCdiTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ContextFromCdi.class, ContextFromCdiResource.class));
+
+    @Test
+    public void testParam() {
+        RestAssured.get("/context-from-cdi")
+                .then().statusCode(200).body(Matchers.equalTo("context"));
+    }
+
+    @ApplicationScoped
+    @Unremovable
+    public static class ContextFromCdi {
+
+        public String get() {
+            return "context";
+        }
+    }
+
+    @Path("context-from-cdi")
+    public static class ContextFromCdiResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get(@Context ContextFromCdi cdi) {
+            return cdi.get();
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/ContextParamExtractor.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/ContextParamExtractor.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.server.core.parameters;
 
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.ResourceContext;
@@ -24,6 +25,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 public class ContextParamExtractor implements ParameterExtractor {
 
     private final Class<?> type;
+    private volatile Instance<?> select;
 
     public ContextParamExtractor(String type) {
         try {
@@ -87,6 +89,15 @@ public class ContextParamExtractor implements ParameterExtractor {
             return ResourceContextImpl.INSTANCE;
         }
         Object instance = context.unwrap(type);
+        if (instance != null) {
+            return instance;
+        }
+        if (select == null) {
+            select = CDI.current().select(type);
+        }
+        if (select != null) {
+            instance = select.get();
+        }
         if (instance != null) {
             return instance;
         }

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/pom.xml
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-amazon-lambda-http-resteasy-reactive</artifactId>
+    <name>Quarkus - Integration Tests - Amazon Lambda HTTP RESTEasy Reactive</name>
+    <description>Test with Resteasy Reactive and Amazon Lambda HTTP</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda-http</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/src/main/java/io/quarkus/it/amazon/lambda/GreetingResource.java
@@ -44,10 +44,13 @@ public class GreetingResource {
 
     }
 
+    @Context
+    com.amazonaws.services.lambda.runtime.Context ctx;
+
     @GET
     @Path("context")
     @Produces(MediaType.TEXT_PLAIN)
-    public void context(@Context com.amazonaws.services.lambda.runtime.Context ctx) {
+    public void context() {
         if (ctx == null)
             throw new RuntimeException();
         if (ctx.getAwsRequestId() == null)
@@ -57,19 +60,19 @@ public class GreetingResource {
     @GET
     @Path("proxyRequestContext")
     @Produces(MediaType.TEXT_PLAIN)
-    public void proxyRequestContext(@Context APIGatewayV2HTTPEvent ctx) {
-        if (ctx == null || ctx.getRequestContext().getHttp().getMethod() == null)
+    public void proxyRequestContext(@Context APIGatewayV2HTTPEvent event) {
+        if (event == null)
             throw new RuntimeException();
     }
 
     @Inject
-    APIGatewayV2HTTPEvent event;
+    APIGatewayV2HTTPEvent injectEvent;
 
     @GET
     @Path("inject-event")
     @Produces(MediaType.TEXT_PLAIN)
     public void injectEvent() {
-        if (event == null)
+        if (injectEvent == null)
             throw new RuntimeException();
     }
 

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.amazon.lambda;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
+}

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -1,0 +1,156 @@
+package io.quarkus.it.amazon.lambda;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+
+import io.quarkus.amazon.lambda.runtime.AmazonLambdaApi;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class AmazonLambdaSimpleTestCase {
+
+    @Test
+    public void testContext() throws Exception {
+        given()
+                .when()
+                .get("/hello/context")
+                .then()
+                .statusCode(204);
+        given()
+                .when()
+                .get("/hello/inject-event")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void testGetText() throws Exception {
+        testGetTextByEvent("/hello");
+        testGetText("/hello");
+    }
+
+    private void testGetTextByEvent(String path) {
+        APIGatewayV2HTTPEvent request = request(path);
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body(request)
+                .when()
+                .post(AmazonLambdaApi.API_BASE_PATH_TEST)
+                .then()
+                .statusCode(200)
+                .body("body", equalTo("hello"))
+                .body("headers.Content-Type", containsString("text/plain"));
+    }
+
+    private void testGetText(String path) {
+        given()
+                .when()
+                .get(path)
+                .then()
+                .statusCode(200)
+                .header("Content-Type", containsString("text/plain"))
+                .body(equalTo("hello"));
+    }
+
+    private APIGatewayV2HTTPEvent request(String path) {
+        APIGatewayV2HTTPEvent request = new APIGatewayV2HTTPEvent();
+        request.setRawPath(path);
+        request.setRequestContext(new APIGatewayV2HTTPEvent.RequestContext());
+        request.getRequestContext().setHttp(new APIGatewayV2HTTPEvent.RequestContext.Http());
+        request.getRequestContext().getHttp().setMethod("GET");
+        return request;
+    }
+
+    @Test
+    public void test404() throws Exception {
+        given()
+                .when()
+                .get("/nowhere")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testPostText() throws Exception {
+        testPostTextByEvent("/hello");
+        testPostText("/hello");
+    }
+
+    private void testPostTextByEvent(String path) {
+        APIGatewayV2HTTPEvent request = request(path);
+        request.getRequestContext().getHttp().setMethod("POST");
+        request.setHeaders(new HashMap<>());
+        request.getHeaders().put("Content-Type", "text/plain");
+        request.setBody("Bill");
+
+        given()
+                .contentType("application/json")
+                .accept("application/json")
+                .body(request)
+                .when()
+                .post(AmazonLambdaApi.API_BASE_PATH_TEST)
+                .then()
+                .statusCode(200)
+                .body("body", equalTo("hello Bill"))
+                .body("headers.Content-Type", containsString("text/plain"));
+    }
+
+    private void testPostText(String path) {
+        given()
+                .contentType("text/plain")
+                .body("Bill")
+                .when()
+                .post(path)
+                .then()
+                .statusCode(200)
+                .header("Content-Type", containsString("text/plain"))
+                .body(equalTo("hello Bill"));
+    }
+
+    @Test
+    public void testPostBinary() throws Exception {
+        byte[] bytes = { 0, 1, 2, 3 };
+        byte[] resBytes = { 4, 5, 6 };
+
+        byte[] result = given()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(bytes)
+                .when()
+                .post("hello")
+                .then()
+                .statusCode(200)
+                .header("Content-Type", containsString(MediaType.APPLICATION_OCTET_STREAM))
+                .extract().asByteArray();
+        Assertions.assertTrue(Arrays.equals(resBytes, result));
+    }
+
+    @Test
+    public void testPostEmpty() throws Exception {
+        given()
+                .when()
+                .post("/hello/empty")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void testProxyRequestContext() throws Exception {
+        given()
+                .when()
+                .get("/hello/proxyRequestContext")
+                .then()
+                .statusCode(204);
+    }
+}

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleTestCase.java
@@ -29,6 +29,11 @@ public class AmazonLambdaSimpleTestCase {
                 .get("/hello/context")
                 .then()
                 .statusCode(204);
+        given()
+                .when()
+                .get("/hello/inject-event")
+                .then()
+                .statusCode(204);
     }
 
     @Test

--- a/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/GreetingResource.java
+++ b/integration-tests/amazon-lambda-rest/src/main/java/io/quarkus/it/amazon/lambda/v1/GreetingResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.amazon.lambda.v1;
 
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -8,6 +9,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import io.quarkus.amazon.lambda.http.model.AwsProxyRequest;
 import io.quarkus.amazon.lambda.http.model.AwsProxyRequestContext;
 
 @Path("/hello")
@@ -58,6 +60,17 @@ public class GreetingResource {
     @Produces(MediaType.TEXT_PLAIN)
     public void proxyRequestContext(@Context AwsProxyRequestContext ctx) {
         if (ctx == null)
+            throw new RuntimeException();
+    }
+
+    @Inject
+    AwsProxyRequest event;
+
+    @GET
+    @Path("inject-event")
+    @Produces(MediaType.TEXT_PLAIN)
+    public void injectEvent() {
+        if (event == null)
             throw new RuntimeException();
     }
 

--- a/integration-tests/amazon-lambda-rest/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaV1SimpleTestCase.java
+++ b/integration-tests/amazon-lambda-rest/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaV1SimpleTestCase.java
@@ -33,6 +33,11 @@ public class AmazonLambdaV1SimpleTestCase {
                 .get("/hello/context")
                 .then()
                 .statusCode(204);
+        given()
+                .when()
+                .get("/hello/inject-event")
+                .then()
+                .statusCode(204);
     }
 
     @Test

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -225,6 +225,7 @@
                 <module>amazon-lambda-http</module>
                 <module>amazon-lambda-rest</module>
                 <module>amazon-lambda-http-resteasy</module>
+                <module>amazon-lambda-http-resteasy-reactive</module>
                 <module>container-image</module>
                 <module>kubernetes</module>
                 <module>kubernetes-client</module>


### PR DESCRIPTION
While you can inject a CDI bean using @Context into a field, you cannot do it via a parameter, i.e.

@GET
public String doit(@Context MyBean bean);

Found this while adding the ability to @Inject AWS context objects, hence the dual PR.