### PR TITLE
Fixes unexpected ClosedChannelException while opening WebSocket

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -31,7 +31,7 @@
         <opentelemetry.version>1.9.1</opentelemetry.version>
         <opentelemetry-alpha.version>1.9.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.8.0</jaeger.version>
-        <quarkus-http.version>4.1.4</quarkus-http.version>
+        <quarkus-http.version>4.1.5</quarkus-http.version>
         <micrometer.version>1.8.2</micrometer.version>
         <google-auth.version>0.22.0</google-auth.version>
         <microprofile-config-api.version>2.0</microprofile-config-api.version>


### PR DESCRIPTION
This is caused by a bug in quarkus-http (fixed in https://github.com/quarkusio/quarkus-http/pull/94).

Fixes #23073