### PR TITLE
Move Funqy GCP function support to preview

### DIFF
--- a/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions-http.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Funqy HTTP Binding with Google Cloud Functions
-:extension-status: experimental
+:extension-status: preview
 
 include::./attributes.adoc[]
 

--- a/docs/src/main/asciidoc/funqy-gcp-functions.adoc
+++ b/docs/src/main/asciidoc/funqy-gcp-functions.adoc
@@ -4,7 +4,7 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Funqy Google Cloud Functions
-:extension-status: experimental
+:extension-status: preview
 
 include::./attributes.adoc[]
 

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
   categories:
     - "cloud"
   guide: "https://quarkus.io/guides/funqy-gcp-functions"
-  status: "experimental"
+  status: "preview"
   codestart:
     name: "funqy-google-cloud-functions-example"
     kind: "example"


### PR DESCRIPTION
Now that Funqy is no longuer experimental, the GCP function support for it can be move to preview.

GCP Function are quite stable but we miss one functionality to be able to move it to the stable stage: testing support, thereby I let them in preview untill I had time to provide it.