### PR TITLE
Support locales resources in native: countries, currencies, timezones, languages

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -105,7 +105,7 @@
         {
             "category": "Misc2",
             "timeout": 65,
-            "test-modules": "hibernate-validator, test-extension, logging-gelf, bootstrap-config, mailer, native-config-profile",
+            "test-modules": "hibernate-validator, test-extension, logging-gelf, bootstrap-config, mailer, native-config-profile, locales",
             "os-name": "ubuntu-latest"
         },
         {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.pkg;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -10,6 +11,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.LocaleConverter;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
@@ -71,34 +73,26 @@ public class NativeConfig {
      * It also serves as te default Locale language for the native executable application runtime.
      * e.g. en or cs as defined by IETF BCP 47 language tags.
      * <p>
-     * Defaults to the system one.
+     * 
+     * @deprecated Use the global quarkus.default-locale.
      */
-    @ConfigItem(defaultValue = "${user.language:}")
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> userLanguage;
+    @ConfigItem
+    @ConvertWith(LocaleConverter.class)
+    @Deprecated
+    public Optional<Locale> userLanguage;
 
     /**
      * Defines the user country used for building the native executable.
      * It also serves as te default Locale country for the native executable application runtime.
      * e.g. US or FR as defined by ISO 3166-1 alpha-2 codes.
      * <p>
-     * Defaults to the system one.
-     */
-    @ConfigItem(defaultValue = "${user.country:}")
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> userCountry;
-
-    /**
-     * Defines the locales to be accessible in the native executable.
-     * The format is a comma separated list of IETF BCP 47 language tags,
-     * e.g. "fr,de,cs" or "de-AT,ja-JP" etc.
-     * See also LocalesBuildTimeConfig for a separate, native-image unrelated usage.
-     * <p>
-     * Defaults to empty, i.e. not explicitly set during native-image build.
+     * 
+     * @deprecated Use the global quarkus.default-locale.
      */
     @ConfigItem
-    @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> locales;
+    @ConvertWith(LocaleConverter.class)
+    @Deprecated
+    public Optional<Locale> userCountry;
 
     /**
      * Defines the file encoding as in -Dfile.encoding=...

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -11,7 +11,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.annotations.ConvertWith;
-import io.quarkus.runtime.configuration.LocaleConverter;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
@@ -70,29 +69,29 @@ public class NativeConfig {
 
     /**
      * Defines the user language used for building the native executable.
-     * It also serves as te default Locale language for the native executable application runtime.
+     * It also serves as the default Locale language for the native executable application runtime.
      * e.g. en or cs as defined by IETF BCP 47 language tags.
      * <p>
      * 
      * @deprecated Use the global quarkus.default-locale.
      */
     @ConfigItem
-    @ConvertWith(LocaleConverter.class)
+    @ConvertWith(TrimmedStringConverter.class)
     @Deprecated
-    public Optional<Locale> userLanguage;
+    public Optional<String> userLanguage;
 
     /**
      * Defines the user country used for building the native executable.
-     * It also serves as te default Locale country for the native executable application runtime.
+     * It also serves as the default Locale country for the native executable application runtime.
      * e.g. US or FR as defined by ISO 3166-1 alpha-2 codes.
      * <p>
      * 
      * @deprecated Use the global quarkus.default-locale.
      */
     @ConfigItem
-    @ConvertWith(LocaleConverter.class)
+    @ConvertWith(TrimmedStringConverter.class)
     @Deprecated
-    public Optional<Locale> userCountry;
+    public Optional<String> userCountry;
 
     /**
      * Defines the file encoding as in -Dfile.encoding=...

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -68,6 +68,8 @@ public class NativeConfig {
 
     /**
      * Defines the user language used for building the native executable.
+     * It also serves as te default Locale language for the native executable application runtime.
+     * e.g. en or cs as defined by IETF BCP 47 language tags.
      * <p>
      * Defaults to the system one.
      */
@@ -77,12 +79,26 @@ public class NativeConfig {
 
     /**
      * Defines the user country used for building the native executable.
+     * It also serves as te default Locale country for the native executable application runtime.
+     * e.g. US or FR as defined by ISO 3166-1 alpha-2 codes.
      * <p>
      * Defaults to the system one.
      */
     @ConfigItem(defaultValue = "${user.country:}")
     @ConvertWith(TrimmedStringConverter.class)
     public Optional<String> userCountry;
+
+    /**
+     * Defines the locales to be accessible in the native executable.
+     * The format is a comma separated list of IETF BCP 47 language tags,
+     * e.g. "fr,de,cs" or "de-AT,ja-JP" etc.
+     * See also LocalesBuildTimeConfig for a separate, native-image unrelated usage.
+     * <p>
+     * Defaults to empty, i.e. not explicitly set during native-image build.
+     */
+    @ConfigItem
+    @ConvertWith(TrimmedStringConverter.class)
+    public Optional<String> locales;
 
     /**
      * Defines the file encoding as in -Dfile.encoding=...

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -613,6 +613,9 @@ public class NativeImageBuildStep {
                 if (nativeConfig.userCountry.isPresent()) {
                     nativeImageArgs.add("-J-Duser.country=" + nativeConfig.userCountry.get());
                 }
+                if (nativeConfig.locales.isPresent()) {
+                    nativeImageArgs.add("-H:IncludeLocales=" + nativeConfig.locales.get());
+                }
                 nativeImageArgs.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding);
 
                 if (enableSslNative) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -41,8 +41,10 @@ import io.quarkus.deployment.pkg.builditem.NativeImageSourceJarBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabled;
 import io.quarkus.deployment.pkg.builditem.ProcessInheritIODisabledBuildItem;
+import io.quarkus.deployment.steps.LocaleProcessor;
 import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.runtime.LocalesBuildTimeConfig;
 
 public class NativeImageBuildStep {
 
@@ -84,6 +86,7 @@ public class NativeImageBuildStep {
 
     @BuildStep(onlyIf = NativeSourcesBuild.class)
     ArtifactResultBuildItem nativeSourcesResult(NativeConfig nativeConfig,
+            LocalesBuildTimeConfig localesBuildTimeConfig,
             BuildSystemTargetBuildItem buildSystemTargetBuildItem,
             NativeImageSourceJarBuildItem nativeImageSourceJarBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
@@ -109,6 +112,7 @@ public class NativeImageBuildStep {
 
         NativeImageInvokerInfo nativeImageArgs = new NativeImageInvokerInfo.Builder()
                 .setNativeConfig(nativeConfig)
+                .setLocalesBuildTimeConfig(localesBuildTimeConfig)
                 .setOutputTargetBuildItem(outputTargetBuildItem)
                 .setNativeImageProperties(nativeImageProperties)
                 .setExcludeConfigs(excludeConfigs)
@@ -140,7 +144,8 @@ public class NativeImageBuildStep {
     }
 
     @BuildStep
-    public NativeImageBuildItem build(NativeConfig nativeConfig, NativeImageSourceJarBuildItem nativeImageSourceJarBuildItem,
+    public NativeImageBuildItem build(NativeConfig nativeConfig, LocalesBuildTimeConfig localesBuildTimeConfig,
+            NativeImageSourceJarBuildItem nativeImageSourceJarBuildItem,
             OutputTargetBuildItem outputTargetBuildItem,
             PackageConfig packageConfig,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
@@ -207,6 +212,7 @@ public class NativeImageBuildStep {
 
             NativeImageInvokerInfo commandAndExecutable = new NativeImageInvokerInfo.Builder()
                     .setNativeConfig(nativeConfig)
+                    .setLocalesBuildTimeConfig(localesBuildTimeConfig)
                     .setOutputTargetBuildItem(outputTargetBuildItem)
                     .setNativeImageProperties(nativeImageProperties)
                     .setExcludeConfigs(excludeConfigs)
@@ -488,6 +494,7 @@ public class NativeImageBuildStep {
 
         static class Builder {
             private NativeConfig nativeConfig;
+            private LocalesBuildTimeConfig localesBuildTimeConfig;
             private OutputTargetBuildItem outputTargetBuildItem;
             private List<NativeImageSystemPropertyBuildItem> nativeImageProperties;
             private List<ExcludeConfigBuildItem> excludeConfigs;
@@ -504,6 +511,11 @@ public class NativeImageBuildStep {
 
             public Builder setNativeConfig(NativeConfig nativeConfig) {
                 this.nativeConfig = nativeConfig;
+                return this;
+            }
+
+            public Builder setLocalesBuildTimeConfig(LocalesBuildTimeConfig localesBuildTimeConfig) {
+                this.localesBuildTimeConfig = localesBuildTimeConfig;
                 return this;
             }
 
@@ -607,15 +619,20 @@ public class NativeImageBuildStep {
                         }
                     }
                 }
-                if (nativeConfig.userLanguage.isPresent()) {
-                    nativeImageArgs.add("-J-Duser.language=" + nativeConfig.userLanguage.get());
+
+                final String userLanguage = LocaleProcessor.nativeImageUserLanguage(nativeConfig, localesBuildTimeConfig);
+                if (!userLanguage.isEmpty()) {
+                    nativeImageArgs.add("-J-Duser.language=" + userLanguage);
                 }
-                if (nativeConfig.userCountry.isPresent()) {
-                    nativeImageArgs.add("-J-Duser.country=" + nativeConfig.userCountry.get());
+                final String userCountry = LocaleProcessor.nativeImageUserCountry(nativeConfig, localesBuildTimeConfig);
+                if (!userCountry.isEmpty()) {
+                    nativeImageArgs.add("-J-Duser.country=" + userCountry);
                 }
-                if (nativeConfig.locales.isPresent()) {
-                    nativeImageArgs.add("-H:IncludeLocales=" + nativeConfig.locales.get());
+                final String includeLocales = LocaleProcessor.nativeImageIncludeLocales(nativeConfig, localesBuildTimeConfig);
+                if (!includeLocales.isEmpty()) {
+                    nativeImageArgs.add("-H:IncludeLocales=" + includeLocales);
                 }
+
                 nativeImageArgs.add("-J-Dfile.encoding=" + nativeConfig.fileEncoding);
 
                 if (enableSslNative) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/LocaleProcessor.java
@@ -1,0 +1,70 @@
+package io.quarkus.deployment.steps;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.pkg.steps.NativeBuild;
+
+/**
+ * In order for a Native image built app to be able to use localized names of e.g. countries,
+ * these language bundles have to be loaded. JDK uses ServiceLoader approach for that.
+ * For instance, Locale.FRANCE.getDisplayCountry(Locale.GERMAN) must print "Frankreich".
+ */
+public class LocaleProcessor {
+
+    @BuildStep(onlyIf = { NativeBuild.class, NonEnglishLocale.class })
+    void nativeResources(BuildProducer<NativeImageResourceBundleBuildItem> resources) {
+        resources.produce(new NativeImageResourceBundleBuildItem("sun.util.resources.LocaleNames"));
+        resources.produce(new NativeImageResourceBundleBuildItem("sun.util.resources.CurrencyNames"));
+        //Adding sun.util.resources.TimeZoneNames is not necessary.
+    }
+
+    @BuildStep(onlyIf = { NativeBuild.class, NonEnglishLocale.class })
+    ReflectiveClassBuildItem setupReflectionClasses() {
+        return new ReflectiveClassBuildItem(false, false,
+                "sun.util.resources.provider.SupplementaryLocaleDataProvider",
+                "sun.util.resources.provider.LocaleDataProvider");
+    }
+
+    @BuildStep(onlyIf = { NativeBuild.class, NonEnglishLocale.class })
+    void servicesResource(BuildProducer<NativeImageResourceBuildItem> nibProducer,
+            BuildProducer<GeneratedResourceBuildItem> genResProducer) {
+        final String r1 = "META-INF/services/sun.util.resources.LocaleData$SupplementaryResourceBundleProvider";
+        final String r2 = "META-INF/services/sun.util.resources.LocaleData$CommonResourceBundleProvider";
+        nibProducer.produce(new NativeImageResourceBuildItem(r1, r2));
+        genResProducer.produce(new GeneratedResourceBuildItem(r1,
+                "sun.util.resources.provider.SupplementaryLocaleDataProvider".getBytes(StandardCharsets.UTF_8)));
+        genResProducer.produce(new GeneratedResourceBuildItem(r2,
+                "sun.util.resources.provider.LocaleDataProvider".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * We activate additional resources in native-image executable only if user opts
+     * for something else than US English.
+     */
+    static final class NonEnglishLocale implements BooleanSupplier {
+        private static final Pattern US_ENGLISH = Pattern.compile("(?i:(en|,|-US)+)");
+        private final NativeConfig nativeConfig;
+
+        public NonEnglishLocale(NativeConfig nativeConfig) {
+            this.nativeConfig = nativeConfig;
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return (nativeConfig.userLanguage.isPresent() && !US_ENGLISH.matcher(nativeConfig.userLanguage.get()).matches())
+                    ||
+                    (nativeConfig.userCountry.isPresent() && !US_ENGLISH.matcher(nativeConfig.userCountry.get()).matches())
+                    ||
+                    (nativeConfig.locales.isPresent() && !US_ENGLISH.matcher(nativeConfig.locales.get()).matches());
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/LocalesBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/LocalesBuildTimeConfig.java
@@ -10,8 +10,9 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(name = ConfigItem.PARENT, phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class LocalesBuildTimeConfig {
 
-    // we set to en as the default language when all else fails since this is what the JDK does as well
-    private static final String DEFAULT_LOCALE_VALUE = "${user.language:en}-${user.country:}";
+    // We set to en as the default language when all else fails since this is what the JDK does as well
+    public static final String DEFAULT_LANGUAGE = "${user.language:en}";
+    public static final String DEFAULT_COUNTRY = "${user.country:}";
 
     /**
      * The set of supported locales that can be consumed by the extensions.
@@ -19,17 +20,23 @@ public class LocalesBuildTimeConfig {
      * The locales must be specified in the IETF BCP 47 format e.g. en-US or fr-FR.
      * <p>
      * For instance, the Hibernate Validator extension makes use of it.
+     * <p>
+     * Native-image build uses it to define additional locales that are supposed
+     * to be available at runtime.
      */
-    @ConfigItem(defaultValue = DEFAULT_LOCALE_VALUE, defaultValueDocumentation = "Set containing the build system locale")
+    @ConfigItem(defaultValue = DEFAULT_LANGUAGE + "-"
+            + DEFAULT_COUNTRY, defaultValueDocumentation = "Set containing the build system locale")
     public Set<Locale> locales;
 
     /**
      * Default locale that can be consumed by the extensions.
      * <p>
-     * The locales must be specified in the IETF BCP 47 format e.g. en-US or fr-FR.
+     * The locale must be specified in the IETF BCP 47 format e.g. en-US or fr-FR.
      * <p>
      * For instance, the Hibernate Validator extension makes use of it.
+     * <p>
+     * Native-image build uses this property to derive user.language and user.country for the application's runtime.
      */
-    @ConfigItem(defaultValue = DEFAULT_LOCALE_VALUE, defaultValueDocumentation = "Build system locale")
+    @ConfigItem(defaultValue = DEFAULT_LANGUAGE + "-" + DEFAULT_COUNTRY, defaultValueDocumentation = "Build system locale")
     public Locale defaultLocale;
 }

--- a/integration-tests/locales/pom.xml
+++ b/integration-tests/locales/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-integration-test-locales</artifactId>
+    <name>Quarkus - Integration Tests - Locales</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/integration-tests/locales/src/main/java/io/quarkus/locales/it/LocalesResource.java
+++ b/integration-tests/locales/src/main/java/io/quarkus/locales/it/LocalesResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.locales.it;
+
+import java.time.ZoneId;
+import java.util.Currency;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("")
+public class LocalesResource {
+
+    @Path("/locale/{country}/{language}")
+    @GET
+    public Response inLocale(@PathParam("country") String country, @NotNull @PathParam("language") String language) {
+        return Response.ok().entity(
+                Locale.forLanguageTag(country).getDisplayCountry(new Locale(language))).build();
+    }
+
+    @Path("/default/{country}")
+    @GET
+    public Response inDefaultLocale(@PathParam("country") String country) {
+        return Response.ok().entity(
+                Locale.forLanguageTag(country).getDisplayCountry()).build();
+    }
+
+    @Path("/currency/{country}/{language}")
+    @GET
+    public Response currencyInLocale(@PathParam("country") String country, @NotNull @PathParam("language") String language) {
+        return Response.ok().entity(
+                Currency.getInstance(Locale.forLanguageTag(country)).getDisplayName(new Locale(language))).build();
+    }
+
+    @Path("/timeZone")
+    @GET
+    public Response timeZoneInLocale(@NotNull @QueryParam("zone") String zone,
+            @NotNull @QueryParam("language") String language) {
+        return Response.ok().entity(
+                TimeZone.getTimeZone(ZoneId.of(zone)).getDisplayName(new Locale(language))).build();
+    }
+}

--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -103,5 +103,4 @@ public class LocalesIT {
                 .body(is("Italy"))
                 .log().all();
     }
-
 }

--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -1,0 +1,107 @@
+package io.quarkus.locales.it;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.junit.NativeImageTest;
+import io.restassured.RestAssured;
+
+@NativeImageTest
+public class LocalesIT {
+
+    private static final Logger LOG = Logger.getLogger(LocalesIT.class);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "en-US|en|United States",
+            "de-DE|de|Deutschland",
+            "de-AT|en|Austria",
+            "de-DE|en|Germany"
+    })
+    public void testCorrectLocales(String countryLanguageTranslation) {
+        final String[] lct = countryLanguageTranslation.split("\\|");
+        LOG.infof("Triggering test: Country: %s, Language: %s, Translation: %s", lct[0], lct[1], lct[2]);
+        RestAssured.given().when()
+                .get(String.format("/locale/%s/%s", lct[0], lct[1]))
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(lct[2]))
+                .log().all();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "en-US|en|US Dollar",
+            "de-DE|fr|euro",
+            "cs-CZ|cs|česká koruna",
+            "ja-JP|ja|日本円",
+            "en-TZ|en|Tanzanian Shilling",
+            "uk-UA|uk|українська гривня"
+    })
+    public void testCurrencies(String countryLanguageCurrency) {
+        final String[] clc = countryLanguageCurrency.split("\\|");
+        LOG.infof("Triggering test: Country: %s, Language: %s, Currency: %s", clc[0], clc[1], clc[2]);
+        RestAssured.given().when()
+                .get(String.format("/currency/%s/%s", clc[0], clc[1]))
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(clc[2]))
+                .log().all();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Asia/Tokyo|fr|heure normale du Japon",
+            "Europe/Prague|cs|Středoevropský standardní čas",
+            "GMT|fr|heure moyenne de Greenwich",
+            "Asia/Yerevan|ja|アルメニア標準時",
+            "US/Pacific|uk|за північноамериканським тихоокеанським стандартним часом"
+    })
+    public void testTimeZones(String zoneLanguageName) {
+        final String[] zln = zoneLanguageName.split("\\|");
+        LOG.infof("Triggering test: Zone: %s, Language: %s, Name: %s", zln[0], zln[1], zln[2]);
+        RestAssured.given().when()
+                .param("zone", zln[0])
+                .param("language", zln[1])
+                .get("/timeZone")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(zln[2]))
+                .log().all();
+    }
+
+    @Test
+    public void testDefaultLocale() {
+        RestAssured.given().when()
+                .get("/default/de-CH")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                /*
+                 * "Švýcarsko" is the correct name for Switzerland in Czech language.
+                 * Czech is the default language as per quarkus.native.user-language=cs.
+                 */
+                .body(is("Švýcarsko"))
+                .log().all();
+    }
+
+    @Test
+    public void testMissingLocaleSorryItaly() {
+        RestAssured.given().when()
+                .get("/locale/it-IT/it")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                /*
+                 * The expected response would be "Italia", not "Italy".
+                 * Our application.properties' quarkus.native.locales property is missing "it" from the list of
+                 * locales available in the native image, so the correct silent fallback is English, hence "Italy".
+                 */
+                .body(is("Italy"))
+                .log().all();
+    }
+
+}

--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesTest.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesTest.java
@@ -1,0 +1,7 @@
+package io.quarkus.locales.it;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LocalesTest {
+}

--- a/integration-tests/locales/src/test/resources/application.properties
+++ b/integration-tests/locales/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.native.locales=de,fr,ja,uk-UA
+quarkus.native.user-language=cs

--- a/integration-tests/locales/src/test/resources/application.properties
+++ b/integration-tests/locales/src/test/resources/application.properties
@@ -1,2 +1,5 @@
-quarkus.native.locales=de,fr,ja,uk-UA
+quarkus.locales=de,fr,ja,uk-UA
+# Note that quarkus.native.user-language is deprecated and solely quarkus.default-locale should be
+# used in your application properties. This test uses it only to verify compatibility.
 quarkus.native.user-language=cs
+quarkus.default-locale=en-US

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -300,6 +300,7 @@
                 <module>logging-min-level-unset</module>
                 <module>logging-min-level-set</module>
                 <module>logging-panache</module>
+                <module>locales</module>
                 <module>redis-devservices</module>
 
                 <!-- gRPC tests -->


### PR DESCRIPTION
Fixes #23338
Fixes #22808

Adds logic to control GraalVM's `-H:IncludeLocales`.

~If user sets anything but US English for any of~

~quarkus.native.user-language~
~quarkus.native.user-country~

~or if user adds anything but US English to a new config option:~

~quarkus.native.locales~

~LoalesProcessor kicks in and augments native-image with necessary providers to enable translation~
~of countries names, timezones and currencies.~

~I intentionally didn't alter the option `quarkus.locales` that is used by Hibernate Validator.~
~It is converted and used for a different purpose than native-image runtime locales availability.~

See https://github.com/quarkusio/quarkus/pull/23518#issuecomment-1034382063