### PR TITLE
Remove now unused Apache HTTP Client dependency from AWS Lambda REST

### DIFF
--- a/extensions/amazon-lambda-rest/deployment/pom.xml
+++ b/extensions/amazon-lambda-rest/deployment/pom.xml
@@ -29,10 +29,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/amazon-lambda-rest/runtime/pom.xml
+++ b/extensions/amazon-lambda-rest/runtime/pom.xml
@@ -31,10 +31,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-apache-httpclient</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The Apache HTTP Client is no longer a dependency because
e2da46707e4eb082a40c2a828947e8286be64062 removed the
dependency on serverless (which had an optional dependency
on the Apache HTTP Client)