### PR TITLE
Fix various Files.list resource leaks

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -1272,12 +1272,14 @@ public class QuteProcessor {
             for (Path path : artifact.getResolvedPaths()) {
                 if (Files.isDirectory(path)) {
                     // Try to find the templates in the root dir
-                    Path basePath = Files.list(path).filter(QuteProcessor::isBasePath).findFirst().orElse(null);
-                    if (basePath != null) {
-                        LOGGER.debugf("Found extension templates dir: %s", path);
-                        scan(basePath, basePath, BASE_PATH + "/", watchedPaths, templatePaths, nativeImageResources,
-                                config);
-                        break;
+                    try (Stream<Path> paths = Files.list(path)) {
+                        Path basePath = paths.filter(QuteProcessor::isBasePath).findFirst().orElse(null);
+                        if (basePath != null) {
+                            LOGGER.debugf("Found extension templates dir: %s", path);
+                            scan(basePath, basePath, BASE_PATH + "/", watchedPaths, templatePaths, nativeImageResources,
+                                    config);
+                            break;
+                        }
                     }
                 } else {
                     try (FileSystem artifactFs = ZipUtils.newFileSystem(path)) {
@@ -1298,8 +1300,8 @@ public class QuteProcessor {
                 for (Path rootDir : tree.getRoots()) {
                     // Note that we cannot use ApplicationArchive.getChildPath(String) here because we would not be able to detect 
                     // a wrong directory name on case-insensitive file systems
-                    try {
-                        Path basePath = Files.list(rootDir).filter(QuteProcessor::isBasePath).findFirst().orElse(null);
+                    try (Stream<Path> rootDirPaths = Files.list(rootDir)) {
+                        Path basePath = rootDirPaths.filter(QuteProcessor::isBasePath).findFirst().orElse(null);
                         if (basePath != null) {
                             LOGGER.debugf("Found templates dir: %s", basePath);
                             basePaths.add(basePath);

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -847,9 +848,11 @@ public class SmallRyeOpenApiProcessor {
             if (classes != null) {
                 Path path = classes.resolve(pathName);
                 if (Files.exists(path)) {
-                    return Files.list(path).map((t) -> {
-                        return pathName + "/" + t.getFileName().toString();
-                    }).collect(Collectors.toList());
+                    try (Stream<Path> paths = Files.list(path)) {
+                        return paths.map((t) -> {
+                            return pathName + "/" + t.getFileName().toString();
+                        }).collect(Collectors.toList());
+                    }
                 }
             }
         }

--- a/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
+++ b/extensions/webjars-locator/deployment/src/main/java/io/quarkus/webjar/locator/deployment/WebJarLocatorStandaloneBuildStep.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
@@ -65,8 +66,8 @@ public class WebJarLocatorStandaloneBuildStep {
                     provider.apply(tree -> {
                         final Path webjarsDir = tree.getPath(WEBJARS_PREFIX);
                         final Path nameDir;
-                        try {
-                            nameDir = Files.list(webjarsDir).filter(Files::isDirectory).findFirst().get();
+                        try (Stream<Path> webjarsDirPaths = Files.list(webjarsDir)) {
+                            nameDir = webjarsDirPaths.filter(Files::isDirectory).findFirst().get();
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/client/maven/MavenRegistryCache.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.eclipse.aether.artifact.DefaultArtifact;
 
 public class MavenRegistryCache implements RegistryCache {
@@ -50,8 +51,8 @@ public class MavenRegistryCache implements RegistryCache {
                 throw new RegistryResolutionException("Failed to resolve " + coords + " locally", e);
             }
             if (Files.exists(dir)) {
-                try {
-                    Files.list(dir).forEach(path -> {
+                try (Stream<Path> dirPaths = Files.list(dir)) {
+                    dirPaths.forEach(path -> {
                         try {
                             Files.delete(path);
                         } catch (IOException e) {


### PR DESCRIPTION
The stream returned by Files.list must be closed according
to the Javadoc.
In most usages it was correctly done, but there were a few that had
slipped through