### PR TITLE
Load MockitoConfiguration parent-first to make it work in continuous testing

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2578,6 +2578,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-junit5-mockito-config</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-junit5-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -170,6 +170,7 @@
                         <parentFirstArtifact>io.quarkus:quarkus-class-change-agent</parentFirstArtifact>
                         <parentFirstArtifact>org.jacoco:org.jacoco.agent:runtime</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-gradle-resolver</parentFirstArtifact>
+                        <parentFirstArtifact>io.quarkus:quarkus-junit5-mockito-config</parentFirstArtifact>
 
                         <!-- RestAssured uses groovy, which seems to do some things with soft references that
                         prevent the ClassLoader from being GC'ed, see https://github.com/quarkusio/quarkus/issues/12498 -->

--- a/test-framework/junit5-mockito-config/pom.xml
+++ b/test-framework/junit5-mockito-config/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-junit5-mockito-config</artifactId>
+    <name>Quarkus - Test framework - JUnit 5 - Mockito Config</name>
+    <description>
+        Contains a MockitoConfiguration that has to be loaded parent-first to work in continuous testing.
+        It is separated from junit5-mockito to minimize the blast radius.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-framework/junit5-mockito-config/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/test-framework/junit5-mockito-config/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -4,8 +4,6 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.mockito.stubbing.Answer;
 
-import io.quarkus.test.junit.mockito.internal.MutinyAnswer;
-
 public class MockitoConfiguration extends DefaultMockitoConfiguration {
 
     @SuppressWarnings("unchecked")
@@ -14,7 +12,7 @@ public class MockitoConfiguration extends DefaultMockitoConfiguration {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
             // we need to load it from the TCCL (QuarkusClassLoader) instead of our class loader (JUnit CL)
-            Class<?> mutinyAnswer = cl.loadClass(MutinyAnswer.class.getName());
+            Class<?> mutinyAnswer = cl.loadClass("io.quarkus.test.junit.mockito.internal.MutinyAnswer");
             return (Answer<Object>) mutinyAnswer.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException | SecurityException | IllegalArgumentException | IllegalAccessException
                 | InstantiationException | NoSuchMethodException | InvocationTargetException e) {

--- a/test-framework/junit5-mockito/pom.xml
+++ b/test-framework/junit5-mockito/pom.xml
@@ -18,6 +18,13 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
         </dependency>
+        <!-- Contains the MockitoConfiguration that adds MutinyAnswer as a default answer.
+             The dependency is in this direction so that users don't need to worry about it
+             and only have to add this dependency (quarkus-junit5-mockito), but not ...-config. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito-config</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>

--- a/test-framework/junit5-properties/pom.xml
+++ b/test-framework/junit5-properties/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>quarkus-junit5-properties</artifactId>
     <name>Quarkus - Test Framework - JUnit 5 - Properties</name>
     <description>
-        Contains junit-platform.properties in a "use-excludable" way
+        Contains junit-platform.properties in a "user-excludable" way
         until https://github.com/junit-team/junit5/issues/2794 is available.
     </description>
 

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -28,6 +28,7 @@
         <module>junit5-properties</module>
         <module>junit5</module>
         <module>junit5-mockito</module>
+        <module>junit5-mockito-config</module>
         <module>junit5-vertx</module>
         <module>amazon-lambda</module>
         <module>arquillian</module>


### PR DESCRIPTION
Moves the class to a separate new module to reduce the blast radius.

Fixes #23109

What I don't get is why it works without this in regular testing. So maybe there is another, less ugly fix?

/cc @aloubyansky 