### PR TITLE
Set oidc-token-propagation status to stable

### DIFF
--- a/extensions/oidc-token-propagation/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/oidc-token-propagation/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,6 @@ metadata:
   guide: "https://quarkus.io/guides/security-openid-connect-client"
   categories:
   - "security"
-  status: "preview"
+  status: "stable"
   config:
-  - "quarkus.oidc-client."
+  - "quarkus.oidc-token-propagation."


### PR DESCRIPTION
Set the status of the existing `oidc-token-propagation` as stable and fix the config namespace description