### PR TITLE
Reduce clutter in logs of the Vertx HTTP tests

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UnhandledExceptionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/UnhandledExceptionTest.java
@@ -252,7 +252,11 @@ public class UnhandledExceptionTest {
             router.route("/unhandled-exception").handler(new Handler<RoutingContext>() {
                 @Override
                 public void handle(RoutingContext event) {
-                    throw new RuntimeException("Simulated failure");
+                    RuntimeException exception = new RuntimeException("Simulated failure");
+                    StackTraceElement[] cutDownStackTrace = new StackTraceElement[1];
+                    cutDownStackTrace[0] = exception.getStackTrace()[0];
+                    exception.setStackTrace(cutDownStackTrace);
+                    throw exception;
                 }
             });
         }


### PR DESCRIPTION
I came across large stacktraces of these simulated failures
when trying to debug a real failure and their prominence
made locating the real cause difficult