### PR TITLE
Update MariaDB image to 10.6 for integration tests and dev services

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- Database images for JDBC/Reactive/Hibernate tests -->
         <postgres.image>docker.io/postgres:14.1</postgres.image>
-        <mariadb.image>docker.io/mariadb:10.4</mariadb.image>
+        <mariadb.image>docker.io/mariadb:10.6</mariadb.image>
         <db2.image>docker.io/ibmcom/db2:11.5.5.0</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04</mssql.image>
         <oracle.image>docker.io/gvenzl/oracle-xe:21.3.0-slim</oracle.image>

--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -40,4 +40,13 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -1,6 +1,10 @@
 package io.quarkus.devservices.common;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Collections;
+import java.util.Properties;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -37,5 +41,28 @@ public final class ConfigureUtil {
         container.setNetworkAliases(Collections.singletonList(hostName));
 
         return hostName;
+    }
+
+    public static String getDefaultImageNameFor(String devserviceName) {
+        var imageName = LazyProperties.INSTANCE.getProperty(devserviceName + ".image");
+        if (imageName == null) {
+            throw new IllegalArgumentException("No default image configured for " + devserviceName);
+        }
+        return imageName;
+    }
+
+    private static class LazyProperties {
+
+        private static final Properties INSTANCE;
+
+        static {
+            var tccl = Thread.currentThread().getContextClassLoader();
+            try (InputStream in = tccl.getResourceAsStream("devservices.properties")) {
+                INSTANCE = new Properties();
+                INSTANCE.load(in);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 }

--- a/extensions/devservices/common/src/main/resources/devservices.properties
+++ b/extensions/devservices/common/src/main/resources/devservices.properties
@@ -1,0 +1,1 @@
+mariadb.image=${mariadb.image}

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -24,7 +24,6 @@ public class MariaDBDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(MariaDBDevServicesProcessor.class);
 
-    public static final String TAG = "10.5.9";
     public static final Integer PORT = 3306;
     public static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
 
@@ -75,8 +74,8 @@ public class MariaDBDevServicesProcessor {
 
         public QuarkusMariaDBContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName
-                    .parse(imageName.orElse("docker.io/" + MariaDBContainer.IMAGE + ":" + MariaDBDevServicesProcessor.TAG))
-                    .asCompatibleSubstituteFor(DockerImageName.parse(MariaDBContainer.IMAGE)));
+                    .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mariadb")))
+                    .asCompatibleSubstituteFor(DockerImageName.parse(MariaDBContainer.NAME)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
         }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -23,7 +23,7 @@ public final class Dialects {
             return "io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect";
         }
         if (DatabaseKind.isMariaDB(resolvedDbKind)) {
-            return "org.hibernate.dialect.MariaDB103Dialect";
+            return "org.hibernate.dialect.MariaDB106Dialect";
         }
         if (DatabaseKind.isMySQL(resolvedDbKind)) {
             return "org.hibernate.dialect.MySQL8Dialect";

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import org.hibernate.dialect.DB297Dialect;
 import org.hibernate.dialect.DerbyTenSevenDialect;
-import org.hibernate.dialect.MariaDB103Dialect;
+import org.hibernate.dialect.MariaDB106Dialect;
 import org.hibernate.dialect.MySQL8Dialect;
 import org.hibernate.dialect.Oracle12cDialect;
 import org.hibernate.dialect.SQLServer2016Dialect;
@@ -38,7 +38,7 @@ public class ConstantsTest {
         assertDialectMatch(DatabaseKind.DB2, DB297Dialect.class);
         assertDialectMatch(DatabaseKind.POSTGRESQL, QuarkusPostgreSQL10Dialect.class);
         assertDialectMatch(DatabaseKind.H2, QuarkusH2Dialect.class);
-        assertDialectMatch(DatabaseKind.MARIADB, MariaDB103Dialect.class);
+        assertDialectMatch(DatabaseKind.MARIADB, MariaDB106Dialect.class);
         assertDialectMatch(DatabaseKind.MYSQL, MySQL8Dialect.class);
         assertDialectMatch(DatabaseKind.DERBY, DerbyTenSevenDialect.class);
         assertDialectMatch(DatabaseKind.MSSQL, SQLServer2016Dialect.class);

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Hibernate ORM settings 
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB103Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
 # We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
@@ -10,7 +10,7 @@ quarkus.datasource.devservices.enabled=false
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".database.generation=none
 quarkus.hibernate-orm."inventory".multitenant=database
-quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB103Dialect
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm."inventory".packages=io.quarkus.it.hibernate.multitenancy.inventory
 
 #mariadb.base_url is set through Maven config

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Hibernate ORM settings 
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB103Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 
 # We create datasources manually, so a lack of configuration doesn't mean Quarkus should step in with defaults.
@@ -10,7 +10,7 @@ quarkus.datasource.devservices.enabled=false
 # Inventory persistence unit
 quarkus.hibernate-orm."inventory".database.generation=none
 quarkus.hibernate-orm."inventory".multitenant=database
-quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB103Dialect
+quarkus.hibernate-orm."inventory".dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm."inventory".packages=io.quarkus.it.hibernate.multitenancy.inventory
 
 #mariadb.base_url is set through Maven config

--- a/integration-tests/jpa-mariadb/src/main/resources/META-INF/persistence.xml
+++ b/integration-tests/jpa-mariadb/src/main/resources/META-INF/persistence.xml
@@ -13,7 +13,7 @@
             <property name="hibernate.archive.autodetection" value="class, hbm"/>
 
             <!-- Connection specific -->
-            <property name="hibernate.dialect" value="org.hibernate.dialect.MariaDB103Dialect"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MariaDB106Dialect"/>
 
             <!-- Tuning and debugging -->
             <property name="hibernate.show_sql" value="false"/>


### PR DESCRIPTION
Came up here: https://github.com/quarkusio/quarkus/pull/23249#issuecomment-1025590576

From a recent poll (ongoing): https://mariadb.org/poll/server-version-with-10-6/

![poll](https://user-images.githubusercontent.com/22860528/151886036-3da4869d-60a3-4fa6-800c-471f0dd6fc34.JPG)

/cc @Sanne 

I also came up with a way to keep the respective dev service aligned by using what was moved to `build-parent` not long ago.
If you guys like it I can adjust the other dev services in a separate PR.