### PR TITLE
Properly support aggregate part items when using @MultipartForm

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/FormData.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.jackson.deployment.test;
 
 import java.util.Map;
 
+import javax.ws.rs.FormParam;
 import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.reactive.PartType;
@@ -14,9 +15,21 @@ public class FormData {
     @PartType(MediaType.APPLICATION_JSON)
     public Map<String, Object> map;
 
+    @FormParam("names")
+    @PartType(MediaType.TEXT_PLAIN)
+    public String[] names;
+
+    @RestForm
+    @PartType(MediaType.TEXT_PLAIN)
+    public int[] numbers;
+
     @RestForm
     @PartType(MediaType.APPLICATION_JSON)
     public Person person;
+
+    @RestForm
+    @PartType(MediaType.APPLICATION_JSON)
+    public Person[] persons;
 
     @RestForm("htmlFile")
     private FileUpload htmlPart;

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartResource.java
@@ -27,6 +27,9 @@ public class MultipartResource {
         result.put("htmlFileSize", formData.getHtmlPart().size());
         result.put("htmlFilePath", formData.getHtmlPart().uploadedFile().toAbsolutePath().toString());
         result.put("htmlFileContentType", formData.getHtmlPart().contentType());
+        result.put("names", formData.names);
+        result.put("numbers", formData.numbers);
+        result.put("persons", formData.persons);
         return result;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/MultipartTest.java
@@ -46,6 +46,12 @@ public class MultipartTest {
                                 "}")
                 .multiPart("person", "{\"first\": \"Bob\", \"last\": \"Builder\"}", "application/json")
                 .multiPart("htmlFile", HTML_FILE, "text/html")
+                .multiPart("names", "name1")
+                .multiPart("names", "name2")
+                .multiPart("numbers", 1)
+                .multiPart("numbers", 2)
+                .multiPart("persons", "{\"first\": \"First1\", \"last\": \"Last1\"}", "application/json")
+                .multiPart("persons", "{\"first\": \"First2\", \"last\": \"Last2\"}", "application/json")
                 .accept("application/json")
                 .when()
                 .post("/multipart/json")
@@ -57,6 +63,14 @@ public class MultipartTest {
                 .body("person.last", equalTo("Builder"))
                 .body("htmlFileSize", equalTo(Files.readAllBytes(HTML_FILE.toPath()).length))
                 .body("htmlFilePath", not(equalTo(HTML_FILE.toPath().toAbsolutePath().toString())))
-                .body("htmlFileContentType", equalTo("text/html"));
+                .body("htmlFileContentType", equalTo("text/html"))
+                .body("names[0]", equalTo("name1"))
+                .body("names[1]", equalTo("name2"))
+                .body("numbers[0]", equalTo(1))
+                .body("numbers[1]", equalTo(2))
+                .body("persons[0].first", equalTo("First1"))
+                .body("persons[0].last", equalTo("Last1"))
+                .body("persons[1].first", equalTo("First2"))
+                .body("persons[1].last", equalTo("Last2"));
     }
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/multipart/MultipartPopulatorGenerator.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/multipart/MultipartPopulatorGenerator.java
@@ -15,6 +15,8 @@ import io.quarkus.gizmo.ResultHandle;
 import java.io.File;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import javax.ws.rs.core.MediaType;
 import org.jboss.jandex.AnnotationInstance;
@@ -350,6 +352,65 @@ public final class MultipartPopulatorGenerator {
                                             "getFormParameter", Object.class, String.class, boolean.class, boolean.class),
                                             rrCtxHandle,
                                             formAttrNameHandle, populate.load(true), populate.load(false)));
