### PR TITLE
Consistent structure in the jdbc deployment pom.xml files

### DIFF
--- a/extensions/jdbc/jdbc-db2/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-db2/deployment/pom.xml
@@ -74,7 +74,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludes>
+                        <exclude>**/DevServices*TestCase.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -94,7 +96,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skip>false</skip>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/jdbc/jdbc-mariadb/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mariadb/deployment/pom.xml
@@ -68,12 +68,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludes>
+                        <exclude>**/DevServices*TestCase.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 
     <profiles>
         <profile>
@@ -89,7 +90,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skip>false</skip>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/jdbc/jdbc-mssql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mssql/deployment/pom.xml
@@ -74,7 +74,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludes>
+                        <exclude>**/DevServices*TestCase.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -94,7 +96,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skip>false</skip>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/jdbc/jdbc-mysql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-mysql/deployment/pom.xml
@@ -68,7 +68,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludes>
+                        <exclude>**/DevServices*TestCase.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -88,7 +90,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skip>false</skip>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
+++ b/extensions/jdbc/jdbc-postgresql/deployment/pom.xml
@@ -78,7 +78,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <excludes>
+                        <exclude>**/DevServices*TestCase.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -98,7 +100,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skip>false</skip>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
For consistency, and also because some of these modules started to have integration tests which aren't necessarily related to DevServices, so the "full skip" we used was misleading.