### PR TITLE
Inject "annotations" and "genericType" in ParamConverterProvider

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
@@ -1,0 +1,127 @@
+package io.quarkus.jaxrs.client.reactive.deployment;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+class ClassRestClientContext implements AutoCloseable {
+
+    public final ClassCreator classCreator;
+    public final MethodCreator constructor;
+    public final MethodCreator clinit;
+
+    public final Map<Integer, FieldDescriptor> methodStaticFields = new HashMap<>();
+    public final Map<Integer, FieldDescriptor> methodParamAnnotationsStaticFields = new HashMap<>();
+    public final Map<Integer, FieldDescriptor> methodGenericParametersStaticFields = new HashMap<>();
+
+    public ClassRestClientContext(String name, BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            String... interfaces) {
+        this(name, MethodDescriptor.ofConstructor(name), generatedClasses, Object.class, interfaces);
+    }
+
+    public ClassRestClientContext(String name, MethodDescriptor constructorDesc,
+            BuildProducer<GeneratedClassBuildItem> generatedClasses,
+            Class<?> superClass, String... interfaces) {
+
+        this.classCreator = new ClassCreator(new GeneratedClassGizmoAdaptor(generatedClasses, true),
+                name, null, superClass.getName(), interfaces);
+        this.constructor = classCreator.getMethodCreator(constructorDesc);
+        this.clinit = classCreator.getMethodCreator(MethodDescriptor.ofMethod(name, "<clinit>", void.class));
+        this.clinit.setModifiers(Opcodes.ACC_STATIC);
+    }
+
+    @Override
+    public void close() {
+        classCreator.close();
+    }
+
+    protected FieldDescriptor createJavaMethodField(ClassInfo interfaceClass, MethodInfo method, int methodIndex) {
+        ResultHandle interfaceClassHandle = clinit.loadClassFromTCCL(interfaceClass.toString());
+
+        ResultHandle parameterArray = clinit.newArray(Class.class, method.parameters().size());
+        for (int i = 0; i < method.parameters().size(); i++) {
+            String parameterClass = method.parameters().get(i).name().toString();
+            clinit.writeArrayValue(parameterArray, i, clinit.loadClassFromTCCL(parameterClass));
+        }
+
+        ResultHandle javaMethodHandle = clinit.invokeVirtualMethod(
+                MethodDescriptor.ofMethod(Class.class, "getMethod", Method.class, String.class, Class[].class),
+                interfaceClassHandle, clinit.load(method.name()), parameterArray);
+        FieldDescriptor javaMethodField = FieldDescriptor.of(classCreator.getClassName(), "javaMethod" + methodIndex,
+                Method.class);
+        classCreator.getFieldCreator(javaMethodField).setModifiers(Modifier.PRIVATE | Modifier.FINAL | Modifier.STATIC);
+        clinit.writeStaticField(javaMethodField, javaMethodHandle);
+
+        methodStaticFields.put(methodIndex, javaMethodField);
+
+        return javaMethodField;
+    }
+
+    /**
+     * Generates "method.getParameterAnnotations()" and it will only be created if and only if the supplier is used
+     * in order to not have a penalty performance.
+     */
+    protected Supplier<FieldDescriptor> getLazyJavaMethodParamAnnotationsField(int methodIndex) {
+        return () -> {
+            FieldDescriptor methodParamAnnotationsField = methodParamAnnotationsStaticFields.get(methodIndex);
+            if (methodParamAnnotationsField != null) {
+                return methodParamAnnotationsField;
+            }
+
+            ResultHandle javaMethodParamAnnotationsHandle = clinit.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(Method.class, "getParameterAnnotations", Annotation[][].class),
+                    clinit.readStaticField(methodStaticFields.get(methodIndex)));
+            FieldDescriptor javaMethodParamAnnotationsField = FieldDescriptor.of(classCreator.getClassName(),
+                    "javaMethodParameterAnnotations" + methodIndex, Annotation[][].class);
+            classCreator.getFieldCreator(javaMethodParamAnnotationsField)
+                    .setModifiers(Modifier.PUBLIC | Modifier.FINAL | Modifier.STATIC);
+            clinit.writeStaticField(javaMethodParamAnnotationsField, javaMethodParamAnnotationsHandle);
+
+            methodParamAnnotationsStaticFields.put(methodIndex, javaMethodParamAnnotationsField);
+
+            return javaMethodParamAnnotationsField;
+        };
+    }
+
+    /**
+     * Generates "method.getGenericParameterTypes()" and it will only be created if and only if the supplier is used
+     * in order to not have a penalty performance.
+     */
+    protected Supplier<FieldDescriptor> getLazyJavaMethodGenericParametersField(int methodIndex) {
+        return () -> {
+            FieldDescriptor methodGenericTypeField = methodGenericParametersStaticFields.get(methodIndex);
+            if (methodGenericTypeField != null) {
+                return methodGenericTypeField;
+            }
+
+            ResultHandle javaMethodGenericParametersHandle = clinit.invokeVirtualMethod(
+                    MethodDescriptor.ofMethod(Method.class, "getGenericParameterTypes", java.lang.reflect.Type[].class),
+                    clinit.readStaticField(methodStaticFields.get(methodIndex)));
+            FieldDescriptor javaMethodGenericParametersField = FieldDescriptor.of(classCreator.getClassName(),
+                    "javaMethodGenericParameters" + methodIndex, java.lang.reflect.Type[].class);
+            classCreator.getFieldCreator(javaMethodGenericParametersField)
+                    .setModifiers(Modifier.PUBLIC | Modifier.FINAL | Modifier.STATIC);
+            clinit.writeStaticField(javaMethodGenericParametersField, javaMethodGenericParametersHandle);
+
+            methodGenericParametersStaticFields.put(methodIndex, javaMethodGenericParametersField);
+
+            return javaMethodGenericParametersField;
+        };
+    }
+}

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveEnricher.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveEnricher.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 
 /**
@@ -42,13 +43,15 @@ public interface JaxrsClientReactiveEnricher {
      * @param index jandex index
      * @param generatedClasses build producer used to generate classes. Used e.g. to generate classes for header filling
      * @param methodIndex 0-based index of the method in the interface. Used to assure there is no clash in generating classes
+     * @param javaMethodField method reference in a static class field
      */
     void forMethod(ClassCreator classCreator, MethodCreator constructor,
             MethodCreator clinit,
             MethodCreator methodCreator,
             ClassInfo interfaceClass,
             MethodInfo method, AssignableResultHandle invocationBuilder,
-            IndexView index, BuildProducer<GeneratedClassBuildItem> generatedClasses, int methodIndex);
+            IndexView index, BuildProducer<GeneratedClassBuildItem> generatedClasses, int methodIndex,
+            FieldDescriptor javaMethodField);
 
     /**
      * Method-level alterations for methods of sub-resources
@@ -65,11 +68,12 @@ public interface JaxrsClientReactiveEnricher {
      * @param generatedClasses build producer used to generate classes
      * @param methodIndex 0-based index of method in the root interface
      * @param subMethodIndex index of the method in the sub-resource interface
+     * @param javaMethodField method reference in a static class field
      */
     void forSubResourceMethod(ClassCreator subClassCreator, MethodCreator subConstructor,
             MethodCreator subClinit,
             MethodCreator subMethodCreator, ClassInfo rootInterfaceClass, ClassInfo subInterfaceClass,
             MethodInfo subMethod, MethodInfo rootMethod, AssignableResultHandle invocationBuilder, // sub-level
             IndexView index, BuildProducer<GeneratedClassBuildItem> generatedClasses,
-            int methodIndex, int subMethodIndex);
+            int methodIndex, int subMethodIndex, FieldDescriptor javaMethodField);
 }

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
@@ -19,8 +19,8 @@ public abstract class RestClientBase implements Closeable {
     }
 
     @SuppressWarnings("unused") // used by generated code
