### PR TITLE
Process OIDC code query param only if the state cookie exists

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -699,7 +699,6 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public void setCookieSuffix(String cookieSuffix) {
             this.cookieSuffix = Optional.of(cookieSuffix);
         }
-
     }
 
     @ConfigGroup

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -1,0 +1,48 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.oidc.OidcRequestContext;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.TenantConfigResolver;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomTenantConfigResolver implements TenantConfigResolver {
+
+    @Inject
+    @ConfigProperty(name = "quarkus.oidc.auth-server-url")
+    String authServerUrl;
+
+    OidcTenantConfig config = new OidcTenantConfig();
+
+    public CustomTenantConfigResolver() {
+    }
+
+    @PostConstruct
+    public void initConfig() {
+        config.setTenantId("tenant-before-wrong-redirect");
+        config.setAuthServerUrl(authServerUrl);
+        config.setClientId("quarkus-app");
+        config.getCredentials().setSecret("secret");
+        config.setApplicationType(ApplicationType.WEB_APP);
+    }
+
+    @Override
+    public Uni<OidcTenantConfig> resolve(RoutingContext context, OidcRequestContext<OidcTenantConfig> requestContext) {
+        if (context.request().path().contains("callback-before-wrong-redirect")) {
+            if (context.getCookie("q_auth_tenant-before-wrong-redirect") != null) {
+                // trigger the code to access token exchange failure due to a redirect uri mismatch
+                config.authentication.setRedirectPath("wrong-path");
+            }
+            return Uni.createFrom().item(config);
+        }
+        return Uni.createFrom().nullItem();
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -73,11 +73,6 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-cookie-path-header";
         }
 
-        if (path.contains("callback-before-wrong-redirect")) {
-            return context.getCookie("q_auth_tenant-before-wrong-redirect") == null ? "tenant-before-wrong-redirect"
-                    : "tenant-1";
-        }
-
         if (path.contains("callback-after-redirect") || path.contains("callback-before-redirect")) {
             return "tenant-1";
         }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource3.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource3.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.keycloak;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/web-app3")
+@Authenticated
+public class ProtectedResource3 {
+
+    @GET
+    public String getName() {
+        // CodeFlowTest#testAuthenticationCompletionFailedNoStateCookie checks that if a state cookie is missing
+        // then 401 is returned when a redirect targets the endpoint requiring authentication
+        throw new InternalServerErrorException("This method must not be invoked");
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -25,7 +25,7 @@ public class TenantHttps {
 
     @GET
     @Path("query")
-    public String getTenantWithQuery(@QueryParam("a") String value) {
-        return getTenant() + "?a=" + value;
+    public String getTenantWithQuery(@QueryParam("code") String value) {
+        return getTenant() + "?code=" + value;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-# Default tenant configuration
+# Default tenant configurationf
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.client-id=quarkus-app
 quarkus.oidc.credentials.secret=secret
@@ -25,13 +25,6 @@ quarkus.oidc.tenant-listener.credentials.secret=secret
 # on Vertx context; so disabling it for the test endpoint to confirm the login event has been accepted
 quarkus.oidc.tenant-listener.authentication.remove-redirect-parameters=false
 quarkus.oidc.tenant-listener.application-type=web-app
-
-
-quarkus.oidc.tenant-before-wrong-redirect.auth-server-url=${keycloak.url}/realms/quarkus
-quarkus.oidc.tenant-before-wrong-redirect.client-id=quarkus-app
-quarkus.oidc.tenant-before-wrong-redirect.credentials.client-secret.value=secret
-quarkus.oidc.tenant-before-wrong-redirect.token.issuer=${keycloak.url}/realms/quarkus
-quarkus.oidc.tenant-before-wrong-redirect.application-type=web-app
 
 # Tenant which does not need to restore a request path after redirect, client_secret_post method
 quarkus.oidc.tenant-1.auth-server-url=${keycloak.url}/realms/quarkus
@@ -103,6 +96,7 @@ quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
 quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 quarkus.oidc.tenant-https.authentication.cookie-suffix=test
+quarkus.oidc.tenant-https.authentication.redirect-without-state-cookie=true
 
 quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-javascript.client-id=quarkus-app
@@ -144,9 +138,6 @@ quarkus.oidc.tenant-split-tokens.application-type=web-app
 quarkus.http.auth.permission.roles1.paths=/index.html
 quarkus.http.auth.permission.roles1.policy=authenticated
 
-quarkus.http.auth.permission.callback.paths=/web-app3
-quarkus.http.auth.permission.callback.policy=authenticated
-
 quarkus.http.auth.permission.logout.paths=/tenant-logout
 quarkus.http.auth.permission.logout.policy=authenticated
 
@@ -169,9 +160,5 @@ quarkus.http.proxy.allow-forwarded=true
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
-quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".min-level=TRACE
-quarkus.log.category."io.vertx.ext.auth.oauth2.impl.OAuth2UserImpl".level=TRACE
-#quarkus.log.category."org.apache.http".min-level=TRACE
-#quarkus.log.category."org.apache.http".level=TRACE
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -46,6 +46,8 @@ public class CodeFlowTest {
                     .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/index.html").toURL()));
             verifyLocationHeader(webClient, webResponse.getResponseHeaderValue("location"), null, "web-app", false);
 
+            webClient.getCookieManager().clearCookies();
+
             webClient.getOptions().setRedirectEnabled(true);
             HtmlPage page = webClient.getPage("http://localhost:8081/index.html");
 
@@ -147,7 +149,7 @@ public class CodeFlowTest {
 
             WebResponse webResponse = webClient
                     .loadWebResponse(
-                            new WebRequest(URI.create("http://localhost:8081/tenant-https/query?a=b").toURL()));
+                            new WebRequest(URI.create("http://localhost:8081/tenant-https/query?code=b").toURL()));
             String keycloakUrl = webResponse.getResponseHeaderValue("location");
             verifyLocationHeader(webClient, keycloakUrl, "tenant-https_test", "tenant-https",
                     true);
@@ -178,10 +180,10 @@ public class CodeFlowTest {
 
             endpointLocationWithoutQuery = "http" + endpointLocationWithoutQuery.substring(5);
             URI endpointLocationWithoutQueryUri = URI.create(endpointLocationWithoutQuery);
-            assertEquals("a=b", endpointLocationWithoutQueryUri.getRawQuery());
+            assertEquals("code=b", endpointLocationWithoutQueryUri.getRawQuery());
 
             page = webClient.getPage(endpointLocationWithoutQueryUri.toURL());
-            assertEquals("tenant-https:reauthenticated?a=b", page.getBody().asText());
+            assertEquals("tenant-https:reauthenticated?code=b", page.getBody().asText());
             Cookie sessionCookie = getSessionCookie(webClient, "tenant-https_test");
             assertNotNull(sessionCookie);
             webClient.getCookieManager().clearCookies();
@@ -241,6 +243,7 @@ public class CodeFlowTest {
                     });
 
             webClient.getOptions().setRedirectEnabled(true);
+            webClient.getCookieManager().clearCookies();
             page = webClient.getPage("http://localhost:8081/index.html");
 
             assertEquals("Sign in to quarkus", page.getTitleText());
@@ -321,6 +324,8 @@ public class CodeFlowTest {
 
             // session invalidated because it ended at the OP, should redirect to login page at the OP
             webClient.getOptions().setRedirectEnabled(true);
+            webClient.getCookieManager().clearCookies();
+
             page = webClient.getPage("http://localhost:8081/tenant-logout");
             assertNull(getSessionCookie(webClient, "tenant-logout"));
             assertEquals("Sign in to logout-realm", page.getTitleText());
@@ -510,6 +515,8 @@ public class CodeFlowTest {
             assertNull(getSessionCookie(webClient, "tenant-2"));
 
             webClient.getOptions().setRedirectEnabled(true);
+            webClient.getCookieManager().clearCookies();
+
             page = webClient.getPage("http://localhost:8081/web-app2/name");
 
             assertEquals("Sign in to quarkus", page.getTitleText());


### PR DESCRIPTION
Fixes #22195 (and next it will be straightforward to resolve both #22189 and #22029).

So Steph reported the issue with the custom `code` parameter triggering the code flow completion process and he was not the first one, I looked at the earlier issue but decided to avoid fixing it back then because of the ambiguity - what to do if the state cookie is missing but the `code` is not - is it a faulty redirect or just an initial custom request.

However, after seeing #22195, and then also #22189, I thought it was not cool to ask users to replace the custom `code` and also `error` query parameters. And especially after seeing #22029, where the post request parameters should not be even checked if it is not an OIDC redirect, I thought it was the right time to address the problem.

So here is what this PR does:
* Makes sure the `code` is checked only if the state cookie exists and valid, confirming it came from the OIDC provider. it really makes sense to make it conditional on the presence of this cookie before deciding to start processing this `code` (and as I said, the same would apply to the `error` and also the form_post response mode processing)
* Right now on main, if no state cookie is found but `code` is then 401 is returned to prevent the redirect loops (i.e, the user successfully logged in, redirect to Quarkus, the state cookie is lost due to the wrong configuration - cookie domain or path is not set correctly, without 401 but with a 302 challenge the user goes back to the provider which already has the user session, send the user back to Quarkus, and the loop starts). I had to introduce a simple property to retain this behavior of reporting `401` if no state cookie is available but `code` is. 
 ** Steph - I did look at your proposal of checking `Referer` which is a good idea and I started coding - but unfortunately it does not work in all the cases , it is not guaranteed to match the actual authorization provider URL with the various port, http vs https translations, I just did not feel it would be a reliable solution. I also think that controlling it with the property is more flexible as some users will want 401, some users - the redirect again (see below why)
 * So if one needs to support custom `code` (or `error`) query parameters during the initial auth request then the only thing they should do is to set `quarkus.oidc.authentication.redirect-without-state-cookie=true`. In this case, if the state cookie is absent, the usual challenge with a redirect to OIDC will occur. The important thing is, it does not compromise on anything really, the only reason `401` is returned by default when no `state cookie` is present but the `code` is is to avoid a redirect loop in case of the bad configuration. So enabling this property will only have an extra `requirement` to make sure the configuration is correct to avoid losing the state cookie - and even it is not correct - what will happen is that if the state cookie is missing then instead of 401 the browser will fail with the redirect loop - unless the loop is prevented with requiring the provider to always challenge even the already authenticated users.

IMHO this is the best compromise we can do to let users supply custom `code` and soon `error` query parameters - but also by making the code processing conditional on the availability of the state cookie is a better approach in any case  
 