### PR TITLE
Deprecate CopyVertxContextDataBuildItem and related cleanup as it's no longer used

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -156,7 +156,6 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.ForbiddenException;
-import io.quarkus.vertx.deployment.CopyVertxContextDataBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
@@ -679,8 +678,7 @@ public class ResteasyReactiveProcessor {
             ParamConverterProvidersBuildItem paramConverterProvidersBuildItem,
             ContextResolversBuildItem contextResolversBuildItem,
             ResteasyReactiveServerConfig serverConfig,
-            LaunchModeBuildItem launchModeBuildItem,
-            List<CopyVertxContextDataBuildItem> copyVertxContextDataBuildItems)
+            LaunchModeBuildItem launchModeBuildItem)
             throws NoSuchMethodException {
 
         if (!resourceScanningResultBuildItem.isPresent()) {
@@ -798,8 +796,7 @@ public class ResteasyReactiveProcessor {
         RuntimeValue<Deployment> deployment = recorder.createDeployment(deploymentInfo,
                 beanContainerBuildItem.getValue(), shutdownContext, vertxConfig,
                 requestContextFactoryBuildItem.map(RequestContextFactoryBuildItem::getFactory).orElse(null),
-                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent,
-                copyVertxContextDataBuildItems.stream().map(CopyVertxContextDataBuildItem::getProperty).collect(toList()));
+                initClassFactory, launchModeBuildItem.getLaunchMode(), servletPresent);
 
         quarkusRestDeploymentBuildItemBuildProducer
                 .produce(new ResteasyReactiveDeploymentBuildItem(deployment, deploymentPath));

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -1,7 +1,5 @@
 package io.quarkus.resteasy.reactive.server.runtime;
 
-import java.util.List;
-
 import javax.enterprise.event.Event;
 import javax.ws.rs.core.SecurityContext;
 
@@ -25,9 +23,8 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
     public QuarkusResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
             RoutingContext context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
             ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl,
-            CurrentIdentityAssociation currentIdentityAssociation, List<String> vertxContextPropsToCopy) {
-        super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl,
-                vertxContextPropsToCopy);
+            CurrentIdentityAssociation currentIdentityAssociation) {
+        super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
         this.association = currentIdentityAssociation;
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -4,7 +4,6 @@ import static io.quarkus.resteasy.reactive.server.runtime.NotFoundExceptionMappe
 
 import java.io.Closeable;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -74,7 +73,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
             ShutdownContext shutdownContext, HttpBuildTimeConfig vertxConfig,
             RequestContextFactory contextFactory,
             BeanFactory<ResteasyReactiveInitialiser> initClassFactory,
-            LaunchMode launchMode, boolean servletPresent, List<String> vertxContextPropsToCopy) {
+            LaunchMode launchMode, boolean servletPresent) {
 
         if (servletPresent) {
             info.setResumeOn404(true);
@@ -108,8 +107,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
                     return new QuarkusResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
                             requestContext,
                             handlerChain,
-                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation,
-                            vertxContextPropsToCopy);
+                            abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation);
                 }
 
             };

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/CopyVertxContextDataBuildItem.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/CopyVertxContextDataBuildItem.java
@@ -5,7 +5,10 @@ import io.quarkus.builder.item.MultiBuildItem;
 /**
  * Build item which indicates that the current Vertx request context data needs
  * to be copied into the connection context
+ * 
+ * @Deprecated currently has no impact: it seems we might be able to remove this.
  */
+@Deprecated
 public final class CopyVertxContextDataBuildItem extends MultiBuildItem {
 
     private final String property;

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
@@ -1,7 +1,6 @@
 package org.jboss.resteasy.reactive.server.vertx;
 
 import io.vertx.ext.web.RoutingContext;
-import java.util.Collections;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.RequestContextFactory;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
@@ -15,6 +14,6 @@ public class VertxRequestContextFactory implements RequestContextFactory {
             ProvidersImpl providers, Object context, ThreadSetupAction requestContext,
             ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
         return new VertxResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
-                requestContext, handlerChain, abortHandlerChain, null, Collections.emptyList());
+                requestContext, handlerChain, abortHandlerChain, null);
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -5,12 +5,12 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 import java.io.ByteArrayInputStream;
@@ -52,7 +52,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     public VertxResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
             RoutingContext context,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain,
-            ClassLoader devModeTccl, List<String> vertxContextPropsToCopy) {
+            ClassLoader devModeTccl) {
         super(deployment, providers, requestContext, handlerChain, abortHandlerChain);
         this.context = context;
         this.request = context.request();
@@ -60,7 +60,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
         this.devModeTccl = devModeTccl;
         context.addHeadersEndHandler(this);
         String expect = request.getHeader(HttpHeaderNames.EXPECT);
-        ContextInternal current = (ContextInternal) Vertx.currentContext();
+        Context current = Vertx.currentContext();
         if (expect != null && expect.equalsIgnoreCase(CONTINUE)) {
             continueState = ContinueState.REQUIRED;
         }


### PR DESCRIPTION
Creating as a DRAFT follow up to #23397 , as I'm not sure if the previous PR really intended to stop applying `CopyVertxContextDataBuildItem`.

cc/ @radcortez @stuartwdouglas 