### PR TITLE
Fix NPE when @NativeImageTest is used with PER_CLASS instance creation

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -218,6 +218,7 @@ public class NativeTestExtension
 
     @Override
     public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+        ensureStarted(context);
         if (!failedBoot) {
             doProcessTestInstance(testInstance, context);
         }


### PR DESCRIPTION
Fixes: https://github.com/quarkusio/quarkus/discussions/23122

P.S. This fix is already part of `@QuarkusIntegrationTest`, so no
fix there is needed