### PR TITLE
Avoid considering Kotlin.Unit as a return type

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/src/main/kotlin/org/jboss/resteasy/reactive/server/runtime/kotlin/CoroutineInvocationHandler.kt
@@ -37,7 +37,10 @@ class CoroutineInvocationHandler(private val invoker: EndpointInvoker,
             // ensure the proper CL is not lost in dev-mode
             Thread.currentThread().contextClassLoader = originalTCCL
             try {
-                requestContext.result = invoker.invokeCoroutine(requestContext.endpointInstance, requestContext.parameters)
+                val result = invoker.invokeCoroutine(requestContext.endpointInstance, requestContext.parameters)
+                if (result != Unit) {
+                    requestContext.result = result
+                }
             } catch (t: Throwable) {
                 // passing true since the target doesn't change and we want response filters to be able to know what the resource method was
                 requestContext.handleException(t, true)

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResource.kt
@@ -14,6 +14,12 @@ class GreetingResource(val headers: HttpHeaders) {
         val lastName = headers.getHeaderString("lastName");
         return Greeting("hello $firstName $lastName")
     }
+
+    @GET
+    @Path("noop")
+    suspend fun noop() {
+
+    }
 }
 
 data class Greeting(val message:String)

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
@@ -34,4 +34,13 @@ class GreetingResourceTest {
             statusCode(204)
         }
     }
+
+    @Test
+    fun testNoopCoroutine() {
+        When {
+            get("/greeting/noop")
+        } Then {
+            statusCode(204)
+        }
+    }
 }


### PR DESCRIPTION
Fixes: #23501