### PR TITLE
Add a `useCurrentTimestamp` flag for Jib

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -173,4 +173,13 @@ public class JibConfig {
      */
     @ConfigItem
     public Optional<String> dockerExecutableName;
+
+    /**
+     * Whether to set the creation time to the actual build time. Otherwise, the creation time
+     * will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC). See <a href=
+     * "https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago">Jib
+     * FAQ</a> for more information
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useCurrentTimestamp;
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -463,8 +463,12 @@ public class JibProcessor {
                     .setWorkingDirectory(workDirInContainer)
                     .setEntrypoint(entrypoint)
                     .setEnvironment(getEnvironmentVariables(jibConfig))
-                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels))
-                    .setCreationTime(Instant.now());
+                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
+
+            if (jibConfig.useCurrentTimestamp) {
+                jibContainerBuilder.setCreationTime(Instant.now());
+            }
+
             for (int port : jibConfig.ports) {
                 jibContainerBuilder.addExposedPort(Port.tcp(port));
             }
@@ -539,8 +543,11 @@ public class JibProcessor {
 
             JibContainerBuilder jibContainerBuilder = javaContainerBuilder.toContainerBuilder()
                     .setEnvironment(getEnvironmentVariables(jibConfig))
-                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels))
-                    .setCreationTime(Instant.now());
+                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
+
+            if (jibConfig.useCurrentTimestamp) {
+                jibContainerBuilder.setCreationTime(Instant.now());
+            }
 
             if (jibConfig.jvmEntrypoint.isPresent()) {
                 jibContainerBuilder.setEntrypoint(jibConfig.jvmEntrypoint.get());
@@ -578,8 +585,12 @@ public class JibProcessor {
                     .setWorkingDirectory(workDirInContainer)
                     .setEntrypoint(entrypoint)
                     .setEnvironment(getEnvironmentVariables(jibConfig))
-                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels))
-                    .setCreationTime(Instant.now());
+                    .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
+
+            if (jibConfig.useCurrentTimestamp) {
+                jibContainerBuilder.setCreationTime(Instant.now());
+            }
+
             for (int port : jibConfig.ports) {
                 jibContainerBuilder.addExposedPort(Port.tcp(port));
             }


### PR DESCRIPTION
Adds a flag for Jib builds which sets the creation time of the produced image to the current timestamp or Unix Epoch otherwhise. Resolves #23462 