-    public <T> Object[] convertParamArray(T[] value, Class<T> type) {
-        ParamConverter<T> converter = getConverter(type, null, null);
+    public <T> Object[] convertParamArray(T[] value, Class<T> type, Type genericType, Annotation[] annotations) {
+        ParamConverter<T> converter = getConverter(type, genericType, annotations);
 
         if (converter == null) {
             return value;
@@ -35,8 +35,8 @@ public abstract class RestClientBase implements Closeable {
     }
 
     @SuppressWarnings("unused") // used by generated code
-    public <T> Object convertParam(T value, Class<T> type) {
-        ParamConverter<T> converter = getConverter(type, null, null);
+    public <T> Object convertParam(T value, Class<T> type, Type genericType, Annotation[] annotations) {
+        ParamConverter<T> converter = getConverter(type, genericType, annotations);
         if (converter != null) {
             return converter.toString(value);
         } else {
@@ -49,7 +49,7 @@ public abstract class RestClientBase implements Closeable {
 
         if (converterProvider == null) {
             for (ParamConverterProvider provider : paramConverterProviders) {
-                ParamConverter<T> converter = provider.getConverter(type, null, null);
+                ParamConverter<T> converter = provider.getConverter(type, genericType, annotations);
                 if (converter != null) {
                     providerForClass.put(type, provider);
                     return converter;
@@ -57,7 +57,7 @@ public abstract class RestClientBase implements Closeable {
             }
             providerForClass.put(type, NO_PROVIDER);
         } else if (converterProvider != NO_PROVIDER) {
-            return converterProvider.getConverter(type, null, null);
+            return converterProvider.getConverter(type, genericType, annotations);
         }
         return null;
     }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
@@ -8,7 +8,6 @@ import static org.jboss.resteasy.reactive.common.processor.HashUtil.sha1;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -132,9 +131,9 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
             ClassInfo subInterfaceClass, MethodInfo subMethod, MethodInfo rootMethod,
             AssignableResultHandle invocationBuilder, // sub-level
             IndexView index, BuildProducer<GeneratedClassBuildItem> generatedClasses,
-            int methodIndex, int subMethodIndex) {
-        addJavaMethodToContext(subClassCreator, subClinit, subMethodCreator, subInterfaceClass, subMethod,
-                invocationBuilder, subMethodIndex);
+            int methodIndex, int subMethodIndex, FieldDescriptor javaMethodField) {
+
+        addJavaMethodToContext(javaMethodField, subMethodCreator, invocationBuilder);
 
         Map<String, HeaderData> headerFillersByName = new HashMap<>();
         collectHeaderFillers(rootInterfaceClass, rootMethod, headerFillersByName);
@@ -149,10 +148,9 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
     public void forMethod(ClassCreator classCreator, MethodCreator constructor,
             MethodCreator clinit, MethodCreator methodCreator, ClassInfo interfaceClass,
             MethodInfo method, AssignableResultHandle invocationBuilder, IndexView index,
-            BuildProducer<GeneratedClassBuildItem> generatedClasses, int methodIndex) {
+            BuildProducer<GeneratedClassBuildItem> generatedClasses, int methodIndex, FieldDescriptor javaMethodField) {
 
-        addJavaMethodToContext(classCreator, clinit, methodCreator, interfaceClass, method, invocationBuilder,
-                methodIndex);
+        addJavaMethodToContext(javaMethodField, methodCreator, invocationBuilder);
 
         // header filler
 
@@ -244,42 +242,18 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
      * create a field in the stub class to contain (interface) java.lang.reflect.Method corresponding to this method
      * MP Rest Client spec says it has to be in the request context, keeping it in a field we don't have to
      * initialize it on each call
-     * 
-     * @param classCreator client (or sub-resource client) class creator
+     *
+     * @param javaMethodField method reference in a static class field
      * @param methodCreator method for which we put the java.lang.reflect.Method to context (aka this method)
-     * @param interfaceClass class of the interface for this client
-     * @param method jandex counterpart of this method
      * @param invocationBuilder Invocation.Builder in this method
-     * @param methodIndex index of this method
      */
-    private void addJavaMethodToContext(ClassCreator classCreator, MethodCreator clinit, MethodCreator methodCreator,
-            ClassInfo interfaceClass, MethodInfo method, AssignableResultHandle invocationBuilder, int methodIndex) {
-        FieldDescriptor javaMethodField = createJavaMethodField(classCreator, clinit, interfaceClass, method, methodIndex);
+    private void addJavaMethodToContext(FieldDescriptor javaMethodField, MethodCreator methodCreator,
+            AssignableResultHandle invocationBuilder) {
         ResultHandle javaMethod = methodCreator.readStaticField(javaMethodField);
         ResultHandle javaMethodAsObject = methodCreator.checkCast(javaMethod, Object.class);
         methodCreator.assign(invocationBuilder,
                 methodCreator.invokeInterfaceMethod(INVOCATION_BUILDER_PROPERTY_METHOD, invocationBuilder,
                         methodCreator.load(INVOKED_METHOD), javaMethodAsObject));
-    }
-
-    private FieldDescriptor createJavaMethodField(ClassCreator classCreator, MethodCreator clinit,
-            ClassInfo interfaceClass, MethodInfo method, int methodIndex) {
-        ResultHandle interfaceClassHandle = clinit.loadClassFromTCCL(interfaceClass.toString());
-
-        ResultHandle parameterArray = clinit.newArray(Class.class, method.parameters().size());
-        for (int i = 0; i < method.parameters().size(); i++) {
-            String parameterClass = method.parameters().get(i).name().toString();
-            clinit.writeArrayValue(parameterArray, i, clinit.loadClassFromTCCL(parameterClass));
-        }
-
-        ResultHandle javaMethodHandle = clinit.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(Class.class, "getMethod", Method.class, String.class, Class[].class),
-                interfaceClassHandle, clinit.load(method.name()), parameterArray);
-        FieldDescriptor javaMethodField = FieldDescriptor.of(classCreator.getClassName(), "javaMethod" + methodIndex,
-                Method.class);
-        classCreator.getFieldCreator(javaMethodField).setModifiers(Modifier.PRIVATE | Modifier.FINAL | Modifier.STATIC);
-        clinit.writeStaticField(javaMethodField, javaMethodHandle);
-        return javaMethodField;
     }
 
     private void putAllHeaderAnnotations(Map<String, HeaderData> headerMap, ClassInfo interfaceClass,

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/converter/ParamConverterProviderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/converter/ParamConverterProviderTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.rest.client.reactive.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -162,6 +163,14 @@ public class ParamConverterProviderTest {
         @Override
         public <T> javax.ws.rs.ext.ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
                 Annotation[] annotations) {
+            if (genericType == null) {
+                fail("Generic Type cannot be null!");
+            }
+
+            if (annotations == null) {
+                fail("Annotations cannot be null!");
+            }
+
             if (rawType == Param.class) {
                 return (javax.ws.rs.ext.ParamConverter<T>) new javax.ws.rs.ext.ParamConverter<Param>() {
                     @Override

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
@@ -118,6 +118,17 @@ public class ClientCallingResource {
             rc.response().end(greeting);
         });
 
+        router.post("/params/param").handler(rc -> rc.response().putHeader("content-type", MediaType.TEXT_PLAIN)
+                .end(getParam(rc)));
+
+        router.route("/call-params-client-with-param-first").blockingHandler(rc -> {
+            String url = rc.getBody().toString();
+            ParamClient client = RestClientBuilder.newBuilder().baseUri(URI.create(url))
+                    .build(ParamClient.class);
+            String result = client.getParam(Param.FIRST);
+            rc.response().end(result);
+        });
+
         router.route("/rest-response").blockingHandler(rc -> {
             String url = rc.getBody().toString();
             RestResponseClient client = RestClientBuilder.newBuilder().baseUri(URI.create(url))
@@ -164,6 +175,10 @@ public class ClientCallingResource {
             return 1;
         }
         return Integer.parseInt(countQueryParam.get(0));
+    }
+
+    private String getParam(io.vertx.ext.web.RoutingContext rc) {
+        return rc.queryParam("param").get(0);
     }
 
     private void callGet(RoutingContext rc, ClientWithExceptionMapper client) {

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/Param.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/Param.java
@@ -1,0 +1,6 @@
+package io.quarkus.it.rest.client.main;
+
+public enum Param {
+    FIRST,
+    SECOND
+}

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ParamClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ParamClient.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.rest.client.main;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("")
+@RegisterRestClient
+@RegisterProvider(ParamConverter.class)
+public interface ParamClient {
+
+    @POST
+    @Path("/param")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getParam(@QueryParam("param") Param param);
+}

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ParamConverter.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ParamConverter.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.rest.client.main;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+public class ParamConverter implements ParamConverterProvider {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> javax.ws.rs.ext.ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+            Annotation[] annotations) {
+        if (genericType == null || !genericType.equals(Param.class)) {
+            throw new RuntimeException("Wrong generic type in ParamConverter!");
+        }
+
+        if (annotations == null || annotations.length != 1 || !(annotations[0] instanceof QueryParam)) {
+            throw new RuntimeException("Wrong annotations in ParamConverter!");
+        }
+
+        if (rawType == Param.class) {
+            return (javax.ws.rs.ext.ParamConverter<T>) new javax.ws.rs.ext.ParamConverter<Param>() {
+                @Override
+                public Param fromString(String value) {
+                    return null;
+                }
+
+                @Override
+                public String toString(Param value) {
+                    if (value == null) {
+                        return null;
+                    }
+                    switch (value) {
+                        case FIRST:
+                            return "1";
+                        case SECOND:
+                            return "2";
+                        default:
+                            return "unexpected";
+                    }
+                }
+            };
+        }
+        return null;
+    }
+}

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 w-exception-mapper/mp-rest/url=${test.url}
 w-fault-tolerance/mp-rest/url=${test.url}
+io.quarkus.it.rest.client.main.ParamClient/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.multipart.MultipartClient/mp-rest/url=${test.url}

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -31,9 +31,10 @@ public class BasicTest {
     String appleUrl;
     @TestHTTPResource()
     String baseUrl;
-
     @TestHTTPResource("/hello")
     String helloUrl;
+    @TestHTTPResource("/params")
+    String paramsUrl;
 
     @Test
     public void shouldMakeTextRequest() {
@@ -207,6 +208,14 @@ public class BasicTest {
         Assertions.assertTrue(outsideServerFound);
         Assertions.assertTrue(clientFound);
         Assertions.assertTrue(clientServerFound);
+    }
+
+    @Test
+    public void shouldConvertParamFirstToOneUsingCustomConverter() {
+        RestAssured.with().body(paramsUrl).post("/call-params-client-with-param-first")
+                .then()
+                .statusCode(200)
+                .body(equalTo("1"));
     }
 
     private List<Map<String, Object>> getSpans() {


### PR DESCRIPTION
Note that this PR will introduce a performance penalty at load time (first time, when the rest client instance is loaded AND if and only if the rest client methods use param annotations - which is most of the times tho).

What I did was to always generate the `javaMethodX` static fields (before, it was also generated always, but it was done in the implementation MicroProfileRestClientEnricher). 
Plus, apart of the method information, we will also load the annotations and the generic types. This is done at load class time (static init).

Moreover, as I had to move some code from MicroProfileRestClientEnricher to 
JaxrsClientReactiveProcessor, in order to not increase the length of this class JaxrsClientReactiveProcessor, I started moving some code to ClassRestClientContext (which is protected - not available for users)

Fix https://github.com/quarkusio/quarkus/issues/22870