### PR TITLE
Properly log InvalidDefinitionException exception in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/NativeInvalidDefinitionExceptionMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/mappers/NativeInvalidDefinitionExceptionMapper.java
@@ -30,6 +30,8 @@ public class NativeInvalidDefinitionExceptionMapper {
                 // we were not able to determine the type, so just log the exception
                 log.error(e);
             }
+        } else {
+            log.error(e);
         }
         return Response.serverError().build();
     }


### PR DESCRIPTION
Relates to: #23342