### PR TITLE
Fix openshift deployment related issues

### DIFF
--- a/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
+++ b/extensions/container-image/container-image-buildpack/deployment/src/main/java/io/quarkus/container/image/buildpack/deployment/BuildpackProcessor.java
@@ -78,6 +78,7 @@ public class BuildpackProcessor {
             return;
         }
 
+        log.info("Starting (local) container image build for jar using builpack.");
         String targetImageName = runBuildpackBuild(buildpackConfig, containerImage, containerImageConfig, pushRequest,
                 outputTarget, false /* isNative */);
 
@@ -109,6 +110,7 @@ public class BuildpackProcessor {
                     "The native binary produced by the build is not a Linux binary and therefore cannot be used in a Linux container image. Consider adding \"quarkus.native.container-build=true\" to your configuration");
         }
 
+        log.info("Starting (local) container image build for native binary using buildpack.");
         String targetImageName = runBuildpackBuild(buildpackConfig, containerImage, containerImageConfig, pushRequest,
                 outputTarget, true /* isNative */);
 

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -99,7 +99,7 @@ public class DockerProcessor {
                             dockerFileBaseInformation.get().getBaseImage()));
         }
 
-        log.info("Building docker image for jar.");
+        log.info("Starting (local) container image build for jar using docker.");
 
         ImageIdReader reader = new ImageIdReader();
         String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImageInfo, out, reader,
@@ -143,7 +143,7 @@ public class DockerProcessor {
                     "The native binary produced by the build is not a Linux binary and therefore cannot be used in a Linux container image. Consider adding \"quarkus.native.container-build=true\" to your configuration");
         }
 
