### PR TITLE
Allow to invalidate ContextState of shareable CDI context and make use of it in ArcContextProvider

### DIFF
--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/context/ArcContextProvider.java
@@ -108,7 +108,7 @@ public class ArcContextProvider implements ThreadContextProvider {
                 return new ThreadContextController() {
                     @Override
                     public void endContext() throws IllegalStateException {
-                        requestContext.activate(toRestore);
+                        requestContext.activate(toRestore.isValid() ? toRestore : null);
                     }
                 };
             } else {
@@ -141,11 +141,13 @@ public class ArcContextProvider implements ThreadContextProvider {
             if (toRestore != null) {
                 // context active, store current state, feed it new one and restore state afterwards
                 // it is not necessary to deactivate the context first - just overwrite the previous state
-                requestContext.activate(state);
+                // if the context state is invalid (i.e. the context was destroyed by Arc), we instead create new state
+                requestContext.activate(state.isValid() ? state : null);
                 return new RestoreContextController(requestContext, toRestore);
             } else {
                 // context not active, activate and pass it new instance, deactivate afterwards
-                requestContext.activate(state);
+                // if the context state is invalid (i.e. the context was destroyed by Arc), we instead create new state
+                requestContext.activate(state.isValid() ? state : null);
                 return requestContext::deactivate;
             }
         }
@@ -165,7 +167,7 @@ public class ArcContextProvider implements ThreadContextProvider {
         @Override
         public void endContext() throws IllegalStateException {
             // it is not necessary to deactivate the context first - just overwrite the previous state
-            requestContext.activate(stateToRestore);
+            requestContext.activate(stateToRestore.isValid() ? stateToRestore : null);
         }
 
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableContext.java
@@ -95,5 +95,15 @@ public interface InjectableContext extends AlterableContext {
          */
         Map<InjectableBean<?>, Object> getContextualInstances();
 
+        /**
+         * Context state is typically invalidated once the context to which is belongs is being destroyed.
+         * This flag is then used by context propagation to indicate that the given state shouldn't be reused anymore.
+         * 
+         * @return true if the context state is valid, false otherwise
+         */
+        default boolean isValid() {
+            return true;
+        }
+
     }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ManagedContext.java
@@ -17,6 +17,8 @@ public interface ManagedContext extends InjectableContext {
 
     /**
      * Activate the context.
+     * If invoked with {@code null} parameter, a fresh {@link io.quarkus.arc.InjectableContext.ContextState} is
+     * automatically created.
      * 
      * @param initialState The initial state, may be {@code null}
      */


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/discussions/23363 and https://github.com/quarkusio/quarkus/issues/23300 and possibly fixing it.

This PR makes it so that CDI context state has a flag for its validity. Context propagation makes a snapshot of the state and reactivates it from there. Once Arc destroys that given context, it will set the validity to `false` which is then recognized by `ArcContextProvider` and instead of refreshing the same state, it creates a new one.

I have tested this with the reproducer from https://github.com/quarkusio/quarkus/issues/23300 and I can see that in subsequent POST requests, new req. scoped beans get created and the session ID @Sanne mentioned is different for every request.