### PR TITLE
Downgrade assertj to 3.21.0 to avoid breaking platform members

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -129,7 +129,7 @@
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <junit-pioneer.version>1.5.0</junit-pioneer.version>
         <testng.version>6.14.2</testng.version>
-        <assertj.version>3.22.0</assertj.version>
+        <assertj.version>3.21.0</assertj.version>
         <infinispan.version>13.0.5.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.3</caffeine.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -41,7 +41,7 @@
         <version.jandex>2.4.2.Final</version.jandex>
         <version.junit5>5.8.2</version.junit5>
         <version.maven>3.8.4</version.maven>
-        <version.assertj>3.22.0</version.assertj>
+        <version.assertj>3.21.0</version.assertj>
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
         <version.gizmo>1.0.10.Final</version.gizmo>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -28,7 +28,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 
         <!-- Dependency versions -->
-        <assertj.version>3.22.0</assertj.version>
+        <assertj.version>3.21.0</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
         <jsoup.version>1.14.2</jsoup.version> <!-- wagon-http dependency -->

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
         <version.junit>5.8.2</version.junit>
-        <version.assertj>3.22.0</version.assertj>
+        <version.assertj>3.21.0</version.assertj>
         <version.gizmo>1.0.10.Final</version.gizmo>
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -40,7 +40,7 @@
         <version.jandex>2.4.2.Final</version.jandex>
         <version.junit5>5.8.2</version.junit5>
         <version.maven>3.8.4</version.maven>
-        <version.assertj>3.22.0</version.assertj>
+        <version.assertj>3.21.0</version.assertj>
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
         <version.gizmo>1.0.10.Final</version.gizmo>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -38,7 +38,7 @@
         <scala-plugin.version>4.4.0</scala-plugin.version>
 
         <!-- Versions -->
-        <assertj.version>3.22.0</assertj.version>
+        <assertj.version>3.21.0</assertj.version>
         <jackson.version>2.13.1</jackson.version>
         <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
         <jakarta.servlet-api.version>4.0.3</jakarta.servlet-api.version>


### PR DESCRIPTION
This should be mostly relevant for 2.7. In 2.8 we should look into removing assertj from the quarkus-bom.