### PR TITLE
Explicitly define the alternative port 55680 in OpenTelemetry collector configuration file in OpenTelemetry guide

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -135,6 +135,11 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: otel-collector:4317
+  otlp/2:
+    protocols:
+      grpc:
+        endpoint: otel-collector:55680
 
 exporters:
   logging:
@@ -153,7 +158,7 @@ service:
   extensions: [health_check]
   pipelines:
     traces:
-      receivers: [otlp]
+      receivers: [otlp,otlp/2]
       processors: [batch]
       exporters: [jaeger]
 


### PR DESCRIPTION
When I run the OpenTelemetry guide in https://quarkus.io/version/main/guides/opentelemetry, more specifically, configuring the OTLP gRPC endpoint via JVM arguments with the alternative port `55680` via command `./mvnw compile quarkus:dev -Djvm.args="-Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680"`

I can see this error:

`
2022-01-27 17:35:28,399 SEVERE [io.ope.exp.otl.int.grp.DefaultGrpcExporter] (grpc-default-executor-1) Failed to export spans. Server is UNAVAILABLE. Make sure your collector is running and reachable from this network. Full error message:UNAVAILABLE: io exception`

Although `OTLP gRPC receiver alternative port 55680` is defined in `docker-compose.yml`, It turns out that the `otel-collector-config.yaml` is not receiving from that alternative port `55680`. This change just explicitly define that alternative port `55680` in otlp receivers.