### PR TITLE
Add BouncyCastle providers to generated AutoFeature

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -1,5 +1,8 @@
 package io.quarkus.security.deployment;
 
+import static io.quarkus.gizmo.MethodDescriptor.ofMethod;
+import static io.quarkus.security.runtime.SecurityProviderUtils.findProviderIndex;
+
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
@@ -42,12 +45,18 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationClassPredicateBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.GeneratedNativeImageClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JPMSExportBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSecurityProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.gizmo.CatchBlockCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TryBlock;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.security.runtime.IdentityProviderManagerCreator;
 import io.quarkus.security.runtime.SecurityBuildTimeConfig;
@@ -149,10 +158,15 @@ public class SecurityProcessor {
                 isFipsMode ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
                         : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME));
         reflection.produce(new ReflectiveClassBuildItem(true, true,
+                "org.bouncycastle.jcajce.provider.symmetric.AES",
+                "org.bouncycastle.jcajce.provider.symmetric.AES$CBC",
+                "org.bouncycastle.crypto.paddings.PKCS7Padding",
                 "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi",
                 "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi$EC",
+                "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi$ECDSA",
                 "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi",
                 "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi$EC",
+                "org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi$ECDSA",
                 "org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyFactorySpi",
                 "org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyPairGeneratorSpi",
                 "org.bouncycastle.jcajce.provider.asymmetric.rsa.PSSSignatureSpi",
@@ -169,13 +183,6 @@ public class SecurityProcessor {
         } else {
             reflection.produce(new ReflectiveClassBuildItem(true, true, true, "org.bouncycastle.crypto.general.AES"));
             runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.crypto.general.AES"));
-            runtimeReInitialized
-                    .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.math.ec.custom.sec.SecP521R1Curve"));
-            runtimeReInitialized
-                    .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.math.ec.custom.sec.SecP384R1Curve"));
-            runtimeReInitialized
-                    .produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.math.ec.custom.sec.SecP256R1Curve"));
-            runtimeReInitialized.produce(new RuntimeReinitializedClassBuildItem("org.bouncycastle.math.ec.ECPoint"));
             runtimeReInitialized
                     .produce(new RuntimeReinitializedClassBuildItem(
                             "org.bouncycastle.crypto.asymmetric.NamedECDomainParameters"));
@@ -221,26 +228,96 @@ public class SecurityProcessor {
     }
 
     @BuildStep
-    void addBouncyCastleProvidersToNativeImage(BuildProducer<NativeImageSecurityProviderBuildItem> additionalProviders,
+    void addBouncyCastleProvidersToNativeImage(
+            BuildProducer<GeneratedNativeImageClassBuildItem> nativeImageClass,
+            BuildProducer<NativeImageSecurityProviderBuildItem> additionalProviders,
             List<BouncyCastleProviderBuildItem> bouncyCastleProviders,
             List<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProviders) {
+
         Optional<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProvider = getOne(bouncyCastleJsseProviders);
-        if (bouncyCastleJsseProvider.isPresent()) {
-            additionalProviders.produce(
-                    new NativeImageSecurityProviderBuildItem(SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME));
-            final String providerName = bouncyCastleJsseProvider.get().isInFipsMode()
-                    ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
-                    : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME;
-            additionalProviders.produce(new NativeImageSecurityProviderBuildItem(providerName));
-        } else {
-            Optional<BouncyCastleProviderBuildItem> bouncyCastleProvider = getOne(bouncyCastleProviders);
-            if (bouncyCastleProvider.isPresent()) {
+        Optional<BouncyCastleProviderBuildItem> bouncyCastleProvider = getOne(bouncyCastleProviders);
+
+        if (bouncyCastleJsseProvider.isPresent() || bouncyCastleProvider.isPresent()) {
+
+            // Prepare BouncyCastle AutoFeature generation
+            ClassCreator file = new ClassCreator(new ClassOutput() {
+                @Override
+                public void write(String s, byte[] bytes) {
+                    nativeImageClass.produce(new GeneratedNativeImageClassBuildItem(s, bytes));
+                }
+            }, "io.quarkus.security.BouncyCastleFeature", null, Object.class.getName(),
+                    org.graalvm.nativeimage.hosted.Feature.class.getName());
+            file.addAnnotation("com.oracle.svm.core.annotate.AutomaticFeature");
+
+            MethodCreator beforeAn = file.getMethodCreator("beforeAnalysis", "V",
+                    org.graalvm.nativeimage.hosted.Feature.BeforeAnalysisAccess.class.getName());
+
+            TryBlock overallCatch = beforeAn.tryBlock();
+
+            if (bouncyCastleJsseProvider.isPresent()) {
+                // BCJSSE or BCJSSEFIPS
+
+                additionalProviders.produce(
+                        new NativeImageSecurityProviderBuildItem(SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME));
+
+                if (!bouncyCastleJsseProvider.get().isInFipsMode()) {
+                    final int sunJsseIndex = findProviderIndex(SecurityProviderUtils.SUN_JSSE_PROVIDER_NAME);
+
+                    ResultHandle bcProvider = overallCatch
+                            .newInstance(
+                                    MethodDescriptor.ofConstructor(SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME));
+                    ResultHandle bcJsseProvider = overallCatch.newInstance(
+                            MethodDescriptor.ofConstructor(SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME));
+
+                    overallCatch.invokeStaticMethod(
+                            MethodDescriptor.ofMethod(Security.class, "insertProviderAt", int.class, Provider.class,
+                                    int.class),
+                            bcProvider, overallCatch.load(sunJsseIndex));
+                    overallCatch.invokeStaticMethod(
+                            MethodDescriptor.ofMethod(Security.class, "insertProviderAt", int.class, Provider.class,
+                                    int.class),
+                            bcJsseProvider, overallCatch.load(sunJsseIndex + 1));
+                } else {
+                    final int sunIndex = findProviderIndex(SecurityProviderUtils.SUN_PROVIDER_NAME);
+
+                    ResultHandle bcFipsProvider = overallCatch
+                            .newInstance(MethodDescriptor
+                                    .ofConstructor(SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME));
+                    MethodDescriptor bcJsseProviderConstructor = MethodDescriptor.ofConstructor(
+                            SecurityProviderUtils.BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME, "boolean",
+                            Provider.class.getName());
+                    ResultHandle bcJsseProvider = overallCatch.newInstance(bcJsseProviderConstructor,
+                            overallCatch.load(true), bcFipsProvider);
+
+                    overallCatch.invokeStaticMethod(
+                            MethodDescriptor.ofMethod(Security.class, "insertProviderAt", int.class, Provider.class,
+                                    int.class),
+                            bcFipsProvider, overallCatch.load(sunIndex));
+                    overallCatch.invokeStaticMethod(
+                            MethodDescriptor.ofMethod(Security.class, "insertProviderAt", int.class, Provider.class,
+                                    int.class),
+                            bcJsseProvider, overallCatch.load(sunIndex + 1));
+                }
+            } else {
+                // BC or BCFIPS
+
                 final String providerName = bouncyCastleProvider.get().isInFipsMode()
                         ? SecurityProviderUtils.BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME
                         : SecurityProviderUtils.BOUNCYCASTLE_PROVIDER_CLASS_NAME;
-                additionalProviders.produce(new NativeImageSecurityProviderBuildItem(providerName));
+
+                ResultHandle bcProvider = overallCatch.newInstance(MethodDescriptor.ofConstructor(providerName));
+                overallCatch.invokeStaticMethod(
+                        MethodDescriptor.ofMethod(Security.class, "addProvider", int.class, Provider.class),
+                        bcProvider);
             }
+
+            // Complete BouncyCastle AutoFeature generation
+            CatchBlockCreator print = overallCatch.addCatch(Throwable.class);
+            print.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class), print.getCaughtException());
+            beforeAn.returnValue(null);
+            file.close();
         }
+
     }
 
     // Work around https://github.com/quarkusio/quarkus/issues/21374

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderUtils.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderUtils.java
@@ -24,7 +24,9 @@ public final class SecurityProviderUtils {
 
     public static void addProvider(Provider provider) {
         try {
-            Security.addProvider(provider);
+            if (Security.getProvider(provider.getName()) == null) {
+                Security.addProvider(provider);
+            }
         } catch (Exception t) {
             final String errorMessage = String.format("Security provider %s can not be added", provider.getName());
             throw new ConfigurationException(errorMessage, t);
@@ -33,7 +35,9 @@ public final class SecurityProviderUtils {
 
     public static void insertProvider(Provider provider, int index) {
         try {
-            Security.insertProviderAt(provider, index);
+            if (Security.getProvider(provider.getName()) == null) {
+                Security.insertProviderAt(provider, index);
+            }
         } catch (Exception t) {
             final String errorMessage = String.format("Security provider %s can not be inserted", provider.getName());
             throw new ConfigurationException(errorMessage, t);

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/graal/BouncyCastleSubstitutions.java
@@ -1,9 +1,13 @@
 package io.quarkus.security.runtime.graal;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
 
 final class BouncyCastlePackages {
     static final String ORG_BOUNCYCASTLE_CRYPTO_PACKAGE = "org.bouncycastle.crypto";
@@ -84,6 +88,24 @@ final class Target_org_bouncycastle_crypto_internal_AsymmetricCipherKeyPair {
 
 @com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.crypto.fips.RsaBlindedEngine", onlyWith = BouncyCastleCryptoFips.class)
 final class Target_org_bouncycastle_crypto_fips_RsaBlindedEngine {
+}
+
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider", onlyWith = BouncyCastleCryptoFips.class)
+final class Target_org_bouncycastle_jcajce_provider_BouncyCastleFipsProvider {
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    private SecureRandom entropySource;
+
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    private SecureRandom providerDefaultRandom;
+}
+
+@com.oracle.svm.core.annotate.TargetClass(className = "org.bouncycastle.math.ec.ECPoint", onlyWith = BouncyCastleCryptoFips.class)
+final class Target_org_bouncycastle_math_ec_ECPoint {
+    @Alias //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    private static SecureRandom testRandom;
 }
 
 class BouncyCastleCryptoFips implements BooleanSupplier {

--- a/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
+++ b/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseTestCase.java
@@ -16,8 +16,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
-
 import org.awaitility.core.ThrowingRunnable;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -41,9 +39,6 @@ public class BouncyCastleFipsJsseTestCase {
     @TestHTTPResource(ssl = true)
     URL url;
 
-    @Inject
-    Vertx vertx;
-
     @Test
     public void testListProviders() throws Exception {
         doTestListProviders();
@@ -51,12 +46,17 @@ public class BouncyCastleFipsJsseTestCase {
     }
 
     protected void doTestListProviders() throws Exception {
-        WebClientOptions options = createWebClientOptions();
-        WebClient webClient = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
-        HttpResponse<io.vertx.mutiny.core.buffer.Buffer> resp = webClient.get("/jsse/listProviders").send().await()
-                .indefinitely();
-        String providers = resp.bodyAsString();
-        assertTrue(providers.contains("BCFIPS,BCJSSE"));
+        Vertx vertx = Vertx.vertx();
+        try {
+            WebClientOptions options = createWebClientOptions();
+            WebClient webClient = WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
+            HttpResponse<io.vertx.mutiny.core.buffer.Buffer> resp = webClient.get("/jsse/listProviders").send().await()
+                    .indefinitely();
+            String providers = resp.bodyAsString();
+            assertTrue(providers.contains("BCFIPS,BCJSSE"));
+        } finally {
+            vertx.close();
+        }
     }
 
     private WebClientOptions createWebClientOptions() throws Exception {

--- a/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseITCase.java
+++ b/integration-tests/bouncycastle-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleJsseITCase.java
@@ -2,13 +2,11 @@ package io.quarkus.it.bouncycastle;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class BouncyCastleJsseITCase extends BouncyCastleJsseTestCase {
     @Test
-    @DisabledOnNativeImage
     @Override
     public void testListProviders() {
         doTestListProviders();

--- a/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
+++ b/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
@@ -10,6 +10,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import javax.crypto.Cipher;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -46,11 +47,26 @@ public class BouncyCastleEndpoint {
     }
 
     @GET
+    @Path("generateEcDsaKeyPair")
+    public String generateEcDsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
+        keyPairGenerator.generateKeyPair();
+        return "success";
+    }
+
+    @GET
     @Path("generateRsaKeyPair")
     public String generateRsaKeyPair() throws Exception {
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
         keyPairGenerator.generateKeyPair();
         return "success";
+    }
+
+    @GET
+    @Path("checkAesCbcPKCS7PaddingCipher")
+    public String checkAesCbcPKCS7PaddingCipher() throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding", "BC");
+        return cipher.getAlgorithm();
     }
 
     @GET

--- a/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
+++ b/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
@@ -41,6 +41,16 @@ public class BouncyCastleTestCase {
     }
 
     @Test
+    public void testGenerateEcDsaKeyPair() {
+        RestAssured.given()
+                .when()
+                .get("/jca/generateEcDsaKeyPair")
+                .then()
+                .statusCode(200)
+                .body(equalTo("success"));
+    }
+
+    @Test
     public void testGenerateRsaKeyPair() {
         RestAssured.given()
                 .when()
@@ -48,6 +58,16 @@ public class BouncyCastleTestCase {
                 .then()
                 .statusCode(200)
                 .body(equalTo("success"));
+    }
+
+    @Test
+    public void testAesCbcPKCS7PaddingCipher() {
+        RestAssured.given()
+                .when()
+                .get("/jca/checkAesCbcPKCS7PaddingCipher")
+                .then()
+                .statusCode(200)
+                .body(equalTo("AES/CBC/PKCS7Padding"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #17046
Related to #23967

Hi @zakkak 

The following trace is produced when `BouncyCastleEndpoint.checkAesCbcPKCS7PaddingCipher` is run in native:
```
Caused by: com.oracle.svm.core.jdk.UnsupportedFeatureError: Trying to verify a provider that was not registered at build time: BC version 1.7. All providers must be registered and verified in the Native Image builder. 
	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:89)
	at javax.crypto.JceSecurity.getVerificationResult(JceSecurity.java:403)
	at javax.crypto.Cipher.getInstance(Cipher.java:690)
	at javax.crypto.Cipher.getInstance(Cipher.java:625)
	at io.quarkus.it.bouncycastle.BouncyCastleEndpoint.checkAesCbcPKCS7PaddingCipher(BouncyCastleEndpoint.java:68)
```
But we do register it at build time as the additional security provider. It is verified OK in all other native tests in the integration test. Is it possible to verify somehow the BC provider is registered in Native, I recall you did some manual updates to GraalVM to trace it.

I wonder if something might've changed in the latest GraalVM, as the user confirms it worked in Quarkus 1.x
