### PR TITLE
Quarkus Gradle should use runtime rather than compile classpath

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -119,9 +119,9 @@ public class QuarkusPlugin implements Plugin<Project> {
         tasks.register(QUARKUS_INFO_TASK_NAME, QuarkusInfo.class);
         tasks.register(QUARKUS_UPDATE_TASK_NAME, QuarkusUpdate.class);
         tasks.register(QUARKUS_GO_OFFLINE_TASK_NAME, QuarkusGoOffline.class, task -> {
-            task.setCompileClasspath(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+            task.setCompileClasspath(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             task.setTestCompileClasspath(
-                    project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME));
+                    project.getConfigurations().getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             task.setQuarkusDevClasspath(project.getConfigurations().getByName(DEV_MODE_CONFIGURATION_NAME));
         });
 
@@ -277,9 +277,9 @@ public class QuarkusPlugin implements Plugin<Project> {
     private void registerConditionalDependencies(Project project) {
         ApplicationDeploymentClasspathBuilder deploymentClasspathBuilder = new ApplicationDeploymentClasspathBuilder(
                 project);
-        project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
+        project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((dependencies) -> {
-                    final String configName = JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME;
+                    final String configName = JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME;
                     final Collection<ExtensionDependency> implementationExtensions = new ConditionalDependenciesEnabler(project,
                             configName).declareConditionalDependencies();
                     deploymentClasspathBuilder.createBuildClasspath(implementationExtensions, configName);
@@ -290,9 +290,9 @@ public class QuarkusPlugin implements Plugin<Project> {
                     .declareConditionalDependencies();
             deploymentClasspathBuilder.createBuildClasspath(devModeExtensions, configName);
         });
-        project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
+        project.getConfigurations().getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((testDependencies) -> {
-                    final String configName = JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME;
+                    final String configName = JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME;
                     final Collection<ExtensionDependency> testExtensions = new ConditionalDependenciesEnabler(project,
                             configName).declareConditionalDependencies();
                     deploymentClasspathBuilder.createBuildClasspath(testExtensions, configName);
@@ -300,7 +300,7 @@ public class QuarkusPlugin implements Plugin<Project> {
         project.getConfigurations().getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve(annotationProcessors -> {
                     Set<ResolvedArtifact> compileClasspathArtifacts = project.getConfigurations()
-                            .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getResolvedConfiguration()
+                            .getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getResolvedConfiguration()
                             .getResolvedArtifacts();
 
                     // enable the Panache annotation processor on the classpath, if it's found among the dependencies
@@ -349,7 +349,7 @@ public class QuarkusPlugin implements Plugin<Project> {
 
         final HashSet<String> visited = new HashSet<>();
         ConfigurationContainer configurations = project.getConfigurations();
-        configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+        configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
                 .getIncoming().getDependencies()
                 .forEach(d -> {
                     if (d instanceof ProjectDependency) {
@@ -429,9 +429,9 @@ public class QuarkusPlugin implements Plugin<Project> {
             }
         }
 
-        final Configuration compileConfig = dep.getConfigurations().findByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
-        if (compileConfig != null) {
-            compileConfig.getIncoming().getDependencies()
+        final Configuration runtimeConfig = dep.getConfigurations().findByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        if (runtimeConfig != null) {
+            runtimeConfig.getIncoming().getDependencies()
                     .forEach(d -> {
                         if (d instanceof ProjectDependency) {
                             visitProjectDep(project, ((ProjectDependency) d).getDependencyProject(), visited);

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -105,12 +105,12 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
 
     private void exportDeploymentClasspath(Project project) {
         DeploymentClasspathBuilder deploymentClasspathBuilder = new DeploymentClasspathBuilder(project);
-        project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
+        project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((dependencies) -> deploymentClasspathBuilder
-                        .exportDeploymentClasspath(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
-        project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME).getIncoming()
+                        .exportDeploymentClasspath(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+        project.getConfigurations().getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).getIncoming()
                 .beforeResolve((testDependencies) -> deploymentClasspathBuilder
-                        .exportDeploymentClasspath(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
+                        .exportDeploymentClasspath(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
 
     }
 

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -106,7 +106,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         deploymentConfiguration = project.getConfigurations().create(DEPLOYMENT_CONFIGURATION)
                 .withDependencies(ds -> ds.addAll(platforms));
         Configuration implementationDeployment = project.getConfigurations().findByName(ToolingUtils
-                .toDeploymentConfigurationName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+                .toDeploymentConfigurationName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
         if (implementationDeployment != null) {
             deploymentConfiguration.extendsFrom(implementationDeployment);
         }
@@ -114,7 +114,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         if (LaunchMode.TEST.equals(mode)) {
             Configuration testDeploymentConfiguration = project.getConfigurations()
                     .findByName(ToolingUtils
-                            .toDeploymentConfigurationName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME));
+                            .toDeploymentConfigurationName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             if (testDeploymentConfiguration != null) {
                 deploymentConfiguration.extendsFrom(testDeploymentConfiguration);
             }


### PR DESCRIPTION
This is an attempt to fix #13052.

Within the `QuarkusPlugin` there are already checks to see if dependencies are project dependencies rather than external dependencies.

This changes the search from the compile classpath to the runtime classpath so that both `implementation` and `runtimeOnly` module dependencies work correctly.

---

Unsure whether `IMPLEMENTATION_CONFIGURATION_NAME` on 282 and 295 should also be changed to their runtime equivalent? This was not necessary in my reproducer, but this was fairly simplistic.