### PR TITLE
Rest-Client-Reactive: Allow FormParams to be used in BeanParams

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanFormParamTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanparam/BeanFormParamTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.rest.client.reactive.beanparam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+
+public class BeanFormParamTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest();
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @Test
+    void shouldPassFormParamsFromBeanParam() {
+        assertThat(formTestClient().postFormParams(new BeanWithFormParams("value1", "value2", Param.SECOND)))
+                .isEqualTo(
+                        "received value1-value2-2");
+    }
+
+    private FormTestClient formTestClient() {
+        return RestClientBuilder.newBuilder().baseUri(baseUri).register(ParamConverter.class).build(FormTestClient.class);
+    }
+
+    @Path("/form")
+    public interface FormTestClient {
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        String postFormParams(@BeanParam BeanWithFormParams beanParam);
+    }
+
+    public static class BeanWithFormParams {
+        private final String param1;
+        private final String param2;
+        private final Param param3;
+
+        public BeanWithFormParams(String param1, String param2, Param param3) {
+            this.param1 = param1;
+            this.param2 = param2;
+            this.param3 = param3;
+        }
+
+        @FormParam("param1")
+        public String getParam1() {
+            return param1;
+        }
+
+        @FormParam("param2")
+        public String getParam2() {
+            return param2;
+        }
+
+        @FormParam("param3")
+        public Param getParam3() {
+            return param3;
+        }
+    }
+
+    @Path("/form")
+    public static class FormTestResource {
+        @POST
+        public String post(@FormParam("param1") String param1, @FormParam("param2") String param2,
+                @FormParam("param3") String param3) {
+            return String.format("received %s-%s-%s", param1, param2, param3);
+        }
+    }
+
+    enum Param {
+        FIRST,
+        SECOND
+    }
+
+    public static class ParamConverter implements ParamConverterProvider {
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> javax.ws.rs.ext.ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+                Annotation[] annotations) {
+            if (rawType == BeanFormParamTest.Param.class) {
+                return (javax.ws.rs.ext.ParamConverter<T>) new javax.ws.rs.ext.ParamConverter<BeanFormParamTest.Param>() {
+                    @Override
+                    public BeanFormParamTest.Param fromString(String value) {
+                        return null;
+                    }
+
+                    @Override
+                    public String toString(BeanFormParamTest.Param value) {
+                        if (value == null) {
+                            return null;
+                        }
+                        switch (value) {
+                            case FIRST:
+                                return "1";
+                            case SECOND:
+                                return "2";
+                            default:
+                                return "unexpected";
+                        }
+                    }
+                };
+            }
+            return null;
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/pom.xml
+++ b/independent-projects/resteasy-reactive/client/processor/pom.xml
@@ -38,23 +38,26 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
 
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParser.java
@@ -2,13 +2,18 @@ package org.jboss.resteasy.reactive.client.processor.beanparam;
 
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.BEAN_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COOKIE_PARAM;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.FORM_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.HEADER_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.PATH_PARAM;
 import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.QUERY_PARAM;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -22,111 +27,89 @@ import org.jboss.resteasy.reactive.common.processor.JandexUtil;
 public class BeanParamParser {
 
     public static List<Item> parse(ClassInfo beanParamClass, IndexView index) {
-        List<Item> resultList = new ArrayList<>();
+        Set<ClassInfo> processedBeanParamClasses = Collections.newSetFromMap(new IdentityHashMap<>());
+        return parseInternal(beanParamClass, index, processedBeanParamClasses);
+    }
 
-        // Parse class tree recursively
-        if (!JandexUtil.DOTNAME_OBJECT.equals(beanParamClass.superName())) {
-            resultList.addAll(parse(index.getClassByName(beanParamClass.superName()), index));
+    private static List<Item> parseInternal(ClassInfo beanParamClass, IndexView index,
+            Set<ClassInfo> processedBeanParamClasses) {
+        if (!processedBeanParamClasses.add(beanParamClass)) {
+            throw new IllegalArgumentException("Cycle detected in BeanParam annotations; already processed class "
+                    + beanParamClass.name());
         }
 
-        Map<DotName, List<AnnotationInstance>> annotations = beanParamClass.annotations();
-        List<AnnotationInstance> queryParams = annotations.get(QUERY_PARAM);
-        if (queryParams != null) {
-            for (AnnotationInstance annotation : queryParams) {
-                AnnotationTarget target = annotation.target();
-                if (target.kind() == AnnotationTarget.Kind.FIELD) {
-                    FieldInfo fieldInfo = target.asField();
-                    resultList.add(new QueryParamItem(annotation.value().asString(),
+        try {
+            List<Item> resultList = new ArrayList<>();
+
+            // Parse class tree recursively
+            if (!JandexUtil.DOTNAME_OBJECT.equals(beanParamClass.superName())) {
+                resultList
+                        .addAll(parseInternal(index.getClassByName(beanParamClass.superName()), index,
+                                processedBeanParamClasses));
+            }
+
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, QUERY_PARAM,
+                    (annotationValue, fieldInfo) -> new QueryParamItem(annotationValue,
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
-                            fieldInfo.type()));
-                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-                    MethodInfo getterMethod = getGetterMethod(beanParamClass, target.asMethod());
-                    resultList.add(new QueryParamItem(annotation.value().asString(),
-                            new GetterExtractor(getterMethod), getterMethod.returnType()));
-                }
-            }
-        }
-        List<AnnotationInstance> beanParams = annotations.get(BEAN_PARAM);
-        if (beanParams != null) {
-            for (AnnotationInstance annotation : beanParams) {
-                AnnotationTarget target = annotation.target();
-                if (target.kind() == AnnotationTarget.Kind.FIELD) {
-                    FieldInfo fieldInfo = target.asField();
-                    Type type = fieldInfo.type();
-                    if (type.kind() == Type.Kind.CLASS) {
-                        List<Item> subBeanParamItems = parse(index.getClassByName(type.asClassType().name()), index);
-                        resultList.add(new BeanParamItem(subBeanParamItems,
-                                new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())));
-                    } else {
-                        throw new IllegalArgumentException("BeanParam annotation used on a field that is not an object: "
-                                + beanParamClass.name() + "." + fieldInfo.name());
-                    }
-                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-                    // this should be getter or setter
-                    MethodInfo methodInfo = target.asMethod();
-                    MethodInfo getter = getGetterMethod(beanParamClass, methodInfo);
-                    Type returnType = getter.returnType();
-                    List<Item> items = parse(index.getClassByName(returnType.name()), index);
-                    resultList.add(new BeanParamItem(items, new GetterExtractor(getter)));
-                }
-            }
-        }
+                            fieldInfo.type()),
+                    (annotationValue, getterMethod) -> new QueryParamItem(annotationValue, new GetterExtractor(getterMethod),
+                            getterMethod.returnType())));
 
-        List<AnnotationInstance> cookieParams = annotations.get(COOKIE_PARAM);
-        if (cookieParams != null) {
-            for (AnnotationInstance annotation : cookieParams) {
-                AnnotationTarget target = annotation.target();
-                if (target.kind() == AnnotationTarget.Kind.FIELD) {
-                    FieldInfo fieldInfo = target.asField();
-                    resultList.add(new CookieParamItem(annotation.value().asString(),
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, BEAN_PARAM,
+                    (annotationValue, fieldInfo) -> {
+                        Type type = fieldInfo.type();
+                        if (type.kind() == Type.Kind.CLASS) {
+                            List<Item> subBeanParamItems = parseInternal(index.getClassByName(type.asClassType().name()), index,
+                                    processedBeanParamClasses);
+                            return new BeanParamItem(subBeanParamItems,
+                                    new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()));
+                        } else {
+                            throw new IllegalArgumentException("BeanParam annotation used on a field that is not an object: "
+                                    + beanParamClass.name() + "." + fieldInfo.name());
+                        }
+                    },
+                    (annotationValue, getterMethod) -> {
+                        Type returnType = getterMethod.returnType();
+                        List<Item> items = parseInternal(index.getClassByName(returnType.name()), index,
+                                processedBeanParamClasses);
+                        return new BeanParamItem(items, new GetterExtractor(getterMethod));
+                    }));
+
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, COOKIE_PARAM,
+                    (annotationValue, fieldInfo) -> new CookieParamItem(annotationValue,
                             new FieldExtractor(null, fieldInfo.name(),
                                     fieldInfo.declaringClass().name().toString()),
-                            fieldInfo.type().name().toString()));
-                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-                    MethodInfo getterMethod = getGetterMethod(beanParamClass, target.asMethod());
-                    resultList.add(new CookieParamItem(annotation.value().asString(),
-                            new GetterExtractor(getterMethod), getterMethod.returnType().name().toString()));
-                }
-            }
-        }
+                            fieldInfo.type().name().toString()),
+                    (annotationValue, getterMethod) -> new CookieParamItem(annotationValue,
+                            new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
-        List<AnnotationInstance> headerParams = annotations.get(HEADER_PARAM);
-        if (headerParams != null) {
-            for (AnnotationInstance headerParamAnnotation : headerParams) {
-                AnnotationTarget target = headerParamAnnotation.target();
-                if (target.kind() == AnnotationTarget.Kind.FIELD) {
-                    FieldInfo fieldInfo = target.asField();
-                    String paramType = fieldInfo.type().name().toString();
-                    resultList.add(new HeaderParamItem(headerParamAnnotation.value().asString(),
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, HEADER_PARAM,
+                    (annotationValue, fieldInfo) -> new HeaderParamItem(annotationValue,
                             new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString()),
-                            paramType));
-                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-                    MethodInfo getterMethod = getGetterMethod(beanParamClass, target.asMethod());
-                    resultList.add(new HeaderParamItem(headerParamAnnotation.value().asString(),
-                            new GetterExtractor(getterMethod), getterMethod.returnType().name().toString()));
-                }
-            }
-        }
+                            fieldInfo.type().name().toString()),
+                    (annotationValue, getterMethod) -> new HeaderParamItem(annotationValue,
+                            new GetterExtractor(getterMethod), getterMethod.returnType().name().toString())));
 
