### PR TITLE
Set quarkusDev configuration in quarkusRemoteDev task

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -205,7 +205,10 @@ public class QuarkusPlugin implements Plugin<Project> {
                                 quarkusGenerateCodeTests);
                         task.setQuarkusDevConfiguration(devModeConfiguration);
                     });
-                    quarkusRemoteDev.configure(task -> task.dependsOn(classesTask, resourcesTask));
+                    quarkusRemoteDev.configure(task -> {
+                        task.dependsOn(classesTask, resourcesTask);
+                        task.setQuarkusDevConfiguration(devModeConfiguration);
+                    });
                     quarkusTest.configure(task -> {
                         task.dependsOn(classesTask, resourcesTask, testClassesTask, testResourcesTask,
                                 quarkusGenerateCode,


### PR DESCRIPTION
This sets the `quarkusDev` configuration required by the `QuarkusDev` super class.

close #23315 