### PR TITLE
Add initializer method validation to ArC

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Annotations.java
@@ -106,6 +106,22 @@ public final class Annotations {
     }
 
     /**
+     *
+     * @param beanDeployment
+     * @param method
+     * @return collection of annotations present on all parameters of given method
+     */
+    public static Set<AnnotationInstance> getParameterAnnotations(BeanDeployment beanDeployment, MethodInfo method) {
+        Set<AnnotationInstance> annotations = new HashSet<>();
+        for (AnnotationInstance annotation : beanDeployment.getAnnotations(method)) {
+            if (Kind.METHOD_PARAMETER == annotation.target().kind()) {
+                annotations.add(annotation);
+            }
+        }
+        return annotations;
+    }
+
+    /**
      * 
      * @param beanDeployment
      * @param method

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -613,6 +613,10 @@ public class BeanDeployment {
         return annotationStore.getAnnotation(target, name);
     }
 
+    public boolean hasAnnotation(AnnotationTarget target, DotName name) {
+        return annotationStore.hasAnnotation(target, name);
+    }
+
     Map<ScopeInfo, Function<MethodCreator, ResultHandle>> getCustomContexts() {
         return customContexts;
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedAsyncObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedAsyncObserverTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InitializerMethodMarkedAsyncObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(MyBean.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+        @Inject
+        void observeAsync(@ObservesAsync Object ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedDisposerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedDisposerTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InitializerMethodMarkedDisposerTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Producers.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @ApplicationScoped
+    static class Producers {
+        @Produces
+        @ApplicationScoped
+        MyBean produce() {
+            return new MyBean();
+        }
+
+        @Inject
+        void dispose(@Disposes MyBean bean) {
+        }
+    }
+
+    static class MyBean {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedObserverTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InitializerMethodMarkedObserverTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(MyBean.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @ApplicationScoped
+    static class MyBean {
+        @Inject
+        void observe(@Observes Object ignored) {
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedProducerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/validation/InitializerMethodMarkedProducerTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InitializerMethodMarkedProducerTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Producers.class).shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        Throwable error = container.getFailure();
+        assertNotNull(error);
+        assertTrue(error instanceof DefinitionException);
+    }
+
+    @ApplicationScoped
+    static class Producers {
+        @Inject
+        @Produces
+        @ApplicationScoped
+        MyBean produce() {
+            return new MyBean();
+        }
+    }
+
+    static class MyBean {
+    }
+}


### PR DESCRIPTION
Fixes #23174

In addition to #23174, this PR also adds other validations the CDI specification prescribes for initializer methods (i.e., not just producers, but also disposers and observers).