### PR TITLE
Update OIDC DefaultTokenStateManager to support the token encryption

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -537,6 +537,23 @@ Note that some endpoints do not require the access token. An access token is onl
 If the ID, access and refresh tokens are JWT tokens then combining all of them (if the strategy is the default `keep-all-tokens`) or only ID and refresh tokens (if the strategy is `id-refresh-token`) may produce a session cookie value larger than 4KB and the browsers may not be able to keep this cookie.
 In such cases, you can use `quarkus.oidc.token-state-manager.split-tokens=true` to have a unique session token per each of these tokens.
 
+You can also configure the default `TokenStateManager` to encrypt the tokens before storing them as cookie values which may be necessary if the tokens contain sensitive claim values.
+For example, here is how you configure it to split the tokens and encrypt them:
+
+[source, properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/quarkus
+quarkus.oidc.client-id=quarkus-app
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+quarkus.oidc.token-state-manager.split-tokens=true
+quarkus.oidc.token-state-manager.encryption-required=true
+quarkus.oidc.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
+----
+
+The tken encryption secret must be 32 characters long. Note that you only have to set `quarkus.oidc.token-state-manager.encryption-secret` if you prefer not to use
+`quarkus.oidc.credentials.secret` for encrypting the tokens or if `quarkus.oidc.credentials.secret` length is less than 32 characters.
+
 Register your own `io.quarkus.oidc.TokenStateManager' implementation as an `@ApplicationScoped` CDI bean if you need to customize the way the tokens are associated with the session cookie. For example, you may want to keep the tokens in a database and have only a database pointer stored in a session cookie. Note though that it may present some challenges in making the tokens available across multiple microservices nodes.
 
 Here is a simple example:

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -233,6 +233,36 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem(defaultValue = "false")
         public boolean splitTokens;
 
+        /**
+         * Requires that the tokens are encrypted before being stored in the cookies.
+         */
+        @ConfigItem(defaultValueDocumentation = "false")
+        public Optional<Boolean> encryptionRequired = Optional.empty();
+
+        /**
+         * Secret which will be used to encrypt the tokens.
+         * This secret must be set if the token encryption is required but no client secret is set.
+         * The length of the secret which will be used to encrypt the tokens must be 32 characters long.
+         */
+        @ConfigItem
+        public Optional<String> encryptionSecret = Optional.empty();
+
+        public Optional<Boolean> isEncryptionRequired() {
+            return encryptionRequired;
+        }
+
+        public void setEncryptionRequired(boolean encryptionRequired) {
+            this.encryptionRequired = Optional.of(encryptionRequired);
+        }
+
+        public Optional<String> getEncryptionSecret() {
+            return encryptionSecret;
+        }
+
+        public void setEncryptionSecret(String encryptionSecret) {
+            this.encryptionSecret = Optional.of(encryptionSecret);
+        }
+
         public boolean isSplitTokens() {
             return splitTokens;
         }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -158,6 +158,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             IdentityProviderManager identityProviderManager,
             TenantConfigContext configContext) {
 
+        context.put(TenantConfigContext.class.getName(), configContext);
         return resolver.getTokenStateManager().getTokens(context, configContext.oidcConfig,
                 sessionCookie.getValue(), getTokenStateRequestContext)
                 .chain(new Function<AuthorizationCodeTokens, Uni<? extends SecurityIdentity>>() {
@@ -525,6 +526,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         }
                         final long sessionMaxAge = maxAge;
                         context.put(SESSION_MAX_AGE_PARAM, maxAge);
+                        context.put(TenantConfigContext.class.getName(), configContext);
                         return resolver.getTokenStateManager()
                                 .createTokenState(context, configContext.oidcConfig, tokens, createTokenStateRequestContext)
                                 .map(new Function<String, Void>() {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -396,20 +396,28 @@ public final class OidcUtils {
     }
 
     public static String encryptJson(JsonObject json, SecretKey key) throws Exception {
+        return encryptString(json.encode(), key);
+    }
+
+    public static String encryptString(String jweString, SecretKey key) throws Exception {
         JsonWebEncryption jwe = new JsonWebEncryption();
         jwe.setAlgorithmHeaderValue(KeyEncryptionAlgorithm.A256KW.getAlgorithm());
         jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithm.A256GCM.getAlgorithm());
         jwe.setKey(key);
-        jwe.setPlaintext(json.encode());
+        jwe.setPlaintext(jweString);
         return jwe.getCompactSerialization();
     }
 
     public static JsonObject decryptJson(String jweString, SecretKey key) throws Exception {
+        return new JsonObject(decryptString(jweString, key));
+    }
+
+    public static String decryptString(String jweString, SecretKey key) throws Exception {
         JsonWebEncryption jwe = new JsonWebEncryption();
         jwe.setAlgorithmConstraints(new AlgorithmConstraints(AlgorithmConstraints.ConstraintType.PERMIT,
                 KeyEncryptionAlgorithm.A256KW.getAlgorithm()));
         jwe.setKey(key);
         jwe.setCompactSerialization(jweString);
-        return new JsonObject(jwe.getPlaintextString());
+        return jwe.getPlaintextString();
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -3,6 +3,7 @@ package io.quarkus.it.keycloak;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -111,8 +112,12 @@ public class ProtectedResource {
 
     @GET
     @Path("tenant-split-tokens")
-    public String getNameSplitTokens() {
-        return "tenant-split-tokens:" + getName();
+    public String getNameSplitTokens(@CookieParam("q_session_tenant-split-tokens") String idToken,
+            @CookieParam("q_session_at_tenant-split-tokens") String accessToken,
+            @CookieParam("q_session_rt_tenant-split-tokens") String refreshToken) {
+        return String.format(
+                "tenant-split-tokens:%s, id token has %d parts, access token has %d parts, refresh token has %d parts",
+                getName(), idToken.split("\\.").length, accessToken.split("\\.").length, refreshToken.split("\\.").length);
     }
 
     @GET

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -135,6 +135,8 @@ quarkus.oidc.tenant-split-tokens.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-split-tokens.client-id=quarkus-app
 quarkus.oidc.tenant-split-tokens.credentials.secret=secret
 quarkus.oidc.tenant-split-tokens.token-state-manager.split-tokens=true
+quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-required=true
+quarkus.oidc.tenant-split-tokens.token-state-manager.encryption-secret=eUk1p7UB3nFiXZGUXi0uph1Y9p34YhBU
 quarkus.oidc.tenant-split-tokens.application-type=web-app
 
 quarkus.http.auth.permission.roles1.paths=/index.html


### PR DESCRIPTION
Fix #23373

This PR does a simple update to `DefaultTokenStateManager` to optionally encrypt the tokens before storing as the session cookie values and decrypt them if the encryption was requested. Update the tests, one of them now decrypts them, and the endpoint code also does a basic check that they contain 5 parts (=> JWE-encrypted), while the id/access/rt token injection still works

CC @debu999