### PR TITLE
Add OIDC error-path property

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -1278,6 +1278,21 @@ You can add more properties to it with `quarkus.oidc.authentication.extra-params
 quarkus.oidc.authentication.extra-params.response_mode=query
 ----
 
+=== Customize authentication error response
+
+If the user authentication has failed at the OpenId Connect Authorization endpoint, for example, due to an invalid scope or other invalid parameters included in the redirect to the provider, then the provider will redirect the user back to Quarkus not with the `code` but `error` and `error_description` parameters.
+
+In such cases HTTP `401` will be returned by default. However, you can instead request that a custom public error endpoint is called in order to return a user friendly HTML error page. Use `quarkus.oidc.authentication.error-path`, for example:
+
+[source,properties]
+----
+quarkus.oidc.authentication.error-path=/error
+----
+
+It has to start fron a forward slash and be relative to the current endpoint's base URI. For example, if it is set as '/error' and the current request URI is `https://localhost:8080/callback?error=invalid_scope` then a final redirect will be made to `https://localhost:8080/error?error=invalid_scope`.
+
+It is important that this error endpoint is a public resource to avoid the user redirected to this page be authenticated again.
+
 == Configuration Reference
 
 include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional]

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -42,6 +42,8 @@ public final class OidcConstants {
     public static final String AUTHORIZATION_CODE = "authorization_code";
     public static final String CODE_FLOW_RESPONSE_TYPE = "response_type";
     public static final String CODE_FLOW_CODE = "code";
+    public static final String CODE_FLOW_ERROR = "error";
+    public static final String CODE_FLOW_ERROR_DESCRIPTION = "error_description";
     public static final String CODE_FLOW_STATE = "state";
     public static final String CODE_FLOW_REDIRECT_URI = "redirect_uri";
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -463,6 +463,23 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public boolean removeRedirectParameters = true;
 
         /**
+         * Relative path to the public endpoint which will process the error response from the OIDC authorization endpoint.
+         * If the user authentication has failed then the OIDC provider will return an 'error' and an optional
+         * 'error_description'
+         * parameters, instead of the expected authorization 'code'.
+         *
+         * If this property is set then the user will be redirected to the endpoint which can return a user friendly
+         * error description page. It has to start from a forward slash and will be appended to the request URI's host and port.
+         * For example, if it is set as '/error' and the current request URI is
+         * 'https://localhost:8080/callback?error=invalid_scope'
+         * then a redirect will be made to 'https://localhost:8080/error?error=invalid_scope'.
+         *
+         * If this property is not set then HTTP 401 status will be returned in case of the user authentication failure.
+         */
+        @ConfigItem
+        public Optional<String> errorPath = Optional.empty();
+
+        /**
          * Both ID and access tokens are fetched from the OIDC provider as part of the authorization code flow.
          * ID token is always verified on every user request as the primary token which is used
          * to represent the principal and extract the roles.
@@ -571,6 +588,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
          */
         @ConfigItem(defaultValueDocumentation = "true")
         public Optional<Boolean> idTokenRequired = Optional.empty();
+
+        public Optional<String> getErrorPath() {
+            return errorPath;
+        }
+
+        public void setErrorPath(String errorPath) {
+            this.errorPath = Optional.of(errorPath);
+        }
 
         public boolean isJavaScriptAutoRedirect() {
             return javaScriptAutoRedirect;

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -10,7 +10,6 @@ import io.quarkus.security.Authenticated;
 import io.vertx.ext.web.RoutingContext;
 
 @Path("/tenant-https")
-@Authenticated
 public class TenantHttps {
 
     @Inject
@@ -19,13 +18,21 @@ public class TenantHttps {
     RoutingContext routingContext;
 
     @GET
+    @Authenticated
     public String getTenant() {
         return session.getTenantId() + (routingContext.get("reauthenticated") != null ? ":reauthenticated" : "");
     }
 
     @GET
     @Path("query")
+    @Authenticated
     public String getTenantWithQuery(@QueryParam("code") String value) {
         return getTenant() + "?code=" + value;
+    }
+
+    @GET
+    @Path("error")
+    public String getError(@QueryParam("error") String error, @QueryParam("error_description") String errorDescription) {
+        return "error: " + error + ", error_description: " + errorDescription;
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -96,7 +96,7 @@ quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
 quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 quarkus.oidc.tenant-https.authentication.cookie-suffix=test
-quarkus.oidc.tenant-https.authentication.redirect-without-state-cookie=true
+quarkus.oidc.tenant-https.authentication.error-path=/tenant-https/error
 
 quarkus.oidc.tenant-javascript.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-javascript.client-id=quarkus-app


### PR DESCRIPTION
Fixes #22189

This PR adds the option to redirect the user to a public error path in case of the OIDC provider redirecting the user back with the error. This would be similar to a form authentication mechanism.

It has to be a public resource for Quarkus Sec not to try to re-authenticate the user.

Steph, I've thought about a callback interface - but it won't really work - we can't call back into a user provided code at this point where the authentication has failed, the error path is a simple solution which will work fine