### PR TITLE
Let the ByteBuddy library version be controlled by the BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,8 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.5.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.6.5.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <bytebuddy.version>1.12.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.2.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.1.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.0.Final</hibernate-search.version>
@@ -2676,6 +2677,15 @@
             </dependency>
 
             <!-- External dependencies -->
+
+            <!-- Normally controlled by Hibernate ORM upstream,
+                but making the version of ByteBuddy explicit so that this BOM can control the version
+                in case of conflicts with other libraries -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
 
             <!-- GRPC dependency -->
             <dependency>


### PR DESCRIPTION
As suggested by Alexey in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/common.20dependencies.20NOT.20in.20the.20BOM

cc/ @beikov 