### PR TITLE
Type-safe message bundles - add a missing validation for localized files

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -156,11 +156,17 @@ public class MessageBundleProcessor {
                     Map<String, ClassInfo> localeToInterface = new HashMap<>();
                     for (ClassInfo localizedInterface : localized) {
                         String locale = localizedInterface.classAnnotation(Names.LOCALIZED).value().asString();
+                        if (defaultLocale.equals(locale)) {
+                            throw new MessageBundleException(
+                                    String.format(
+                                            "Locale of [%s] conflicts with the locale [%s] of the default message bundle [%s]",
+                                            localizedInterface, locale, bundleClass));
+                        }
                         ClassInfo previous = localeToInterface.put(locale, localizedInterface);
-                        if (defaultLocale.equals(locale) || previous != null) {
+                        if (previous != null) {
                             throw new MessageBundleException(String.format(
-                                    "A localized message bundle interface [%s] already exists for locale %s: [%s]",
-                                    previous != null ? previous : bundleClass, locale, localizedInterface));
+                                    "Cannot register [%s] - a localized message bundle interface exists for locale [%s]: %s",
+                                    localizedInterface, locale, previous));
                         }
                         localizedInterfaces.add(localizedInterface.name());
                     }
@@ -172,12 +178,18 @@ public class MessageBundleProcessor {
                         if (fileName.startsWith(name)) {
                             // msg_en.txt -> en
                             String locale = fileName.substring(fileName.indexOf('_') + 1, fileName.indexOf('.'));
+                            if (defaultLocale.equals(locale)) {
+                                throw new MessageBundleException(
+                                        String.format(
+                                                "Locale of [%s] conflicts with the locale [%s] of the default message bundle [%s]",
+                                                fileName, locale, bundleClass));
+                            }
                             ClassInfo localizedInterface = localeToInterface.get(locale);
                             if (localizedInterface != null) {
                                 throw new MessageBundleException(
                                         String.format(
-                                                "A localized message bundle interface [%s] already exists for locale %s: [%s]",
-                                                localizedInterface, locale, fileName));
+                                                "Cannot register [%s] - a localized message bundle interface exists for locale [%s]: %s",
+                                                fileName, locale, localizedInterface));
                             }
                             localeToFile.put(locale, messageFile);
                         }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedBundleDefaultLocaleConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedBundleDefaultLocaleConflictTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LocalizedBundleDefaultLocaleConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Messages.class, EnMessages.class))
+            .overrideConfigKey("quarkus.default-locale", "en")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof MessageBundleException) {
+                    assertEquals(
+                            "Locale of [io.quarkus.qute.deployment.i18n.LocalizedBundleDefaultLocaleConflictTest$EnMessages] conflicts with the locale [en] of the default message bundle [io.quarkus.qute.deployment.i18n.LocalizedBundleDefaultLocaleConflictTest$Messages]",
+                            rootCause.getMessage());
+                } else {
+                    fail("No message bundle exception thrown: " + t);
+                }
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Ahoj svete!")
+        String helloWorld();
+
+    }
+
+    @Localized("en")
+    public interface EnMessages extends Messages {
+
+        @Message("Hello world!")
+        String helloWorld();
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedBundleLocaleConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedBundleLocaleConflictTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LocalizedBundleLocaleConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(Messages.class, EnMessages.class, AnotherEnMessages.class))
+            .overrideConfigKey("quarkus.default-locale", "cs")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof MessageBundleException) {
+                    assertTrue(rootCause.getMessage().contains("a localized message bundle interface exists for locale [en]"));
+                } else {
+                    fail("No message bundle exception thrown: " + t);
+                }
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Ahoj svete!")
+        String helloWorld();
+
+    }
+
+    @Localized("en")
+    public interface EnMessages extends Messages {
+
+        @Message("Hello world!")
+        String helloWorld();
+
+    }
+
+    @Localized("en")
+    public interface AnotherEnMessages extends Messages {
+
+        @Message("Hello world!")
+        String helloWorld();
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileBundleLocaleConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileBundleLocaleConflictTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.qute.i18n.Localized;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LocalizedFileBundleLocaleConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Messages.class, EnMessages.class)
+                    // This localized file conflicts with the default locale
+                    .addAsResource(new StringAsset(
+                            "hello=Hello!"),
+                            "messages/msg_en.properties"))
+            .overrideConfigKey("quarkus.default-locale", "cs")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof MessageBundleException) {
+                    assertEquals(
+                            "Cannot register [msg_en.properties] - a localized message bundle interface exists for locale [en]: io.quarkus.qute.deployment.i18n.LocalizedFileBundleLocaleConflictTest$EnMessages",
+                            rootCause.getMessage());
+                } else {
+                    fail("No message bundle exception thrown: " + t);
+                }
+
+            });;
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Ahoj svete!")
+        String helloWorld();
+
+    }
+
+    @Localized("en")
+    public interface EnMessages extends Messages {
+
+        @Message("Hello world!")
+        String helloWorld();
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileDefaultLocaleConflictTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/LocalizedFileDefaultLocaleConflictTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.qute.deployment.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.deployment.MessageBundleException;
+import io.quarkus.qute.i18n.Message;
+import io.quarkus.qute.i18n.MessageBundle;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LocalizedFileDefaultLocaleConflictTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Messages.class)
+                    // This localized file conflicts with the default locale
+                    .addAsResource(new StringAsset(
+                            "hello=Hello!"),
+                            "messages/msg_en.properties"))
+            .overrideConfigKey("quarkus.default-locale", "en")
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof MessageBundleException) {
+                    assertEquals(
+                            "Locale of [msg_en.properties] conflicts with the locale [en] of the default message bundle [io.quarkus.qute.deployment.i18n.LocalizedFileDefaultLocaleConflictTest$Messages]",
+                            rootCause.getMessage());
+                } else {
+                    fail("No message bundle exception thrown: " + t);
+                }
+            });
+
+    @Test
+    public void testValidation() {
+        fail();
+    }
+
+    @MessageBundle
+    public interface Messages {
+
+        @Message("Hello world!")
+        String helloWorld();
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/i18n/MessageBundles.java
@@ -76,9 +76,14 @@ public final class MessageBundles {
                     continue;
                 }
                 Instance<?> found = container.select(locEntry.getValue(), new Localized.Literal(locEntry.getKey()));
-                if (!found.isResolvable()) {
+                if (found.isUnsatisfied()) {
                     throw new IllegalStateException(
                             Qute.fmt("Bean not found for localized interface [{e.value}] and locale [{e.key}]")
+                                    .data("e", locEntry).render());
+                }
+                if (found.isAmbiguous()) {
+                    throw new IllegalStateException(
+                            Qute.fmt("Multiple beans found for localized interface [{e.value}] and locale [{e.key}]")
                                     .data("e", locEntry).render());
                 }
                 interfaces.put(locEntry.getKey(), (Resolver) found.get());


### PR DESCRIPTION
- there was a missing validation that a localized file conflicts with
the locale of the default message bundle interface
- fixes #19617