-        List<AnnotationInstance> pathParams = annotations.get(PATH_PARAM);
-        if (pathParams != null) {
-            for (AnnotationInstance pathParamAnnotation : pathParams) {
-                AnnotationTarget target = pathParamAnnotation.target();
-                if (target.kind() == AnnotationTarget.Kind.FIELD) {
-                    FieldInfo fieldInfo = target.asField();
-                    String fieldType = fieldInfo.type().name().toString();
-                    resultList.add(new PathParamItem(pathParamAnnotation.value().asString(), fieldType,
-                            new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())));
-                } else if (target.kind() == AnnotationTarget.Kind.METHOD) {
-                    MethodInfo getterMethod = getGetterMethod(beanParamClass, target.asMethod());
-                    String paramType = getterMethod.returnType().name().toString();
-                    resultList.add(new PathParamItem(pathParamAnnotation.value().asString(), paramType,
-                            new GetterExtractor(getterMethod)));
-                }
-            }
-        }
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, PATH_PARAM,
+                    (annotationValue, fieldInfo) -> new PathParamItem(annotationValue, fieldInfo.type().name().toString(),
+                            new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
+                    (annotationValue, getterMethod) -> new PathParamItem(annotationValue,
+                            getterMethod.returnType().name().toString(),
+                            new GetterExtractor(getterMethod))));
 
