### PR TITLE
Remove printing of thread id from DiagnosticPrinter

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
@@ -4,27 +4,10 @@ import java.io.PrintStream;
 import java.time.Instant;
 import java.util.Map;
 
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platforms;
-
-import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.posix.headers.Pthread;
-
 /**
  * A signal handler that prints diagnostic thread info to standard output.
  */
 public final class DiagnosticPrinter {
-    @TargetClass(className = "com.oracle.svm.core.posix.thread.PosixJavaThreads")
-    @Platforms({ Platform.LINUX.class, Platform.DARWIN.class })
-    static final class Target_PosixJavaThreads {
-        @Alias
-        static native Pthread.pthread_t getPthreadIdentifier(Thread thread);
-
-        @Alias
-        static native boolean hasThreadIdentifier(Thread thread);
-    }
-
     public static void printDiagnostics(PrintStream w) {
         Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
         w.println(Instant.now().toString());
@@ -42,15 +25,6 @@ public final class DiagnosticPrinter {
                 w.print("daemon ");
             w.print("prio=");
             w.print(thread.getPriority());
-            w.print(" tid=");
-            if ((Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class))
-                    && Target_PosixJavaThreads.hasThreadIdentifier(thread)) {
-                final long nativeId = Target_PosixJavaThreads.getPthreadIdentifier(thread).rawValue();
-                w.print("0x");
-                w.println(Long.toHexString(nativeId));
-            } else {
-                w.println("(unknown)");
-            }
             w.print("   java.lang.thread.State: ");
             w.println(thread.getState());
             for (StackTraceElement element : stackTrace) {


### PR DESCRIPTION
Removes the dependency on the GraalVM internal `com.oracle.svm.core.posix.headers.Pthread`.

Fix #23517