### PR TITLE
Support for OIDC Proof Of Key for Code Exchange (PKCE)

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -592,6 +592,24 @@ public class CustomTokenStateManager implements TokenStateManager {
 }
 ----
 
+=== Proof Of Key for Code Exchange (PKCE)
+
+link:https://datatracker.ietf.org/doc/html/rfc7636[Proof Of Key for Code Exchange] (PKCE) minimizes the risk of the authorization code interception.
+
+While `PKCE` is of primary importance to the public OpenId Connect clients (such as the SPA scripts running in a browser), it can also provide an extra level of protection to Quarkus OIDC `web-app` applications which are confidential OpenId Connect clients capable of securely storing the client secret and using it to exchange the code for the tokens.
+
+If can enable `PKCE` for your OIDC `web-app` endpoint with a `quarkus.oidc.authentication.pkce-required` property and a 32 characters long secret, for example:
+
+[source, properties]
+----
+quarkus.oidc.authentication.pkce-required
+quarkus.oidc.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
+----
+
+If you already have a 32 character long client secret then `quarkus.oidc.authentication.pkce-secret` does not have to be set unless you prefer to use a different secret key.
+
+The secret key is required for encrypting a randomly generated `PKCE` `code_verifier` while the user is being redirected with the `code_challenge` query parameter to OpenId Connect Provider to authenticate. The `code_verifier` will be decrypted when the user is redirected back to Quarkus and sent to the token endpoint alongside the `code`, client secret and other parameters to complete the code exchange. The provider will fail the code exchange if a `SHA256` digest of the `code_verifier` does not match the `code_challenge` provided during the authentication request.
+
 === Listening to important authentication events
 
 One can register `@ApplicationScoped` bean which will observe important OIDC authentication events. The listener will be updated when a user has logged in for the first time or re-authenticated, as well as when the session has been refreshed. More events may be reported in the future. For example:

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -51,4 +51,10 @@ public final class OidcConstants {
 
     public static final String EXPIRES_IN = "expires_in";
     public static final String REFRESH_EXPIRES_IN = "refresh_expires_in";
+
+    public static final String PKCE_CODE_VERIFIER = "code_verifier";
+    public static final String PKCE_CODE_CHALLENGE = "code_challenge";
+
+    public static final String PKCE_CODE_CHALLENGE_METHOD = "code_challenge_method";
+    public static final String PKCE_CODE_CHALLENGE_S256 = "S256";
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -589,6 +589,36 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem(defaultValueDocumentation = "true")
         public Optional<Boolean> idTokenRequired = Optional.empty();
 
+        /**
+         * Requires that a Proof Key for Code Exchange (PKCE) is used.
+         */
+        @ConfigItem(defaultValueDocumentation = "false")
+        public Optional<Boolean> pkceRequired = Optional.empty();
+
+        /**
+         * Secret which will be used to encrypt a Proof Key for Code Exchange (PKCE) code verifier in the code flow state.
+         * This secret must be set if PKCE is required but no client secret is set.
+         * The length of the secret which will be used to encrypt the code verifier must be 32 characters long.
+         */
+        @ConfigItem
+        public Optional<String> pkceSecret = Optional.empty();
+
+        public Optional<Boolean> isPkceRequired() {
+            return pkceRequired;
+        }
+
+        public void setPkceRequired(boolean pkceRequired) {
+            this.pkceRequired = Optional.of(pkceRequired);
+        }
+
+        public Optional<String> getPkceSecret() {
+            return pkceSecret;
+        }
+
+        public void setPkceSecret(String pkceSecret) {
+            this.pkceSecret = Optional.of(pkceSecret);
+        }
+
         public Optional<String> getErrorPath() {
             return errorPath;
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationStateBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationStateBean.java
@@ -1,0 +1,29 @@
+package io.quarkus.oidc.runtime;
+
+public class CodeAuthenticationStateBean {
+
+    private String restorePath;
+
+    private String codeVerifier;
+
+    public String getRestorePath() {
+        return restorePath;
+    }
+
+    public void setRestorePath(String restorePath) {
+        this.restorePath = restorePath;
+    }
+
+    public String getCodeVerifier() {
+        return codeVerifier;
+    }
+
+    public void setCodeVerifier(String codeVerifier) {
+        this.codeVerifier = codeVerifier;
+    }
+
+    public boolean isEmpty() {
+        return this.restorePath == null && this.codeVerifier == null;
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -197,8 +197,8 @@ public class OidcProvider implements Closeable {
         return client.getUserInfo(accessToken);
     }
 
-    public Uni<AuthorizationCodeTokens> getCodeFlowTokens(String code, String redirectUri) {
-        return client.getAuthorizationCodeTokens(code, redirectUri);
+    public Uni<AuthorizationCodeTokens> getCodeFlowTokens(String code, String redirectUri, String codeVerifier) {
+        return client.getAuthorizationCodeTokens(code, redirectUri, codeVerifier);
     }
 
     public Uni<AuthorizationCodeTokens> refreshTokens(String refreshToken) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -87,11 +87,14 @@ public class OidcProviderClient implements Closeable {
         return oidcConfig;
     }
 
-    public Uni<AuthorizationCodeTokens> getAuthorizationCodeTokens(String code, String redirectUri) {
+    public Uni<AuthorizationCodeTokens> getAuthorizationCodeTokens(String code, String redirectUri, String codeVerifier) {
         MultiMap codeGrantParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
         codeGrantParams.add(OidcConstants.GRANT_TYPE, OidcConstants.AUTHORIZATION_CODE);
         codeGrantParams.add(OidcConstants.CODE_FLOW_CODE, code);
         codeGrantParams.add(OidcConstants.CODE_FLOW_REDIRECT_URI, redirectUri);
+        if (codeVerifier != null) {
+            codeGrantParams.add(OidcConstants.PKCE_CODE_VERIFIER, codeVerifier);
+        }
         return getHttpResponse(metadata.getTokenUri(), codeGrantParams).transform(resp -> getAuthorizationCodeTokens(resp));
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/PkceStateBean.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/PkceStateBean.java
@@ -1,0 +1,25 @@
+package io.quarkus.oidc.runtime;
+
+public class PkceStateBean {
+
+    private String codeChallenge;
+
+    private String codeVerifier;
+
+    public String getCodeVerifier() {
+        return codeVerifier;
+    }
+
+    public void setCodeVerifier(String codeVerifier) {
+        this.codeVerifier = codeVerifier;
+    }
+
+    public String getCodeChallenge() {
+        return codeChallenge;
+    }
+
+    public void setCodeChallenge(String codeChallenge) {
+        this.codeChallenge = codeChallenge;
+    }
+
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -1,6 +1,10 @@
 package io.quarkus.oidc.runtime;
 
+import javax.crypto.SecretKey;
+
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.smallrye.jwt.util.KeyUtils;
 
 public class TenantConfigContext {
 
@@ -14,6 +18,11 @@ public class TenantConfigContext {
      */
     final OidcTenantConfig oidcConfig;
 
+    /**
+     * PKCE Secret Key
+     */
+    private final SecretKey pkceSecretKey;
+
     final boolean ready;
 
     public TenantConfigContext(OidcProvider client, OidcTenantConfig config) {
@@ -24,9 +33,27 @@ public class TenantConfigContext {
         this.provider = client;
         this.oidcConfig = config;
         this.ready = ready;
+
+        pkceSecretKey = createPkceSecretKey(config);
+    }
+
+    private static SecretKey createPkceSecretKey(OidcTenantConfig config) {
+        if (config.authentication.pkceRequired.orElse(false)) {
+            String pkceSecret = config.authentication.pkceSecret
+                    .orElse(OidcCommonUtils.clientSecret(config.credentials));
+            if (pkceSecret.length() < 32) {
+                throw new RuntimeException("Secret key for encrypting PKCE code verifier must be at least 32 characters long");
+            }
+            return KeyUtils.createSecretKeyFromSecret(pkceSecret);
+        }
+        return null;
     }
 
     public OidcTenantConfig getOidcTenantConfig() {
         return oidcConfig;
+    }
+
+    public SecretKey getPkceSecretKey() {
+        return pkceSecretKey;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -97,6 +97,8 @@ quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 quarkus.oidc.tenant-https.authentication.cookie-suffix=test
 quarkus.oidc.tenant-https.authentication.error-path=/tenant-https/error
+quarkus.oidc.tenant-https.authentication.pkce-required=true
+quarkus.oidc.tenant-https.authentication.pkce-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 
 quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-javascript.client-id=quarkus-app


### PR DESCRIPTION
Fixes #12856

This PR resolves one of the oldest open OIDC issues. It introduces PKCE support (without the plain challenge algorithm which is not really required).

It is not really strictly necessary for Quarkus OIDC `web-app` applications which are confidential OIDC clients capable of storing safely the client secret - thus eliminating the risk of the code being used by someone else to get the token. 
However it does add one more layer of protection even in this case, OAuth 2.1 will not accept the code flows without PKCE,  and it will help with some integrations, example, with [Twitter](https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code) (@FroMage, FYI).

So it is the right time to add this feature.

The actual PKCE support is not difficult - but I had to introduce an option to encrypt the extra state cookie content to avoid leaking the code verifier. I decided for now not to encrypt it all into the actual state query parameter as it can stress the URI limit, so it is kept in the encrypted form in the state cookie. If the PKCE is not required then the state cookie will not have any encryption applied to it, there is nothing sensitive in it without the PKCE code verifier.

[A256KW](https://datatracker.ietf.org/doc/html/rfc7518#section-4.4) requiring a 32 byte keys is currently used by default which is very secure but I've opened a smallrye-jwt [issue](https://github.com/smallrye/smallrye-jwt/issues/564) to facilitate the use of [A256GCMKW](https://datatracker.ietf.org/doc/html/rfc7518#section-4.7) and switch to it a bit later on.

Testing that it works against Keycloak proved easy enough, it had to be done against Keycloak. But testing that it does not work after submitting a code challenge and dropping the code verifier during the code exchange proved trickier, with Wiremock it would be straightforward but with Wiremock we can't really prove that quarkus-oidc calculates the code verifier and challenge correctly.

So I have updated the existing `CodeFlowTest` https tests to verify the content of the state cookie that it contains the correct code verifier and it matches, after the s256 digest applied to it, the code challenge query parameter, then I created a new test, where this verification also passes, then, before forwarding a redirect from Keycloak to Quarkus, I removed the existing state cookie, created a new one containing only the `state` value which is also returned from Keycloak, but without the code verifier, and this time it reports 401 as expected. Not sure if anything else can be done to verify this case.

Docs have also been updated.