### PR TITLE
Make resteasy-qute extension stable

### DIFF
--- a/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
   guide: "https://quarkus.io/guides/qute"
   categories:
   - "web"
-  status: "experimental"
+  status: "stable"
   codestart:
     name: "resteasy-qute"
     languages:


### PR DESCRIPTION
All the other Qute extensions are marked as stable, I think this one got
forgotten somehow.