### PR TITLE
Fix noise about missing `src/main/resources/overrides` in GraphQL TCK module

### DIFF
--- a/tcks/microprofile-graphql/src/main/java/io/quarkus/tck/graphql/TestInterceptor.java
+++ b/tcks/microprofile-graphql/src/main/java/io/quarkus/tck/graphql/TestInterceptor.java
@@ -60,10 +60,12 @@ public class TestInterceptor extends TestListenerAdapter {
     }
 
     private void loadSchemaOverride() {
+        Path folderPath = Paths.get(OVERRIDES);
+        if (!Files.isDirectory(folderPath)) {
+            return;
+        }
         // Get all csv files
-        try {
-            Path folderPath = Paths.get(OVERRIDES);
-            DirectoryStream<Path> overrides = Files.newDirectoryStream(folderPath);
+        try (DirectoryStream<Path> overrides = Files.newDirectoryStream(folderPath)) {
             List<Path> overrideFiles = toListOfPathsForSchema(overrides);
             List<org.eclipse.microprofile.graphql.tck.dynamic.schema.TestData> testDataList = toListOfTestDataForSchema(
                     overrideFiles);
@@ -78,9 +80,11 @@ public class TestInterceptor extends TestListenerAdapter {
     }
 
     private void loadExecutionOverride() {
-        try {
-            Path folderPath = Paths.get(OVERRIDES);
-            DirectoryStream<Path> overrides = Files.newDirectoryStream(folderPath);
+        Path folderPath = Paths.get(OVERRIDES);
+        if (!Files.isDirectory(folderPath)) {
+            return;
+        }
+        try (DirectoryStream<Path> overrides = Files.newDirectoryStream(folderPath)) {
             Set<Path> overrideFolders = toListOfPathsForExecution(overrides);
             executionTestDataMap.putAll(toMapOfTestDataForExecution(overrideFolders));
         } catch (IOException ex) {


### PR DESCRIPTION
Prevents:
```
java.nio.file.NoSuchFileException: src/main/resources/overrides
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:432)
        at java.base/java.nio.file.Files.newDirectoryStream(Files.java:472)
        at io.quarkus.tck.graphql.TestInterceptor.loadSchemaOverride(TestInterceptor.java:66)
```

Led my astray here: https://github.com/quarkusio/quarkus/pull/23089#issuecomment-1019211664

AFAICS, the last overrides file was removed in #17845.