### PR TITLE
Fix documentation of ClientExceptionMapper

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -699,7 +699,7 @@ public interface ExtensionsService {
     @ClientExceptionMapper
     static RuntimeException toException(Response response) {
         if (response.getStatus() == 500) {
-            throw new RuntimeException("The remote service responded with HTTP 500");
+            return new RuntimeException("The remote service responded with HTTP 500");
         }
         return null;
     }


### PR DESCRIPTION
As the ResponseExceptionMapper, and the ClientExceptionMapper's Javadoc states. The exception should be returned, not thrown.