### PR TITLE
Do not force mp.jwt.verify.publickey.location to be a build time property

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PublicKeyLocationBuildTimeConfigSourceFactory.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PublicKeyLocationBuildTimeConfigSourceFactory.java
@@ -1,0 +1,26 @@
+package io.quarkus.jwt.test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.common.MapBackedConfigSource;
+
+public class PublicKeyLocationBuildTimeConfigSourceFactory implements ConfigSourceFactory {
+    @Override
+    public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
+        // This property is only available in runtime.
+        ConfigValue value = context.getValue("quarkus.uuid");
+        if (value == null || value.getValue() == null) {
+            return List.of(new MapBackedConfigSource(PublicKeyLocationBuildTimeConfigSourceFactory.class.getName(),
+                    Map.of("mp.jwt.verify.publickey.location", "${invalid}"), 1000) {
+            });
+        }
+        return Collections.emptyList();
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PublicKeyLocationConfigTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/PublicKeyLocationConfigTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.jwt.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.logging.Level;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.config.ConfigSourceFactory;
+import io.smallrye.config.SmallRyeConfig;
+
+public class PublicKeyLocationConfigTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withApplicationRoot((jar) -> jar.addAsResource("publicKey.pem")
+            .addClass(PublicKeyLocationBuildTimeConfigSourceFactory.class)
+            .addAsServiceProvider(ConfigSourceFactory.class, PublicKeyLocationBuildTimeConfigSourceFactory.class))
+            .overrideConfigKey("mp.jwt.verify.publickey.location", "publicKey.pem")
+            .overrideConfigKey("quarkus.package.type", "native")
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+            .assertLogRecords(logRecords -> {
+                assertEquals("Cannot determine %s of mp.jwt.verify.publickey.location to register with the native image",
+                        logRecords.get(0).getMessage());
+            });
+
+    @Inject
+    SmallRyeConfig config;
+
+    @Test
+    void config() {
+        assertEquals("publicKey.pem", config.getRawValue("mp.jwt.verify.publickey.location"));
+    }
+}


### PR DESCRIPTION
- Fixes #16099
- Fixes #18641