### PR TITLE
Add RoutingContext attribute to JWT SecurityIdentity

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/CustomSecurityIdentityAugmentor.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/CustomSecurityIdentityAugmentor.java
@@ -1,0 +1,22 @@
+package io.quarkus.jwt.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmentor {
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+        builder.addAttribute("routing-context-available", identity.getAttributes().containsKey(RoutingContext.class.getName()));
+        return Uni.createFrom().item(builder.build());
+    }
+
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsEndpoint.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsEndpoint.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.HttpHeaders;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import io.quarkus.security.identity.SecurityIdentity;
 import io.smallrye.jwt.auth.principal.JWTParser;
 
 @Path("/endp")
@@ -20,6 +21,9 @@ public class DefaultGroupsEndpoint {
 
     @Inject
     JsonWebToken jwtPrincipal;
+
+    @Inject
+    SecurityIdentity securityIdentity;
 
     @Inject
     JWTParser parser;
@@ -32,6 +36,14 @@ public class DefaultGroupsEndpoint {
     @RolesAllowed("User")
     public String echoGroups() {
         return jwtPrincipal.getGroups().stream().reduce("", String::concat);
+    }
+
+    @GET
+    @Path("/routingContext")
+    @RolesAllowed("User")
+    public String checkRoutingContext() {
+        return jwtPrincipal.getGroups().stream().reduce("", String::concat)
+                + "; routing-context-available:" + securityIdentity.getAttributes().containsKey("routing-context-available");
     }
 
     @GET

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DefaultGroupsUnitTest.java
@@ -12,6 +12,7 @@ import io.restassured.RestAssured;
 public class DefaultGroupsUnitTest {
     private static Class<?>[] testClasses = {
             DefaultGroupsEndpoint.class,
+            CustomSecurityIdentityAugmentor.class,
             TokenUtils.class
     };
     /**
@@ -45,6 +46,15 @@ public class DefaultGroupsUnitTest {
                 .get("/endp/echo")
                 .then().assertThat().statusCode(200)
                 .body(equalTo("User"));
+    }
+
+    @Test
+    public void checkRoutingContext() {
+        RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/routingContext")
+                .then().assertThat().statusCode(200)
+                .body(equalTo("User; routing-context-available:true"));
     }
 
     @Test

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/MpJwtValidator.java
@@ -14,10 +14,12 @@ import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.TokenAuthenticationRequest;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityUtils;
 import io.smallrye.jwt.auth.principal.JWTParser;
 import io.smallrye.jwt.auth.principal.ParseException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.subscription.UniEmitter;
+import io.vertx.ext.web.RoutingContext;
 
 /**
  * Validates a bearer token according to the MP-JWT rules
@@ -72,10 +74,15 @@ public class MpJwtValidator implements IdentityProvider<TokenAuthenticationReque
     private SecurityIdentity createSecurityIdentity(TokenAuthenticationRequest request) {
         try {
             JsonWebToken jwtPrincipal = parser.parse(request.getToken().getToken());
-            return QuarkusSecurityIdentity.builder().setPrincipal(jwtPrincipal)
+            QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder().setPrincipal(jwtPrincipal)
                     .addCredential(request.getToken())
                     .addRoles(jwtPrincipal.getGroups())
-                    .addAttribute(SecurityIdentity.USER_ATTRIBUTE, jwtPrincipal).build();
+                    .addAttribute(SecurityIdentity.USER_ATTRIBUTE, jwtPrincipal);
+            RoutingContext routingContext = HttpSecurityUtils.getRoutingContextAttribute(request);
+            if (routingContext != null) {
+                builder.addAttribute(RoutingContext.class.getName(), routingContext);
+            }
+            return builder.build();
         } catch (ParseException e) {
             log.debug("Authentication failed", e);
             throw new AuthenticationFailedException(e);


### PR DESCRIPTION
This PR just adds a `RoutingContext` attribute to `SecurityIdentity` produced by `quarkus-smallrye-jwt`, similarly to how it is done in `quarkus-oidc`