### PR TITLE
Database image tag alignments and updates in context of devservices

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -86,9 +86,10 @@
         <!-- Database images for JDBC/Reactive/Hibernate tests -->
         <postgres.image>docker.io/postgres:14.1</postgres.image>
         <mariadb.image>docker.io/mariadb:10.6</mariadb.image>
-        <db2.image>docker.io/ibmcom/db2:11.5.5.0</db2.image>
-        <mssql.image>mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04</mssql.image>
-        <oracle.image>docker.io/gvenzl/oracle-xe:21.3.0-slim</oracle.image>
+        <db2.image>docker.io/ibmcom/db2:11.5.7.0</db2.image>
+        <mssql.image>mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04</mssql.image>
+        <mysql.image>docker.io/mysql:8.0</mysql.image>
+        <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
 
         <!-- Align various dependencies that are not really part of the bom-->
         <junit4.version>4.13.2</junit4.version>

--- a/extensions/devservices/common/pom.xml
+++ b/extensions/devservices/common/pom.xml
@@ -40,13 +40,4 @@
             <artifactId>quarkus-core</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
-    </build>
 </project>

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -4,13 +4,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.Base58;
 
 public final class ConfigureUtil {
+
+    private static final Map<String, Properties> DEVSERVICES_PROPS = new ConcurrentHashMap<>();
 
     private ConfigureUtil() {
     }
@@ -44,25 +48,25 @@ public final class ConfigureUtil {
     }
 
     public static String getDefaultImageNameFor(String devserviceName) {
-        var imageName = LazyProperties.INSTANCE.getProperty(devserviceName + ".image");
+        var imageName = DEVSERVICES_PROPS.computeIfAbsent(devserviceName, ConfigureUtil::loadProperties)
+                .getProperty("default.image");
         if (imageName == null) {
-            throw new IllegalArgumentException("No default image configured for " + devserviceName);
+            throw new IllegalArgumentException("No default.image configured for " + devserviceName);
         }
         return imageName;
     }
 
-    private static class LazyProperties {
-
-        private static final Properties INSTANCE;
-
-        static {
-            var tccl = Thread.currentThread().getContextClassLoader();
-            try (InputStream in = tccl.getResourceAsStream("devservices.properties")) {
-                INSTANCE = new Properties();
-                INSTANCE.load(in);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+    private static Properties loadProperties(String devserviceName) {
+        var fileName = devserviceName + "-devservice.properties";
+        try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
+            if (in == null) {
+                throw new IllegalArgumentException(fileName + " not found on classpath");
             }
+            var properties = new Properties();
+            properties.load(in);
+            return properties;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/extensions/devservices/common/src/main/resources/devservices.properties
+++ b/extensions/devservices/common/src/main/resources/devservices.properties
@@ -1,1 +1,0 @@
-mariadb.image=${mariadb.image}

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -24,11 +24,6 @@ public class DB2DevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(DB2DevServicesProcessor.class);
 
-    /**
-     * If you update this remember to update the container-license-acceptance.txt in the tests
-     */
-    public static final String TAG = "11.5.5.1";
-
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupDB2(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
@@ -70,7 +65,7 @@ public class DB2DevServicesProcessor {
         private String hostName = null;
 
         public QuarkusDb2Container(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
-            super(DockerImageName.parse(imageName.orElse("ibmcom/db2:" + DB2DevServicesProcessor.TAG))
+            super(DockerImageName.parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("db2")))
                     .asCompatibleSubstituteFor(DockerImageName.parse("ibmcom/db2")));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;

--- a/extensions/devservices/db2/src/main/resources/db2-devservice.properties
+++ b/extensions/devservices/db2/src/main/resources/db2-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${db2.image}

--- a/extensions/devservices/mariadb/pom.xml
+++ b/extensions/devservices/mariadb/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/devservices/mariadb/src/main/resources/mariadb-devservice.properties
+++ b/extensions/devservices/mariadb/src/main/resources/mariadb-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${mariadb.image}

--- a/extensions/devservices/mssql/pom.xml
+++ b/extensions/devservices/mssql/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -24,11 +24,6 @@ public class MSSQLDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(MSSQLDevServicesProcessor.class);
 
-    /**
-     * If you update this remember to update the container-license-acceptance.txt in the tests
-     */
-    public static final String TAG = "2019-CU10-ubuntu-20.04";
-
     @BuildStep
     DevServicesDatasourceProviderBuildItem setupMSSQL(
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem) {
@@ -69,7 +64,7 @@ public class MSSQLDevServicesProcessor {
 
         public QuarkusMSSQLServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName
-                    .parse(imageName.orElse(MSSQLServerContainer.IMAGE + ":" + MSSQLDevServicesProcessor.TAG))
+                    .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mssql")))
                     .asCompatibleSubstituteFor(MSSQLServerContainer.IMAGE));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;

--- a/extensions/devservices/mssql/src/main/resources/mssql-devservice.properties
+++ b/extensions/devservices/mssql/src/main/resources/mssql-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${mssql.image}

--- a/extensions/devservices/mysql/pom.xml
+++ b/extensions/devservices/mysql/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -24,7 +24,6 @@ public class MySQLDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(MySQLDevServicesProcessor.class);
 
-    public static final String TAG = "8.0.24";
     public static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
 
     @BuildStep
@@ -75,8 +74,8 @@ public class MySQLDevServicesProcessor {
 
         public QuarkusMySQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName
-                    .parse(imageName.orElse("docker.io/" + MySQLContainer.IMAGE + ":" + MySQLDevServicesProcessor.TAG))
-                    .asCompatibleSubstituteFor(DockerImageName.parse(MySQLContainer.IMAGE)));
+                    .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mysql")))
+                    .asCompatibleSubstituteFor(DockerImageName.parse(MySQLContainer.NAME)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
         }

--- a/extensions/devservices/mysql/src/main/resources/mysql-devservice.properties
+++ b/extensions/devservices/mysql/src/main/resources/mysql-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${mysql.image}

--- a/extensions/devservices/oracle/pom.xml
+++ b/extensions/devservices/oracle/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -25,7 +25,6 @@ public class OracleDevServicesProcessor {
     private static final Logger LOG = Logger.getLogger(OracleDevServicesProcessor.class);
 
     public static final String IMAGE = "gvenzl/oracle-xe";
-    public static final String TAG = "21.3.0-slim";
     public static final String DEFAULT_DATABASE_USER = "quarkus";
     public static final String DEFAULT_DATABASE_PASSWORD = "quarkus";
     public static final String DEFAULT_DATABASE_NAME = "quarkusdb";
@@ -74,8 +73,7 @@ public class OracleDevServicesProcessor {
         public QuarkusOracleServerContainer(Optional<String> imageName, OptionalInt fixedExposedPort,
                 boolean useSharedNetwork) {
             super(DockerImageName
-                    .parse(imageName
-                            .orElse("docker.io/" + OracleDevServicesProcessor.IMAGE + ":" + OracleDevServicesProcessor.TAG))
+                    .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("oracle")))
                     .asCompatibleSubstituteFor(OracleDevServicesProcessor.IMAGE));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;

--- a/extensions/devservices/postgresql/pom.xml
+++ b/extensions/devservices/postgresql/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -26,8 +26,6 @@ public class PostgresqlDevServicesProcessor {
 
     private static final Logger LOG = Logger.getLogger(PostgresqlDevServicesProcessor.class);
 
-    public static final String TAG = "14.1";
-
     @BuildStep
     ConsoleCommandBuildItem psqlCommand(DevServicesLauncherConfigResultBuildItem devServices) {
         return new ConsoleCommandBuildItem(new PostgresCommand(devServices));
@@ -76,8 +74,7 @@ public class PostgresqlDevServicesProcessor {
 
         public QuarkusPostgreSQLContainer(Optional<String> imageName, OptionalInt fixedExposedPort, boolean useSharedNetwork) {
             super(DockerImageName
-                    .parse(imageName
-                            .orElse("docker.io/" + PostgreSQLContainer.IMAGE + ":" + PostgresqlDevServicesProcessor.TAG))
+                    .parse(imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("postgresql")))
                     .asCompatibleSubstituteFor(DockerImageName.parse(PostgreSQLContainer.IMAGE)));
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;

--- a/extensions/devservices/postgresql/src/main/resources/postgresql-devservice.properties
+++ b/extensions/devservices/postgresql/src/main/resources/postgresql-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${postgres.image}

--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -51,6 +51,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-db2/deployment/src/test/resources/container-license-acceptance.txt
+++ b/extensions/jdbc/jdbc-db2/deployment/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-ibmcom/db2:11.5.5.1
+${db2.image}

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -51,6 +51,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/container-license-acceptance.txt
+++ b/extensions/jdbc/jdbc-mssql/deployment/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+${mssql.image}

--- a/extensions/reactive-mssql-client/deployment/src/test/resources/container-license-acceptance.txt
+++ b/extensions/reactive-mssql-client/deployment/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+${mssql.image}

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/pom.xml
@@ -11,6 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
+    <db2.image>@db2.image@</db2.image>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -56,6 +57,12 @@
     </dependency>
   </dependencies>
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/src/test/resources/container-license-acceptance.txt
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-ibmcom/db2:11.5.5.1
+${db2.image}

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/pom.xml
@@ -11,6 +11,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
+    <mssql.image>@mssql.image@</mssql.image>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -56,6 +57,12 @@
     </dependency>
   </dependencies>
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/src/test/resources/container-license-acceptance.txt
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04
+${mssql.image}

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <mysql.url>jdbc:mysql://localhost:3306/hibernate_orm_test?allowPublicKeyRetrieval=true</mysql.url>
-        <mysql.image>mysql:8.0.22</mysql.image>
     </properties>
 
     <dependencies>

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -22,7 +22,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21.3.0-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21-slim
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/reactive-oracle-client/README.md
+++ b/integration-tests/reactive-oracle-client/README.md
@@ -23,7 +23,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21.3.0-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21-slim
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.


### PR DESCRIPTION
Follows up on #23329 (/cc @gsmet @Sanne).

I decided to use separate property files instead of a single one.

Where available, I also changed a few tags so that the properties don't have to be touched for every small patch update (who remembers this anyway?).