-        return resultList;
+            resultList.addAll(paramItemsForFieldsAndMethods(beanParamClass, FORM_PARAM,
+                    (annotationValue, fieldInfo) -> new FormParamItem(annotationValue,
+                            fieldInfo.type().name().toString(),
+                            new FieldExtractor(null, fieldInfo.name(), fieldInfo.declaringClass().name().toString())),
+                    (annotationValue, getterMethod) -> new FormParamItem(annotationValue,
+                            getterMethod.returnType().name().toString(),
+                            new GetterExtractor(getterMethod))));
+
+            return resultList;
+
+        } finally {
+            processedBeanParamClasses.remove(beanParamClass);
+        }
     }
 
     private static MethodInfo getGetterMethod(ClassInfo beanParamClass, MethodInfo methodInfo) {
@@ -148,6 +131,52 @@ public class BeanParamParser {
         return getter;
     }
 
+    private static <T extends Item> List<T> paramItemsForFieldsAndMethods(ClassInfo beanParamClass, DotName parameterType,
+            BiFunction<String, FieldInfo, T> fieldExtractor, BiFunction<String, MethodInfo, T> methodExtractor) {
+        return ParamTypeAnnotations.of(beanParamClass, parameterType).itemsForFieldsAndMethods(fieldExtractor, methodExtractor);
+    }
+
     private BeanParamParser() {
+    }
+
+    private static class ParamTypeAnnotations {
+        private final ClassInfo beanParamClass;
+        private final List<AnnotationInstance> annotations;
+
+        private ParamTypeAnnotations(ClassInfo beanParamClass, DotName parameterType) {
+            this.beanParamClass = beanParamClass;
+
+            List<AnnotationInstance> relevantAnnotations = beanParamClass.annotations().get(parameterType);
+            this.annotations = relevantAnnotations == null
+                    ? Collections.emptyList()
+                    : relevantAnnotations.stream().filter(this::isFieldOrMethodAnnotation).collect(Collectors.toList());
+        }
+
+        private static ParamTypeAnnotations of(ClassInfo beanParamClass, DotName parameterType) {
+            return new ParamTypeAnnotations(beanParamClass, parameterType);
+        }
+
+        private <T extends Item> List<T> itemsForFieldsAndMethods(BiFunction<String, FieldInfo, T> itemFromFieldExtractor,
+                BiFunction<String, MethodInfo, T> itemFromMethodExtractor) {
+            return annotations.stream()
+                    .map(annotation -> toItem(annotation, itemFromFieldExtractor, itemFromMethodExtractor))
+                    .collect(Collectors.toList());
+        }
+
+        private <T extends Item> T toItem(AnnotationInstance annotation,
+                BiFunction<String, FieldInfo, T> itemFromFieldExtractor,
+                BiFunction<String, MethodInfo, T> itemFromMethodExtractor) {
+            String annotationValue = annotation.value() == null ? null : annotation.value().asString();
+
+            return annotation.target().kind() == AnnotationTarget.Kind.FIELD
+                    ? itemFromFieldExtractor.apply(annotationValue, annotation.target().asField())
+                    : itemFromMethodExtractor.apply(annotationValue,
+                            getGetterMethod(beanParamClass, annotation.target().asMethod()));
+        }
+
+        private boolean isFieldOrMethodAnnotation(AnnotationInstance annotation) {
+            return annotation.target().kind() == AnnotationTarget.Kind.FIELD
+                    || annotation.target().kind() == AnnotationTarget.Kind.METHOD;
+        }
     }
 }

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/FormParamItem.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.reactive.client.processor.beanparam;
+
+public class FormParamItem extends Item {
+
+    private final String formParamName;
+    private final String paramType;
+
+    public FormParamItem(String formParamName, String paramType, ValueExtractor valueExtractor) {
+        super(ItemType.FORM_PARAM, valueExtractor);
+        this.formParamName = formParamName;
+        this.paramType = paramType;
+    }
+
+    public String getFormParamName() {
+        return formParamName;
+    }
+
+    public String getParamType() {
+        return paramType;
+    }
+}