+                        } else if (fieldType.kind() == Type.Kind.ARRAY) {
+                            // Media Type static field
+                            FieldDescriptor mediaTypeField = cc.getFieldCreator(field.name() + "_mediaType", MediaType.class)
+                                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC).getFieldDescriptor();
+                            clinit.writeStaticField(mediaTypeField, clinit.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(MediaType.class, "valueOf", MediaType.class, String.class),
+                                    clinit.load(partType)));
+
+                            // Component Type static field
+                            Type componentType = fieldType.asArrayType().component();
+                            ClassInfo componentClassInfo = index.getClassByName(componentType.name());
+                            FieldDescriptor genericComponentTypeField = cc
+                                    .getFieldCreator(field.name() + "_genericComponentType", java.lang.reflect.Type.class)
+                                    .setModifiers(Modifier.PRIVATE | Modifier.STATIC).getFieldDescriptor();
+                            TypeArgMapper componentTypeArgMapper = new TypeArgMapper(componentClassInfo, index);
+                            ResultHandle genericComponentTypeHandle = clinit.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(TypeSignatureParser.class, "parse",
+                                            java.lang.reflect.Type.class, String.class),
+                                    clinit.load(AsmUtil.getSignature(componentType, componentTypeArgMapper)));
+                            clinit.writeStaticField(genericComponentTypeField, genericComponentTypeHandle);
+
+                            ResultHandle formCollectionValueHandle = populate.invokeVirtualMethod(
+                                    MethodDescriptor.ofMethod(ResteasyReactiveRequestContext.class,
+                                            "getFormParameter", Object.class, String.class, boolean.class, boolean.class),
+                                    rrCtxHandle,
+                                    formAttrNameHandle, populate.load(false), populate.load(false));
+
+                            ResultHandle arrayResultHandle = populate.newArray(componentType.toString(),
+                                    populate.invokeInterfaceMethod(MethodDescriptor.ofMethod(
+                                            Collection.class, "size", int.class), formCollectionValueHandle));
+
+                            ResultHandle formValueIterator = populate.invokeInterfaceMethod(
+                                    MethodDescriptor.ofMethod(Collection.class, "iterator", Iterator.class),
+                                    populate.checkCast(formCollectionValueHandle, Collection.class));
+                            AssignableResultHandle indexArray = populate.createVariable(int.class);
+                            populate.assign(indexArray, populate.load(0));
+
+                            BytecodeCreator loopIterator = populate.whileLoop(c -> c.ifTrue(
+                                    c.invokeInterfaceMethod(
+                                            MethodDescriptor.ofMethod(Iterator.class, "hasNext", boolean.class),
+                                            formValueIterator)))
+                                    .block();
+                            ResultHandle formValueAsString = loopIterator.invokeInterfaceMethod(
+                                    MethodDescriptor.ofMethod(Iterator.class, "next", Object.class), formValueIterator);
+                            loopIterator.writeArrayValue(arrayResultHandle, indexArray, loopIterator.invokeStaticMethod(
+                                    MethodDescriptor.ofMethod(MultipartSupport.class, "convertFormAttribute", Object.class,
+                                            String.class,
+                                            Class.class,
+                                            java.lang.reflect.Type.class, MediaType.class,
+                                            ResteasyReactiveRequestContext.class, String.class),
+                                    loopIterator.checkCast(formValueAsString, String.class),
+                                    loopIterator.loadClass(componentType.toString()),
+                                    loopIterator.readStaticField(genericComponentTypeField),
+                                    loopIterator.readStaticField(mediaTypeField),
+                                    rrCtxHandle, formAttrNameHandle));
+
+                            loopIterator.assign(indexArray, loopIterator.increment(indexArray));
+
+                            populate.assign(resultHandle, arrayResultHandle);
                         } else {
                             // we need to use the field type and the media type to locate a MessageBodyReader
 


### PR DESCRIPTION
When using standard HTML select[multiple]:
```html
<form ...>
    <select name="values" multiple ...>
    </select>
</form>
```

The request that HTML is doing to the server looks like: `values=X&values=Y&...` (if X and Y was both selected).

The problem happens in the server side, when using resteasy reactive:

```
@POST
    @Consumes(MediaType.MULTIPART_FORM_DATA)
    @Path("/endpoint")
    public String greeting(@MultipartForm FormData formData) {
        // formData.values fails!
        // ...
    }
```

And FormData:

```
public class FormData {

    @RestParam
    @PartType(MediaType.TEXT_PLAIN)
    public String[] values;
}
```

This fails with a serialization error (it cannot find a serializer that works with arrays). (Related stackoverflow question: https://stackoverflow.com/questions/67151539/multiple-file-upload-using-quarkus-and-resteasy - for Resteasy classic).

However, we could make it work with arrays to support the above scenario with the changes part of this PR.

Note that I did check that it works fine with complex objects like Person.