### PR TITLE
Qute - implement timeout for async rendering methods

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -519,6 +519,35 @@ If a part of an expression resolves to a `CompletionStage`, the resolution conti
 For example, if there is an expression `{foo.size}` and `foo` resolves to `CompletionStage<List<String>>` then `size` is resolved against the completed result, i.e. `List<String>`.
 If a part of an expression resolves to a `Uni`, a `CompletionStage` is first created from `Uni` using `Uni#subscribeAsCompletionStage()` and then evaluated as described above.
 
+It can happen that a `CompletionStage` never completes or a `Uni` emits no item/failure. 
+In this case, the rendering methods (such as `TemplateInstance#render()` and `TemplateInstance#createUni()`) fail after a specific timeout.
+The timeout can be specified as a template instance `timeout` attribute.
+If no `timeout` attribute is set the global rendering timeout is used.
+
+TIP: In Quarkus, the default timeout can be set via the `io.quarkus.qute.timeout` configuration property. If using Qute standalone then the `EngineBuilder#timeout()` method can be used.
+
+NOTE: In previous versions, only the `TemplateInstance#render()` method honored the timeout attribute. You can use the `io.quarkus.qute.useAsyncTimeout=false` config property to preserve the old behavior and take care of the timeout yourself, for example `templateInstance.createUtni().ifNoItem().after(Duration.ofMillis(500)).fail()`.
+
+===== How to Identify a Problematic Part of the Template
+
+It's not easy to find the problematic part of a template when a timeout occurs.
+You can set the `TRACE` level for the logger `io.quarkus.qute.nodeResolve` and try analyze the log output afterwards.
+
+.`application.properties` Example
+[source,properties]
+----
+quarkus.log.category."io.quarkus.qute.nodeResolve".min-level=TRACE
+quarkus.log.category."io.quarkus.qute.nodeResolve".level=TRACE
+----
+
+You should see the following pair of log messages for every expression and section used in a template:
+----
+TRACE [io.qua.qut.nodeResolve] Resolve {name} started: Template hello.html at line 8
+TRACE [io.qua.qut.nodeResolve] Resolve {name} completed: Template hello.html at line 8
+----
+
+If a `completed` log message is missing then you have a good candidate to explore.
+
 ==== Missing Properties
 
 It can happen that an expression may not be evaluated at runtime.

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -188,6 +188,9 @@ public class EngineProducer {
             builder.addTemplateInstanceInitializer(createInitializer(initializerClass));
         }
 
