### PR TITLE
Bump smallrye-jwt version to 3.3.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -50,7 +50,7 @@
         <smallrye-graphql.version>1.4.2</smallrye-graphql.version>
         <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>3.3.2</smallrye-jwt.version>
+        <smallrye-jwt.version>3.3.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>

--- a/docs/src/main/asciidoc/security-jwt-build.adoc
+++ b/docs/src/main/asciidoc/security-jwt-build.adoc
@@ -311,8 +311,10 @@ SmallRye JWT supports the following properties which can be used to customize th
 |smallrye.jwt.sign.key|none|Key value which will be used to sign the claims when either a no-argument sign() or innerSign() method is called.
 |smallrye.jwt.sign.key.id|`none`|Signing key identifier which is checked only when JWK keys are used.
 |smallrye.jwt.encrypt.key.location|`none`|Location of a public key which will be used to encrypt the claims or inner JWT when a no-argument `encrypt()` method is called.
+|smallrye.jwt.sign.relax-key-validation|false|Relax the validation of the signing keys.
 |smallrye.jwt.encrypt.key|none|Key value which will be used to encrypt the claims or inner JWT when a no-argument encrypt() method is called.
 |smallrye.jwt.encrypt.key.id|`none`|Encryption key identifier which is checked only when JWK keys are used.
+|smallrye.jwt.encrypt.relax-key-validation|false|Relax the validation of the encryption keys.
 |smallrye.jwt.new-token.signature-algorithm|RS256|Signature algorithm. This property will be checked if the JWT signature builder has not already set the signature algorithm.
 |smallrye.jwt.new-token.key-encryption-algorithm|RSA-OAEP|Key encryption algorithm. This property will be checked if the JWT encryption builder has not already set the key encryption algorithm.
 |smallrye.jwt.new-token.content-encryption-algorithm|A256GCM|Content encryption algorithm. This property will be checked if the JWT encryption builder has not already set the content encryption algorithm.

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtParserEndpoint.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtParserEndpoint.java
@@ -1,0 +1,35 @@
+package io.quarkus.jwt.test;
+
+import java.security.PublicKey;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+import io.smallrye.jwt.auth.principal.JWTParser;
+import io.smallrye.jwt.util.KeyUtils;
+
+@Path("/parser")
+@ApplicationScoped
+public class JwtParserEndpoint {
+
+    @Inject
+    JWTParser parser;
+
+    @GET
+    @Path("/name")
+    public String tokenWithoutIssuedAt(@HeaderParam("Authorization") String authorization) throws Exception {
+        String rawToken = authorization.split(" ")[1].trim();
+        return parser.parse(rawToken).getName();
+    }
+
+    @GET
+    @Path("/name-with-key")
+    public String tokenWithoutIssuedAtWithKey(@HeaderParam("Authorization") String authorization) throws Exception {
+        String rawToken = authorization.split(" ")[1].trim();
+        PublicKey key = KeyUtils.readPublicKey("publicKey.pem");
+        return parser.verify(rawToken, key).getName();
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtParserUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/JwtParserUnitTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.jwt.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import java.security.PrivateKey;
+
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.jwt.util.KeyUtils;
+
+public class JwtParserUnitTest {
+    private static Class<?>[] testClasses = {
+            JwtParserEndpoint.class
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsResource("publicKey.pem")
+                    .addAsResource("privateKey.pem")
+                    .addAsResource("applicationJwtParser.properties", "application.properties"));
+
+    @Test
+    public void verifyTokenWithoutIssuedAt() throws Exception {
+        RestAssured.given().auth()
+                .oauth2(generateTokenWithoutIssuedAt())
+                .get("/parser/name")
+                .then().assertThat().statusCode(200)
+                .body(equalTo("alice"));
+    }
+
+    @Test
+    public void verifyTokenWithoutIssuedAtWithKey() throws Exception {
+        RestAssured.given().auth()
+                .oauth2(generateTokenWithoutIssuedAt())
+                .get("/parser/name-with-key")
+                .then().assertThat().statusCode(200)
+                .body(equalTo("alice"));
+    }
+
+    private String generateTokenWithoutIssuedAt() throws Exception {
+        String payload = "{"
+                + "\"sub\":\"alice\","
+                + "\"iss\":\"https://server.example.com\","
+                + "\"exp\":" + (System.currentTimeMillis() / 1000 + 5) + ","
+                + "}";
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(payload);
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+        PrivateKey privateKey = KeyUtils.readPrivateKey("privateKey.pem");
+        jws.setKey(privateKey);
+        return jws.getCompactSerialization();
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtParser.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtParser.properties
@@ -1,0 +1,4 @@
+mp.jwt.verify.publickey.location=/publicKey.pem
+smallrye.jwt.sign.key.location=/privateKey.pem
+smallrye.jwt.time-to-live=-1
+mp.jwt.verify.issuer=https://server.example.com


### PR DESCRIPTION
Bump to 3.3.3 and

Fixes #22969 (Let users relax the key size validation if they have no control over creating them as discussed with @FroMage )
Fixes #22736 (Test that the smallrye-jwt fix related to this discussion is effective)