### PR TITLE
Do not ban reloadable dependencies from the base runtime classloader

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -293,16 +293,11 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             builder.addBannedElement(new MemoryClassPathElement(banned, true));
 
             for (ResolvedDependency dependency : appModel.getDependencies()) {
-                if (!dependency.isRuntimeCp() ||
-                        isHotReloadable(dependency, hotReloadPaths) ||
-                        configuredClassLoading.reloadableArtifacts.contains(dependency.getKey())) {
-                    continue;
-                }
-                if (!flatTestClassPath && dependency.isReloadable()
-                        && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey())) {
-                    if (dependency.getType().equals(ArtifactCoords.TYPE_JAR)) {
-                        builder.addBannedElement(new ClassFilteredBannedElement(ClassPathElement.fromDependency(dependency)));
-                    }
+                if (!dependency.isRuntimeCp()
+                        || isHotReloadable(dependency, hotReloadPaths)
+                        || configuredClassLoading.reloadableArtifacts.contains(dependency.getKey())
+                        || !flatTestClassPath && dependency.isReloadable()
+                                && appModel.getReloadableWorkspaceDependencies().contains(dependency.getKey())) {
                     continue;
                 }
 


### PR DESCRIPTION
This fixes a regression after https://github.com/quarkusio/quarkus/pull/22673
The issue was found in the Kogito repo where a QuarkusTest would fail with a CNFE, because it appeared to be banned in the base runtime classloader.