### PR TITLE
Introduce image build / push commands

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Image.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Image.java
@@ -1,0 +1,36 @@
+package io.quarkus.cli;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.common.HelpOption;
+import io.quarkus.cli.common.OutputOptionMixin;
+import io.quarkus.cli.image.Build;
+import io.quarkus.cli.image.Push;
+import picocli.CommandLine;
+import picocli.CommandLine.ParseResult;
+import picocli.CommandLine.Unmatched;
+
+@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Perform a container image operation.", subcommands = {
+        Build.class, Push.class
+}, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
+public class Image implements Callable<Integer> {
+
+    @CommandLine.Mixin(name = "output")
+    protected OutputOptionMixin output;
+
+    @CommandLine.Mixin
+    protected HelpOption helpOption;
+
+    @CommandLine.Spec
+    protected CommandLine.Model.CommandSpec spec;
+
+    @Unmatched // avoids throwing errors for unmatched arguments
+    List<String> unmatchedArgs;
+
+    public Integer call() throws Exception {
+        ParseResult result = spec.commandLine().getParseResult();
+        CommandLine buildCommand = spec.subcommands().get("build");
+        return buildCommand.execute(result.originalArgs().stream().filter(x -> !"image".equals(x)).toArray(String[]::new));
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/Image.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Image.java
@@ -11,7 +11,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.ParseResult;
 import picocli.CommandLine.Unmatched;
 
-@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Perform a container image operation.", subcommands = {
+@CommandLine.Command(name = "image", sortOptions = false, mixinStandardHelpOptions = false, header = "Build or push project container image.", subcommands = {
         Build.class, Push.class
 }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "%nOptions:%n")
 public class Image implements Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -23,7 +23,8 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.UnmatchedArgumentException;
 
 @CommandLine.Command(name = "quarkus", subcommands = {
-        Create.class, Build.class, Dev.class, Test.class, ProjectExtensions.class, Image.class, Registry.class, Info.class, Update.class,
+        Create.class, Build.class, Dev.class, Test.class, ProjectExtensions.class, Image.class, Registry.class, Info.class,
+        Update.class,
         Version.class,
         Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.UnmatchedArgumentException;
 
 @CommandLine.Command(name = "quarkus", subcommands = {
-        Create.class, Build.class, Dev.class, Test.class, ProjectExtensions.class, Registry.class, Info.class, Update.class,
+        Create.class, Build.class, Dev.class, Test.class, ProjectExtensions.class, Image.class, Registry.class, Info.class, Update.class,
         Version.class,
         Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -104,6 +104,8 @@ public interface BuildSystemRunner {
 
     Integer update(boolean rectify, boolean recommendedState, boolean perModule) throws Exception;
 
+    BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode, List<String> params);
+
     BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
 
     List<Supplier<BuildCommandArgs>> prepareDevTestMode(boolean devMode, DevOptions commonOptions,

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -152,13 +152,19 @@ public class GradleRunner implements BuildSystemRunner {
 
     @Override
     public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        return prepareAction("build", buildOptions, runMode, params);
+    }
+
+    @Override
+    public BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setGradleProperties(args, runMode.isBatchMode());
 
         if (buildOptions.clean) {
             args.add("clean");
         }
-        args.add("build");
+        args.add(action);
 
         if (buildOptions.buildNative) {
             args.add("-Dquarkus.package.type=native");

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -80,7 +80,8 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
-    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+    public BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
 
         if (buildOptions.offline) {
@@ -96,12 +97,17 @@ public class JBangRunner implements BuildSystemRunner {
             args.add("--fresh");
         }
 
-        args.add("build");
+        args.add(action);
         args.addAll(flattenMappedProperties(propertiesOptions.properties));
         args.add(registryClient.getRegistryClientProperty());
         args.addAll(params);
         args.add(getMainPath());
         return prependExecutable(args);
+    }
+
+    @Override
+    public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        return prepareAction("build", buildOptions, runMode, params);
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/MavenRunner.java
@@ -161,6 +161,12 @@ public class MavenRunner implements BuildSystemRunner {
 
     @Override
     public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
+        return prepareAction("install", buildOptions, runMode, params);
+    }
+
+    @Override
+    public BuildCommandArgs prepareAction(String action, BuildOptions buildOptions, RunModeOption runMode,
+            List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setMavenProperties(args, runMode.isBatchMode());
 
@@ -175,7 +181,7 @@ public class MavenRunner implements BuildSystemRunner {
         if (buildOptions.clean) {
             args.add("clean");
         }
-        args.add("install");
+        args.add(action);
 
         if (buildOptions.buildNative) {
             args.add("-Dnative");

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
@@ -24,6 +24,7 @@ public class BaseImageCommand extends BaseBuildCommand implements Callable<Integ
     private static final String QUARKUS_CONTAINER_IMAGE_NAME = "quarkus.container-image.name";
     private static final String QUARKUS_CONTAINER_IMAGE_TAG = "quarkus.container-image.tag";
     protected static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
+    protected static final String QUARKUS_CONTAINER_IMAGE_DRY_RUN = "quarkus.container-image.dry-run";
 
     protected static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-build",
             BuildTool.GRADLE, "imageBuild");
@@ -45,6 +46,9 @@ public class BaseImageCommand extends BaseBuildCommand implements Callable<Integ
         imageOptions.name.ifPresent(name -> properties.put(QUARKUS_CONTAINER_IMAGE_NAME, name));
         imageOptions.tag.ifPresent(tag -> properties.put(QUARKUS_CONTAINER_IMAGE_TAG, tag));
         imageOptions.registry.ifPresent(registry -> properties.put(QUARKUS_CONTAINER_IMAGE_REGISTRY, registry));
+        if (runMode.isDryRun()) {
+            properties.put(QUARKUS_CONTAINER_IMAGE_DRY_RUN, "true");
+        }
     }
 
     public Optional<String> getAction() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
@@ -3,14 +3,18 @@ package io.quarkus.cli.image;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import io.quarkus.cli.build.BaseBuildCommand;
 import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
+import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 import picocli.CommandLine.Parameters;
 
-public class BaseImageCommand extends BaseBuildCommand {
+public class BaseImageCommand extends BaseBuildCommand implements Callable<Integer> {
 
     protected static final String QUARKUS_FORCED_EXTENSIONS = "quarkus.application.forced-extensions";
     protected static final String QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX = "io.quarkus:quarkus-container-image-";
@@ -19,7 +23,10 @@ public class BaseImageCommand extends BaseBuildCommand {
     private static final String QUARKUS_CONTAINER_IMAGE_GROUP = "quarkus.container-image.group";
     private static final String QUARKUS_CONTAINER_IMAGE_NAME = "quarkus.container-image.name";
     private static final String QUARKUS_CONTAINER_IMAGE_TAG = "quarkus.container-image.tag";
-    private static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
+    protected static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
+
+    protected static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-build",
+            BuildTool.GRADLE, "imageBuild");
 
     @CommandLine.Mixin
     protected RunModeOption runMode;
@@ -35,8 +42,21 @@ public class BaseImageCommand extends BaseBuildCommand {
 
     public void populateImageConfiguration(Map<String, String> properties) {
         imageOptions.group.ifPresent(group -> properties.put(QUARKUS_CONTAINER_IMAGE_GROUP, group));
-        imageOptions.group.ifPresent(name -> properties.put(QUARKUS_CONTAINER_IMAGE_NAME, name));
-        imageOptions.group.ifPresent(tag -> properties.put(QUARKUS_CONTAINER_IMAGE_TAG, tag));
-        imageOptions.group.ifPresent(registry -> properties.put(QUARKUS_CONTAINER_IMAGE_REGISTRY, registry));
+        imageOptions.name.ifPresent(name -> properties.put(QUARKUS_CONTAINER_IMAGE_NAME, name));
+        imageOptions.tag.ifPresent(tag -> properties.put(QUARKUS_CONTAINER_IMAGE_TAG, tag));
+        imageOptions.registry.ifPresent(registry -> properties.put(QUARKUS_CONTAINER_IMAGE_REGISTRY, registry));
+    }
+
+    public Optional<String> getAction() {
+        return Optional.empty();
+    }
+
+    public PropertiesOptions getPropertiesOptions() {
+        return this.propertiesOptions;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return 0;
     }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
@@ -1,0 +1,42 @@
+package io.quarkus.cli.image;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.cli.build.BaseBuildCommand;
+import io.quarkus.cli.common.BuildOptions;
+import io.quarkus.cli.common.RunModeOption;
+import picocli.CommandLine;
+import picocli.CommandLine.Parameters;
+
+public class BaseImageCommand extends BaseBuildCommand {
+
+    protected static final String QUARKUS_FORCED_EXTENSIONS = "quarkus.application.forced-extensions";
+    protected static final String QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX = "io.quarkus:quarkus-container-image-";
+
+    protected static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
+    private static final String QUARKUS_CONTAINER_IMAGE_GROUP = "quarkus.container-image.group";
+    private static final String QUARKUS_CONTAINER_IMAGE_NAME = "quarkus.container-image.name";
+    private static final String QUARKUS_CONTAINER_IMAGE_TAG = "quarkus.container-image.tag";
+    private static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
+
+    @CommandLine.Mixin
+    protected RunModeOption runMode;
+
+    @CommandLine.ArgGroup(order = 1, exclusive = false, validate = false, heading = "%nBuild options:%n")
+    BuildOptions buildOptions = new BuildOptions();
+
+    @CommandLine.ArgGroup(order = 2, exclusive = false, validate = false, heading = "%nImage options:%n")
+    ImageOptions imageOptions = new ImageOptions();
+
+    @Parameters(description = "Additional parameters passed to the build system")
+    List<String> params = new ArrayList<>();
+
+    public void populateImageConfiguration(Map<String, String> properties) {
+        imageOptions.group.ifPresent(group -> properties.put(QUARKUS_CONTAINER_IMAGE_GROUP, group));
+        imageOptions.group.ifPresent(name -> properties.put(QUARKUS_CONTAINER_IMAGE_NAME, name));
+        imageOptions.group.ifPresent(tag -> properties.put(QUARKUS_CONTAINER_IMAGE_TAG, tag));
+        imageOptions.group.ifPresent(registry -> properties.put(QUARKUS_CONTAINER_IMAGE_REGISTRY, registry));
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
@@ -1,0 +1,40 @@
+package io.quarkus.cli.image;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image.", description = "%n"
+        + "This command will build a container image for the project.", subcommands = { Docker.class, Jib.class,
+                Openshift.class }, footer = { "%n"
+                        + "For example (using default values), it will create a container image using docker with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'."
+                        + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Build extends BaseImageCommand implements Callable<Integer> {
+
+    private static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        super.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            BuildSystemRunner runner = getRunner();
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Build {imageOptions='" + imageOptions + "'}";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
@@ -15,7 +15,7 @@ import picocli.CommandLine;
                         + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Build extends BaseImageCommand {
 
-    private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "compile quarkus:image-build",
+    private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-build",
             BuildTool.GRADLE, "imageBuild");
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Build.java
@@ -1,24 +1,31 @@
 package io.quarkus.cli.image;
 
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.Optional;
 
 import io.quarkus.cli.build.BuildSystemRunner;
+import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "build", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image.", description = "%n"
-        + "This command will build a container image for the project.", subcommands = { Docker.class, Jib.class,
+        + "This command will build a container image for the project.", subcommands = { Docker.class, Buildpack.class,
+                Jib.class,
                 Openshift.class }, footer = { "%n"
                         + "For example (using default values), it will create a container image using docker with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'."
                         + "%n" }, headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
-public class Build extends BaseImageCommand implements Callable<Integer> {
+public class Build extends BaseImageCommand {
 
-    private static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
+    private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "compile quarkus:image-build",
+            BuildTool.GRADLE, "imageBuild");
 
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
         super.populateImageConfiguration(properties);
-        properties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+    }
+
+    @Override
+    public Optional<String> getAction() {
+        return Optional.ofNullable(ACTION_MAPPING.get(getRunner().getBuildTool()));
     }
 
     @Override
@@ -26,7 +33,10 @@ public class Build extends BaseImageCommand implements Callable<Integer> {
         try {
             populateImageConfiguration(propertiesOptions.properties);
             BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+
+            String action = getAction().orElseThrow(
+                    () -> new IllegalStateException("Unknown image push action for " + runner.getBuildTool().name()));
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareAction(action, buildOptions, runMode, params);
             return runner.run(commandArgs);
         } catch (Exception e) {
             return output.handleCommandException(e, "Unable to build image: " + e.getMessage());

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Builder.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Builder.java
@@ -1,0 +1,8 @@
+package io.quarkus.cli.image;
+
+public enum Builder {
+    docker,
+    jib,
+    buildpack,
+    openshift
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
@@ -1,0 +1,86 @@
+package io.quarkus.cli.image;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import picocli.CommandLine;
+import picocli.CommandLine.ParentCommand;
+
+@CommandLine.Command(name = "buildpack", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Buildpack.", description = "%n"
+        + "This command will build or push a container image for the project, using Buildpack.", footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Buildpack extends BaseImageCommand {
+
+    private static final String BUILDPACK = "buildpack";
+    private static final String BUILDPACK_CONFIG_PREFIX = "quarkus.buildpack.";
+    private static final String JVM_BUILDER_IMAGE = "jvm-builder-image";
+    private static final String NATIVE_BUILDER_IMAGE = "native-builder-image";
+    private static final String BUILDER_REGISTRY_USERNAME = "base-registry-username";
+    private static final String BUILDER_REGISTRY_PASSWORD = "base-registry-password";
+    private static final String PULL_TIMEOUT_SECONDS = "pull-timeout-seconds";
+    private static final String RUN_IMAGE = "run-image";
+    private static final String BUILDER_ENV = "builder-env";
+    private static final String DOCKER_HOST = "docker-host";
+
+    @CommandLine.Option(order = 7, names = { "--builder-image" }, description = "The builder image to use.")
+    public Optional<String> builderImage = Optional.empty();
+
+    @CommandLine.Option(order = 8, names = {
+            "--builder-registry-username" }, description = "The builder image registry username.")
+    public Optional<String> builderRegistryUsername = Optional.empty();
+
+    @CommandLine.Option(order = 9, names = {
+            "--builder-registry-password" }, description = "The builder image registry password.")
+    public Optional<String> builderRegistryPassword = Optional.empty();
+
+    @CommandLine.Option(order = 10, names = {
+            "--pull-image-timeout" }, description = "The amount of time to wait in seconds for pulling the builder image.")
+    public Optional<Integer> pullTimeout = Optional.empty();
+
+    @CommandLine.Option(order = 11, names = { "--run-image" }, description = "The run image to use.")
+    public Optional<String> runImage = Optional.empty();
+
+    @CommandLine.Option(order = 12, names = { "--docker-host" }, description = "The docker host.")
+    public Optional<String> dockerHost = Optional.empty();
+
+    @CommandLine.Option(order = 13, names = { "--build-env" }, description = "A build environment variable.")
+    public Map<String, String> buildEnv = new HashMap<>();
+
+    @ParentCommand
+    BaseImageCommand parent;
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        super.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, BUILDPACK);
+        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + BUILDPACK);
+
+        builderImage.ifPresent(i -> properties
+                .put(BUILDPACK_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_BUILDER_IMAGE : JVM_BUILDER_IMAGE), i));
+        builderRegistryUsername.ifPresent(u -> properties.put(BUILDPACK_CONFIG_PREFIX + BUILDER_REGISTRY_USERNAME, u));
+        builderRegistryPassword.ifPresent(p -> properties.put(BUILDPACK_CONFIG_PREFIX + BUILDER_REGISTRY_PASSWORD, p));
+        pullTimeout.ifPresent(t -> properties.put(BUILDPACK_CONFIG_PREFIX + PULL_TIMEOUT_SECONDS, t.toString()));
+        dockerHost.ifPresent(h -> properties.put(BUILDPACK_CONFIG_PREFIX + DOCKER_HOST, h));
+        runImage.ifPresent(i -> properties.put(BUILDPACK_CONFIG_PREFIX + RUN_IMAGE, i));
+        buildEnv.forEach((k, v) -> properties.put(BUILDPACK_CONFIG_PREFIX + BUILDER_ENV + "." + k, v));
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(parent.getPropertiesOptions().properties);
+            return parent.call();
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Buildpack {imageOptions:'" + imageOptions + "', buildEnv:'" + buildEnv + "'', builderImage:'" + builderImage
+                + "', builderRegistryPassword:'"
+                + builderRegistryPassword + "', builderRegistryUsername:'" + builderRegistryUsername + "', dockerHost:'"
+                + dockerHost + "', parent:'" + parent + "', pullTimeout:'" + pullTimeout + "', runImage:'" + runImage + "'}";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
@@ -1,0 +1,52 @@
+package io.quarkus.cli.image;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+import picocli.CommandLine.ParentCommand;
+
+@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build/Push a container image using Docker.", description = "%n"
+        + "This command will build or push a container image for the project, using Docker.", footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Docker extends BaseImageCommand implements Callable<Integer> {
+
+    private static final String DOCKER = "docker";
+    private static final String DOCKER_CONFIG_PREFIX = "quarkus.docker.";
+    private static final String DOCKERFILE_JVM_PATH = "dockerfileJvmPath";
+    private static final String DOCKERFILE_NATIVE_PATH = "dockerfileNativePath";
+
+    @CommandLine.Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
+    public Optional<String> dockerFile;
+
+    @ParentCommand
+    BaseImageCommand parent;
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        parent.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, DOCKER);
+        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + DOCKER);
+        dockerFile.ifPresent(d -> properties.put(DOCKER_CONFIG_PREFIX
+                + (buildOptions.buildNative ? DOCKERFILE_NATIVE_PATH : DOCKERFILE_JVM_PATH), d));
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            BuildSystemRunner runner = getRunner();
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Docker {imageOptions='" + imageOptions + "', dockerFile:'" + dockerFile.orElse("<none>") + "'}";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
@@ -2,21 +2,19 @@ package io.quarkus.cli.image;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 
-import io.quarkus.cli.build.BuildSystemRunner;
 import picocli.CommandLine;
 import picocli.CommandLine.ParentCommand;
 
-@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build/Push a container image using Docker.", description = "%n"
+@CommandLine.Command(name = "docker", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Docker.", description = "%n"
         + "This command will build or push a container image for the project, using Docker.", footer = "%n"
                 + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
-public class Docker extends BaseImageCommand implements Callable<Integer> {
+public class Docker extends BaseImageCommand {
 
     private static final String DOCKER = "docker";
     private static final String DOCKER_CONFIG_PREFIX = "quarkus.docker.";
-    private static final String DOCKERFILE_JVM_PATH = "dockerfileJvmPath";
-    private static final String DOCKERFILE_NATIVE_PATH = "dockerfileNativePath";
+    private static final String DOCKERFILE_JVM_PATH = "dockerfile-jvm-path";
+    private static final String DOCKERFILE_NATIVE_PATH = "dockerfile-native-path";
 
     @CommandLine.Option(order = 7, names = { "--dockerfile" }, description = "The path to the Dockerfile.")
     public Optional<String> dockerFile;
@@ -26,7 +24,7 @@ public class Docker extends BaseImageCommand implements Callable<Integer> {
 
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
-        parent.populateImageConfiguration(properties);
+        super.populateImageConfiguration(properties);
         properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, DOCKER);
         properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + DOCKER);
         dockerFile.ifPresent(d -> properties.put(DOCKER_CONFIG_PREFIX
@@ -36,10 +34,8 @@ public class Docker extends BaseImageCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         try {
-            populateImageConfiguration(propertiesOptions.properties);
-            BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
-            return runner.run(commandArgs);
+            populateImageConfiguration(parent.getPropertiesOptions().properties);
+            return parent.call();
         } catch (Exception e) {
             return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
@@ -1,0 +1,30 @@
+
+package io.quarkus.cli.image;
+
+import java.util.Optional;
+
+import picocli.CommandLine;
+
+public class ImageOptions {
+
+    @CommandLine.Option(order = 3, names = {
+            "--group" }, description = "The group part of the container image. Defaults to the ${user.name}.")
+    public Optional<String> group = Optional.of(System.getProperty("user.name"));
+
+    @CommandLine.Option(order = 4, names = {
+            "--name" }, description = "The name part of the container image. Defaults to the ${project.artifactId}.")
+    public Optional<String> name;
+
+    @CommandLine.Option(order = 5, names = {
+            "--tag" }, description = "The tag part of the container image. Defaults to the ${project.version}.")
+    public Optional<String> tag;
+
+    @CommandLine.Option(order = 6, names = {
+            "--registry" }, description = "The registry part of the container image. Empty by default.")
+    public Optional<String> registry;
+
+    @Override
+    public String toString() {
+        return "ImageOptions [group=" + group + ", name=" + name + ", tag=" + tag + ", registry=" + registry + "]";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/ImageOptions.java
@@ -13,15 +13,15 @@ public class ImageOptions {
 
     @CommandLine.Option(order = 4, names = {
             "--name" }, description = "The name part of the container image. Defaults to the ${project.artifactId}.")
-    public Optional<String> name;
+    public Optional<String> name = Optional.empty();
 
     @CommandLine.Option(order = 5, names = {
             "--tag" }, description = "The tag part of the container image. Defaults to the ${project.version}.")
-    public Optional<String> tag;
+    public Optional<String> tag = Optional.empty();
 
     @CommandLine.Option(order = 6, names = {
             "--registry" }, description = "The registry part of the container image. Empty by default.")
-    public Optional<String> registry;
+    public Optional<String> registry = Optional.empty();
 
     @Override
     public String toString() {

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
@@ -1,0 +1,156 @@
+package io.quarkus.cli.image;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+import picocli.CommandLine.ParentCommand;
+
+@CommandLine.Command(name = "jib", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build/Push a container image using Jib.", description = "%n"
+        + "This command will build or push a container image for the project, using Jib.", footer = "%n"
+                + "For example (using default values), it will create a container image using with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Jib extends BaseImageCommand implements Callable<Integer> {
+
+    private static final String JIB = "jib";
+    private static final String JIB_CONFIG_PREFIX = "quarkus.jib.";
+    private static final String BASE_JVM_IMAGE = "base-jvm-image";
+    private static final String JVM_ARGUMENTS = "jvm-arguments";
+    private static final String JVM_ENTRYPOINT = "jvm-entrypoint";
+    private static final String BASE_NATIVE_IMAGE = "base-native-image";
+    private static final String NATIVE_ARGUMENTS = "native-arguments";
+    private static final String NATIVE_ENTRYPOINT = "native-entrypoint";
+    private static final String LABELS = "labels.";
+    private static final String ENV_VARS = "environment-varialbes.";
+    private static final String PORTS = "ports";
+    private static final String PLATFORMS = "platforms";
+    private static final String IMAGE_DIGEST_FILE = "image-digest-file";
+    private static final String IMAGE_ID_FILE = "image-id-file";
+    private static final String OFFLINE_MODE = "offline-mode";
+
+    private static final String USER = "user";
+
+    @CommandLine.Option(order = 7, names = { "--baseImage" }, description = "The base image to use.")
+    public Optional<String> baseImage;
+
+    @CommandLine.Option(order = 8, names = {
+            "--arg" }, description = "Additional argument to pass when starting the application.")
+    public List<String> arguments = new ArrayList<>();
+
+    @CommandLine.Option(order = 9, names = { "--entrypoint" }, description = "The entrypoint of the container image.")
+    public List<String> entrypoint = new ArrayList<>();
+
+    @CommandLine.Option(order = 10, names = { "--env" }, description = "Environment variables to add to the container image.")
+    public Map<String, String> environmentVariables = new HashMap<>();
+
+    @CommandLine.Option(order = 11, names = { "--label" }, description = "Custom labels to add to the generated image.")
+    public Map<String, String> labels = new HashMap<>();
+
+    @CommandLine.Option(order = 12, names = { "--port" }, description = "The ports to expose.")
+    public List<Integer> ports = new ArrayList<>();
+
+    @CommandLine.Option(order = 13, names = { "--user" }, description = "The user in the generated image.")
+    public String user;
+
+    @CommandLine.Option(order = 14, names = {
+            "--always-cache-base-image" }, description = "Controls the optimization which skips downloading base image layers that exist in a target registry.")
+    public boolean alwaysCacheBaseImage;
+
+    @CommandLine.Option(order = 15, names = {
+            "--platform" }, description = "The target platforms defined using the pattern <os>[/arch][/variant]|<os>/<arch>[/variant]")
+    public Set<String> platforms = new HashSet<>();
+
+    @CommandLine.Option(order = 16, names = {
+            "--image-digest-file" }, description = "The path of a file that will be written containing the digest of the generated image.")
+    public String imageDigestFile;
+
+    @CommandLine.Option(order = 17, names = {
+            "--image-id-file" }, description = "The path of a file that will be written containing the id of the generated image.")
+    public String imageIdFile;
+
+    @ParentCommand
+    BaseImageCommand parent;
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        parent.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, JIB);
+        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + JIB);
+
+        baseImage.ifPresent(
+                d -> properties.put(JIB_CONFIG_PREFIX + (buildOptions.buildNative ? BASE_NATIVE_IMAGE : BASE_JVM_IMAGE), d));
+
+        if (!arguments.isEmpty()) {
+            String joinedArgs = arguments.stream().collect(Collectors.joining(","));
+            properties.put(JIB_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_ARGUMENTS : JVM_ARGUMENTS), joinedArgs);
+        }
+
+        if (!entrypoint.isEmpty()) {
+            String joinedEntrypoint = entrypoint.stream().collect(Collectors.joining(","));
+            properties.put(JIB_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_ENTRYPOINT : JVM_ENTRYPOINT),
+                    joinedEntrypoint);
+        }
+
+        if (!environmentVariables.isEmpty()) {
+            environmentVariables.forEach((key, value) -> {
+                properties.put(JIB_CONFIG_PREFIX + ENV_VARS + key, value);
+            });
+        }
+
+        if (!labels.isEmpty()) {
+            labels.forEach((key, value) -> {
+                properties.put(JIB_CONFIG_PREFIX + LABELS + key, value);
+            });
+        }
+
+        if (!ports.isEmpty()) {
+            String joinedPorts = ports.stream().map(String::valueOf).collect(Collectors.joining(","));
+            properties.put(JIB_CONFIG_PREFIX + PORTS, joinedPorts);
+        }
+
+        if (!platforms.isEmpty()) {
+            String joinedPlatforms = platforms.stream().collect(Collectors.joining(","));
+            properties.put(JIB_CONFIG_PREFIX + PLATFORMS, joinedPlatforms);
+        }
+
+        if (user != null && !user.isEmpty()) {
+            properties.put(JIB_CONFIG_PREFIX + USER, user);
+        }
+
+        if (imageDigestFile != null && !imageDigestFile.isEmpty()) {
+            properties.put(JIB_CONFIG_PREFIX + IMAGE_DIGEST_FILE, imageDigestFile);
+        }
+
+        if (imageIdFile != null && !imageIdFile.isEmpty()) {
+            properties.put(JIB_CONFIG_PREFIX + IMAGE_ID_FILE, imageIdFile);
+        }
+
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            if (buildOptions.offline) {
+                propertiesOptions.properties.put(JIB_CONFIG_PREFIX + OFFLINE_MODE, "true");
+            }
+            BuildSystemRunner runner = getRunner();
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Jib {imageOptions='" + imageOptions + "', baseImage:'" + baseImage.orElse("<none>") + "'}";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
@@ -1,0 +1,109 @@
+package io.quarkus.cli.image;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+import picocli.CommandLine.ParentCommand;
+
+@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build/Push a container image using Openshift.", description = "%n"
+        + "This command will build or push a container image for the project, using Openshift.", footer = "%n"
+                + "For example (using default values), it will create a container image in Openshift using the docker build strategy with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Openshift extends BaseImageCommand implements Callable<Integer> {
+
+    private static final String OPENSHIFT = "openshift";
+    private static final String OPENSHIFT_CONFIG_PREFIX = "quarkus.openshift.";
+    private static final String BASE_JVM_IMAGE = "base-jvm-image";
+    private static final String JVM_ARGUMENTS = "jvm-arguments";
+    private static final String JVM_DOCKERFILE = "jvm-dockerfile";
+    private static final String JAR_DIRECTORY = "jar-directory";
+    private static final String JAR_FILE_NAME = "jar-file-name";
+
+    private static final String BASE_NATIVE_IMAGE = "base-native-image";
+    private static final String NATIVE_ARGUMENTS = "native-arguments";
+    private static final String NATIVE_DOCKERFILE = "native-dockerfile";
+    private static final String NATIVE_DIRECTORY = "native-directory";
+    private static final String NATIVE_FILE_NAME = "native-file-name";
+
+    private static final String BUILD_STRATEGY = "build-strategy";
+    private static final String BUILD_TIMEOUT = "build-timeout";
+
+    @CommandLine.Option(order = 7, names = { "--build-strategy" }, description = "The build strategy to use (docker or s2i).")
+    public Optional<String> buildStrategy;
+
+    @CommandLine.Option(order = 8, names = { "--baseImage" }, description = "The base image to use.")
+    public Optional<String> baseImage = Optional.empty();
+
+    @CommandLine.Option(order = 9, names = {
+            "--arg" }, description = "Additional argument to pass when starting the application.")
+    public List<String> arguments = new ArrayList<>();
+
+    @CommandLine.Option(order = 10, names = { "--dockerfile" }, description = "The dockerfile of the container image.")
+    public String dockerfile;
+
+    @CommandLine.Option(order = 11, names = {
+            "--artifact-directory" }, description = "The directory where the jar/native binary is added during the assemble phase.")
+    public String artifactDirectory;
+
+    @CommandLine.Option(order = 12, names = { "--artifact-filename" }, description = "The filename of the jar/native binary.")
+    public String artifactFilename;
+
+    @CommandLine.Option(order = 13, names = { "--build-timeout" }, description = "The build timeout.")
+    public String buildTimeout;
+
+    @ParentCommand
+    BaseImageCommand parent;
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        parent.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, OPENSHIFT);
+        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + OPENSHIFT);
+        properties.put(OPENSHIFT_CONFIG_PREFIX + BUILD_STRATEGY, buildStrategy.orElse("docker"));
+
+        baseImage.ifPresent(d -> properties
+                .put(OPENSHIFT_CONFIG_PREFIX + (buildOptions.buildNative ? BASE_NATIVE_IMAGE : BASE_JVM_IMAGE), d));
+
+        if (!arguments.isEmpty()) {
+            String joinedArgs = arguments.stream().collect(Collectors.joining(","));
+            properties.put(OPENSHIFT_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_ARGUMENTS : JVM_ARGUMENTS), joinedArgs);
+        }
+
+        if (dockerfile != null && !dockerfile.isEmpty()) {
+            properties.put(OPENSHIFT_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_DOCKERFILE : JVM_DOCKERFILE),
+                    dockerfile);
+        }
+
+        if (artifactDirectory != null && !artifactDirectory.isEmpty()) {
+            properties.put(OPENSHIFT_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_DIRECTORY : JAR_DIRECTORY),
+                    artifactDirectory);
+        }
+
+        if (artifactFilename != null && !artifactFilename.isEmpty()) {
+            properties.put(OPENSHIFT_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_FILE_NAME : JAR_FILE_NAME),
+                    artifactFilename);
+        }
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            BuildSystemRunner runner = getRunner();
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Openshift {imageOptions='" + imageOptions + "', baseImage:'" + baseImage.orElse("<none>") + "'}";
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Openshift.java
@@ -7,11 +7,10 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
-import io.quarkus.cli.build.BuildSystemRunner;
 import picocli.CommandLine;
 import picocli.CommandLine.ParentCommand;
 
-@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build/Push a container image using Openshift.", description = "%n"
+@CommandLine.Command(name = "openshift", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Build a container image using Openshift.", description = "%n"
         + "This command will build or push a container image for the project, using Openshift.", footer = "%n"
                 + "For example (using default values), it will create a container image in Openshift using the docker build strategy with REPOSITORY='${user.name}/<project.artifactId>' and TAG='<project.version>'.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Openshift extends BaseImageCommand implements Callable<Integer> {
@@ -36,7 +35,7 @@ public class Openshift extends BaseImageCommand implements Callable<Integer> {
     @CommandLine.Option(order = 7, names = { "--build-strategy" }, description = "The build strategy to use (docker or s2i).")
     public Optional<String> buildStrategy;
 
-    @CommandLine.Option(order = 8, names = { "--baseImage" }, description = "The base image to use.")
+    @CommandLine.Option(order = 8, names = { "--base-image" }, description = "The base image to use.")
     public Optional<String> baseImage = Optional.empty();
 
     @CommandLine.Option(order = 9, names = {
@@ -61,7 +60,7 @@ public class Openshift extends BaseImageCommand implements Callable<Integer> {
 
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
-        parent.populateImageConfiguration(properties);
+        super.populateImageConfiguration(properties);
         properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, OPENSHIFT);
         properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + OPENSHIFT);
         properties.put(OPENSHIFT_CONFIG_PREFIX + BUILD_STRATEGY, buildStrategy.orElse("docker"));
@@ -93,10 +92,8 @@ public class Openshift extends BaseImageCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         try {
-            populateImageConfiguration(propertiesOptions.properties);
-            BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
-            return runner.run(commandArgs);
+            populateImageConfiguration(parent.getPropertiesOptions().properties);
+            return parent.call();
         } catch (Exception e) {
             return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
         }

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -27,12 +27,21 @@ public class Push extends BaseImageCommand implements Callable<Integer> {
             "--registry-password" }, description = "The image registry password.")
     public Optional<String> registryPassword = Optional.empty();
 
+    @CommandLine.Option(order = 10, names = {
+            "--registry-password-stdin" }, description = "Read the image registry password from stdin.")
+    public boolean registryPasswordStdin;
+
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
         super.populateImageConfiguration(properties);
         registryUsername.ifPresent(u -> properties.put(QUARKUS_CONTAINER_IMAGE_USERNAME, u));
-        registryPassword.ifPresent(p -> properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, p));
 
+        if (registryPasswordStdin) {
+            String password = new String(System.console().readPassword("Registry password:"));
+            properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, password);
+        } else {
+            registryPassword.ifPresent(p -> properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, p));
+        }
         properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -1,21 +1,44 @@
 package io.quarkus.cli.image;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.build.BuildSystemRunner;
+import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Push a container image.", description = "%n"
         + "This command will build and push a container image for the project.", footer = "%n", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
 public class Push extends BaseImageCommand implements Callable<Integer> {
 
-    private static final String QUARKUS_CONTAINER_IMAGE_PUSH = "quarkus.container-image.push";
+    protected static final String QUARKUS_CONTAINER_IMAGE_EXTENSION = "io.quarkus:quarkus-container-image";
+    private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-push",
+            BuildTool.GRADLE, "imagePush");
+
+    private static final String QUARKUS_CONTAINER_IMAGE_USERNAME = "quarkus.container-image.username";
+    private static final String QUARKUS_CONTAINER_IMAGE_PASSWORD = "quarkus.container-image.password";
+
+    @CommandLine.Option(order = 8, names = {
+            "--registry-username" }, description = "The image registry username.")
+    public Optional<String> registryUsername = Optional.empty();
+
+    @CommandLine.Option(order = 9, names = {
+            "--registry-password" }, description = "The image registry password.")
+    public Optional<String> registryPassword = Optional.empty();
 
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
         super.populateImageConfiguration(properties);
-        properties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
+        registryUsername.ifPresent(u -> properties.put(QUARKUS_CONTAINER_IMAGE_USERNAME, u));
+        registryPassword.ifPresent(p -> properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, p));
+
+        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION);
+    }
+
+    @Override
+    public Optional<String> getAction() {
+        return Optional.ofNullable(ACTION_MAPPING.get(getRunner().getBuildTool()));
     }
 
     @Override
@@ -23,10 +46,13 @@ public class Push extends BaseImageCommand implements Callable<Integer> {
         try {
             populateImageConfiguration(propertiesOptions.properties);
             BuildSystemRunner runner = getRunner();
-            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+
+            String action = getAction().orElseThrow(
+                    () -> new IllegalStateException("Unknown image push action for " + runner.getBuildTool().name()));
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareAction(action, buildOptions, runMode, params);
             return runner.run(commandArgs);
         } catch (Exception e) {
-            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+            return output.handleCommandException(e, "Unable to push image: " + e.getMessage());
         }
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -1,0 +1,37 @@
+package io.quarkus.cli.image;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "push", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Push a container image.", description = "%n"
+        + "This command will build and push a container image for the project.", footer = "%n", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "Options:%n")
+public class Push extends BaseImageCommand implements Callable<Integer> {
+
+    private static final String QUARKUS_CONTAINER_IMAGE_PUSH = "quarkus.container-image.push";
+
+    @Override
+    public void populateImageConfiguration(Map<String, String> properties) {
+        super.populateImageConfiguration(properties);
+        properties.put(QUARKUS_CONTAINER_IMAGE_PUSH, "true");
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            BuildSystemRunner runner = getRunner();
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareBuild(buildOptions, runMode, params);
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Push {imageOptions='" + imageOptions + "'}";
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliDriver.java
@@ -195,6 +195,30 @@ public class CliDriver {
         String stdout;
         String stderr;
 
+        public int getExitCode() {
+            return exitCode;
+        }
+
+        public String getStdout() {
+            return stdout;
+        }
+
+        public void setStdout(String stdout) {
+            this.stdout = stdout;
+        }
+
+        public String getStderr() {
+            return stderr;
+        }
+
+        public void setStderr(String stderr) {
+            this.stderr = stderr;
+        }
+
+        public void setExitCode(int exitCode) {
+            this.exitCode = exitCode;
+        }
+
         public void echoSystemOut() {
             System.out.println(stdout);
             System.out.println();

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -197,4 +197,77 @@ public class CliHelpTest {
         writer.info(MessageIcons.NOK_ICON + " info");
         writer.debug("debug");
     }
+
+    @Test
+    @Order(90)
+    public void testImageHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(92)
+    public void testImageBuildHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(93)
+    public void testImageBuildDockerHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "docker", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(94)
+    public void testImageBuildJibHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "jib", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(95)
+    public void testImageBuildOpenshiftHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "openshift", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(96)
+    public void testImagePushHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(97)
+    public void testImagePushDockerHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "docker", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(98)
+    public void testImagePushJibHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "jib", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
+    @Test
+    @Order(99)
+    public void testImagePushOpenshiftHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "openshift", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
+
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/CliHelpTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -204,6 +205,9 @@ public class CliHelpTest {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
+        assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
+        assertTrue(result.getStdout().contains("build"), "Should list build subcommand\n");
+        assertTrue(result.getStdout().contains("push"), "Should list build subcommand\n");
     }
 
     @Test
@@ -212,6 +216,12 @@ public class CliHelpTest {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "build", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
+        assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
+        assertTrue(result.getStdout().contains("docker"), "Should list docker subcommand\n");
+        assertTrue(result.getStdout().contains("jib"), "Should list jib subcommand\n");
+        assertTrue(result.getStdout().contains("openshift"), "Should list openshift subcommand\n");
+        assertTrue(result.getStdout().contains("buildpack"), "Should list buildpack subcommand\n");
+
     }
 
     @Test
@@ -244,6 +254,10 @@ public class CliHelpTest {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "--help");
         result.echoSystemOut();
         assertThat(result.stdout).contains("Usage");
+        assertThat(result.stdout).contains("--registry");
+        assertThat(result.stdout).contains("--registry-username");
+        assertThat(result.stdout).contains("--registry-password");
+        assertThat(result.stdout).contains("--registry-password-stdin");
     }
 
     @Test
@@ -270,4 +284,11 @@ public class CliHelpTest {
         assertThat(result.stdout).contains("Usage");
     }
 
+    @Test
+    @Order(99)
+    public void testImagePushBuildpackHelp() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "image", "push", "buildpack", "--help");
+        result.echoSystemOut();
+        assertThat(result.stdout).contains("Usage");
+    }
 }

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -1,0 +1,68 @@
+package io.quarkus.cli.image;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.cli.CliDriver;
+import io.quarkus.devtools.testing.RegistryClientTestHelper;
+import picocli.CommandLine;
+
+/**
+ * Similar to CliProjecMavenTest ..
+ */
+public class CliImageMavenTest {
+    static Path workspaceRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("target/test-project/CliImageMavenTest");
+    Path project;
+
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
+
+    @BeforeEach
+    public void setupTestDirectories() throws Exception {
+        CliDriver.deleteDir(workspaceRoot);
+        project = workspaceRoot.resolve("code-with-quarkus");
+    }
+
+    @Test
+    public void testUsage() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+
+        // 1 image --help
+        result = CliDriver.execute(project, "image", "--help");
+        Assertions.assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
+        Assertions.assertTrue(result.getStdout().contains("build"), "Should list build subcommand\n");
+        Assertions.assertTrue(result.getStdout().contains("push"), "Should list build subcommand\n");
+
+        // 2 image build --help
+        result = CliDriver.execute(project, "image", "build", "--help");
+        Assertions.assertTrue(result.getStdout().contains("--group"), "Should have --group option\n");
+        Assertions.assertTrue(result.getStdout().contains("--name"), "Should have --name  option\n");
+        Assertions.assertTrue(result.getStdout().contains("--tag"), "Should have --tag  option\n");
+        Assertions.assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
+        Assertions.assertTrue(result.getStdout().contains("docker"), "Should list docker subcommand\n");
+        Assertions.assertTrue(result.getStdout().contains("jib"), "Should list jib subcommand\n");
+        Assertions.assertTrue(result.getStdout().contains("openshift"), "Should list openshift subcommand\n");
+        Assertions.assertTrue(result.getStdout().contains("buildpack"), "Should list buildpack subcommand\n");
+
+        // 3 image push --help
+        result = CliDriver.execute(project, "image", "push", "--help");
+        Assertions.assertTrue(result.getStdout().contains("--group"), "Should have --group option\n");
+        Assertions.assertTrue(result.getStdout().contains("--name"), "Should have --name  option\n");
+        Assertions.assertTrue(result.getStdout().contains("--tag"), "Should have --tag  option\n");
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -1,10 +1,12 @@
 package io.quarkus.cli.image;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,29 +42,22 @@ public class CliImageMavenTest {
     @Test
     public void testUsage() throws Exception {
         CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "-e", "-B", "--verbose");
-        Assertions.assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
 
-        // 1 image --help
-        result = CliDriver.execute(project, "image", "--help");
-        Assertions.assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
-        Assertions.assertTrue(result.getStdout().contains("build"), "Should list build subcommand\n");
-        Assertions.assertTrue(result.getStdout().contains("push"), "Should list build subcommand\n");
+        // 1 image --dry-run
+        result = CliDriver.execute(project, "image", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        // 2 image build --dry-run
+        result = CliDriver.execute(project, "image", "build", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        result = CliDriver.execute(project, "image", "build", "--group=mygroup", "--name=myname", "--tag=1.0", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.group=mygroup"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.name=myname"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
 
-        // 2 image build --help
-        result = CliDriver.execute(project, "image", "build", "--help");
-        Assertions.assertTrue(result.getStdout().contains("--group"), "Should have --group option\n");
-        Assertions.assertTrue(result.getStdout().contains("--name"), "Should have --name  option\n");
-        Assertions.assertTrue(result.getStdout().contains("--tag"), "Should have --tag  option\n");
-        Assertions.assertTrue(result.getStdout().contains("Commands:"), "Should list subcommands\n");
-        Assertions.assertTrue(result.getStdout().contains("docker"), "Should list docker subcommand\n");
-        Assertions.assertTrue(result.getStdout().contains("jib"), "Should list jib subcommand\n");
-        Assertions.assertTrue(result.getStdout().contains("openshift"), "Should list openshift subcommand\n");
-        Assertions.assertTrue(result.getStdout().contains("buildpack"), "Should list buildpack subcommand\n");
-
-        // 3 image push --help
+        // 3 image push --dry-run
         result = CliDriver.execute(project, "image", "push", "--help");
-        Assertions.assertTrue(result.getStdout().contains("--group"), "Should have --group option\n");
-        Assertions.assertTrue(result.getStdout().contains("--name"), "Should have --name  option\n");
-        Assertions.assertTrue(result.getStdout().contains("--tag"), "Should have --tag  option\n");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/GradleUtils.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/GradleUtils.java
@@ -1,0 +1,61 @@
+
+package io.quarkus.gradle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.plugins.JavaPlugin;
+
+public class GradleUtils {
+
+    public static String getQuarkusCoreVersion(Project project) {
+        final List<Dependency> bomDeps = listProjectBoms(project);
+        if (bomDeps.isEmpty()) {
+            throw new GradleException("No platforms detected in the project");
+        }
+
+        final Configuration boms = project.getConfigurations()
+                .detachedConfiguration(bomDeps.toArray(new org.gradle.api.artifacts.Dependency[0]));
+
+        final AtomicReference<String> quarkusVersionRef = new AtomicReference<>();
+        boms.getResolutionStrategy().eachDependency(d -> {
+            if (quarkusVersionRef.get() == null && d.getTarget().getName().equals("quarkus-core")
+                    && d.getTarget().getGroup().equals("io.quarkus")) {
+                quarkusVersionRef.set(d.getTarget().getVersion());
+            }
+        });
+        boms.getResolvedConfiguration();
+        final String quarkusCoreVersion = quarkusVersionRef.get();
+        if (quarkusCoreVersion == null) {
+            throw new IllegalStateException("Failed to determine the Quarkus core version for the project");
+        }
+        return quarkusCoreVersion;
+    }
+
+    public static List<Dependency> listProjectBoms(Project project) {
+        final Configuration impl = project.getConfigurations().getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME);
+        List<Dependency> boms = new ArrayList<>();
+        impl.getIncoming().getDependencies()
+                .forEach(d -> {
+                    if (!(d instanceof ModuleDependency)) {
+                        return;
+                    }
+                    final ModuleDependency module = (ModuleDependency) d;
+                    final Category category = module.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
+                    if (category != null
+                            && (Category.ENFORCED_PLATFORM.equals(category.getName())
+                                    || Category.REGULAR_PLATFORM.equals(category.getName()))) {
+                        boms.add(d);
+                    }
+                });
+        return boms;
+    }
+
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -1,6 +1,19 @@
 
 package io.quarkus.gradle.tasks;
 
-public class ImageBuild extends QuarkusBuild {
+import java.util.Map;
 
+import javax.inject.Inject;
+
+public abstract class ImageBuild extends ImageTask {
+
+    @Inject
+    public ImageBuild(QuarkusBuildConfiguration buildConfiguration) {
+        super(buildConfiguration, "Perform an image build");
+    }
+
+    @Override
+    public Map<String, String> forcedProperties() {
+        return Map.of("quarkus.container-image.build", "true");
+    }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -1,11 +1,30 @@
 
 package io.quarkus.gradle.tasks;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
 public abstract class ImageBuild extends ImageTask {
+
+    public enum Builder {
+        docker,
+        jib,
+        buildpack,
+        openshift
+    }
+
+    Builder builder = Builder.docker;
+
+    @Option(option = "builder", description = "The container image extension to use for building the image (e.g. docker, jib, buildpack, openshift).")
+    public void setBuilder(Builder builder) {
+        this.builder = builder;
+    }
 
     @Inject
     public ImageBuild(QuarkusBuildConfiguration buildConfiguration) {
@@ -14,6 +33,24 @@ public abstract class ImageBuild extends ImageTask {
 
     @Override
     public Map<String, String> forcedProperties() {
-        return Map.of("quarkus.container-image.build", "true");
+        return Map.of("quarkus.container-image.build", "true",
+                "quarkus.container-image.builder", builder.name());
+    }
+
+    @TaskAction
+    public void checkRequiredExtensions() {
+        // Currently forcedDependencies() is not implemented for gradle.
+        // So, let's give users a meaningful warning message.
+        String requiredExtension = "quarkus-container-image-" + builder.name();
+        String requiredDependency = requiredExtension + "-deployment";
+        List<String> projectDependencies = getProject().getConfigurations().stream().flatMap(c -> c.getDependencies().stream())
+                .map(d -> d.getName())
+                .collect(Collectors.toList());
+
+        if (!projectDependencies.contains(requiredDependency)) {
+            getProject().getLogger().warn("Task: {} requires extensions: {}", getName(), requiredDependency);
+            getProject().getLogger().warn("To add the extensions to the project you can run the following command:");
+            getProject().getLogger().warn("\tgradle addExtension --extensions={}", requiredExtension);
+        }
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageBuild.java
@@ -1,0 +1,6 @@
+
+package io.quarkus.gradle.tasks;
+
+public class ImageBuild extends QuarkusBuild {
+
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
@@ -1,9 +1,14 @@
 
 package io.quarkus.gradle.tasks;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+
+import org.gradle.api.tasks.TaskAction;
 
 public abstract class ImagePush extends ImageTask {
 
@@ -15,5 +20,28 @@ public abstract class ImagePush extends ImageTask {
     @Override
     public Map<String, String> forcedProperties() {
         return Map.of("quarkus.container-image.push", "true");
+    }
+
+    @TaskAction
+    public void checkRequiredExtensions() {
+        List<String> containerImageExtensions = getProject().getConfigurations().stream()
+                .flatMap(c -> c.getDependencies().stream())
+                .map(d -> d.getName())
+                .filter(n -> n.startsWith("quarkus-container-image"))
+                .map(n -> n.replaceAll("-deployment$", ""))
+                .collect(Collectors.toList());
+
+        List<String> extensions = Arrays.stream(ImageBuild.Builder.values()).map(b -> "quarkus-container-image-" + b.name())
+                .collect(Collectors.toList());
+
+        if (containerImageExtensions.isEmpty()) {
+            getProject().getLogger().warn("Task: {} requires a container image extension.", getName());
+            getProject().getLogger().warn("Available container image exntesions: [{}]",
+                    extensions.stream().collect(Collectors.joining(", ")));
+            getProject().getLogger().warn("To add an extension to the project, you can run one of the commands below:");
+            extensions.forEach(e -> {
+                getProject().getLogger().warn("\tgradle addExtension --extensions={}", e);
+            });
+        }
     }
 }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImagePush.java
@@ -1,0 +1,19 @@
+
+package io.quarkus.gradle.tasks;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public abstract class ImagePush extends ImageTask {
+
+    @Inject
+    public ImagePush(QuarkusBuildConfiguration buildConfiguration) {
+        super(buildConfiguration, "Perfom an image push");
+    }
+
+    @Override
+    public Map<String, String> forcedProperties() {
+        return Map.of("quarkus.container-image.push", "true");
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -1,42 +1,12 @@
 
 package io.quarkus.gradle.tasks;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-
-import org.gradle.api.tasks.options.Option;
-
-import io.quarkus.gradle.GradleUtils;
-import io.quarkus.maven.dependency.ArtifactCoords;
-import io.quarkus.maven.dependency.ArtifactDependency;
-import io.quarkus.maven.dependency.Dependency;
 
 public abstract class ImageTask extends QuarkusBuildProviderTask {
 
-    public enum Builder {
-        docker,
-        jib,
-        buildpack,
-        openshift
-    }
-
-    Builder builder = Builder.docker;
-
     public ImageTask(QuarkusBuildConfiguration buildConfiguration, String description) {
         super(buildConfiguration, description);
-    }
-
-    @Option(option = "builder", description = "The container image extension to use for building the image (e.g. docker, jib, buildpack, openshift).")
-    public void setBuilder(Builder builder) {
-        this.builder = builder;
-    }
-
-    @Override
-    public List<Dependency> forcedDependencies() {
-        String quarkusVersion = GradleUtils.getQuarkusCoreVersion(getProject());
-        return Arrays.asList(new ArtifactDependency("io.quarkus", "quarkus-container-image-" + builder.name(), null,
-                ArtifactCoords.TYPE_JAR, quarkusVersion));
     }
 
     @Override

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/ImageTask.java
@@ -1,0 +1,46 @@
+
+package io.quarkus.gradle.tasks;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.gradle.api.tasks.options.Option;
+
+import io.quarkus.gradle.GradleUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactDependency;
+import io.quarkus.maven.dependency.Dependency;
+
+public abstract class ImageTask extends QuarkusBuildProviderTask {
+
+    public enum Builder {
+        docker,
+        jib,
+        buildpack,
+        openshift
+    }
+
+    Builder builder = Builder.docker;
+
+    public ImageTask(QuarkusBuildConfiguration buildConfiguration, String description) {
+        super(buildConfiguration, description);
+    }
+
+    @Option(option = "builder", description = "The container image extension to use for building the image (e.g. docker, jib, buildpack, openshift).")
+    public void setBuilder(Builder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public List<Dependency> forcedDependencies() {
+        String quarkusVersion = GradleUtils.getQuarkusCoreVersion(getProject());
+        return Arrays.asList(new ArtifactDependency("io.quarkus", "quarkus-container-image-" + builder.name(), null,
+                ArtifactCoords.TYPE_JAR, quarkusVersion));
+    }
+
+    @Override
+    public Map<String, String> forcedProperties() {
+        return Map.of("quarkus.container-image.build", "true");
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -11,8 +11,6 @@ import java.util.Properties;
 
 import javax.inject.Inject;
 
-import javax.inject.Inject;
-
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -9,10 +9,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.inject.Inject;
+
+import javax.inject.Inject;
+
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -32,7 +37,7 @@ import io.quarkus.gradle.dsl.Manifest;
 import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.runtime.util.StringUtil;
 
-public class QuarkusBuild extends QuarkusTask {
+public abstract class QuarkusBuild extends QuarkusTask {
 
     private static final String NATIVE_PROPERTY_NAMESPACE = "quarkus.native";
     private static final String MANIFEST_SECTIONS_PROPERTY_PREFIX = "quarkus.package.manifest.manifest-sections";
@@ -41,8 +46,13 @@ public class QuarkusBuild extends QuarkusTask {
     private List<String> ignoredEntries = new ArrayList<>();
     private Manifest manifest = new Manifest();
 
+    @Inject
     public QuarkusBuild() {
         super("Quarkus builds a runner jar based on the build jar");
+    }
+
+    public QuarkusBuild(String description) {
+        super(description);
     }
 
     public QuarkusBuild nativeArgs(Action<Map<String, ?>> action) {
@@ -53,6 +63,10 @@ public class QuarkusBuild extends QuarkusTask {
         }
         return this;
     }
+
+    @Optional
+    @Input
+    public abstract MapProperty<String, String> getForcedProperties();
 
     @Optional
     @Input
@@ -125,6 +139,8 @@ public class QuarkusBuild extends QuarkusTask {
     @TaskAction
     public void buildQuarkus() {
         final ApplicationModel appModel;
+        final Map<String, String> forcedProperties = getForcedProperties().getOrElse(Collections.emptyMap());
+
         try {
             appModel = extension().getAppModelResolver().resolveModel(new GACTV(getProject().getGroup().toString(),
                     getProject().getName(), getProject().getVersion().toString()));
@@ -133,6 +149,7 @@ public class QuarkusBuild extends QuarkusTask {
         }
 
         final Properties effectiveProperties = getBuildSystemProperties(appModel.getAppArtifact());
+        effectiveProperties.putAll(forcedProperties);
         if (ignoredEntries != null && ignoredEntries.size() > 0) {
             String joinedEntries = String.join(",", ignoredEntries);
             effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildConfiguration.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildConfiguration.java
@@ -1,0 +1,39 @@
+
+package io.quarkus.gradle.tasks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+
+public class QuarkusBuildConfiguration {
+
+    private final Project project;
+
+    private ListProperty<String> forcedDependencies;
+    private MapProperty<String, String> forcedProperties;
+
+    public QuarkusBuildConfiguration(Project project) {
+        this.project = project;
+        forcedDependencies = project.getObjects().listProperty(String.class);
+        forcedProperties = project.getObjects().mapProperty(String.class, String.class);
+    }
+
+    public ListProperty<String> getForcedDependencies() {
+        return forcedDependencies;
+    }
+
+    public void setForcedDependencies(List<String> forcedDependencies) {
+        this.forcedDependencies.addAll(forcedDependencies);
+    }
+
+    public MapProperty<String, String> getForcedProperties() {
+        return forcedProperties;
+    }
+
+    public void setForcedProperties(Map<String, String> forcedProperties) {
+        this.forcedProperties.putAll(forcedProperties);
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildProviderTask.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuildProviderTask.java
@@ -1,0 +1,26 @@
+
+package io.quarkus.gradle.tasks;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.gradle.api.tasks.TaskAction;
+
+public abstract class QuarkusBuildProviderTask extends QuarkusTask {
+
+    private final QuarkusBuildConfiguration buildConfiguration;
+
+    @Inject
+    public QuarkusBuildProviderTask(QuarkusBuildConfiguration buildConfiguration, String description) {
+        super(description);
+        this.buildConfiguration = buildConfiguration;
+    }
+
+    public abstract Map<String, String> forcedProperties();
+
+    @TaskAction
+    public void configureBuild() {
+        buildConfiguration.setForcedProperties(forcedProperties());
+    }
+}

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -46,6 +46,8 @@ public class QuarkusPluginTest {
         assertNotNull(tasks.getByName(QuarkusPlugin.BUILD_NATIVE_TASK_NAME));
         assertNotNull(tasks.getByName(QuarkusPlugin.LIST_EXTENSIONS_TASK_NAME));
         assertNotNull(tasks.getByName(QuarkusPlugin.ADD_EXTENSION_TASK_NAME));
+        assertNotNull(tasks.getByName(QuarkusPlugin.IMAGE_BUILD_TASK_NAME));
+        assertNotNull(tasks.getByName(QuarkusPlugin.IMAGE_PUSH_TASK_NAME));
     }
 
     @Test
@@ -166,5 +168,14 @@ public class QuarkusPluginTest {
             }
         }
         return dependantTaskNames;
+    }
+
+    private static final String getFinalizedByTaskName(Task task) {
+        try {
+            return ((Provider<Task>) task.getFinalizedBy()).get().getName();
+        } catch (ClassCastException e) {
+            // Nothing to do here
+            return null;
+        }
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
@@ -26,10 +26,27 @@ public class AbstractImageMojo extends BuildMojo {
     @Parameter(defaultValue = "docker", property = "quarkus.container-image.builder")
     Builder builder = Builder.docker;
 
+    @Parameter(property = "quarkus.container-image.dry-run")
+    boolean dryRun;
+
     @Override
     protected boolean beforeExecute() throws MojoExecutionException {
         systemProperties.put("quarkus.container-image.builder", builder.name());
         return super.beforeExecute();
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException {
+        if (dryRun) {
+            getLog().info("Container image confiugration:");
+            systemProperties.entrySet().stream()
+                    .filter(e -> e.getKey().contains("quarkus.container-image"))
+                    .forEach(e -> {
+                        getLog().info(" - " + e.getKey() + ": " + e.getValue());
+                    });
+        } else {
+            super.doExecute();
+        }
     }
 
     @Override

--- a/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/AbstractImageMojo.java
@@ -1,0 +1,54 @@
+package io.quarkus.maven;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.maven.dependency.ArtifactDependency;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Base class for Image related mojos.
+ */
+public class AbstractImageMojo extends BuildMojo {
+
+    public enum Builder {
+        docker,
+        jib,
+        buildpack,
+        openshift
+    }
+
+    @Parameter(defaultValue = "docker", property = "quarkus.container-image.builder")
+    Builder builder = Builder.docker;
+
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException {
+        systemProperties.put("quarkus.container-image.builder", builder.name());
+        return super.beforeExecute();
+    }
+
+    @Override
+    protected List<Dependency> forcedDependencies(LaunchMode mode) {
+        List<Dependency> dependencies = new ArrayList<>();
+        getContainerImageExtension(builder).ifPresent(d -> dependencies.add(d));
+        return dependencies;
+    }
+
+    protected Optional<ArtifactDependency> getContainerImageExtension(Builder builder) {
+        return getExtension("quarkus-container-image-" + builder.name());
+    }
+
+    protected Optional<ArtifactDependency> getExtension(String artifactId) {
+        return mavenProject().getDependencyManagement().getDependencies().stream()
+                .filter(d -> "io.quarkus".equals(d.getGroupId()) && artifactId.equals(d.getArtifactId()))
+                .map(d -> new ArtifactDependency(d.getGroupId(), d.getArtifactId(), null, ArtifactCoords.TYPE_JAR,
+                        d.getVersion()))
+                .findFirst();
+    }
+
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -36,30 +36,30 @@ import io.quarkus.bootstrap.util.IoUtils;
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class BuildMojo extends QuarkusBootstrapMojo {
 
-    private static final String PACKAGE_TYPE_PROP = "quarkus.package.type";
-    private static final String NATIVE_PROFILE_NAME = "native";
-    private static final String NATIVE_PACKAGE_TYPE = "native";
+    static final String PACKAGE_TYPE_PROP = "quarkus.package.type";
+    static final String NATIVE_PROFILE_NAME = "native";
+    static final String NATIVE_PACKAGE_TYPE = "native";
 
     @Component
-    private MavenProjectHelper projectHelper;
+    MavenProjectHelper projectHelper;
 
     /**
      * The project's remote repositories to use for the resolution of plugins and their dependencies.
      */
     @Parameter(defaultValue = "${project.remotePluginRepositories}", readonly = true, required = true)
-    private List<RemoteRepository> pluginRepos;
+    List<RemoteRepository> pluginRepos;
 
     /**
      * The directory for generated source files.
      */
     @Parameter(defaultValue = "${project.build.directory}/generated-sources")
-    private File generatedSourcesDirectory;
+    File generatedSourcesDirectory;
 
     /**
      * Skips the execution of this mojo
      */
     @Parameter(defaultValue = "false", property = "quarkus.build.skip")
-    private boolean skip = false;
+    boolean skip = false;
 
     @Deprecated
     @Parameter(property = "skipOriginalJarRename")
@@ -69,7 +69,7 @@ public class BuildMojo extends QuarkusBootstrapMojo {
      * The list of system properties defined for the plugin.
      */
     @Parameter
-    private Map<String, String> systemProperties = Collections.emptyMap();
+    Map<String, String> systemProperties = Collections.emptyMap();
 
     @Override
     protected boolean beforeExecute() throws MojoExecutionException {
@@ -166,7 +166,7 @@ public class BuildMojo extends QuarkusBootstrapMojo {
         }
     }
 
-    private boolean isNativeProfileEnabled(MavenProject mavenProject) {
+    boolean isNativeProfileEnabled(MavenProject mavenProject) {
         // gotcha: mavenProject.getActiveProfiles() does not always contain all active profiles (sic!),
         //         but getInjectedProfileIds() does (which has to be "flattened" first)
         Stream<String> activeProfileIds = mavenProject.getInjectedProfileIds().values().stream().flatMap(List<String>::stream);

--- a/devtools/maven/src/main/java/io/quarkus/maven/ImageBuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ImageBuildMojo.java
@@ -1,0 +1,22 @@
+package io.quarkus.maven;
+
+import java.util.HashMap;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Builds a container image.
+ */
+@Mojo(name = "image-build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class ImageBuildMojo extends AbstractImageMojo {
+
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException {
+        systemProperties = new HashMap<>(systemProperties);
+        systemProperties.put("quarkus.container-image.build", "true");
+        return super.beforeExecute();
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/ImagePushMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/ImagePushMojo.java
@@ -1,0 +1,22 @@
+package io.quarkus.maven;
+
+import java.util.HashMap;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Pushes a container image.
+ */
+@Mojo(name = "image-push", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class ImagePushMojo extends AbstractImageMojo {
+
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException {
+        systemProperties = new HashMap<>(systemProperties);
+        systemProperties.put("quarkus.container-image.push", "true");
+        return super.beforeExecute();
+    }
+}

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -599,7 +599,5 @@ The `image push` command is similar to `image build`, and surfaces some basic op
 
 [source, shell]
 ----
-quarkus image push --registry=<<image registry>> --registry-username=<<registry username>> --registry-passowrd=<<registry password>>
+quarkus image push --registry=<<image registry>> --registry-username=<<registry username>> --registry-password-stdin
 ----
-
-Note: It's not recommended to pass username and password as command line arguments.

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -599,5 +599,5 @@ The `image push` command is similar to `image build`, and surfaces some basic op
 
 [source, shell]
 ----
-quarkus image push --registry=<<image registry>> --registry-username=<<registry username>> --registry-password-stdin
+quarkus image push --registry=<image registry> --registry-username=<registry username> --registry-password-stdin
 ----

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -566,36 +566,36 @@ complete -F _complete_quarkus q
 ----
 
 
-=== Image building and pushing
+=== Container images
 
-The quarkus cli allows building container images without tampering with your project configuration (adding / removing container image extensions).
-To perform a build:
+The Quarkus CLI allows building container images without tampering with your project configuration (adding / removing container image extensions).
+To build the image for your project:
 
 [source, shell]
 ----
 quarkus image build
 ----
 
-The build command can be used directly, or a subcommand can be selected. The available subcommands are:
+The `image build` command can be used directly, or a subcommand can be selected. The available subcommands are:
 
 - docker
 - buildpacks
 - jib
 - openshift
 
-Each subcommand corresponds to an image building tool supported by quarkus and gives access to specific configuration options.
+Each subcommand corresponds to an image building tool supported by Quarkus and gives access to specific configuration options.
 
-For example to use `buildpacks` instead of `docker` and set the builder image of choice:
+For example, to use a https://buildpacks.io/[Cloud Native Buildpack] with a custom builder image, use the following:
 
 [source, shell]
 ----
-quarkus image build buildpack --builder-image <<your builder image>>
+quarkus image build buildpack --builder-image <your builder image>
 ----
 
 
 ==== Pushing
 
-Similar to `build` the `push` command works similarly. It allows allows for pushing images and exposes some basic options related to the target registry.
+The `image push` command is similar to `image build`, and surfaces some basic options required to push images to a target container registry.
 
 [source, shell]
 ----

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -282,6 +282,14 @@ Commands:
     add                   Add a Quarkus extension registry
     remove                Remove a Quarkus extension registry
   version                 Display version information.
+  image                   Perform a container image operation.
+    build                 Build a container image.
+      docker              Build a container image using Docker.
+      buildpack           Build a container image using Buildpack.
+      jib                 Build a container image using Jib.
+      openshift           Build a container image using Openshift.
+    push                  Push a container image.
+  completion              bash/zsh completion:  source <(quarkus completion)
 ----
 
 [TIP]
@@ -556,3 +564,42 @@ alias q=quarkus
 # Add q to list of commands included in quarkus autocompletion
 complete -F _complete_quarkus q
 ----
+
+
+=== Image building and pushing
+
+The quarkus cli allows building container images without tampering with your project configuration (adding / removing container image extensions).
+To perform a build:
+
+[source, shell]
+----
+quarkus image build
+----
+
+The build command can be used directly, or a subcommand can be selected. The available subcommands are:
+
+- docker
+- buildpacks
+- jib
+- openshift
+
+Each subcommand corresponds to an image building tool supported by quarkus and gives access to specific configuration options.
+
+For example to use `buildpacks` instead of `docker` and set the builder image of choice:
+
+[source, shell]
+----
+quarkus image build buildpack --builder-image <<your builder image>>
+----
+
+
+==== Pushing
+
+Similar to `build` the `push` command works similarly. It allows allows for pushing images and exposes some basic options related to the target registry.
+
+[source, shell]
+----
+quarkus image push --registry=<<image registry>> --registry-username=<<registry username>> --registry-passowrd=<<registry password>>
+----
+
+Note: It's not recommended to pass username and password as command line arguments.

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ImageBuildTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@Disabled("Forced dependencies for gradle still don't work")
+public class ImageBuildTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void shouldRunIntegrationTestAsPartOfBuild() throws Exception {
+        File projectDir = getProjectDir("it-test-basic-project");
+        BuildResult buildResult = runGradleWrapper(projectDir, "imageBuild", "--builder=jib");
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":imageBuild"))).isTrue();
+
+        final File buildDir = new File(projectDir, "build");
+        final Path mainLib = buildDir.toPath().resolve("quarkus-app").resolve("lib").resolve("main");
+
+        boolean hasContainerImageExtension = Arrays.stream(mainLib.toFile().list()).filter(l -> l.startsWith("io.quarkus"))
+                .anyMatch(l -> l.contains("container-image-jib"));
+        assertTrue(hasContainerImageExtension);
+    }
+}

--- a/integration-tests/maven/src/test/java/io/quarkus/maven/it/ImageBuildIT.java
+++ b/integration-tests/maven/src/test/java/io/quarkus/maven/it/ImageBuildIT.java
@@ -1,0 +1,36 @@
+package io.quarkus.maven.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
+import io.quarkus.maven.it.verifier.RunningInvoker;
+
+@DisableForNative
+public class ImageBuildIT extends MojoTestBase {
+
+    private RunningInvoker running;
+    private File testDir;
+
+    // We can only test with jib as its the only extension that has 0 dependencies from the system.
+    @Test
+    @EnabledOnOs({ OS.LINUX })
+    public void testImageBuildWithJib() throws Exception {
+        Properties buildProperties = new Properties();
+        buildProperties.put("quarkus.container-image.builder", "jib");
+
+        testDir = initProject("projects/classic");
+        running = new RunningInvoker(testDir, false);
+        final MavenProcessInvocationResult result = running.execute(Collections.singletonList("quarkus:image-build"),
+                Collections.emptyMap(), buildProperties);
+        assertThat(result.getProcess().waitFor()).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces the following:

1. The ability to use force extensions via System properties.
2. CLI commands for building container images.

The commands work like:

```
quarkus image build 
quarkus image push
```

for build commands user has access to more specific sub-commands which expose container image extension specific options:

```
quarkus image build docker 
quarkus image build jib
quarkus image build openshift
```

The commands above also force the extension, so it doesn't need to be in the pom.

This is still work in progress as there are some tasks that will most probably require collaboration:
- [ ] Need to find a cleaner way for forcing extensions.
- [ ] Need to discuss if the proposed format is ideal.
- [ ] Need to align push with build commands