### PR TITLE
Enforce stricter checks on whenever Hibernate Reactive is allowed to access the Vert.x Context

### DIFF
--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/VertxContextSafetyToggle.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/VertxContextSafetyToggle.java
@@ -1,0 +1,85 @@
+package io.quarkus.hibernate.reactive.runtime;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * This is meant for other extensions to integrate with, to help
+ * identify in which contexts it's safe for Hibernate Reactive to
+ * use the Vert.x {@link Context}.
+ * The current context can be explicitly marked as safe, or it can
+ * be explicitly marked as unsafe, or if no marker is found it will
+ * by default be considered unsafe so to highlight possible integration
+ * issues with other components.
+ * The system property {@link #UNDEFINED_IS_SAFE_PROPERTY} can be set to
+ * make the default "safe" instead; generally this should not be used:
+ * if the current context is indeed to be considered as safe, the better
+ * solution is to track down where it was created and ensure that this
+ * specific context (and only this one) is marked as safe.
+ * It might also be useful to explicitly mark certain contexts as unsafe,
+ * as that will provide more useful error messages.
+ */
+public final class VertxContextSafetyToggle {
+
+    private static final Object ACCESS_TOGGLE_KEY = new Object();
+    public static final String UNDEFINED_IS_SAFE_PROPERTY = "io.quarkus.hibernate.reactive.runtime.VertxContextSafetyToggle.UNDEFINED_IS_SAFE";
+    private static final boolean UNDEFINED_IS_SAFE = Boolean.getBoolean(UNDEFINED_IS_SAFE_PROPERTY);
+
+    /**
+     * Verifies if the current Vert.x context was flagged as valid
+     * for the usage of Hibernate Reactive.
+     * 
+     * @return the validated Context instance
+     * @throws IllegalStateException if there is no context, or if the context failed to be validated
+     */
+    public static Context assertContextUseAllowed() {
+        final io.vertx.core.Context context = Vertx.currentContext();
+        if (context == null) {
+            throw new IllegalStateException(
+                    "The current operation requires a Vert.x context to be active: none was found");
+        } else {
+            checkIsSafe(context);
+            return context;
+        }
+    }
+
+    private static void checkIsSafe(Context context) {
+        final Object safeFlag = context.getLocal(ACCESS_TOGGLE_KEY);
+        if (safeFlag == Boolean.TRUE) {
+            return;
+        } else if (safeFlag == null && UNDEFINED_IS_SAFE) {
+            //flag was not set, and we're instructed to consider the undefined safeFlag as safe
+            return;
+        } else {
+            final String sharedmsg = " You can still use Hibernate Reactive, you just need to avoid using the methods which implicitly require accessing the stateful context, such as MutinySessionFactory#withTransaction and #withSession.";
+            if (safeFlag == null) {
+                throw new IllegalStateException(
+                        "The current operation requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such. "
+                                +
+                                "This is most likely an integration problem; if you're sure this is a valid use case you can override by setting the "
+                                +
+                                "system property '" + UNDEFINED_IS_SAFE_PROPERTY
+                                + "' to true. This will disable all similar checks, so it might be better to mark the current context specifically as safe. See "
+                                + VertxContextSafetyToggle.class.getName() + "." + sharedmsg);
+            } else {
+                throw new IllegalStateException(
+                        "The current operation requires a safe (isolated) Vert.x sub-context, while the current context has been explicitly flagged as not compatible for this purpose."
+                                + sharedmsg);
+            }
+        }
+    }
+
+    /**
+     * @param safe set to {@code true} to explicitly mark the current context as safe, or {@code false} to explicitly mark it as
+     *        unsafe.
+     */
+    public static void setCurrentContextSafe(boolean safe) {
+        final io.vertx.core.Context context = Vertx.currentContext();
+        if (context == null) {
+            throw new IllegalStateException("Can't set the context safety flag: no Vert.x context found");
+        } else {
+            context.putLocal(ACCESS_TOGGLE_KEY, Boolean.valueOf(safe));
+        }
+    }
+
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -20,7 +20,6 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
-import org.hibernate.reactive.context.impl.VertxContextInitiator;
 import org.hibernate.reactive.id.impl.ReactiveIdentifierGeneratorFactoryInitiator;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
@@ -43,6 +42,7 @@ import io.quarkus.hibernate.orm.runtime.service.DisabledJMXInitiator;
 import io.quarkus.hibernate.orm.runtime.service.FlatClassLoaderService;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusImportSqlCommandExtractorInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
+import io.quarkus.hibernate.reactive.runtime.customized.CheckingVertxContextInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcEnvironmentInitiator;
 
@@ -138,7 +138,9 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
 
         // Definitely exclusive to Hibernate Reactive, as it marks the registry as Reactive:
         serviceInitiators.add(ReactiveMarkerServiceInitiator.INSTANCE);
-        serviceInitiators.add(VertxContextInitiator.INSTANCE);
+
+        // Custom to Quarkus: Hibernate Reactive upstream would use org.hibernate.reactive.context.impl.VertxContextInitiator
+        serviceInitiators.add(CheckingVertxContextInitiator.INSTANCE);
 
         //Custom for Hibernate Reactive:
         serviceInitiators.add(ReactiveSessionFactoryBuilderInitiator.INSTANCE);

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContext.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContext.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import org.hibernate.reactive.context.impl.VertxContext;
+
+import io.quarkus.hibernate.reactive.runtime.VertxContextSafetyToggle;
+
+/**
+ * The {@link VertxContext} in Hibernate Reactive is accessing the
+ * Vert.x context directly, assuming this is the correct context as
+ * intended by the developer, as Hibernate Reactive has no opinion in
+ * regards to how Vert.x is integrated with other components.
+ * The precise definition of "correct context" will most likely depend
+ * on the runtime model and how other components are integrated with Vert.x;
+ * in particular the lifecycle of the context needs to be specified.
+ * For example in Quarkus's RestEasy Reactive we ensure that each request
+ * will run on a separate context; this ensures operations relating to
+ * different web requests are isolated among each other.
+ * To ensure that Quarkus users are using Hibernate Reactive on a context
+ * which is compatible with its expectations, this alternative implementation
+ * of {@link VertxContext} actually checks on each context access if it's safe
+ * to use by invoking {@link VertxContextSafetyToggle#assertContextUseAllowed()}.
+ *
+ * @see VertxContextSafetyToggle
+ */
+public final class CheckingVertxContext extends VertxContext {
+
+    @Override
+    public <T> void put(Key<T> key, T instance) {
+        VertxContextSafetyToggle.assertContextUseAllowed().putLocal(key, instance);
+    }
+
+    @Override
+    public <T> T get(Key<T> key) {
+        return VertxContextSafetyToggle.assertContextUseAllowed().getLocal(key);
+    }
+
+    @Override
+    public void remove(Key<?> key) {
+        VertxContextSafetyToggle.assertContextUseAllowed().removeLocal(key);
+    }
+
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContextInitiator.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContextInitiator.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.reactive.context.Context;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * Custom Quarkus initiator for the {@link Context} service; this
+ * one creates instances of {@link CheckingVertxContext}.
+ */
+public class CheckingVertxContextInitiator implements StandardServiceInitiator<Context> {
+
+    public static final CheckingVertxContextInitiator INSTANCE = new CheckingVertxContextInitiator();
+
+    @Override
+    public Context initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        return new CheckingVertxContext();
+    }
+
+    @Override
+    public Class<Context> getServiceInitiated() {
+        return Context.class;
+    }
+
+}


### PR DESCRIPTION

This is a POC of how I'd model the "context poisoning" idea I've suggested in our recent chats @cescoffier @geoand  : a very simple marker object to be stored in the context, controlled by a static helper method.

The next element of the puzzle would be to have RR invoke `VertxContextSafetyToggle.setCurrentContextSafe(true)` just after the context was duplicated.

Do we have any smart pattern to invoke this w/o directly coupling the extension? Or should we adapt this `VertxContextSafetyToggle` to live in the vert.x extension instead?
