### PR TITLE
Add default serialVersionUID to serializable classes in bootstrap model

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -27,6 +27,8 @@ import io.quarkus.paths.PathList;
  */
 public class DevModeContext implements Serializable {
 
+    private static final long serialVersionUID = 4688502145533897982L;
+
     public static final CompilationUnit EMPTY_COMPILATION_UNIT = new CompilationUnit(PathList.of(), null, null, null);
 
     public static final String ENABLE_PREVIEW_FLAG = "--enable-preview";
@@ -238,6 +240,8 @@ public class DevModeContext implements Serializable {
 
     public static class ModuleInfo implements Serializable {
 
+        private static final long serialVersionUID = -1376678003747618410L;
+
         private final ArtifactKey appArtifactKey;
         private final String name;
         private final String projectDirectory;
@@ -404,6 +408,9 @@ public class DevModeContext implements Serializable {
     }
 
     public static class CompilationUnit implements Serializable {
+
+        private static final long serialVersionUID = -511238068393954948L;
+
         private PathCollection sourcePaths;
         private final String classesPath;
         private final PathCollection resourcePaths;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifact.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifact.java
@@ -14,6 +14,8 @@ import java.nio.file.Path;
  */
 public class AppArtifact extends AppArtifactCoords implements ResolvedDependency, Serializable {
 
+    private static final long serialVersionUID = -6226544163467103712L;
+
     protected PathsCollection paths;
     private final WorkspaceModule module;
     private final String scope;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactCoords.java
@@ -13,6 +13,8 @@ import java.util.Objects;
  */
 public class AppArtifactCoords implements ArtifactCoords, Serializable {
 
+    private static final long serialVersionUID = -4401898149727779844L;
+
     public static final String TYPE_JAR = "jar";
     public static final String TYPE_POM = "pom";
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppArtifactKey.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
  */
 public class AppArtifactKey implements ArtifactKey, Serializable {
 
+    private static final long serialVersionUID = -6758193261385541101L;
+
     public static AppArtifactKey fromString(String str) {
         return new AppArtifactKey(split(str, new String[4], str.length()));
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppDependency.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 
 public class AppDependency implements ResolvedDependency, Serializable {
 
+    private static final long serialVersionUID = 7030281544498286020L;
+
     private final AppArtifact artifact;
     private final String scope;
     private int flags;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
@@ -26,6 +26,8 @@ import org.jboss.logging.Logger;
 @Deprecated
 public class AppModel implements ApplicationModel, Serializable {
 
+    private static final long serialVersionUID = 6728602422991848950L;
+
     private static final Logger log = Logger.getLogger(AppModel.class);
 
     private final AppArtifact appArtifact;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityContract.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityContract.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 
 public class CapabilityContract implements ExtensionCapabilities, Serializable {
 
+    private static final long serialVersionUID = -2817736967526011849L;
+
     public static CapabilityContract providesCapabilities(String extension, String commaSeparatedList) {
         final List<String> list = Arrays.asList(commaSeparatedList.split("\\s*,\\s*"));
         for (String provided : list) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/DefaultApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/DefaultApplicationModel.java
@@ -9,6 +9,8 @@ import java.util.Set;
 
 public class DefaultApplicationModel implements ApplicationModel, Serializable {
 
+    private static final long serialVersionUID = -3878782344578748234L;
+
     private final ResolvedDependency appArtifact;
     private final List<ResolvedDependency> dependencies;
     private final PlatformImports platformImports;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/MutableJarApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/MutableJarApplicationModel.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
  */
 public class MutableJarApplicationModel implements Serializable {
 
+    private static final long serialVersionUID = 2046278141713688084L;
+
     private final String baseName;
     private final SerializedDep appArtifact;
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PathsCollection.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PathsCollection.java
@@ -15,6 +15,8 @@ import java.util.List;
 
 public class PathsCollection implements PathCollection, Serializable {
 
+    private static final long serialVersionUID = -7214825505580070033L;
+
     public static PathsCollection from(Iterable<Path> paths) {
         final List<Path> list = new ArrayList<>();
         paths.forEach(list::add);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformImportsImpl.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 
 public class PlatformImportsImpl implements PlatformImports, Serializable {
 
+    private static final long serialVersionUID = -1722573527738064746L;
     public static final String PROPERTY_PREFIX = "platform.release-info@";
 
     public static final char PLATFORM_KEY_STREAM_SEPARATOR = '$';
@@ -212,6 +213,8 @@ public class PlatformImportsImpl implements PlatformImports, Serializable {
     }
 
     private static class PlatformImport implements Serializable {
+
+        private static final long serialVersionUID = -400741166176498944L;
         boolean descriptorFound;
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformInfo.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformInfo.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public class PlatformInfo implements Serializable {
 
+    private static final long serialVersionUID = 7143227956636416934L;
+
     private final String key;
     private final List<PlatformStreamInfo> streams = new ArrayList<>(1); // most of the time there will be only one
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformReleaseInfo.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformReleaseInfo.java
@@ -12,6 +12,7 @@ import java.util.List;
  */
 public class PlatformReleaseInfo implements Serializable {
 
+    private static final long serialVersionUID = 7751600738849301644L;
     private final String platformKey;
     private final String stream;
     private final String version;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformStreamInfo.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PlatformStreamInfo.java
@@ -12,6 +12,8 @@ import java.util.function.Supplier;
 
 public class PlatformStreamInfo implements Serializable {
 
+    private static final long serialVersionUID = 7472307823974997268L;
+
     private final String id;
     private final Map<String, PlatformReleaseInfo> releases = new HashMap<>();
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/ModelParameterImpl.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/gradle/impl/ModelParameterImpl.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 
 public class ModelParameterImpl implements ModelParameter, Serializable {
 
+    private static final long serialVersionUID = 4617775770506785059L;
+
     private String mode;
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultArtifactSources.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultArtifactSources.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 
 public class DefaultArtifactSources implements ArtifactSources, Serializable {
 
+    private static final long serialVersionUID = 2053702489268820757L;
+
     private final String classifier;
     private final Collection<SourceDir> sources;
     private final Collection<SourceDir> resources;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultSourceDir.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultSourceDir.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 
 public class DefaultSourceDir implements SourceDir, Serializable {
 
+    private static final long serialVersionUID = 6544177650615687691L;
     private final PathTree srcTree;
     private final PathTree outputTree;
     private final Map<Object, Object> data;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
 
+    private static final long serialVersionUID = 6906903256002107806L;
+
     public static final String MAIN = "";
     public static final String TEST = "tests";
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 public class ArtifactDependency extends GACTV implements Dependency, Serializable {
 
+    private static final long serialVersionUID = 5669341172899612719L;
+
     public static ArtifactDependency of(String groupId, String artifactId, String version) {
         return new ArtifactDependency(groupId, artifactId, null, ArtifactCoords.TYPE_JAR, version);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 public class GACT implements ArtifactKey, Serializable {
 
+    private static final long serialVersionUID = 2860156541775021365L;
+
     public static GACT fromString(String str) {
         return new GACT(split(str, new String[4], str.length()));
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 public class GACTV implements ArtifactCoords, Serializable {
 
+    private static final long serialVersionUID = -8362130311897578173L;
+
     public static GACTV fromString(String str) {
         return new GACTV(split(str, new String[5]));
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GAV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GAV.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 
 public class GAV implements WorkspaceModuleId, Serializable {
 
+    private static final long serialVersionUID = -1110768961345248967L;
+
     private final String groupId;
     private final String artifactId;
     private final String version;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedArtifactDependency.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 
 public class ResolvedArtifactDependency extends ArtifactDependency implements ResolvableDependency, Serializable {
 
+    private static final long serialVersionUID = 4038042391733012566L;
+
     private PathCollection paths;
     private WorkspaceModule module;
     private volatile transient PathTree contentTree;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
 
 public class DirectoryPathTree extends PathTreeWithManifest implements OpenPathTree, Serializable {
 
+    private static final long serialVersionUID = 2255956884896445059L;
+
     private Path dir;
     private PathFilter pathFilter;
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathFilter.java
@@ -10,6 +10,8 @@ import java.util.regex.Pattern;
 
 public class PathFilter implements Serializable {
 
+    private static final long serialVersionUID = -5712472676677054175L;
+
     public static boolean isVisible(PathFilter filter, String path) {
         if (filter == null) {
             return true;

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathList.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathList.java
@@ -14,6 +14,8 @@ import java.util.Objects;
 
 public class PathList implements PathCollection, Serializable {
 
+    private static final long serialVersionUID = 4972894992642525297L;
+
     public static PathList from(Iterable<Path> paths) {
         final List<Path> list = new ArrayList<>();
         paths.forEach(list::add);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AdditionalDependency.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/AdditionalDependency.java
@@ -17,6 +17,8 @@ import java.nio.file.Path;
  */
 public class AdditionalDependency implements Serializable {
 
+    private static final long serialVersionUID = -6987195473010677257L;
+
     /**
      * The path to the application archive
      */

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 public class ConfiguredClassLoading implements Serializable {
 
+    private static final long serialVersionUID = 8458420778153976864L;
+
     public final Set<ArtifactKey> parentFirstArtifacts;
     public final Set<ArtifactKey> reloadableArtifacts;
     public final Set<ArtifactKey> removedArtifacts;

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
  */
 public class CuratedApplication implements Serializable, AutoCloseable {
 
+    private static final long serialVersionUID = 7816596453653911149L;
+
     private static final String AUGMENTOR = "io.quarkus.runner.bootstrap.AugmentActionImpl";
 
     /**

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -40,6 +40,8 @@ import java.util.Set;
  */
 public class QuarkusBootstrap implements Serializable {
 
+    private static final long serialVersionUID = -3400622859354530408L;
+
     /**
      * The root of the application, where the application classes live.
      */

--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusModelBuildAction.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusModelBuildAction.java
@@ -7,6 +7,9 @@ import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 
 public class QuarkusModelBuildAction implements BuildAction<ApplicationModel>, Serializable {
+
+    private static final long serialVersionUID = 9152408068581769671L;
+
     private final String mode;
 
     public QuarkusModelBuildAction(String mode) {


### PR DESCRIPTION
`java.io.ObjectStreamClass#computeDefaultSUID` was called for each class to be serializied if no serialVersionUID  was specified.
This method does a bit of reflection though, which can easily be prevented by adding the uids to the app bootstrap model classes.

related to #21552