### PR TITLE
Add List<Dependency> forcedDependencies(LaunchMode) to the QuarkusBootstrapMojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -1,6 +1,7 @@
 package io.quarkus.maven;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.LaunchMode;
 
 public abstract class QuarkusBootstrapMojo extends AbstractMojo {
@@ -148,6 +150,17 @@ public abstract class QuarkusBootstrapMojo extends AbstractMojo {
 
     protected String appArtifactCoords() {
         return appArtifact;
+    }
+
+    /**
+     * Allows implementations to provide extra dependencies that should be enforced on the application.
+     * Originally requested by Camel K.
+     * 
+     * @param mode launch mode the application is being bootstrapped in
+     * @return list of extra dependencies that should be enforced on the application
+     */
+    protected List<Dependency> forcedDependencies(LaunchMode mode) {
+        return Collections.emptyList();
     }
 
     protected RepositorySystem repositorySystem() {

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -203,7 +203,8 @@ public class QuarkusBootstrapProvider implements Closeable {
                     .setBuildSystemProperties(effectiveProperties)
                     .setProjectRoot(mojo.baseDir().toPath())
                     .setBaseName(mojo.finalName())
-                    .setTargetDirectory(mojo.buildDir().toPath());
+                    .setTargetDirectory(mojo.buildDir().toPath())
+                    .setForcedDependencies(mojo.forcedDependencies(mode));
 
             try {
                 return builder.build().bootstrap();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -409,7 +409,7 @@ public class QuarkusBootstrap implements Serializable {
         boolean isolateDeployment;
         MavenArtifactResolver mavenArtifactResolver;
         ArtifactCoords managingProject;
-        List<Dependency> forcedDependencies = new ArrayList<>();
+        List<Dependency> forcedDependencies = Collections.emptyList();
         boolean disableClasspathCache;
         ApplicationModel existingModel;
         final Set<ArtifactKey> localArtifacts = new HashSet<>();


### PR DESCRIPTION
Allow implementations of QuarkusBootstrapMojo to enforce certain dependencies on the application.
This will help the Camel K tools.
FYI @lburgazzoli 