-        log.info("Starting docker image build");
+        log.info("Starting (local) container image build for native binary using docker.");
 
         ImageIdReader reader = new ImageIdReader();
         String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImage, out, reader, true,

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -157,6 +157,7 @@ public class JibProcessor {
         setUser(jibConfig, jibContainerBuilder);
         setPlatforms(jibConfig, jibContainerBuilder);
         handleExtraFiles(outputTarget, jibContainerBuilder);
+        log.info("Starting (local) container image build for jar using jib.");
         JibContainer container = containerize(containerImageConfig, jibConfig, containerImage, jibContainerBuilder,
                 pushRequest.isPresent());
         writeOutputFiles(container, jibConfig, outputTarget);
@@ -195,6 +196,8 @@ public class JibProcessor {
         setUser(jibConfig, jibContainerBuilder);
         setPlatforms(jibConfig, jibContainerBuilder);
         handleExtraFiles(outputTarget, jibContainerBuilder);
+
+        log.info("Starting (local) container image build for native binary using jib.");
         JibContainer container = containerize(containerImageConfig, jibConfig, containerImage, jibContainerBuilder,
                 pushRequest.isPresent());
         writeOutputFiles(container, jibConfig, outputTarget);
@@ -221,7 +224,6 @@ public class JibProcessor {
             previousContextStorageSysProp = System.setProperty(OPENTELEMETRY_CONTEXT_CONTEXT_STORAGE_PROVIDER_SYS_PROP,
                     "default");
 
-            log.info("Starting container image build");
             JibContainer container = jibContainerBuilder.containerize(containerizer);
             log.infof("%s container image %s (%s)\n",
                     containerImageConfig.isPushExplicitlyEnabled() ? "Pushed" : "Created",

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -247,9 +247,8 @@ public class OpenshiftProcessor {
         }
 
         String namespace = Optional.ofNullable(kubernetesClient.getClient().getNamespace()).orElse("default");
-        LOG.info("Performing openshift binary build with jar on server: " + kubernetesClient.getClient().getMasterUrl()
-                + " in namespace:" + namespace + ".");
-
+        LOG.info("Starting (in-cluster) container image build for jar using: " + config.buildStrategy + " on server: "
+                + kubernetesClient.getClient().getMasterUrl() + " in namespace:" + namespace + ".");
         //The contextRoot is where inside the tarball we will add the jars. A null value means everything will be added under '/' while "target" means everything will be added under '/target'.
         //For docker kind of builds where we use instructions like: `COPY target/*.jar /deployments` it using '/target' is a requirement.
         //For s2i kind of builds where jars are expected directly in the '/' we have to use null.
@@ -302,9 +301,9 @@ public class OpenshiftProcessor {
         }
 
         String namespace = Optional.ofNullable(kubernetesClient.getClient().getNamespace()).orElse("default");
-        LOG.info("Performing openshift binary build with native image on server: " + kubernetesClient.getClient().getMasterUrl()
-                + " in namespace:" + namespace + ".");
 
+        LOG.info("Starting (in-cluster) container image build for jar using: " + config.buildStrategy + " on server: "
+                + kubernetesClient.getClient().getMasterUrl() + " in namespace:" + namespace + ".");
         Optional<GeneratedFileSystemResourceBuildItem> openshiftYml = generatedResources
                 .stream()
                 .filter(r -> r.getName().endsWith("kubernetes" + File.separator + "openshift.yml"))

--- a/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/openshift/deployment/src/main/java/io/quarkus/openshift/deployment/OpenshiftProcessor.java
@@ -6,6 +6,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.kubernetes.deployment.OpenshiftConfig;
+import io.quarkus.kubernetes.deployment.OpenshiftConfig.DeploymentResourceKind;
 import io.quarkus.kubernetes.deployment.ResourceNameUtil;
 import io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem;
 import io.quarkus.kubernetes.spi.KubernetesResourceMetadataBuildItem;
@@ -17,17 +18,15 @@ public class OpenshiftProcessor {
             BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
             BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
 
-        String kind = config.getDepoymentResourceKind();
-        String group = config.getDepoymentResourceGroup();
-        String version = config.getDepoymentResourceVersion();
-
+        DeploymentResourceKind deploymentResourceKind = config.getDeploymentResourceKind();
         deploymentTargets
                 .produce(
-                        new KubernetesDeploymentTargetBuildItem(OPENSHIFT, kind, group,
-                                version, true));
+                        new KubernetesDeploymentTargetBuildItem(OPENSHIFT, deploymentResourceKind.kind,
+                                deploymentResourceKind.apiGroup,
+                                deploymentResourceKind.apiVersion, true));
 
         String name = ResourceNameUtil.getResourceName(config, applicationInfo);
-        resourceMeta.produce(new KubernetesResourceMetadataBuildItem(OPENSHIFT, group,
-                version, kind, name));
+        resourceMeta.produce(new KubernetesResourceMetadataBuildItem(OPENSHIFT, deploymentResourceKind.apiGroup,
+                deploymentResourceKind.apiVersion, deploymentResourceKind.kind, name));
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -128,7 +128,7 @@ public class KubernetesDeployer {
         final DeploymentTargetEntry selectedTarget;
 
         boolean checkForMissingRegistry = true;
-        boolean checkForNamespaceGroupAlignment = true;
+        boolean checkForNamespaceGroupAlignment = false;
         List<String> userSpecifiedDeploymentTargets = KubernetesConfigUtil.getUserSpecifiedDeploymentTargets();
         if (userSpecifiedDeploymentTargets.isEmpty()) {
             selectedTarget = targets.getEntriesSortedByPriority().get(0);
@@ -155,6 +155,8 @@ public class KubernetesDeployer {
         if (OPENSHIFT.equals(selectedTarget.getName())) {
             checkForMissingRegistry = Capability.CONTAINER_IMAGE_S2I.equals(activeContainerImageCapability)
                     || Capability.CONTAINER_IMAGE_OPENSHIFT.equals(activeContainerImageCapability);
+
+            // We should ensure that we have image group and namespace alignment we are not using deployment triggers via DeploymentConfig.
             if (!targets.getEntriesSortedByPriority().get(0).getKind().equals("DeploymentConfig")) {
                 checkForNamespaceGroupAlignment = true;
             }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -16,7 +16,9 @@ import java.util.OptionalInt;
 
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.ServiceType;
+import io.quarkus.container.image.deployment.ContainerImageCapabilitiesUtil;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -506,8 +508,10 @@ public class OpenshiftConfig implements PlatformConfiguration {
         return Optional.of(route);
     }
 
-    public static boolean isOpenshiftBuildEnabled(ContainerImageConfig containerImageConfig) {
-        return containerImageConfig.builder.map(b -> b.equals("openshfit") || b.equals("s2i")).orElse(false);
+    public static boolean isOpenshiftBuildEnabled(ContainerImageConfig containerImageConfig, Capabilities capabilities) {
+        boolean implictlyEnabled = ContainerImageCapabilitiesUtil.getActiveContainerImageCapability(capabilities)
+                .filter(c -> c.contains("openshift") || c.contains("s2i")).isPresent();
+        return containerImageConfig.builder.map(b -> b.equals("openshfit") || b.equals("s2i")).orElse(implictlyEnabled);
     }
 
     public DeploymentResourceKind getDeploymentResourceKind() {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -16,6 +16,7 @@ import java.util.OptionalInt;
 
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.ServiceType;
+import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
@@ -32,9 +33,9 @@ public class OpenshiftConfig implements PlatformConfiguration {
         DeploymentConfig(DEPLOYMENT_CONFIG, DEPLOYMENT_CONFIG_GROUP, DEPLOYMENT_CONFIG_VERSION),
         StatefulSet(STATEFULSET, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION);
 
-        final String kind;
-        final String apiGroup;
-        final String apiVersion;
+        public final String kind;
+        public final String apiGroup;
+        public final String apiVersion;
 
         DeploymentResourceKind(String kind, String apiGroup, String apiVersion) {
             this.kind = kind;
@@ -55,8 +56,8 @@ public class OpenshiftConfig implements PlatformConfiguration {
      * The kind of the deployment resource to use.
      * Supported values are 'Deployment' and 'DeploymentConfig' defaulting to the later.
      */
-    @ConfigItem(defaultValue = "DeploymentConfig")
-    DeploymentResourceKind deploymentKind;
+    @ConfigItem
+    Optional<DeploymentResourceKind> deploymentKind;
 
     /**
      * The name of the group this component belongs too
@@ -505,15 +506,11 @@ public class OpenshiftConfig implements PlatformConfiguration {
         return Optional.of(route);
     }
 
-    public String getDepoymentResourceGroup() {
-        return deploymentKind.apiGroup;
+    public static boolean isOpenshiftBuildEnabled(ContainerImageConfig containerImageConfig) {
+        return containerImageConfig.builder.map(b -> b.equals("openshfit") || b.equals("s2i")).orElse(false);
     }
 
-    public String getDepoymentResourceVersion() {
-        return deploymentKind.apiVersion;
-    }
-
-    public String getDepoymentResourceKind() {
-        return deploymentKind.kind;
+    public DeploymentResourceKind getDeploymentResourceKind() {
+        return deploymentKind.orElse(DeploymentResourceKind.DeploymentConfig);
     }
 }

--- a/integration-tests/kubernetes/quarkus-standard-way-kafka/src/test/java/io/quarkus/it/kubernetes/kafka/BasicOpenshiftTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way-kafka/src/test/java/io/quarkus/it/kubernetes/kafka/BasicOpenshiftTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -50,9 +49,6 @@ public class BasicOpenshiftTest {
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
             specAssert.extracting("replicas").isEqualTo(1);
-            specAssert.extracting("triggers").isInstanceOfSatisfying(Collection.class, c -> {
-                assertThat(c).isEmpty();
-            });
             specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {
                 assertThat(selectorsMap).containsOnly(entry("app.kubernetes.io/name", "basic-openshift"),
                         entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicOpenshiftTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicOpenshiftTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -49,9 +48,6 @@ public class BasicOpenshiftTest {
             });
             AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
             specAssert.extracting("replicas").isEqualTo(1);
-            specAssert.extracting("triggers").isInstanceOfSatisfying(Collection.class, c -> {
-                assertThat(c).isEmpty();
-            });
             specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {
                 assertThat(selectorsMap).containsOnly(entry("app.kubernetes.io/name", "basic-openshift"),
                         entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerAndDeploymentResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerAndDeploymentResourceTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+//
+// The purpose of this test is to assert that
+// When: We run local container builds targeting Openshift using `Deployment` (instead of `DeploymentConfig`)
+// Then: No BuildConfg and ImageStreams are generated and that `docker.io` is used as the default registry
+//
+public class OpenshiftWithLocalDockerAndDeploymentResourceTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-with-local-docker-and-deployment-resource")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.openshift.deployment-kind", "Deployment")
+            .overrideConfigKey("quarkus.container-image.builder", "docker")
+            .overrideConfigKey("quarkus.container-image.group", "testme")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-with-local-docker-and-deployment-resource");
+            });
+
+            assertThat(kubernetesList).filteredOn(h -> "BuildConfig".equals(h.getKind())).hasSize(0);
+            assertThat(kubernetesList).filteredOn(h -> "ImageStream".equals(h.getKind())).hasSize(0);
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getImage())
+                                    .isEqualTo(
+                                            "docker.io/testme/openshift-with-local-docker-and-deployment-resource:0.1-SNAPSHOT");
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+//
+// The purpose of this test is to assert that
+// When: We run local container builds targeting Openshift (and `DeploymentConfig` is used).
+// Then:
+//   - No BuildConfg is generated.
+//   - A signle docker ImageStreams are generated and that `docker.io` is used as the default registry.
+//
+public class OpenshiftWithLocalDockerTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClasses(GreetingResource.class))
+            .setApplicationName("openshift-with-local-docker")
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .overrideConfigKey("quarkus.container-image.builder", "docker")
+            .overrideConfigKey("quarkus.container-image.group", "testme")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(DeploymentConfig.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo("openshift-with-local-docker");
+            });
+
+            assertThat(kubernetesList).filteredOn(h -> "ImageStream".equals(h.getKind())).hasSize(1)
+                    .anySatisfy(h -> {
+                        assertThat(h).isInstanceOfSatisfying(ImageStream.class, imageStream -> {
+                            assertThat(imageStream.getSpec().getDockerImageRepository())
+                                    .isEqualTo("docker.io/testme/openshift-with-local-docker");
+                        });
+                    });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-deployment-resource.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-deployment-resource.properties
@@ -1,2 +1,0 @@
-quarkus.openshift.deployment-kind=Deployment
-quarkus.openshift.replicas=3


### PR DESCRIPTION
Resolves: #23203 
Resolves: #23417

The pull request addressed the following issues around openshift deployment:

- Remove irrelevant warning about namespace/group mismatch on non-openshift builds: #23203 
- Generate missing streams when using local docker on Openshift.
- Improve / Align logging between container image extension so that it's clear when the build is local or in-cluster.
- Fallback to openshift internal registry when using in-cluster builds with `Deploment` / `StatefulSet`
- Fallback to docker.io when using local builds on Openshift (align with container image extensions).