### PR TITLE
Fix OidcClient not to lose a public client id

### DIFF
--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/KeycloakRealmUserPasswordManager.java
@@ -30,6 +30,7 @@ public class KeycloakRealmUserPasswordManager implements QuarkusTestResourceLife
             RealmRepresentation realm = createRealm(KEYCLOAK_REALM);
 
             realm.getClients().add(createClient("quarkus-app"));
+            realm.getClients().add(createPublicClient("quarkus-public-app"));
             realm.getUsers().add(createUser("alice", "user"));
             realm.getUsers().add(createUser("bob", "user"));
 
@@ -89,6 +90,17 @@ public class KeycloakRealmUserPasswordManager implements QuarkusTestResourceLife
         client.setClientId(clientId);
         client.setPublicClient(false);
         client.setSecret("secret");
+        client.setDirectAccessGrantsEnabled(true);
+        client.setEnabled(true);
+
+        return client;
+    }
+
+    private static ClientRepresentation createPublicClient(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+
+        client.setClientId(clientId);
+        client.setPublicClient(true);
         client.setDirectAccessGrantsEnabled(true);
         client.setEnabled(true);
 

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcClientUserPasswordTestCase.java
@@ -23,6 +23,7 @@ public class OidcClientUserPasswordTestCase {
 
     private static Class<?>[] testClasses = {
             OidcClientResource.class,
+            OidcPublicClientResource.class,
             ProtectedResource.class
     };
 
@@ -35,6 +36,17 @@ public class OidcClientUserPasswordTestCase {
     @Test
     public void testPasswordGrantToken() {
         String token = RestAssured.when().get("/client/token").body().asString();
+        RestAssured.given().auth().oauth2(token)
+                .when().get("/protected")
+                .then()
+                .statusCode(200)
+                .body(equalTo("alice"));
+
+    }
+
+    @Test
+    public void testPublicClientPasswordGrantToken() {
+        String token = RestAssured.when().get("/public-client/token").body().asString();
         RestAssured.given().auth().oauth2(token)
                 .when().get("/protected")
                 .then()

--- a/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcPublicClientResource.java
+++ b/extensions/oidc-client/deployment/src/test/java/io/quarkus/oidc/client/OidcPublicClientResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.oidc.client;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/public-client")
+public class OidcPublicClientResource {
+
+    @Inject
+    @NamedOidcClient("public")
+    OidcClient client;
+
+    @GET
+    @Path("token")
+    public Uni<String> tokenUni() {
+        return client.getTokens().flatMap(tokens -> Uni.createFrom().item(tokens.getAccessToken()));
+    }
+}

--- a/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
+++ b/extensions/oidc-client/deployment/src/test/resources/application-oidc-client-user-password.properties
@@ -1,10 +1,14 @@
 quarkus.oidc.auth-server-url=${keycloak.url}/realms/quarkus/
-quarkus.oidc.client-id=quarkus-app
-quarkus.oidc.credentials.secret=secret
 
 quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
-quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
-quarkus.oidc-client.credentials.secret=${quarkus.oidc.credentials.secret}
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
 quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
+
+quarkus.oidc-client.public.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.public.client-id=quarkus-public-app
+quarkus.oidc-client.public.grant.type=password
+quarkus.oidc-client.public.grant-options.password.username=alice
+quarkus.oidc-client.public.grant-options.password.password=alice

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -107,6 +107,8 @@ public class OidcClientImpl implements OidcClient {
                         body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
                         body.add(OidcConstants.CLIENT_ASSERTION, jwt);
                     }
+                } else if (!OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
+                    body.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
                 }
                 if (!additionalGrantParameters.isEmpty()) {
                     body = copyMultiMap(body);


### PR DESCRIPTION
Fixes #23510

This PR makes a simple update to `OidcClientImpl`, if no client authentication is configured then a client id only is sent. This is already done for `quarkus-oidc` [here](https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java#L124). The only difference with `quarkus-oidc-client` is that it is done only if the client post authentication is not required - in `quarkus-oidc` it is checked [just above](https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java#L120) to defaulting to sending a client id, while `quarkus-oidc-client` prepares the client post auth data early in `OidcClientRecorder`. In both cases only the client id is sent if it has been confirmed no client auth is required.

Added a simple test to confirm - a named OIDC client representing a public client is added to `application.properties` where I also removed the client id and secret properties from the `quarkus-oidc` configuration since it is not required/used. 

CC @pedroigor 