### PR TITLE
Fix `serialization` flag handling in `ReflectiveClassBuildItem.MultiBuildItem`

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ReflectiveClassBuildItem.java
@@ -192,12 +192,13 @@ public final class ReflectiveClassBuildItem extends MultiBuildItem {
         }
 
         public Builder serialization(boolean serialize) {
-            this.serialization = serialization;
+            this.serialization = serialize;
             return this;
         }
 
         public ReflectiveClassBuildItem build() {
-            return new ReflectiveClassBuildItem(constructors, methods, fields, finalFieldsWritable, weak, className);
+            return new ReflectiveClassBuildItem(constructors, methods, fields, finalFieldsWritable, weak, serialization,
+                    className);
         }
     }
 }


### PR DESCRIPTION
Stumbled upon this while reviewing https://github.com/quarkiverse/quarkus-cxf/pull/347 because Eclipse showed a warning.

Broken since the very beginning, AFAICS: #15380