### PR TITLE
Properly determine return type in RESTEasy Reactive methods

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.Path;
 
 import org.jboss.resteasy.reactive.FilePart;
 import org.jboss.resteasy.reactive.PathPart;
+import org.jboss.resteasy.reactive.RestResponse;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.file.AsyncFile;
@@ -50,6 +51,19 @@ public class FileResource {
             vertxRequest.vertx().fileSystem().open(FILE, new OpenOptions(), result -> {
                 if (result.succeeded())
                     emitter.complete(result.result());
+                else
+                    emitter.fail(result.cause());
+            });
+        });
+    }
+
+    @Path("rest-response-async-file")
+    @GET
+    public Uni<RestResponse<AsyncFile>> getRestResponseAsyncFile(RoutingContext vertxRequest) {
+        return Uni.createFrom().emitter(emitter -> {
+            vertxRequest.vertx().fileSystem().open(FILE, new OpenOptions(), result -> {
+                if (result.succeeded())
+                    emitter.complete(RestResponse.ResponseBuilder.ok(result.result()).header("foo", "bar").build());
                 else
                     emitter.fail(result.cause());
             });

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
@@ -76,6 +76,11 @@ public class FileTestCase {
                 .header(HttpHeaders.CONTENT_LENGTH, Matchers.nullValue())
                 .statusCode(200)
                 .body(Matchers.equalTo(content));
+        RestAssured.get("/providers/file/rest-response-async-file")
+                .then()
+                .header("foo", "bar")
+                .statusCode(200)
+                .body(Matchers.equalTo(content));
         RestAssured.get("/providers/file/mutiny-async-file")
                 .then()
                 .header(HttpHeaders.CONTENT_LENGTH, Matchers.nullValue())

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/types/TypeSignatureParser.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/types/TypeSignatureParser.java
@@ -5,10 +5,9 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-// FIXME: move to quarkus-core?
 public class TypeSignatureParser {
 
-    private char[] chars;
+    private final char[] chars;
     private int i;
 
     public TypeSignatureParser(String signature) {
@@ -17,7 +16,7 @@ public class TypeSignatureParser {
 
     public Type parseType() {
         int arrayCount = 0;
-        Type ret = null;
+        Type ret;
         int start = i;
         LOOP: do {
             char c = chars[i++];
@@ -60,13 +59,6 @@ public class TypeSignatureParser {
                     // in signatures unless we have access to the current context, we should not support them
                     throw new IllegalArgumentException(
                             "Invalid type variable in signature: " + new String(chars) + " at position " + i);
-                //                // consume until the ;
-                //                int tStart = i;
-                //                while(chars[i++] != ';') {
-                //                }
-                //                ret = new FixedTypeVariableImpl<>(new String(chars, tStart, i - tStart - 1));
-                //                break LOOP;
-                // ArrayTypeSignature
                 case '[':
                     arrayCount++;
                     break;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -358,8 +358,8 @@ public class RuntimeResourceDeployment {
         }
 
         Type returnType = TypeSignatureParser.parse(method.getReturnType());
-        Type nonAsyncReturnType = getNonAsyncReturnType(returnType);
-        Class<?> rawNonAsyncReturnType = getRawType(nonAsyncReturnType);
+        Type effectiveReturnType = getEffectiveReturnType(returnType);
+        Class<?> rawEffectiveReturnType = getRawType(effectiveReturnType);
 
         ServerMediaType serverMediaType = null;
         if (method.getProduces() != null && method.getProduces().length > 0) {
@@ -371,7 +371,7 @@ public class RuntimeResourceDeployment {
         if (method.getHttpMethod() == null) {
             //this is a resource locator method
             handlers.add(resourceLocatorHandler);
-        } else if (!Response.class.isAssignableFrom(rawNonAsyncReturnType)) {
+        } else if (!Response.class.isAssignableFrom(rawEffectiveReturnType)) {
             //try and statically determine the media type and response writer
             //we can't do this for all cases, but we can do it for the most common ones
             //in practice this should work for the majority of endpoints
@@ -383,9 +383,9 @@ public class RuntimeResourceDeployment {
                     if (mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
                         handlers.add(new VariableProducesHandler(serverMediaType, serialisers));
                         score.add(ScoreSystem.Category.Writer, ScoreSystem.Diagnostic.WriterRunTime);
-                    } else if (rawNonAsyncReturnType != Void.class
-                            && rawNonAsyncReturnType != void.class) {
-                        List<MessageBodyWriter<?>> buildTimeWriters = serialisers.findBuildTimeWriters(rawNonAsyncReturnType,
+                    } else if (rawEffectiveReturnType != Void.class
+                            && rawEffectiveReturnType != void.class) {
+                        List<MessageBodyWriter<?>> buildTimeWriters = serialisers.findBuildTimeWriters(rawEffectiveReturnType,
                                 RuntimeType.SERVER, Collections.singletonList(
                                         MediaTypeHelper.withSuffixAsSubtype(MediaType.valueOf(method.getProduces()[0]))));
                         if (buildTimeWriters == null) {
@@ -465,7 +465,7 @@ public class RuntimeResourceDeployment {
                 method.getProduces() == null ? null : serverMediaType,
                 consumesMediaTypes, invoker,
                 clazz.getFactory(), handlers.toArray(EMPTY_REST_HANDLER_ARRAY), method.getName(), parameterDeclaredTypes,
-                nonAsyncReturnType, method.isBlocking(), resourceClass,
+                effectiveReturnType, method.isBlocking(), resourceClass,
                 lazyMethod,
                 pathParameterIndexes, info.isDevelopmentMode() ? score : null, streamElementType,
                 clazz.resourceExceptionMapper());
@@ -626,23 +626,22 @@ public class RuntimeResourceDeployment {
         throw new UnsupportedOperationException("Endpoint return type not supported yet: " + type);
     }
 
-    private Type getNonAsyncReturnType(Type returnType) {
+    private Type getEffectiveReturnType(Type returnType) {
         if (returnType instanceof Class)
             return returnType;
         if (returnType instanceof ParameterizedType) {
-            // NOTE: same code in EndpointIndexer.getNonAsyncReturnType
             ParameterizedType type = (ParameterizedType) returnType;
             if (type.getRawType() == CompletionStage.class) {
-                return type.getActualTypeArguments()[0];
+                return getEffectiveReturnType(type.getActualTypeArguments()[0]);
             }
             if (type.getRawType() == Uni.class) {
-                return type.getActualTypeArguments()[0];
+                return getEffectiveReturnType(type.getActualTypeArguments()[0]);
             }
             if (type.getRawType() == Multi.class) {
-                return type.getActualTypeArguments()[0];
+                return getEffectiveReturnType(type.getActualTypeArguments()[0]);
             }
             if (type.getRawType() == RestResponse.class) {
-                return type.getActualTypeArguments()[0];
+                return getEffectiveReturnType(type.getActualTypeArguments()[0]);
             }
             return returnType;
         }


### PR DESCRIPTION
This is done in order to support complex return types like
`Uni<RestResponse<AsyncFile>>`

Fixes: #23489