### PR TITLE
Remove vert-http from oidc-common

### DIFF
--- a/extensions/oidc-common/deployment/pom.xml
+++ b/extensions/oidc-common/deployment/pom.xml
@@ -28,10 +28,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-credentials-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/oidc-common/runtime/pom.xml
+++ b/extensions/oidc-common/runtime/pom.xml
@@ -28,10 +28,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-credentials</artifactId>
         </dependency>
         <dependency>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -125,8 +125,8 @@
         <module>smallrye-jwt</module>
         <module>oidc-common</module>
         <module>oidc</module>
-        <module>oidc-token-propagation</module>
         <module>oidc-client</module>
+        <module>oidc-token-propagation</module>
         <module>oidc-client-filter</module>
         <module>oidc-client-reactive-filter</module>
         <module>keycloak-authorization</module>


### PR DESCRIPTION
Fix #22082

Oidc client would not work with a regular AWS Lambda vanilla project.  This was because quarkus-oidc-common was pulling in vertx-http which was starting an http server.