### PR TITLE
Update SmallRye OpenTracing to 2.1.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -21,10 +21,6 @@
         <jandex.version>2.4.2.Final</jandex.version>
         <resteasy.version>4.7.5.Final</resteasy.version>
         <opentracing.version>0.33.0</opentracing.version>
-        <opentracing-jaxrs.version>1.0.0</opentracing-jaxrs.version>
-        <opentracing-web-servlet-filter.version>0.4.1</opentracing-web-servlet-filter.version>
-        <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
-        <opentracing-concurrent.version>0.4.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
@@ -48,7 +44,7 @@
         <smallrye-metrics.version>3.0.4</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.17</smallrye-open-api.version>
         <smallrye-graphql.version>1.4.2</smallrye-graphql.version>
-        <smallrye-opentracing.version>2.0.1</smallrye-opentracing.version>
+        <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.3.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
@@ -3050,26 +3046,6 @@
                 <artifactId>opentracing-util</artifactId>
                 <version>${opentracing.version}</version>
                 <type>test-jar</type>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing.contrib</groupId>
-                <artifactId>opentracing-jaxrs2</artifactId>
-                <version>${opentracing-jaxrs.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing.contrib</groupId>
-                <artifactId>opentracing-concurrent</artifactId>
-                <version>${opentracing-concurrent.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing.contrib</groupId>
-                <artifactId>opentracing-web-servlet-filter</artifactId>
-                <version>${opentracing-web-servlet-filter.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing.contrib</groupId>
-                <artifactId>opentracing-tracerresolver</artifactId>
-                <version>${opentracing-tracerresolver.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentracing.contrib</groupId>

--- a/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
+++ b/extensions/smallrye-opentracing/deployment/src/main/java/io/quarkus/smallrye/opentracing/deployment/SmallRyeOpenTracingProcessor.java
@@ -6,8 +6,6 @@ import javax.enterprise.inject.spi.ObserverMethod;
 import javax.servlet.DispatcherType;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.interceptors.OpenTracingInterceptor;
-import io.opentracing.contrib.jaxrs2.server.SpanFinishingFilter;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -26,6 +24,8 @@ import io.quarkus.smallrye.opentracing.runtime.QuarkusSmallRyeTracingStandaloneC
 import io.quarkus.smallrye.opentracing.runtime.QuarkusSmallRyeTracingStandaloneVertxDynamicFeature;
 import io.quarkus.smallrye.opentracing.runtime.TracerProducer;
 import io.quarkus.undertow.deployment.FilterBuildItem;
+import io.smallrye.opentracing.contrib.interceptor.OpenTracingInterceptor;
+import io.smallrye.opentracing.contrib.jaxrs2.server.SpanFinishingFilter;
 
 public class SmallRyeOpenTracingProcessor {
 

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingDynamicFeature.java
@@ -8,8 +8,8 @@ import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.jaxrs2.server.OperationNameProvider;
-import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
+import io.smallrye.opentracing.contrib.jaxrs2.server.OperationNameProvider;
+import io.smallrye.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 
 @Provider
 public class QuarkusSmallRyeTracingDynamicFeature implements DynamicFeature {

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingStandaloneContainerResponseFilter.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingStandaloneContainerResponseFilter.java
@@ -13,8 +13,8 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 
 import org.jboss.resteasy.reactive.server.ServerResponseFilter;
 
-import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.opentracing.tag.Tags;
+import io.smallrye.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 
 @Provider
 // We must close the span after everything else has finished

--- a/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingStandaloneVertxDynamicFeature.java
+++ b/extensions/smallrye-opentracing/runtime/src/main/java/io/quarkus/smallrye/opentracing/runtime/QuarkusSmallRyeTracingStandaloneVertxDynamicFeature.java
@@ -10,9 +10,9 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
-import io.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.opentracing.tag.Tags;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.opentracing.contrib.jaxrs2.internal.SpanWrapper;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 


### PR DESCRIPTION
This removes somes of the OpenTracing dependencies which are now provided by SmallRye OpenTracing, due to the lack of maintenance from OpenTracing projects.