### PR TITLE
Handle configured parent first resources

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -81,8 +81,10 @@ import org.fusesource.jansi.internal.Kernel32;
 import org.fusesource.jansi.internal.WindowsSupport;
 
 import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.devmode.DependenciesFilter;
 import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
@@ -1028,11 +1030,20 @@ public class DevMojo extends AbstractMojo {
         }
 
         addQuarkusDevModeDeps(builder);
+        //look for an application.properties
+        Set<Path> resourceDirs = new HashSet<>();
+        for (Resource resource : project.getResources()) {
+            String dir = resource.getDirectory();
+            Path path = Paths.get(dir);
+            resourceDirs.add(path);
+        }
+        Set<ArtifactKey> configuredParentFirst = QuarkusBootstrap.createClassLoadingConfig(PathsCollection.from(resourceDirs),
+                QuarkusBootstrap.Mode.DEV, Collections.emptyList()).parentFirstArtifacts;
 
         //in most cases these are not used, however they need to be present for some
         //parent-first cases such as logging
         //first we go through and get all the parent first artifacts
-        Set<ArtifactKey> parentFirstArtifacts = new HashSet<>();
+        Set<ArtifactKey> parentFirstArtifacts = new HashSet<>(configuredParentFirst);
         for (Artifact appDep : project.getArtifacts()) {
             if (appDep.getArtifactHandler().getExtension().equals(ArtifactCoords.TYPE_JAR) && appDep.getFile().isFile()) {
                 try (ZipFile file = new ZipFile(appDep.getFile())) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/QuarkusBootstrap.java
@@ -162,7 +162,7 @@ public class QuarkusBootstrap implements Serializable {
         return new CuratedApplication(this, appModelFactory.resolveAppModel(), classLoadingConfig);
     }
 
-    private static ConfiguredClassLoading createClassLoadingConfig(PathCollection applicationRoot, Mode mode,
+    public static ConfiguredClassLoading createClassLoadingConfig(PathCollection applicationRoot, Mode mode,
             List<ArtifactKey> parentFirstArtifacts) {
         //look for an application.properties
         for (Path path : applicationRoot) {


### PR DESCRIPTION
Configured parent first resources need to be placed on the class path to
take effect.

This fixes it for maven, a similar fix will be needed for gradle