+        builder.timeout(runtimeConfig.timeout);
+        builder.useAsyncTimeout(runtimeConfig.useAsyncTimeout);
+
         engine = builder.build();
 
         // Load discovered templates

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/QuteRuntimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateInstance;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -39,6 +40,19 @@ public class QuteRuntimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean strictRendering;
+
+    /**
+     * The global rendering timeout in milliseconds. It is used if no {@code timeout} template instance attribute is set.
+     */
+    @ConfigItem(defaultValue = "10000")
+    public long timeout;
+
+    /**
+     * If set to {@code true} then the timeout should also be used for asynchronous rendering methods, such as
+     * {@link TemplateInstance#createUni()} and {@link TemplateInstance#renderAsync()}.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useAsyncTimeout;
 
     public enum PropertyNotFoundStrategy {
         /**

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -109,7 +109,7 @@ public class TemplateProducer {
 
         @Override
         public TemplateInstance instance() {
-            return new InjectableTemplateInstanceImpl(path, variants, engine);
+            return new InjectableTemplateInstanceImpl();
         }
 
         @Override
@@ -127,76 +127,78 @@ public class TemplateProducer {
             throw new UnsupportedOperationException("Injected templates do not support getVariant()");
         }
 
-    }
-
-    static class InjectableTemplateInstanceImpl extends TemplateInstanceBase {
-
-        private final String path;
-        private final TemplateVariants variants;
-        private final Engine engine;
-
-        public InjectableTemplateInstanceImpl(String path, TemplateVariants variants, Engine engine) {
-            this.path = path;
-            this.variants = variants;
-            this.engine = engine;
-            if (variants != null) {
-                setAttribute(TemplateInstance.VARIANTS, List.copyOf(variants.variantToTemplate.keySet()));
-            }
-        }
-
         @Override
-        public String render() {
-            return templateInstance().render();
+        public String toString() {
+            return "Injectable template [path=" + path + "]";
         }
 
-        @Override
-        public CompletionStage<String> renderAsync() {
-            return templateInstance().renderAsync();
-        }
+        class InjectableTemplateInstanceImpl extends TemplateInstanceBase {
 
-        @Override
-        public Multi<String> createMulti() {
-            return templateInstance().createMulti();
-        }
-
-        @Override
-        public Uni<String> createUni() {
-            return templateInstance().createUni();
-        }
-
-        @Override
-        public CompletionStage<Void> consume(Consumer<String> consumer) {
-            return templateInstance().consume(consumer);
-        }
-
-        private TemplateInstance templateInstance() {
-            TemplateInstance instance = template().instance();
-            if (dataMap != null) {
-                dataMap.forEach(instance::data);
-            } else if (data != null) {
-                instance.data(data);
-            }
-            if (!attributes.isEmpty()) {
-                attributes.forEach(instance::setAttribute);
-            }
-            return instance;
-        }
-
-        private Template template() {
-            Variant selected = (Variant) getAttribute(TemplateInstance.SELECTED_VARIANT);
-            String id;
-            if (selected != null) {
-                // Currently, we only use the content type to match the template
-                id = variants.getId(selected.getContentType());
-                if (id == null) {
-                    id = variants.defaultTemplate;
+            InjectableTemplateInstanceImpl() {
+                if (variants != null) {
+                    setAttribute(TemplateInstance.VARIANTS, List.copyOf(variants.variantToTemplate.keySet()));
                 }
-            } else {
-                id = path;
             }
-            return engine.getTemplate(id);
-        }
 
+            @Override
+            public String render() {
+                return templateInstance().render();
+            }
+
+            @Override
+            public CompletionStage<String> renderAsync() {
+                return templateInstance().renderAsync();
+            }
+
+            @Override
+            public Multi<String> createMulti() {
+                return templateInstance().createMulti();
+            }
+
+            @Override
+            public Uni<String> createUni() {
+                return templateInstance().createUni();
+            }
+
+            @Override
+            public CompletionStage<Void> consume(Consumer<String> consumer) {
+                return templateInstance().consume(consumer);
+            }
+
+            @Override
+            protected Engine engine() {
+                return engine;
+            }
+
+            private TemplateInstance templateInstance() {
+                TemplateInstance instance = template().instance();
+                if (dataMap != null) {
+                    dataMap.forEach(instance::data);
+                } else if (data != null) {
+                    instance.data(data);
+                }
+                if (!attributes.isEmpty()) {
+                    attributes.forEach(instance::setAttribute);
+                }
+                return instance;
+            }
+
+            private Template template() {
+                Variant selected = (Variant) getAttribute(TemplateInstance.SELECTED_VARIANT);
+                String id;
+                if (selected != null) {
+                    // Currently, we only use the content type to match the template
+                    id = variants.getId(selected.getContentType());
+                    if (id == null) {
+                        id = variants.defaultTemplate;
+                    }
+                } else {
+                    id = path;
+                }
+                return engine.getTemplate(id);
+            }
+
+        }
     }
 
     static class TemplateVariants {
@@ -220,7 +222,7 @@ public class TemplateProducer {
 
         @Override
         public String toString() {
-            return "TemplateVariants{default=" + defaultTemplate + ", variants=" + variantToTemplate + "}";
+            return "TemplateVariants [default=" + defaultTemplate + ", variants=" + variantToTemplate + "]";
         }
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Engine.java
@@ -140,4 +140,18 @@ public interface Engine {
      */
     public List<TemplateInstance.Initializer> getTemplateInstanceInitializers();
 
