### PR TITLE
Update to SmallRye Fault Tolerance 5.3.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -45,7 +45,7 @@
         <smallrye-open-api.version>2.1.17</smallrye-open-api.version>
         <smallrye-graphql.version>1.4.2</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
-        <smallrye-fault-tolerance.version>5.2.1</smallrye-fault-tolerance.version>
+        <smallrye-fault-tolerance.version>5.3.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.3.3</smallrye-jwt.version>
         <smallrye-context-propagation.version>1.2.2</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
@@ -3444,6 +3444,11 @@
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
+                <version>${smallrye-fault-tolerance.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
                 <version>${smallrye-fault-tolerance.version}</version>
             </dependency>
             <dependency>

--- a/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/main/java/io/quarkus/smallrye/faulttolerance/deployment/SmallRyeFaultToleranceProcessor.java
@@ -61,6 +61,7 @@ import io.quarkus.smallrye.faulttolerance.runtime.QuarkusExistingCircuitBreakerN
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusFallbackHandlerProvider;
 import io.quarkus.smallrye.faulttolerance.runtime.QuarkusFaultToleranceOperationProvider;
 import io.quarkus.smallrye.faulttolerance.runtime.SmallRyeFaultToleranceRecorder;
+import io.smallrye.faulttolerance.CdiFaultToleranceSpi;
 import io.smallrye.faulttolerance.CircuitBreakerMaintenanceImpl;
 import io.smallrye.faulttolerance.ExecutorHolder;
 import io.smallrye.faulttolerance.FaultToleranceBinding;
@@ -200,7 +201,7 @@ public class SmallRyeFaultToleranceProcessor {
         // are currently resolved dynamically at runtime because per the spec interceptor bindings cannot be declared on interfaces
         beans.produce(AdditionalBeanBuildItem.builder().setUnremovable()
                 .addBeanClasses(FaultToleranceInterceptor.class, QuarkusFaultToleranceOperationProvider.class,
-                        QuarkusExistingCircuitBreakerNames.class)
+                        QuarkusExistingCircuitBreakerNames.class, CdiFaultToleranceSpi.Dependencies.class)
                 .build());
 
         if (!metricsCapability.isPresent()) {

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/types/mutiny/resubscription/MutinyHelloService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/types/mutiny/resubscription/MutinyHelloService.java
@@ -1,0 +1,22 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.types.mutiny.resubscription;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class MutinyHelloService {
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @NonBlocking
+    @Retry
+    public Uni<String> hello() {
+        COUNTER.incrementAndGet();
+        return Uni.createFrom().failure(IllegalArgumentException::new);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/types/mutiny/resubscription/MutinyResubscriptionTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/asynchronous/types/mutiny/resubscription/MutinyResubscriptionTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.smallrye.faulttolerance.test.asynchronous.types.mutiny.resubscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+
+public class MutinyResubscriptionTest {
+    // this test verifies resubscription, which is triggered via retry
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MutinyHelloService.class));
+
+    @Inject
+    MutinyHelloService service;
+
+    @Test
+    public void test() {
+        Uni<String> hello = service.hello()
+                .onFailure().retry().atMost(2)
+                .onFailure().recoverWithItem("hello");
+
+        assertThat(MutinyHelloService.COUNTER).hasValue(0);
+
+        assertThat(hello.await().indefinitely()).isEqualTo("hello");
+
+        // the service.hello() method has @Retry with default settings, so 1 initial attempt + 3 retries = 4 total
+        // the onFailure().retry() handler does 1 initial attempt + 2 retries = 3 total
+        assertThat(MutinyHelloService.COUNTER).hasValue(4 * 3);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/HelloService.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/HelloService.java
@@ -1,0 +1,40 @@
+package io.quarkus.smallrye.faulttolerance.test.programmatic;
+
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import io.smallrye.faulttolerance.api.CircuitBreakerName;
+import io.smallrye.faulttolerance.api.FaultTolerance;
+
+@ApplicationScoped
+public class HelloService {
+    static final String OK = "Hello";
+    static final int THRESHOLD = 5;
+    static final int DELAY = 500;
+
+    private final Supplier<String> anotherHello = FaultTolerance.createSupplier(this::anotherHelloImpl)
+            .withCircuitBreaker().requestVolumeThreshold(THRESHOLD).delay(DELAY, ChronoUnit.MILLIS).name("another-hello").done()
+            .build();
+
+    @CircuitBreaker(requestVolumeThreshold = THRESHOLD, delay = DELAY)
+    @CircuitBreakerName("hello")
+    public String hello(Exception exception) throws Exception {
+        if (exception != null) {
+            throw exception;
+        }
+
+        return OK;
+    }
+
+    public String anotherHello() {
+        return anotherHello.get();
+    }
+
+    private String anotherHelloImpl() {
+        throw new RuntimeException();
+    }
+}

--- a/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/ProgrammaticCircuitBreakerTest.java
+++ b/extensions/smallrye-fault-tolerance/deployment/src/test/java/io/quarkus/smallrye/faulttolerance/test/programmatic/ProgrammaticCircuitBreakerTest.java
@@ -1,0 +1,103 @@
+package io.quarkus.smallrye.faulttolerance.test.programmatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.faulttolerance.api.CircuitBreakerMaintenance;
+import io.smallrye.faulttolerance.api.CircuitBreakerState;
+import io.smallrye.faulttolerance.api.FaultTolerance;
+
+public class ProgrammaticCircuitBreakerTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(HelloService.class));
+
+    @Inject
+    HelloService helloService;
+
+    @Inject
+    CircuitBreakerMaintenance cb;
+
+    @BeforeEach
+    public void reset() {
+        FaultTolerance.circuitBreakerMaintenance().resetAll();
+
+        helloService.toString(); // force bean instantiation
+    }
+
+    @Test
+    public void test() {
+        CircuitBreakerMaintenance cbm = FaultTolerance.circuitBreakerMaintenance();
+
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+        assertThat(cb.currentState("another-hello")).isEqualTo(CircuitBreakerState.CLOSED);
+        assertThat(cbm.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+        assertThat(cbm.currentState("another-hello")).isEqualTo(CircuitBreakerState.CLOSED);
+
+        AtomicInteger helloStateChanges = new AtomicInteger();
+        AtomicInteger anotherHelloStateChanges = new AtomicInteger();
+
+        cbm.onStateChange("hello", ignored -> {
+            helloStateChanges.incrementAndGet();
+        });
+        cb.onStateChange("another-hello", ignored -> {
+            anotherHelloStateChanges.incrementAndGet();
+        });
+
+        for (int i = 0; i < HelloService.THRESHOLD; i++) {
+            assertThatThrownBy(() -> {
+                helloService.hello(new IOException());
+            }).isExactlyInstanceOf(IOException.class);
+
+            assertThatThrownBy(() -> {
+                helloService.anotherHello();
+            }).isExactlyInstanceOf(RuntimeException.class);
+        }
+
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.OPEN);
+        assertThat(cb.currentState("another-hello")).isEqualTo(CircuitBreakerState.OPEN);
+        assertThat(cbm.currentState("hello")).isEqualTo(CircuitBreakerState.OPEN);
+        assertThat(cbm.currentState("another-hello")).isEqualTo(CircuitBreakerState.OPEN);
+
+        // hello 1. closed -> open
+        assertThat(helloStateChanges).hasValue(1);
+        // another-hello 1. closed -> open
+        assertThat(anotherHelloStateChanges).hasValue(1);
+
+        await().atMost(HelloService.DELAY * 2, TimeUnit.MILLISECONDS)
+                .ignoreException(CircuitBreakerOpenException.class)
+                .untilAsserted(() -> {
+                    assertThat(helloService.hello(null)).isEqualTo(HelloService.OK);
+                });
+        await().atMost(HelloService.DELAY * 2, TimeUnit.MILLISECONDS)
+                .ignoreException(CircuitBreakerOpenException.class)
+                .untilAsserted(() -> {
+                    assertThatThrownBy(helloService::anotherHello).isExactlyInstanceOf(RuntimeException.class);
+                });
+
+        assertThat(cb.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+        assertThat(cb.currentState("another-hello")).isEqualTo(CircuitBreakerState.OPEN);
+        assertThat(cbm.currentState("hello")).isEqualTo(CircuitBreakerState.CLOSED);
+        assertThat(cbm.currentState("another-hello")).isEqualTo(CircuitBreakerState.OPEN);
+
+        // hello 2. open -> half-open
+        // hello 3. half-open -> closed
+        assertThat(helloStateChanges).hasValue(3);
+        // another-hello 2. open -> half-open
+        // another-hello 3. half-open -> open
+        assertThat(anotherHelloStateChanges).hasValue(3);
+    }
+}

--- a/extensions/smallrye-fault-tolerance/runtime/pom.xml
+++ b/extensions/smallrye-fault-tolerance/runtime/pom.xml
@@ -70,8 +70,8 @@
             <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-converter-mutiny</artifactId>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This SmallRye Fault Tolerance release includes a significant
new feature: programmatic API. Support for additional async
types (such as Mutiny `Uni`) was revamped, so that resubscription
works correctly. The fallback, circuit breaker and retry strategies
now also inspect the exception cause chain to determine whether
the strategy should apply or not (in the non-compatible mode).

Fixes #19924
Fixes #22832