### PR TITLE
Better error messages for not resolved platforms

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -10,6 +10,7 @@ import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.registry.CatalogMergeUtility;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.selection.OriginPreference;
+import io.quarkus.registry.util.PlatformArtifacts;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -112,7 +113,14 @@ public class ToolsUtils {
                 }
             }
             if (platformJson == null) {
-                throw new RuntimeException("Failed to resolve the default platform JSON descriptor", e);
+                final StringBuilder sb = new StringBuilder();
+                sb.append("Failed to resolve extension catalog for ");
+                sb.append(PlatformArtifacts.ensureBomArtifact(new ArtifactCoords(catalogCoords.getGroupId(),
+                        catalogCoords.getArtifactId(), catalogCoords.getClassifier(), catalogCoords.getExtension(),
+                        catalogCoords.getVersion())).toCompactCoords());
+                sb.append(
+                        ". Make sure the groupId, artifactId and version are spelled correctly and the relevant Maven repositories are configured.");
+                throw new RuntimeException(sb.toString(), e);
             }
         }
         ExtensionCatalog catalog;

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/RegistryExtensionResolver.java
@@ -8,6 +8,8 @@ import io.quarkus.registry.catalog.PlatformCatalog;
 import io.quarkus.registry.client.RegistryClient;
 import io.quarkus.registry.config.RegistryConfig;
 import io.quarkus.registry.util.GlobUtil;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -22,7 +24,8 @@ class RegistryExtensionResolver {
     private final RegistryClient extensionResolver;
     private final int index;
 
-    private Pattern recognizedQuarkusVersions;
+    private final Pattern recognizedQuarkusVersions;
+    private final Collection<String> recognizedGroupIds;
 
     RegistryExtensionResolver(RegistryClient extensionResolver,
             MessageWriter log, int index) throws RegistryResolutionException {
@@ -30,11 +33,11 @@ class RegistryExtensionResolver {
         this.config = extensionResolver.resolveRegistryConfig();
         this.index = index;
 
-        String versionExpr = config.getQuarkusVersions() == null ? null
+        final String versionExpr = config.getQuarkusVersions() == null ? null
                 : config.getQuarkusVersions().getRecognizedVersionsExpression();
-        if (versionExpr != null) {
-            recognizedQuarkusVersions = Pattern.compile(GlobUtil.toRegexPattern(versionExpr));
-        }
+        recognizedQuarkusVersions = versionExpr == null ? null : Pattern.compile(GlobUtil.toRegexPattern(versionExpr));
+        this.recognizedGroupIds = config.getQuarkusVersions() == null ? Collections.emptyList()
+                : config.getQuarkusVersions().getRecognizedGroupIds();
     }
 
     String getId() {
@@ -48,6 +51,9 @@ class RegistryExtensionResolver {
     int checkQuarkusVersion(String quarkusVersion) {
         if (recognizedQuarkusVersions == null) {
             return VERSION_NOT_CONFIGURED;
+        }
+        if (quarkusVersion == null) {
+            throw new IllegalArgumentException();
         }
         if (!recognizedQuarkusVersions.matcher(quarkusVersion).matches()) {
             return VERSION_NOT_RECOGNIZED;
@@ -65,7 +71,9 @@ class RegistryExtensionResolver {
     }
 
     int checkPlatform(ArtifactCoords platform) {
-        // TODO this should be allowed to check the full coordinates
+        if (!recognizedGroupIds.isEmpty() && !recognizedGroupIds.contains(platform.getGroupId())) {
+            return VERSION_NOT_RECOGNIZED;
+        }
         return checkQuarkusVersion(platform.getVersion());
     }
 

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenPlatformExtensionsResolver.java
@@ -56,9 +56,10 @@ public class MavenPlatformExtensionsResolver implements RegistryPlatformExtensio
                 t = t.getCause();
             }
             final StringBuilder buf = new StringBuilder();
-            buf.append("Failed to resolve Quarkus extension catalog ").append(catalogArtifact);
+            buf.append("Failed to resolve extension catalog of ")
+                    .append(PlatformArtifacts.ensureBomArtifact(platformCoords).toCompactCoords());
             if (repo != null) {
-                buf.append(" from ").append(repo.getId()).append(" (").append(repo.getUrl()).append(")");
+                buf.append(" from Maven repository ").append(repo.getId()).append(" (").append(repo.getUrl()).append(")");
                 final List<RemoteRepository> mirrored = repo.getMirroredRepositories();
                 if (!mirrored.isEmpty()) {
                     buf.append(" which is a mirror of ");

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfig.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.registry.config;
 
 import io.quarkus.registry.json.JsonBuilder;
+import java.util.Collection;
 
 /**
  * A registry may be configured to accept requests only for the Quarkus versions
@@ -16,6 +17,8 @@ public interface RegistryQuarkusVersionsConfig {
      * @return Quarkus version filtering expression or null
      */
     String getRecognizedVersionsExpression();
+
+    Collection<String> getRecognizedGroupIds();
 
     /**
      * If the Quarkus version expression is provided, this method may also enforce that
@@ -35,6 +38,10 @@ public interface RegistryQuarkusVersionsConfig {
 
     interface Mutable extends RegistryQuarkusVersionsConfig, JsonBuilder<RegistryQuarkusVersionsConfig> {
         Mutable setRecognizedVersionsExpression(String recognizedVersionsExpression);
+
+        Mutable addRecognizedGroupId(String recorgnizedGroupId);
+
+        Mutable setRecognizedGroupIds(Collection<String> recorgnizedGroupIds);
 
         Mutable setExclusiveProvider(boolean exclusiveProvider);
 

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/config/RegistryQuarkusVersionsConfigImpl.java
@@ -3,6 +3,8 @@ package io.quarkus.registry.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.registry.json.JsonBuilder;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
 
 /**
@@ -18,16 +20,24 @@ import java.util.Objects;
 public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersionsConfig {
 
     private final String recognizedVersionsExpression;
+    private final Collection<String> recognizedGroupIds;
     private final boolean exclusiveProvider;
 
-    private RegistryQuarkusVersionsConfigImpl(String recognizedVersionsExpression, boolean exclusiveProvider) {
+    private RegistryQuarkusVersionsConfigImpl(String recognizedVersionsExpression, Collection<String> recognizedGroupIds,
+            boolean exclusiveProvider) {
         this.exclusiveProvider = exclusiveProvider;
         this.recognizedVersionsExpression = recognizedVersionsExpression;
+        this.recognizedGroupIds = recognizedGroupIds;
     }
 
     @Override
     public String getRecognizedVersionsExpression() {
         return recognizedVersionsExpression;
+    }
+
+    @Override
+    public Collection<String> getRecognizedGroupIds() {
+        return recognizedGroupIds;
     }
 
     @Override
@@ -56,6 +66,7 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
     public static class Builder implements RegistryQuarkusVersionsConfig.Mutable {
         protected String recognizedVersionsExpression;
         protected boolean exclusiveProvider;
+        protected Collection<String> recognizedGroupIds = new ArrayList<>(0);
 
         public Builder() {
         }
@@ -68,7 +79,7 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
 
         @Override
         public RegistryQuarkusVersionsConfigImpl build() {
-            return new RegistryQuarkusVersionsConfigImpl(recognizedVersionsExpression, exclusiveProvider);
+            return new RegistryQuarkusVersionsConfigImpl(recognizedVersionsExpression, recognizedGroupIds, exclusiveProvider);
         }
 
         @Override
@@ -76,9 +87,27 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
             return recognizedVersionsExpression;
         }
 
+        @Override
         public Mutable setRecognizedVersionsExpression(String recognizedVersionsExpression) {
             this.recognizedVersionsExpression = recognizedVersionsExpression;
             return this;
+        }
+
+        @Override
+        public Mutable addRecognizedGroupId(String recognizedGropuId) {
+            this.recognizedGroupIds.add(recognizedGropuId);
+            return this;
+        }
+
+        @Override
+        public Mutable setRecognizedGroupIds(Collection<String> recognizedGroupIds) {
+            this.recognizedGroupIds = recognizedGroupIds;
+            return this;
+        }
+
+        @Override
+        public Collection<String> getRecognizedGroupIds() {
+            return recognizedGroupIds;
         }
 
         @Override
@@ -86,6 +115,7 @@ public class RegistryQuarkusVersionsConfigImpl implements RegistryQuarkusVersion
             return exclusiveProvider;
         }
 
+        @Override
         public Mutable setExclusiveProvider(boolean exclusiveProvider) {
             this.exclusiveProvider = exclusiveProvider;
             return this;


### PR DESCRIPTION
Currently, targeting a platform that does not exist with e.g.
````
mvn com.redhat.quarkus.platform:quarkus-maven-plugin:2.2.3.SP2-redhat-00001:create \
          -DprojectGroupId=org.acme \
          -DprojectArtifactId=getting-started \
          -DplatformGroupId=com.redhat.quarkus \
          -DplatformVersion=2.2.3.SP2-redhat-00001 \
          -DclassName="org.acme.quickstart.GreetingResource" \
          -Dpath="/hello"
````
results weird warning and error messages in the log:
````
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] Failed to resolve platform com.redhat.quarkus:quarkus-bom::pom:2.2.3.SP2-redhat-00001 using the following registries: registry.quarkus.io
[WARNING] Failed to resolve the extension catalog
[WARNING] The extension catalog will be narrowed to the com.redhat.quarkus:quarkus-bom:2.2.3.SP2-redhat-00001 platform release. To enable the complete Quarkiverse extension catalog along with the latest recommended platform releases, please, make sure the following registries are accessible from your environment: registry.quarkus.io
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.992 s
[INFO] Finished at: 2022-02-04T14:34:11+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) on project standalone-pom: Execution default-cli of goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create failed: Failed to resolve the default platform JSON descriptor: Failed to resolve artifact com.redhat.quarkus:quarkus-bom-quarkus-platform-descriptor:json:2.2.3.SP2-redhat-00001:2.2.3.SP2-redhat-00001: com.redhat.quarkus:quarkus-bom-quarkus-platform-descriptor:json:2.2.3.SP2-redhat-00001:2.2.3.SP2-redhat-00001 was not found in https://maven.repository.redhat.com/ga during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of redhat has elapsed or updates are forced -> [Help 1]
````
For the CLI it will be
````
[aloubyansky@localhost playground]$ qs create -P com.redhat.quarkus:quarkus-bom:2.2.3.SP2-redhat-00001
Creating an app (default project type, see --help).
[ERROR] ❗  Unable to create project: Failed to resolve the default platform JSON descriptor
````

This PR changes it to
````
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) @ standalone-pom ---
[WARNING] Failed to resolve extension catalog of com.redhat.quarkus:quarkus-bom:pom:2.2.3.SP2-redhat-00001 from Maven repository redhat (https://maven.repository.redhat.com/ga)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.852 s
[INFO] Finished at: 2022-02-04T19:07:23+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create (default-cli) on project standalone-pom: Execution default-cli of goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:create failed: Failed to resolve extension catalog for com.redhat.quarkus:quarkus-bom:pom:2.2.3.SP2-redhat-00001: Failed to resolve artifact com.redhat.quarkus:quarkus-bom-quarkus-platform-descriptor:json:2.2.3.SP2-redhat-00001:2.2.3.SP2-redhat-00001: com.redhat.quarkus:quarkus-bom-quarkus-platform-descriptor:json:2.2.3.SP2-redhat-00001:2.2.3.SP2-redhat-00001 was not found in https://maven.repository.redhat.com/ga during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of redhat has elapsed or updates are forced -> [Help 1]
````
and
````
[aloubyansky@localhost playground]$ qs create -P com.redhat.quarkus:quarkus-bom:2.2.3.SP2-redhat-00001
Creating an app (default project type, see --help).
[ERROR] ❗  Unable to create project: Failed to resolve extension catalog for com.redhat.quarkus:quarkus-bom:pom:2.2.3.SP2-redhat-00001
````