### PR TITLE
Move quarkus-devtools-utils and the codestarts artifact to the quarkus-bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2669,6 +2669,16 @@
                 <artifactId>quarkus-webjars-locator-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-devtools-utilities</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-project-core-extension-codestarts</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- External dependencies -->
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -180,22 +180,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-devtools-utilities</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-                <type>pom</type>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
                 <version>${freemarker.version}</version>

--- a/devtools/gradle/gradle-application-plugin/pom.xml
+++ b/devtools/gradle/gradle-application-plugin/pom.xml
@@ -37,6 +37,7 @@
             <artifactId>quarkus-project-core-extension-codestarts</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/integration-tests/devtools/pom.xml
+++ b/integration-tests/devtools/pom.xml
@@ -22,6 +22,7 @@
             <artifactId>quarkus-project-core-extension-codestarts</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/integration-tests/maven/pom.xml
+++ b/integration-tests/maven/pom.xml
@@ -69,6 +69,7 @@
             <artifactId>quarkus-project-core-extension-codestarts</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION
These are used by some core artifacts.