### PR TITLE
Reduce amount of bytecode generated

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -189,7 +189,7 @@ public class BytecodeRecorderTestCase {
     public void testLargeCollection() throws Exception {
 
         List<TestJavaBean> beans = new ArrayList<>();
-        for (int i = 0; i < 10000; ++i) {
+        for (int i = 0; i < 100000; ++i) {
             beans.add(new TestJavaBean("A string", 99));
         }
 


### PR DESCRIPTION
Reduces the amount of code generated by the bytecode recorders. In
particular:

- Don't store values in the cross-method array unless they are actually
  used be a later method
- Add objects to collections earlier to reduce the chance the add code
  will be in a different method to the load code

Fixes #22833