+    /**
+     * The global rendering timeout in milliseconds. It is used if no {@code timeout} instance attribute is set.
+     * 
+     * @return the global rendering timeout
+     * @see TemplateInstance#TIMEOUT
+     */
+    public long getTimeout();
+
+    /**
+     * 
+     * @return {@code true} if the timeout should also used for asynchronous rendering methods
+     */
+    public boolean useAsyncTimeout();
+
 }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineBuilder.java
@@ -35,6 +35,8 @@ public final class EngineBuilder {
     boolean removeStandaloneLines;
     boolean strictRendering;
     String iterationMetadataPrefix;
+    long timeout;
+    boolean useAsyncTimeout;
 
     EngineBuilder() {
         this.sectionHelperFactories = new HashMap<>();
@@ -47,6 +49,8 @@ public final class EngineBuilder {
         this.strictRendering = true;
         this.removeStandaloneLines = true;
         this.iterationMetadataPrefix = LoopSectionHelper.Factory.ITERATION_METADATA_PREFIX_ALIAS_UNDERSCORE;
+        this.timeout = 10_000;
+        this.useAsyncTimeout = true;
     }
 
     public EngineBuilder addSectionHelper(SectionHelperFactory<?> factory) {
@@ -243,6 +247,29 @@ public final class EngineBuilder {
                     + "] is not a valid iteration metadata prefix. The value can only consist of alphanumeric characters and underscores.");
         }
         this.iterationMetadataPrefix = prefix;
+        return this;
+    }
+
+    /**
+     * The global rendering timeout.
+     * 
+     * @param value Timeout in milliseconds
+     * @return self
+     */
+    public EngineBuilder timeout(long value) {
+        this.timeout = value;
+        return this;
+    }
+
+    /**
+     * If set to {@code true} the timeout (either global or set via the {@code timeout} instance attribute) is also used for
+     * asynchronous rendering methods, such as {@link TemplateInstance#createUni()} and {@link TemplateInstance#renderAsync()}.
+     * 
+     * @param value
+     * @return self
+     */
+    public EngineBuilder useAsyncTimeout(boolean value) {
+        this.useAsyncTimeout = value;
         return this;
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EngineImpl.java
@@ -34,6 +34,8 @@ class EngineImpl implements Engine {
     private final List<ParserHook> parserHooks;
     final List<TemplateInstance.Initializer> initializers;
     final boolean removeStandaloneLines;
+    private final long timeout;
+    private final boolean useAsyncTimeout;
 
     EngineImpl(EngineBuilder builder) {
         this.sectionHelperFactories = Map.copyOf(builder.sectionHelperFactories);
@@ -48,6 +50,8 @@ class EngineImpl implements Engine {
         this.parserHooks = ImmutableList.copyOf(builder.parserHooks);
         this.removeStandaloneLines = builder.removeStandaloneLines;
         this.initializers = ImmutableList.copyOf(builder.initializers);
+        this.timeout = builder.timeout;
+        this.useAsyncTimeout = builder.useAsyncTimeout;
     }
 
     @Override
@@ -130,6 +134,16 @@ class EngineImpl implements Engine {
     @Override
     public List<Initializer> getTemplateInstanceInitializers() {
         return initializers;
+    }
+
+    @Override
+    public long getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public boolean useAsyncTimeout() {
+        return useAsyncTimeout;
     }
 
     String generateId() {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionNode.java
@@ -4,29 +4,40 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.jboss.logging.Logger;
 
 /**
  * This node holds a single expression such as {@code foo.bar}.
  */
 class ExpressionNode implements TemplateNode, Function<Object, CompletionStage<ResultNode>> {
 
+    private static final Logger LOG = Logger.getLogger("io.quarkus.qute.nodeResolve");
+
     final ExpressionImpl expression;
     private final Engine engine;
     private final Origin origin;
+    private final boolean traceLevel;
 
     public ExpressionNode(ExpressionImpl expression, Engine engine, Origin origin) {
         this.expression = expression;
         this.engine = engine;
         this.origin = origin;
+        this.traceLevel = LOG.isTraceEnabled();
     }
 
     @Override
     public CompletionStage<ResultNode> resolve(ResolutionContext context) {
+        if (traceLevel) {
+            LOG.tracef("Resolve {%s} started: %s", expression.toOriginalString(), expression.getOrigin());
+        }
         return context.evaluate(expression).thenCompose(this);
     }
 
     @Override
     public CompletionStage<ResultNode> apply(Object result) {
+        if (traceLevel) {
+            LOG.tracef("Resolve {%s} completed: %s", expression.toOriginalString(), expression.getOrigin());
+        }
         if (result instanceof ResultNode) {
             return CompletedStage.of((ResultNode) result);
         } else if (result instanceof CompletionStage) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -35,7 +35,7 @@ import org.jboss.logging.Logger;
 class Parser implements Function<String, Expression>, ParserHelper {
 
     private static final Logger LOGGER = Logger.getLogger(Parser.class);
-    private static final String ROOT_HELPER_NAME = "$root";
+    static final String ROOT_HELPER_NAME = "$root";
 
     static final Origin SYNTHETIC_ORIGIN = new OriginImpl(0, 0, 0, "<<synthetic>>", "<<synthetic>>", Optional.empty());
 
@@ -163,7 +163,7 @@ class Parser implements Function<String, Expression>, ParserHelper {
             if (!root.helperName.equals(ROOT_HELPER_NAME)) {
                 throw parserError("unterminated section [" + root.helperName + "] detected");
             }
-            TemplateImpl template = new TemplateImpl(engine, root.build(), generatedId, variant);
+            TemplateImpl template = new TemplateImpl(engine, root.build(), templateId, generatedId, variant);
 
             Set<TemplateNode> nodesToRemove = Collections.emptySet();
             if (hasLineSeparator && engine.removeStandaloneLines) {

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
@@ -7,11 +7,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.jboss.logging.Logger;
 
 /**
  * Section node.
  */
 class SectionNode implements TemplateNode {
+
+    private static final Logger LOG = Logger.getLogger("io.quarkus.qute.nodeResolve");
 
     static Builder builder(String helperName, Origin origin, Function<String, Expression> expressionFun,
             Function<String, TemplateException> errorFun) {
@@ -22,16 +25,25 @@ class SectionNode implements TemplateNode {
     final List<SectionBlock> blocks;
     private final SectionHelper helper;
     private final Origin origin;
+    private final boolean traceLevel;
 
     SectionNode(String name, List<SectionBlock> blocks, SectionHelper helper, Origin origin) {
         this.name = name;
         this.blocks = blocks;
         this.helper = helper;
         this.origin = origin;
+        this.traceLevel = LOG.isTraceEnabled();
     }
 
     @Override
     public CompletionStage<ResultNode> resolve(ResolutionContext context) {
+        if (traceLevel && !Parser.ROOT_HELPER_NAME.equals(name)) {
+            LOG.tracef("Resolve {#%s} started: %s", name, origin);
+            return helper.resolve(new SectionResolutionContextImpl(context)).thenApply(r -> {
+                LOG.tracef("Resolve {#%s} completed: %s", name, origin);
+                return r;
+            });
+        }
         return helper.resolve(new SectionResolutionContextImpl(context));
     }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateException.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateException.java
@@ -20,6 +20,10 @@ public class TemplateException extends RuntimeException {
         this(origin, message, null);
     }
 
+    public TemplateException(String message, Throwable cause) {
+        this(null, message, cause);
+    }
+
     public TemplateException(Origin origin, String message, Throwable cause) {
         super(message, cause);
         this.origin = origin;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstance.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstance.java
@@ -14,6 +14,8 @@ public interface TemplateInstance {
 
     /**
      * Attribute key - the timeout for {@link #render()} in milliseconds.
+     * 
+     * @see #getTimeout()
      */
     String TIMEOUT = "timeout";
 
@@ -103,6 +105,13 @@ public interface TemplateInstance {
      * @return a completion stage that is completed once the rendering finished
      */
     CompletionStage<Void> consume(Consumer<String> consumer);
+
+    /**
+     * 
+     * @return the timeout
+     * @see TemplateInstance#TIMEOUT
+     */
+    long getTimeout();
 
     /**
      * This component can be used to initialize a template instance, i.e. the data and attributes.

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
@@ -3,8 +3,11 @@ package io.quarkus.qute;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 public abstract class TemplateInstanceBase implements TemplateInstance {
+
+    private static final Logger LOG = Logger.getLogger(TemplateInstanceBase.class);
 
     static final String DATA_MAP_KEY = "io.quarkus.qute.dataMap";
     static final Map<String, Object> EMPTY_DATA_MAP = Collections.singletonMap(DATA_MAP_KEY, true);
@@ -54,6 +57,25 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
             return Mapper.wrap(dataMap);
         }
         return EMPTY_DATA_MAP;
+    }
+
+    protected abstract Engine engine();
+
+    @Override
+    public long getTimeout() {
+        Object t = getAttribute(TemplateInstance.TIMEOUT);
+        if (t != null) {
+            if (t instanceof Long) {
+                return ((Long) t).longValue();
+            } else {
+                try {
+                    return Long.parseLong(t.toString());
+                } catch (NumberFormatException e) {
+                    LOG.warnf("Invalid timeout value set for " + toString() + ": " + t);
+                }
+            }
+        }
+        return engine().getTimeout();
     }
 
 }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/MutinyTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/MutinyTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.qute;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -62,6 +63,19 @@ public class MutinyTest {
         Uni<Object> fooUni = Uni.createFrom().item("FOO");
         Uni<List<String>> itemsUni = Uni.createFrom().item(() -> Arrays.asList("foo", "bar", "baz"));
         assertEquals("foo::1.foo,2.bar,3.baz", template.data("foo", fooUni, "items", itemsUni).render());
+    }
+
+    @Test
+    public void testUniFailure() {
+        Engine engine = Engine.builder().addDefaults().addValueResolver(new ReflectionValueResolver()).build();
+        Template template = engine.parse("{foo.toLowerCase}");
+        Uni<String> fooUni = Uni.createFrom().item(() -> {
+            throw new IllegalStateException("Foo!");
+        });
+        assertThatIllegalStateException()
+                .isThrownBy(() -> template.data("foo", fooUni).render())
+                .withMessage("Foo!");
+
     }
 
     private void assertMulti(Multi<String> multi, String expected) throws InterruptedException {

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NodeResolveTraceLoggingTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NodeResolveTraceLoggingTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.qute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+public class NodeResolveTraceLoggingTest {
+
+    @Test
+    public void testTraceLog() {
+        Logger root = Logger.getLogger("");
+        TestHandler handler = new TestHandler();
+        root.addHandler(handler);
+        Level previousLevel = root.getLevel();
+        setLevel(root, Level.FINEST);
+
+        Engine engine = Engine.builder().addDefaults().timeout(200).build();
+
+        assertEquals("Hello world!", engine.parse("Hello {name}!", null, "hello").data("name", "world").render());
+        List<LogRecord> records = handler.records;
+        assertEquals(2, records.size());
+        assertEquals("Resolve {name} started: Template hello at line 1", records.get(0).getMessage());
+        assertEquals("Resolve {name} completed: Template hello at line 1", records.get(1).getMessage());
+        records.clear();
+
+        try {
+            engine.parse("{foo}", null, "foo").data("foo", new CompletableFuture<>()).render();
+            fail();
+        } catch (TemplateException expected) {
+        }
+        assertEquals(1, records.size());
+        assertEquals("Resolve {foo} started: Template foo at line 1", records.get(0).getMessage());
+        records.clear();
+
+        assertEquals("Hello world!", engine.parse("Hello {#if true}world{/if}!", null, "helloIf").render());
+        assertEquals(2, records.size());
+        assertEquals("Resolve {#if} started: Template helloIf at line 1", records.get(0).getMessage());
+        assertEquals("Resolve {#if} completed: Template helloIf at line 1", records.get(1).getMessage());
+        records.clear();
+
+        try {
+            engine.parse("{#if foo}{/if}", null, "fooIf").data("foo", new CompletableFuture<>()).render();
+            fail();
+        } catch (TemplateException expected) {
+        }
+        assertEquals(1, records.size());
+        assertEquals("Resolve {#if} started: Template fooIf at line 1", records.get(0).getMessage());
+        records.clear();
+
+        try {
+            engine.parse("{#if true}{foo}{/if}", null, "fooIf").data("foo", new CompletableFuture<>()).render();
+            fail();
+        } catch (TemplateException expected) {
+        }
+        assertEquals(2, records.size());
+        assertEquals("Resolve {#if} started: Template fooIf at line 1", records.get(0).getMessage());
+        assertEquals("Resolve {foo} started: Template fooIf at line 1", records.get(1).getMessage());
+        records.clear();
+
+        setLevel(root, previousLevel);
+    }
+
+    static void setLevel(Logger logger, Level level) {
+        logger.setLevel(level);
+        for (Handler handler : logger.getHandlers()) {
+            handler.setLevel(level);
+        }
+    }
+
+    static class TestHandler extends Handler {
+
+        final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLoggerName().equals("io.quarkus.qute.nodeResolve")) {
+                records.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+
+    }
+
+}

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/TimeoutTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/TimeoutTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.qute;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.smallrye.mutiny.Uni;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+public class TimeoutTest {
+
+    @Test
+    public void testTimeout() {
+        Engine engine = Engine.builder().addDefaults().timeout(100).build();
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(() -> engine.parse("{foo}").data("foo", new CompletableFuture<>())
+                        // Invalid timeout is ignored
+                        .setAttribute("timeout", "bar")
+                        .render())
+                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occured");
+
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(
+                        () -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).createUni().await().indefinitely())
+                .withMessage("Template 2 [generatedId=2] rendering timeout [100ms] occured");
+
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(
+                        () -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).renderAsync().toCompletableFuture()
+                                .get());
+
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(
+                        () -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).consume(s -> {
+                        }).toCompletableFuture()
+                                .get());
+    }
+
+    @Test
+    public void testTimeoutAttribute() {
+        Engine engine = Engine.builder().addDefaults().build();
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(() -> engine.parse("{foo}").data("foo", new CompletableFuture<>()).setAttribute("timeout", 300)
+                        .render())
+                .withMessage("Template 1 [generatedId=1] rendering timeout [300ms] occured");
+    }
+
+    @Test
+    public void testUniNoItemOrFailure() {
+        Engine engine = Engine.builder().addDefaults().timeout(100).build();
+        Template template = engine.parse("{foo.toLowerCase}");
+        Uni<String> fooUni = Uni.createFrom().completionStage(new CompletableFuture<>());
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(() -> template.data("foo", fooUni).render())
+                .withMessage("Template 1 [generatedId=1] rendering timeout [100ms] occured");
+    }
+
+}


### PR DESCRIPTION
- introduce the "io.quarkus.qute.timeout" config property
- improve the test coverage
- ensure the JAX-RS response filters use the timeout as well
- add TRACE logging to help to identify problematic parts of the
template when a timeout occurs