### PR TITLE
Allow to disable contextual error messages in reactive rest client

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -103,11 +103,18 @@ public class RestClientsConfig {
     public Long connectTimeout;
 
     /**
-     * Global default read timeout for automatically generated REST Clients. The attribute specifies a timeout
+     * Global default read timeout for automatically generated REST clients. The attribute specifies a timeout
      * in milliseconds that a client should wait for a response from the remote endpoint.
      */
     @ConfigItem(defaultValue = "30000", defaultValueDocumentation = "30000 ms")
     public Long readTimeout;
+
+    /**
+     * If true, the reactive REST clients will not provide additional contextual information (like REST client class and method
+     * names) when exception occurs during a client invocation.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean disableContextualErrorMessages;
 
     public RestClientConfig getClientConfig(String configKey) {
         if (configKey == null) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesConfigTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesConfigTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.rest.client.reactive;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.configuration.EchoResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ContextualErrorMessagesConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(EchoResource.class, HelloClient2.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.rest-client.hello2.url=http://localhost:${quarkus.http.test-port:8081}/wrong-url\n"
+                                    + "quarkus.rest-client.disable-contextual-error-messages=true\n"),
+                            "application.properties"));
+
+    @RestClient
+    HelloClient2 client;
+
+    /**
+     * Contextual error messages can be disabled via configuration.
+     */
+    @Test
+    void errorMessageDoesNotContainContext() {
+        try {
+            client.echo("Bob");
+            Assertions.fail("An exception was expected.");
+        } catch (ClientWebApplicationException e) {
+            Assertions.assertThat(e.getMessage()).doesNotContain("io.quarkus.rest.client.reactive.HelloClient2#echo");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ContextualErrorMessagesTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.rest.client.reactive;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.configuration.EchoResource;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ContextualErrorMessagesTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(EchoResource.class, HelloClient2.class)
+                    .addAsResource(new StringAsset(
+                            "quarkus.rest-client.hello2.url=http://localhost:${quarkus.http.test-port:8081}/wrong-url"),
+                            "application.properties"));
+
+    @RestClient
+    HelloClient2 client;
+
+    /**
+     * By default, contextual messages should be enabled.
+     */
+    @Test
+    void errorMessageContainsContext() {
+        try {
+            client.echo("Bob");
+            Assertions.fail("An exception was expected.");
+        } catch (ClientWebApplicationException e) {
+            Assertions.assertThat(e.getMessage()).contains("io.quarkus.rest.client.reactive.HelloClient2#echo");
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -104,6 +104,9 @@ public class RestClientCDIDelegateBuilder<T> {
         if ((headers != null) && !headers.isEmpty()) {
             builder.property(QuarkusRestClientProperties.STATIC_HEADERS, headers);
         }
+
+        builder.property(QuarkusRestClientProperties.DISABLE_CONTEXTUAL_ERROR_MESSAGES,
+                configRoot.disableContextualErrorMessages);
     }
 
     private void configureProxy(RestClientBuilderImpl builder) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -42,4 +42,10 @@ public class QuarkusRestClientProperties {
      */
     public static final String NAME = "io.quarkus.rest.client.name";
 
+    /**
+     * Set to true to prevent the client from providing additional contextual information (REST client class and method names)
+     * when exception happens during a client invocation.
+     */
+    public static final String DISABLE_CONTEXTUAL_ERROR_MESSAGES = "io.quarkus.rest.client.disable-contextual-error-messages";
+
 }


### PR DESCRIPTION
* By default, contextual error messages are enabled.
* Can be disabled by setting configuration property  `quarkus.rest-client.disable-contextual-error-messages=true`, or a  system property of the same name.

Fixes https://github.com/quarkusio/quarkus/issues/22777.