--- a/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/ItemType.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/main/java/org/jboss/resteasy/reactive/client/processor/beanparam/ItemType.java
@@ -6,5 +6,6 @@ public enum ItemType {
     COOKIE,
     HEADER_PARAM,
     PATH_PARAM,
+    FORM_PARAM,
     // TODO: more
 }

--- a/independent-projects/resteasy-reactive/client/processor/src/test/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParserTest.java
+++ b/independent-projects/resteasy-reactive/client/processor/src/test/java/org/jboss/resteasy/reactive/client/processor/beanparam/BeanParamParserTest.java
@@ -1,0 +1,106 @@
+package org.jboss.resteasy.reactive.client.processor.beanparam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link BeanParamParser}.
+ */
+public class BeanParamParserTest {
+
+    @Test
+    public void mustRecursivelyParseAllParamTypes() throws IOException {
+        Index index = Index.of(BeanExample.class, BeanExample.InnerBean.class);
+        List<Item> parseResult = BeanParamParser.parse(index.getClassByName(DotName.createSimple(BeanExample.class.getName())),
+                index);
+        assertNotNull(parseResult);
+        parseResult.sort(Comparator.comparing(Item::type));
+
+        assertThat(parseResult).hasSize(4);
+        Iterator<Item> itemIterator = parseResult.iterator();
+
+        assertThatNextItemSatisfies(itemIterator, BeanParamItem.class, item -> {
+            List<Item> beanParamItems = item.items();
+            beanParamItems.sort(Comparator.comparing(Item::type));
+            assertThat(beanParamItems).hasSize(2);
+            Iterator<Item> subItemIterator = beanParamItems.iterator();
+            assertThatNextItemSatisfies(subItemIterator, QueryParamItem.class,
+                    subItem -> assertThat(subItem.name()).isEqualTo("queryParam"));
+            assertThatNextItemSatisfies(subItemIterator, HeaderParamItem.class,
+                    subItem -> assertThat(subItem.getHeaderName()).isEqualTo("headerParam"));
+        });
+
+        assertThatNextItemSatisfies(itemIterator, CookieParamItem.class,
+                subItem -> assertThat(subItem.getCookieName()).isEqualTo("cookieParam"));
+        assertThatNextItemSatisfies(itemIterator, PathParamItem.class,
+                subItem -> assertThat(subItem.getPathParamName()).isEqualTo("pathParam"));
+        assertThatNextItemSatisfies(itemIterator, FormParamItem.class,
+                subItem -> assertThat(subItem.getFormParamName()).isEqualTo("formParam"));
+    }
+
+    @Test
+    public void mustDetectCycleInBeanParamsChain() throws IOException {
+        Index index = Index.of(CyclingBeanParamsExample.class, CyclingBeanParamsExample.InnerBean.class);
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> BeanParamParser.parse(
+                        index.getClassByName(DotName.createSimple(CyclingBeanParamsExample.class.getName())),
+                        index));
+        assertThat(thrown.getMessage()).isEqualTo(
+                "Cycle detected in BeanParam annotations; already processed class " + CyclingBeanParamsExample.class.getName());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Item> void assertThatNextItemSatisfies(Iterator<Item> itemIterator, Class<T> clazz,
+            Consumer<T> condition) {
+        Item nextItem = itemIterator.next();
+        assertThat(nextItem).isInstanceOf(clazz);
+        condition.accept((T) nextItem);
+    }
+
+    private static class BeanExample {
+        @FormParam("formParam")
+        String formParam;
+
+        @CookieParam("cookieParam")
+        String cookieParam;
+
+        @PathParam("pathParam")
+        String pathParam;
+
+        @BeanParam
+        InnerBean innerBean;
+
+        private static class InnerBean {
+            @QueryParam("queryParam")
+            String queryParam;
+
+            @HeaderParam("headerParam")
+            String headerParam;
+        }
+    }
+
+    private static class CyclingBeanParamsExample {
+        @BeanParam
+        InnerBean inner;
+
+        private static class InnerBean {
+            @BeanParam
+            CyclingBeanParamsExample outer;
+        }
+    }
+}


### PR DESCRIPTION
This PR ensures that `@FormParam`s are taken into account when parsing `@BeanParam`s at Rest Client Reactive interface stubs.

@geoand I certainly imagined the change to be simpler. Please take a closer look at the changes regarding the `BeanParamParser`; I tried to simplify the parameter extraction, hopefully easing the way for upcoming additional param type integrations.