### PR TITLE
Show CLI version and useful text with base quarkus command

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Build.java
@@ -14,7 +14,7 @@ import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, showEndOfOptionsDelimiterInUsageHelp = true, header = "Build the current project.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "build", showEndOfOptionsDelimiterInUsageHelp = true, header = "Build the current project.")
 public class Build extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Completion.java
@@ -4,7 +4,7 @@ import picocli.AutoComplete.GenerateCompletion;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "completion", version = "generate-completion "
-        + CommandLine.VERSION, mixinStandardHelpOptions = true, header = "bash/zsh completion:  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})", helpCommand = true, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
+        + CommandLine.VERSION, header = "bash/zsh completion:  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})", helpCommand = true)
 public class Completion extends GenerateCompletion {
 
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/Create.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Create.java
@@ -9,10 +9,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.Unmatched;
 
-@CommandLine.Command(name = "create", sortOptions = false, mixinStandardHelpOptions = false, header = "Create a new project.", subcommands = {
+@CommandLine.Command(name = "create", header = "Create a new project.", subcommands = {
         CreateApp.class,
         CreateCli.class,
-        CreateExtension.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+        CreateExtension.class })
 public class Create implements Callable<Integer> {
 
     @CommandLine.Mixin(name = "output")

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateApp.java
@@ -17,11 +17,11 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "app", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Create a Quarkus application project.", description = "%n"
+@CommandLine.Command(name = "app", header = "Create a Quarkus application project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory", footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
-                + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+                + "%n" })
 public class CreateApp extends BaseCreateCommand {
     @CommandLine.Mixin
     TargetGAVGroup gav = new TargetGAVGroup();

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateCli.java
@@ -17,11 +17,11 @@ import io.quarkus.devtools.project.BuildTool;
 import io.quarkus.devtools.project.codegen.SourceType;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "cli", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Create a Quarkus command-line project.", description = "%n"
+@CommandLine.Command(name = "cli", header = "Create a Quarkus command-line project.", description = "%n"
         + "This command will create a Java project in a new ARTIFACT-ID directory.", footer = { "%n"
                 + "For example (using default values), a new Java project will be created in a 'code-with-quarkus' directory; "
                 + "it will use Maven to build an artifact with GROUP-ID='org.acme', ARTIFACT-ID='code-with-quarkus', and VERSION='1.0.0-SNAPSHOT'."
-                + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+                + "%n" })
 public class CreateCli extends BaseCreateCommand {
     @CommandLine.Mixin
     TargetGAVGroup gav = new TargetGAVGroup();

--- a/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/CreateExtension.java
@@ -18,7 +18,7 @@ import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "extension", sortOptions = false, mixinStandardHelpOptions = false, showDefaultValues = true, header = "Create a Quarkus extension project", description = "%n"
+@CommandLine.Command(name = "extension", header = "Create a Quarkus extension project", description = "%n"
         + "Quarkus extensions are built from multiple modules: runtime, deployment, integration-test and "
         + "docs. This command will generate a Maven multi-module project in a directory called EXTENSION-ID "
         + "by applying naming conventions to the specified EXTENSION-ID.", footer = { "%nDefault Naming conventions%n",
@@ -65,7 +65,7 @@ import picocli.CommandLine;
                 "    artifact:\torg.acme:hello-world-docs:1.0.0-SNAPSHOT",
                 "    name:\tHello World - Documentation",
                 "%nGenerated classes will use 'HelloWorld' as a class name prefix."
-        }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+        })
 public class CreateExtension extends BaseCreateCommand {
 
     @CommandLine.Spec

--- a/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Dev.java
@@ -15,7 +15,7 @@ import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 
-@CommandLine.Command(name = "dev", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in dev (live coding) mode.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "dev", showEndOfOptionsDelimiterInUsageHelp = true, header = "Run the current project in dev (live coding) mode.")
 public class Dev extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.ArgGroup(order = 1, exclusive = false, heading = "%nDev Mode options:%n")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensions.java
@@ -10,11 +10,11 @@ import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.Unmatched;
 
 @CommandLine.Command(name = "extension", aliases = {
-        "ext" }, sortOptions = false, mixinStandardHelpOptions = false, header = "Configure extensions of an existing project.", subcommands = {
+        "ext" }, header = "Configure extensions of an existing project.", subcommands = {
                 ProjectExtensionsList.class,
                 ProjectExtensionsCategories.class,
                 ProjectExtensionsAdd.class,
-                ProjectExtensionsRemove.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
+                ProjectExtensionsRemove.class })
 public class ProjectExtensions implements Callable<Integer> {
 
     @CommandLine.Mixin(name = "output")

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsAdd.java
@@ -11,7 +11,7 @@ import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "add", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Add extension(s) to this project.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "add", header = "Add extension(s) to this project.")
 public class ProjectExtensionsAdd extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsCategories.java
@@ -18,7 +18,7 @@ import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.registry.RegistryResolutionException;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "categories", aliases = "cat", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List extension categories.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "categories", aliases = "cat", header = "List extension categories.")
 public class ProjectExtensionsCategories extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsList.java
@@ -18,14 +18,14 @@ import io.quarkus.devtools.project.QuarkusProjectHelper;
 import io.quarkus.registry.RegistryResolutionException;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", aliases = "ls", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List platforms and extensions. ", footer = {
+@CommandLine.Command(name = "list", aliases = "ls", header = "List platforms and extensions. ", footer = {
         "%nList modes:%n",
         "(relative). Active when invoked within a project unless an explicit release is specified. " +
                 "The current project configuration will determine what extensions are listed, " +
                 "with installed (available) extensions listed by default.%n",
         "(absolute). Active when invoked outside of a project or when an explicit release is specified. " +
                 "All extensions for the specified release will be listed. " +
-                "The CLI release will be used if this command is invoked outside of a project and no other release is specified.%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+                "The CLI release will be used if this command is invoked outside of a project and no other release is specified.%n" })
 public class ProjectExtensionsList extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/ProjectExtensionsRemove.java
@@ -11,7 +11,7 @@ import io.quarkus.cli.common.RunModeOption;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "remove", aliases = "rm", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Remove extension(s) from this project.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+@CommandLine.Command(name = "remove", aliases = "rm", header = "Remove extension(s) from this project.")
 public class ProjectExtensionsRemove extends BaseBuildCommand implements Callable<Integer> {
 
     @CommandLine.Mixin

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -58,7 +58,23 @@ public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        output.info("%n@|bold Quarkus CLI|@ version %s", Version.clientVersion());
+        output.info("");
+        output.info("Create Quarkus projects with Maven, Gradle, or JBang.");
+        output.info("Manage extensions and source registries.");
+        output.info("");
+        output.info("Create: @|bold quarkus create|@");
+        output.info("@|italic Iterate|@: @|bold quarkus dev|@");
+        output.info("Build and test: @|bold quarkus build|@");
+        output.info("");
+        output.info("Find more information at https://quarkus.io");
+        output.info("If you have questions, check https://github.com/quarkusio/quarkus/discussions");
+
         spec.commandLine().usage(output.out());
+
+        output.info("");
+        output.info("Use \"quarkus <command> --help\" for more information about a given command.");
+
         return spec.exitCodeOnUsageHelp();
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
+import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.runtime.QuarkusApplication;
@@ -18,20 +19,25 @@ import picocli.CommandLine.IParameterExceptionHandler;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.UsageMessageSpec;
 import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.UnmatchedArgumentException;
 
-@CommandLine.Command(name = "quarkus", versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = true, subcommands = {
+@CommandLine.Command(name = "quarkus", subcommands = {
         Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Version.class,
-        Completion.class }, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+        Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     static {
         System.setProperty("picocli.endofoptions.description", "End of command line options.");
-        // Change default short option to display version from "-V" to "-v":
-        System.setProperty("picocli.version.name.0", "-v");
     }
 
     @Inject
     CommandLine.IFactory factory;
+
+    @CommandLine.Mixin
+    protected HelpOption helpOption;
+
+    @CommandLine.Option(names = { "-v", "--version" }, versionHelp = true, description = "Print version information and exit.")
+    public boolean showVersion;
 
     @CommandLine.Mixin(name = "output")
     OutputOptionMixin output;

--- a/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Registry.java
@@ -8,10 +8,10 @@ import io.quarkus.cli.common.OutputOptionMixin;
 import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
 
-@CommandLine.Command(name = "registry", sortOptions = false, mixinStandardHelpOptions = false, header = "Configure Quarkus registry client", subcommands = {
+@CommandLine.Command(name = "registry", header = "Configure Quarkus registry client", subcommands = {
         RegistryListCommand.class,
         RegistryAddCommand.class,
-        RegistryRemoveCommand.class }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+        RegistryRemoveCommand.class })
 public class Registry implements Callable<Integer> {
 
     @CommandLine.Mixin(name = "output")

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryAddCommand.java
@@ -10,8 +10,8 @@ import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "add", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Add a Quarkus extension registry", description = "%n"
-        + "This command will add a Quarkus extension registry to the registry client configuration unless it's already present.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "add", header = "Add a Quarkus extension registry", description = "%n"
+        + "This command will add a Quarkus extension registry to the registry client configuration unless it's already present.")
 public class RegistryAddCommand extends BaseRegistryCommand {
 
     @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to add to the registry client configuration%n"

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryListCommand.java
@@ -9,8 +9,8 @@ import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "list", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "List enabled Quarkus registries", description = "%n"
-        + "This command will list currently enabled Quarkus extension registries.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "list", header = "List enabled Quarkus registries", description = "%n"
+        + "This command will list currently enabled Quarkus extension registries.")
 public class RegistryListCommand extends BaseRegistryCommand {
 
     @CommandLine.Option(names = {

--- a/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/RegistryRemoveCommand.java
@@ -10,8 +10,8 @@ import io.quarkus.registry.config.RegistriesConfig;
 import io.quarkus.registry.config.RegistryConfig;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "remove", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Remove a Quarkus extension registry", description = "%n"
-        + "This command will remove a Quarkus extension registry from the registry client configuration.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "remove", header = "Remove a Quarkus extension registry", description = "%n"
+        + "This command will remove a Quarkus extension registry from the registry client configuration.")
 public class RegistryRemoveCommand extends BaseRegistryCommand {
 
     @CommandLine.Parameters(arity = "1..*", split = ",", paramLabel = "REGISTRY-ID[,REGISTRY-ID]", description = "Registry ID to remove from the registry client configuration%n"

--- a/devtools/cli/src/main/java/io/quarkus/cli/Version.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Version.java
@@ -14,7 +14,7 @@ import io.smallrye.common.classloader.ClassPathUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
-@CommandLine.Command(name = "version", sortOptions = false, header = "Display version information.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n")
+@CommandLine.Command(name = "version", header = "Display version information.")
 public class Version implements CommandLine.IVersionProvider, Callable<Integer> {
 
     private static String version;

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -1,9 +1,10 @@
 package io.quarkus.cli;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -24,11 +25,12 @@ public class CliHelpTest {
     public void testCommandHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot);
-        Assertions.assertEquals(result.stdout, result2.stdout, "Invoking the base command should show usage help");
-        CliDriver.println("-- same as above\n\n");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+        assertThat(result2.stdout).contains(result.stdout);
     }
 
     @Test
@@ -36,7 +38,7 @@ public class CliHelpTest {
     public void testCreateHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -44,7 +46,7 @@ public class CliHelpTest {
     public void testCreateAppHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -52,7 +54,7 @@ public class CliHelpTest {
     public void testCreateCliHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "cli", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -60,7 +62,7 @@ public class CliHelpTest {
     public void testCreateExtensionHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "extension", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -68,7 +70,7 @@ public class CliHelpTest {
     public void testBuildHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "build", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -76,7 +78,7 @@ public class CliHelpTest {
     public void testDevHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "dev", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -84,10 +86,10 @@ public class CliHelpTest {
     public void testExtHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "extension", "--help");
-        Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
+        assertThat(result.stdout).isEqualTo(result2.stdout);
         CliDriver.println("-- same as above\n\n");
     }
 
@@ -96,10 +98,10 @@ public class CliHelpTest {
     public void testExtCatHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "cat", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "ext", "cat", "--help");
-        Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
+        assertThat(result.stdout).isEqualTo(result2.stdout);
         CliDriver.println("-- same as above\n\n");
     }
 
@@ -108,10 +110,10 @@ public class CliHelpTest {
     public void testExtListHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "ls", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "ext", "list", "--help");
-        Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
+        assertThat(result.stdout).isEqualTo(result2.stdout);
         CliDriver.println("-- same as above\n\n");
     }
 
@@ -120,7 +122,7 @@ public class CliHelpTest {
     public void testExtAddHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "add", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -128,10 +130,10 @@ public class CliHelpTest {
     public void testExtRemoveHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "ext", "rm", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
 
         CliDriver.Result result2 = CliDriver.execute(workspaceRoot, "ext", "remove", "--help");
-        Assertions.assertEquals(result.stdout, result2.stdout, "Help output for command aliases should be the same.");
+        assertThat(result.stdout).isEqualTo(result2.stdout);
         CliDriver.println("-- same as above\n\n");
     }
 
@@ -140,7 +142,7 @@ public class CliHelpTest {
     public void testRegistryHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -148,7 +150,7 @@ public class CliHelpTest {
     public void testRegistryListHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "list", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -156,7 +158,7 @@ public class CliHelpTest {
     public void testRegistryAddHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "add", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -164,7 +166,7 @@ public class CliHelpTest {
     public void testRegistryRemoveHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "registry", "rm", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Order(60)
@@ -172,7 +174,7 @@ public class CliHelpTest {
     public void testGenerateCompletionHelp() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "completion", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test
@@ -180,7 +182,7 @@ public class CliHelpTest {
     public void testCommandVersion() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "version", "--help");
         result.echoSystemOut();
-        Assertions.assertTrue(result.stdout.contains("Usage"), "Help output should show usage instructions");
+        assertThat(result.stdout).contains("Usage");
     }
 
     @Test


### PR DESCRIPTION
Resolves #23067

- CLI: Inherit headings and options from root command -- cleanup.
- CLI: Add version/intro text to quarkus command
