### PR TITLE
Fix Oracle devservices by adding missing `oracle-devservice.properties`

### DIFF
--- a/extensions/devservices/oracle/src/main/resources/oracle-devservice.properties
+++ b/extensions/devservices/oracle/src/main/resources/oracle-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${oracle.image}


### PR DESCRIPTION
I forgot to add that file in #23428.

@Sanne is there a reason why there is no devservice test for Oracle? Too slow to boot?