### PR TITLE
Upgrade to Hibernate Search 6.1.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -93,7 +93,7 @@
         <hibernate-orm.version>5.6.4.Final</hibernate-orm.version>
         <hibernate-reactive.version>1.1.2.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.1.Final</hibernate-validator.version>
-        <hibernate-search.version>6.1.0.CR1</hibernate-search.version>
+        <hibernate-search.version>6.1.0.Final</hibernate-search.version>
         <narayana.version>5.12.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.14</agroal.version>

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.java
@@ -121,7 +121,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * When analysis is configured both through an analysis configurer and these custom settings, the behavior is undefined;
          * it should not be relied upon.
          *
-         * See https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/#_custom_index_settings[this section of the reference documentation]
+         * See https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#backend-elasticsearch-configuration-index-settings[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet
@@ -138,7 +138,7 @@ public class HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit {
          * The file does not need to (and generally shouldn't) contain the full mapping:
          * Hibernate Search will automatically inject missing properties (index fields) in the given mapping.
          *
-         * See https://docs.jboss.org/hibernate/search/6.1/reference/en-US/html_single/#_custom_index_mapping[this section of the reference documentation]
+         * See https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#backend-elasticsearch-mapping-custom[this section of the reference documentation]
          * for more information.
          *
          * @asciidoclet


### PR DESCRIPTION
No release announcement yet, but nothing interesting changed since 6.1.0.CR1.