### PR TITLE
Implement the ability to inject custom configured instances of ManagedExecutor and ThreadContext

### DIFF
--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -274,6 +274,47 @@ You can also inject a custom-built `ThreadContext` using the https://javadoc.io/
     }
 ----
 
+Likewise, there is a similar way to inject a configured instance of `ManagedExecutor` using the https://javadoc.io/doc/io.smallrye/smallrye-context-propagation-api/latest/io/smallrye/context/api/ManagedExecutorConfig.html[`@ManagedExecutorConfig`] annotation:
+
+[source,java]
+----
+    // Custom ManagedExecutor with different async limit, queue and no propagation
+    @Inject
+    @ManagedExecutorConfig(maxAsync = 2, maxQueued = 3, cleared = ThreadContext.ALL_REMAINING)
+    ManagedExecutor configuredCustomExecutor;
+----
+
+=== Sharing configured CDI instances of ManagedExecutor and ThreadContext
+
+If you need to inject the same `ManagedExecutor` or `ThreadContext` into several places and share it's capacity, you can name the instance with https://javadoc.io/doc/io.smallrye/smallrye-context-propagation-api/latest/io/smallrye/context/api/NamedInstance.html[`@NamedInstance`] annotation.
+`@NamedInstance` is a CDI qualifier and all injections of the same type and name will therefore share the same underlying instance.
+If you also need to customize your instance, you can do so using `@ManagedExecutorConfig`/`ThreadContextConfig` annotation on one of its injection points:
+
+[source,java]
+----
+    // Custom configured ManagedExecutor with name
+    @Inject
+    @ManagedExecutorConfig(maxAsync = 2, maxQueued = 3, cleared = ThreadContext.ALL_REMAINING)
+    @NamedInstance("myExecutor")
+    ManagedExecutor sharedConfiguredExecutor;
+
+    // Since this executor has the same name, it will be the same instance as above
+    @Inject
+    @NamedInstance("myExecutor")
+    ManagedExecutor sameExecutor;
+
+    // Custom ThreadContext with a name
+    @Inject
+    @ThreadContextConfig(unchanged = ThreadContext.ALL_REMAINING)
+    @NamedInstance("myContext")
+    ThreadContext sharedConfiguredThreadContext;
+
+    // Given equal value of @NamedInstance, this ThreadContext will be the same as the above one
+    @Inject
+    @NamedInstance("myContext")
+    ThreadContext sameContext;
+----
+
 == Context Propagation for CDI
 
 In terms of CDI, `@RequestScoped`, `@ApplicationScoped` and `@Singleton` beans get propagated and are available in other threads.

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/DotNames.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/DotNames.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.context.deployment;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.jboss.jandex.DotName;
+
+import io.smallrye.context.api.ManagedExecutorConfig;
+import io.smallrye.context.api.NamedInstance;
+import io.smallrye.context.api.ThreadContextConfig;
+
+public final class DotNames {
+
+    public static final DotName MANAGED_EXECUTOR_CONFIG = DotName.createSimple(ManagedExecutorConfig.class.getName());
+    public static final DotName THREAD_CONTEXT_CONFIG = DotName.createSimple(ThreadContextConfig.class.getName());
+    public static final DotName NAMED_INSTANCE = DotName.createSimple(NamedInstance.class.getName());
+    public static final DotName MANAGED_EXECUTOR = DotName.createSimple(ManagedExecutor.class.getName());
+    public static final DotName THREAD_CONTEXT = DotName.createSimple(ThreadContext.class.getName());
+}

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -3,16 +3,34 @@ package io.quarkus.smallrye.context.deployment;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
+import io.quarkus.arc.deployment.InjectionPointTransformerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.arc.processor.InjectionPointsTransformer;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -25,6 +43,8 @@ import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.smallrye.context.runtime.SmallRyeContextPropagationProvider;
 import io.quarkus.smallrye.context.runtime.SmallRyeContextPropagationRecorder;
 import io.smallrye.context.SmallRyeManagedExecutor;
+import io.smallrye.context.api.ManagedExecutorConfig;
+import io.smallrye.context.api.ThreadContextConfig;
 
 /**
  * The deployment processor for MP-CP applications
@@ -85,5 +105,234 @@ class SmallRyeContextPropagationProcessor {
                         .unremovable()
                         .supplier(recorder.initializeManagedExecutor(executorBuildItem.getExecutorProxy()))
                         .setRuntimeInit().done());
+    }
+
+    // transform IPs for ManagedExecutor/ThreadContext that use config annotation and don't yet have @NamedInstance
+    @BuildStep
+    InjectionPointTransformerBuildItem transformInjectionPoint() {
+        return new InjectionPointTransformerBuildItem(new InjectionPointsTransformer() {
+            @Override
+            public boolean appliesTo(Type requiredType) {
+                // filter the type, we only care about ManagedExecutor/ThreadContext injection points
+                DotName typeName = requiredType.name();
+                return DotNames.MANAGED_EXECUTOR.equals(typeName) || DotNames.THREAD_CONTEXT.equals(typeName);
+            }
+
+            @Override
+            public void transform(TransformationContext transformationContext) {
+                // we don't care about any injection point that has custom qualifiers on it (including @NamedInstance)
+                if (transformationContext.getQualifiers().stream()
+                        .anyMatch(ann -> !ann.name().equals(io.quarkus.arc.processor.DotNames.ANY)
+                                && !ann.name().equals(io.quarkus.arc.processor.DotNames.DEFAULT))) {
+                    return;
+                }
+                // create a unique name based on the injection point
+                String mpConfigIpName;
+                AnnotationTarget target = transformationContext.getTarget();
+                final String nameDelimiter = "/";
+                switch (target.kind()) {
+                    case FIELD:
+                        mpConfigIpName = target.asField().declaringClass().name().toString()
+                                + nameDelimiter
+                                + target.asField().name();
+                        break;
+                    case METHOD_PARAMETER:
+                        mpConfigIpName = target.asMethodParameter().method().declaringClass().name().toString()
+                                + nameDelimiter
+                                + target.asMethodParameter().method().name()
+                                + nameDelimiter
+                                + (target.asMethodParameter().position() + 1);
+                        break;
+                    // any other value is unexpected and we skip that
+                    default:
+                        return;
+                }
+                AnnotationInstance meConfigInstance = Annotations.find(transformationContext.getAllAnnotations(),
+                        DotNames.MANAGED_EXECUTOR_CONFIG);
+                AnnotationInstance tcConfigInstance = Annotations.find(transformationContext.getAllAnnotations(),
+                        DotNames.THREAD_CONTEXT_CONFIG);
+
+                if (meConfigInstance != null || tcConfigInstance != null) {
+                    // add @NamedInstance with the generated name
+                    transformationContext.transform()
+                            .add(DotNames.NAMED_INSTANCE, AnnotationValue.createStringValue("value", mpConfigIpName)).done();
+                }
+            }
+        });
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void createSynthBeansForConfiguredInjectionPoints(BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
+            SmallRyeContextPropagationRecorder recorder, BeanDiscoveryFinishedBuildItem bdFinishedBuildItem) {
+        Map<String, ExecutorConfig> executorMap = new HashMap<>();
+        Set<String> unconfiguredExecutorIPs = new HashSet<>();
+        Map<String, ThreadConfig> threadContextMap = new HashMap<>();
+        Set<String> unconfiguredContextIPs = new HashSet<>();
+        for (InjectionPointInfo ipInfo : bdFinishedBuildItem.getInjectionPoints()) {
+            AnnotationInstance namedAnnotation = ipInfo.getRequiredQualifier(DotNames.NAMED_INSTANCE);
+            // only look for IP with @NamedInstance on it because the IP transformation made sure it's there
+            if (namedAnnotation == null) {
+                continue;
+            }
+            // furthermore, we only look for any IP that doesn't have other custom qualifier
+            if (ipInfo.getRequiredQualifiers().stream()
+                    .anyMatch(ann -> !ann.name().equals(DotNames.NAMED_INSTANCE)
+                            && !ann.name().equals(io.quarkus.arc.processor.DotNames.ANY)
+                            && !ann.name().equals(io.quarkus.arc.processor.DotNames.DEFAULT))) {
+                continue;
+            }
+
+            AnnotationInstance meConfigInstance = Annotations.find(extractAnnotations(ipInfo.getTarget()),
+                    DotNames.MANAGED_EXECUTOR_CONFIG);
+            AnnotationInstance tcConfigInstance = Annotations.find(extractAnnotations(ipInfo.getTarget()),
+                    DotNames.THREAD_CONTEXT_CONFIG);
+
+            // get the name from @NamedInstance qualifier
+            String nameValue = namedAnnotation.value().asString();
+
+            if (meConfigInstance == null && tcConfigInstance == null) {
+                // injection point with @NamedInstance on it but no configuration
+                if (ipInfo.getType().name().equals(DotNames.MANAGED_EXECUTOR)) {
+                    unconfiguredExecutorIPs.add(nameValue);
+                } else {
+                    unconfiguredContextIPs.add(nameValue);
+                }
+                continue;
+            }
+            // we are looking for injection points with @ManagedExecutorConfig/@ThreadContextConfig
+            if (meConfigInstance != null || tcConfigInstance != null) {
+                if (meConfigInstance != null) {
+                    // parse ME config annotation and store in a map
+                    executorMap.putIfAbsent(nameValue,
+                            new ExecutorConfig(meConfigInstance.value("cleared"),
+                                    meConfigInstance.value("propagated"),
+                                    meConfigInstance.value("maxAsync"),
+                                    meConfigInstance.value("maxQueued")));
+
+                } else if (tcConfigInstance != null) {
+                    // parse TC config annotation
+                    threadContextMap.putIfAbsent(nameValue,
+                            new ThreadConfig(tcConfigInstance.value("cleared"),
+                                    tcConfigInstance.value("propagated"),
+                                    tcConfigInstance.value("unchanged")));
+                }
+            }
+        }
+        // check all unconfigured IPs, if we also found same name and configured ones, then drop these from the set
+        unconfiguredExecutorIPs.removeAll(unconfiguredExecutorIPs.stream()
+                .filter((name) -> (executorMap.containsKey(name)))
+                .collect(Collectors.toSet()));
+
+        unconfiguredContextIPs.removeAll(unconfiguredContextIPs.stream()
+                .filter((name) -> (threadContextMap.containsKey(name)))
+                .collect(Collectors.toSet()));
+
+        // add beans for configured ManagedExecutors
+        for (Map.Entry<String, ExecutorConfig> entry : executorMap.entrySet()) {
+            syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(ManagedExecutor.class)
+                    .defaultBean()
+                    .unremovable()
+                    .setRuntimeInit()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier().annotation(DotNames.NAMED_INSTANCE).addValue("value", entry.getKey())
+                    .done()
+                    .supplier(recorder.initializeConfiguredManagedExecutor(entry.getValue().cleared,
+                            entry.getValue().propagated, entry.getValue().maxAsync, entry.getValue().maxQueued))
+                    // disposers should be unnecessary as all beans run on Quarkus thread pool
+                    .done());
+        }
+
+        // add beans for unconfigured ManagedExecutors
+        for (String ipName : unconfiguredExecutorIPs) {
+            syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(ManagedExecutor.class)
+                    .defaultBean()
+                    .unremovable()
+                    .setRuntimeInit()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier().annotation(DotNames.NAMED_INSTANCE).addValue("value", ipName).done()
+                    .supplier(recorder.initializeConfiguredManagedExecutor(
+                            ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.cleared(),
+                            ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.propagated(),
+                            ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync(),
+                            ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued()))
+                    // disposers should be unnecessary as all beans run on Quarkus thread pool
+                    .done());
+        }
+
+        // add beans for configured ThreadContext
+        for (Map.Entry<String, ThreadConfig> entry : threadContextMap.entrySet()) {
+            syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(ThreadContext.class)
+                    .defaultBean()
+                    .unremovable()
+                    .setRuntimeInit()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier().annotation(DotNames.NAMED_INSTANCE).addValue("value", entry.getKey())
+                    .done()
+                    .supplier(recorder.initializeConfiguredThreadContext(entry.getValue().cleared,
+                            entry.getValue().propagated,
+                            entry.getValue().unchanged))
+                    // disposers should be unnecessary as all beans run on Quarkus thread pool
+                    .done());
+        }
+
+        // add beans for unconfigured ThreadContext
+        for (String ipName : unconfiguredContextIPs) {
+            syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem.configure(ThreadContext.class)
+                    .defaultBean()
+                    .unremovable()
+                    .setRuntimeInit()
+                    .scope(ApplicationScoped.class)
+                    .addQualifier().annotation(DotNames.NAMED_INSTANCE).addValue("value", ipName).done()
+                    .supplier(recorder.initializeConfiguredThreadContext(
+                            ThreadContextConfig.Literal.DEFAULT_INSTANCE.cleared(),
+                            ThreadContextConfig.Literal.DEFAULT_INSTANCE.propagated(),
+                            ThreadContextConfig.Literal.DEFAULT_INSTANCE.unchanged()))
+                    // disposers should be unnecessary as all beans run on Quarkus thread pool
+                    .done());
+        }
+    }
+
+    private Collection<AnnotationInstance> extractAnnotations(AnnotationTarget target) {
+        switch (target.kind()) {
+            case FIELD:
+                return target.asField().annotations();
+            case METHOD_PARAMETER:
+                return target.asMethodParameter().method().annotations();
+            // any other value is unexpected and we skip that
+            default:
+                return Collections.EMPTY_SET;
+        }
+    }
+
+    class ExecutorConfig {
+
+        String[] cleared;
+        String[] propagated;
+        int maxAsync;
+        int maxQueued;
+
+        ExecutorConfig(AnnotationValue cleared, AnnotationValue propagated, AnnotationValue maxAsync,
+                AnnotationValue maxQueued) {
+            this.cleared = cleared == null ? ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.cleared() : cleared.asStringArray();
+            this.propagated = propagated == null ? ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.propagated()
+                    : propagated.asStringArray();
+            this.maxAsync = maxAsync == null ? ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxAsync() : maxAsync.asInt();
+            this.maxQueued = maxQueued == null ? ManagedExecutorConfig.Literal.DEFAULT_INSTANCE.maxQueued() : maxQueued.asInt();
+        }
+    }
+
+    class ThreadConfig {
+        String[] cleared;
+        String[] propagated;
+        String[] unchanged;
+
+        ThreadConfig(AnnotationValue cleared, AnnotationValue propagated, AnnotationValue unchanged) {
+            this.cleared = cleared == null ? ThreadContextConfig.Literal.DEFAULT_INSTANCE.cleared() : cleared.asStringArray();
+            this.propagated = propagated == null ? ThreadContextConfig.Literal.DEFAULT_INSTANCE.propagated()
+                    : propagated.asStringArray();
+            this.unchanged = unchanged == null ? ThreadContextConfig.Literal.DEFAULT_INSTANCE.unchanged()
+                    : unchanged.asStringArray();
+        }
     }
 }

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ConfiguredAndSharedBeansTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ConfiguredAndSharedBeansTest.java
@@ -1,0 +1,271 @@
+package io.quarkus.smallrye.context.deployment.test.cdi;
+
+import static io.quarkus.smallrye.context.deployment.test.cdi.Utils.providersToStringSet;
+import static io.quarkus.smallrye.context.deployment.test.cdi.Utils.unwrapExecutor;
+import static io.quarkus.smallrye.context.deployment.test.cdi.Utils.unwrapThreadContext;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.context.SmallRyeManagedExecutor;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.context.api.ManagedExecutorConfig;
+import io.smallrye.context.api.NamedInstance;
+import io.smallrye.context.api.ThreadContextConfig;
+import io.smallrye.context.impl.ThreadContextProviderPlan;
+
+/**
+ * Tests that @ManagedExecutorConfig/@ThreadContextConfig and @NamedInstance can be used and injected
+ */
+public class ConfiguredAndSharedBeansTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Utils.class));
+
+    @Inject
+    SomeBean bean;
+
+    @Test
+    public void test() {
+        bean.ping();
+
+        // firstly, assert that all beans are injectable with their respective names
+        Assertions.assertTrue(Arc.container().select(ManagedExecutor.class, NamedInstance.Literal.of(
+                SomeBean.class.getName() + "/configuredExecutor"))
+                .isResolvable());
+        Assertions.assertTrue(Arc.container().select(ManagedExecutor.class, NamedInstance.Literal.of("sharedDefaultExecutor"))
+                .isResolvable());
+        Assertions.assertTrue(Arc.container()
+                .select(ManagedExecutor.class, NamedInstance.Literal.of("sharedConfiguredExecutor")).isResolvable());
+        Assertions.assertTrue(Arc.container().select(ThreadContext.class, NamedInstance.Literal.of(
+                SomeBean.class.getName() + "/configuredThreadContext"))
+                .isResolvable());
+        Assertions.assertTrue(Arc.container()
+                .select(ThreadContext.class, NamedInstance.Literal.of("sharedDefaultThreadContext")).isResolvable());
+        Assertions.assertTrue(Arc.container()
+                .select(ThreadContext.class, NamedInstance.Literal.of("sharedConfiguredThreadContext")).isResolvable());
+
+        bean.assertDefaultExecutor();
+        bean.assertConfiguredManagedExecutor();
+        bean.assertSharedExecutorsAreTheSame();
+
+        bean.assertDefaultThreadContext();
+        bean.assertConfiguredThreadContext();
+        bean.assertSharedThreadContextsAreTheSame();
+
+        bean.assertUserDefinedProducersAreRespected();
+    }
+
+    @Qualifier
+    @Inherited
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface MyQualifier {
+    }
+
+    //no proxy bean just so that we can access fields directly
+    @Singleton
+    static class SomeBean {
+
+        @Inject
+        @ManagedExecutorConfig
+        ManagedExecutor defaultExecutor;
+        @Inject
+        @ManagedExecutorConfig(maxAsync = 2, maxQueued = 3)
+        ManagedExecutor configuredExecutor;
+        @Inject
+        @NamedInstance("sharedDefaultExecutor")
+        ManagedExecutor sharedDefaultExecutor1;
+        @Inject
+        @NamedInstance("sharedDefaultExecutor")
+        ManagedExecutor sharedDefaultExecutor2;
+        @Inject
+        @NamedInstance("sharedConfiguredExecutor")
+        ManagedExecutor sharedConfiguredExecutor1;
+        @Inject
+        @ManagedExecutorConfig(maxQueued = 2, maxAsync = 2, cleared = "CDI")
+        @NamedInstance("sharedConfiguredExecutor")
+        ManagedExecutor sharedConfiguredExecutor2;
+        @Inject
+        @ThreadContextConfig
+        ThreadContext defaultThreadContext;
+        @Inject
+        @ThreadContextConfig(cleared = "CDI")
+        ThreadContext configuredThreadContext;
+        @Inject
+        @NamedInstance("sharedDefaultThreadContext")
+        ThreadContext sharedDefaultThreadContext1;
+        @Inject
+        @NamedInstance("sharedDefaultThreadContext")
+        ThreadContext sharedDefaultThreadContext2;
+        @Inject
+        @ThreadContextConfig(cleared = "CDI", unchanged = "Remaining", propagated = "")
+        @NamedInstance("sharedConfiguredThreadContext")
+        ThreadContext sharedConfiguredThreadContext1;
+        @Inject
+        @NamedInstance("sharedConfiguredThreadContext")
+        ThreadContext sharedConfiguredThreadContext2;
+        @Inject
+        @NamedInstance("userProduced")
+        ManagedExecutor userProducedME;
+        @Inject
+        @NamedInstance("userProduced")
+        ThreadContext userProducedTC;
+        @Inject
+        @MyQualifier
+        ManagedExecutor userProducedMEWithQualifier;
+        @Inject
+        @MyQualifier
+        ThreadContext userProducedTCWithQualifier;
+
+        public void ping() {
+            // noop method just to verify bean injection
+        }
+
+        public void assertDefaultExecutor() {
+            SmallRyeManagedExecutor exec = unwrapExecutor(defaultExecutor);
+            assertEquals(-1, exec.getMaxAsync());
+            assertEquals(-1, exec.getMaxQueued());
+            ThreadContextProviderPlan plan = exec.getThreadContextProviderPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            assertEquals(0, plan.clearedProviders.size());
+            Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+            assertTrue(propagated.contains(ThreadContext.CDI));
+        }
+
+        public void assertSharedExecutorsAreTheSame() {
+            // simply unwrap both and compare reference
+            SmallRyeManagedExecutor shared1 = unwrapExecutor(sharedConfiguredExecutor1);
+            SmallRyeManagedExecutor shared2 = unwrapExecutor(sharedConfiguredExecutor2);
+            assertSame(shared1, shared2);
+
+            shared1 = unwrapExecutor(sharedDefaultExecutor1);
+            shared2 = unwrapExecutor(sharedDefaultExecutor2);
+            assertSame(shared1, shared2);
+        }
+
+        public void assertConfiguredManagedExecutor() {
+            SmallRyeManagedExecutor exec = unwrapExecutor(configuredExecutor);
+            assertEquals(2, exec.getMaxAsync());
+            assertEquals(3, exec.getMaxQueued());
+            ThreadContextProviderPlan plan = exec.getThreadContextProviderPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+            assertTrue(propagated.contains(ThreadContext.CDI));
+        }
+
+        public void assertSharedThreadContextsAreTheSame() {
+            //unwrap and compare references
+            SmallRyeThreadContext shared1 = unwrapThreadContext(sharedDefaultThreadContext1);
+            SmallRyeThreadContext shared2 = unwrapThreadContext(sharedDefaultThreadContext2);
+            assertSame(shared1, shared2);
+
+            shared1 = unwrapThreadContext(sharedConfiguredThreadContext1);
+            shared2 = unwrapThreadContext(sharedConfiguredThreadContext2);
+            assertSame(shared1, shared2);
+        }
+
+        public void assertConfiguredThreadContext() {
+            SmallRyeThreadContext context = unwrapThreadContext(configuredThreadContext);
+            ThreadContextProviderPlan plan = context.getPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+            Set<String> cleared = providersToStringSet(plan.clearedProviders);
+            assertTrue(propagated.isEmpty());
+            assertTrue(cleared.contains(ThreadContext.CDI));
+        }
+
+        public void assertDefaultThreadContext() {
+            SmallRyeThreadContext context = unwrapThreadContext(defaultThreadContext);
+            ThreadContextProviderPlan plan = context.getPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            assertEquals(0, plan.clearedProviders.size());
+            Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+            assertTrue(propagated.contains(ThreadContext.CDI));
+        }
+
+        public void assertUserDefinedProducersAreRespected() {
+            SmallRyeManagedExecutor userDefinedExec = unwrapExecutor(userProducedME);
+            assertEquals(2, userDefinedExec.getMaxAsync());
+
+            userDefinedExec = unwrapExecutor(userProducedMEWithQualifier);
+            assertEquals(2, userDefinedExec.getMaxAsync());
+
+            SmallRyeThreadContext userDefinedContext = unwrapThreadContext(userProducedTC);
+            ThreadContextProviderPlan plan = userDefinedContext.getPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            assertEquals(1, plan.clearedProviders.size());
+            Set<String> propagated = providersToStringSet(plan.propagatedProviders);
+            assertTrue(propagated.isEmpty());
+
+            userDefinedContext = unwrapThreadContext(userProducedTCWithQualifier);
+            plan = userDefinedContext.getPlan();
+            assertEquals(0, plan.unchangedProviders.size());
+            assertEquals(1, plan.clearedProviders.size());
+            propagated = providersToStringSet(plan.propagatedProviders);
+            assertTrue(propagated.isEmpty());
+        }
+    }
+
+    @ApplicationScoped
+    static class ProducerBean {
+
+        @Produces
+        @ApplicationScoped
+        @NamedInstance("userProduced")
+        ManagedExecutor produceEM() {
+            //create any non-default
+            return ManagedExecutor.builder().maxAsync(2).build();
+        }
+
+        @Produces
+        @ApplicationScoped
+        @NamedInstance("userProduced")
+        ThreadContext produceTC() {
+            //create any non-default
+            return ThreadContext.builder().propagated().build();
+        }
+
+        @Produces
+        @ApplicationScoped
+        @MyQualifier
+        ManagedExecutor produceQualifiedEM() {
+            //create any non-default
+            return ManagedExecutor.builder().maxAsync(2).build();
+        }
+
+        @Produces
+        @ApplicationScoped
+        @MyQualifier
+        ThreadContext produceQualifiedTC() {
+            //create any non-default
+            return ThreadContext.builder().propagated().build();
+        }
+    }
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/Utils.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/Utils.java
@@ -1,0 +1,43 @@
+package io.quarkus.smallrye.context.deployment.test.cdi;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+
+import io.quarkus.arc.ClientProxy;
+import io.smallrye.context.SmallRyeManagedExecutor;
+import io.smallrye.context.SmallRyeThreadContext;
+
+public class Utils {
+
+    private Utils() {
+    }
+
+    // util methods
+    public static SmallRyeManagedExecutor unwrapExecutor(ManagedExecutor executor) {
+        if (executor instanceof ClientProxy) {
+            return (SmallRyeManagedExecutor) ((ClientProxy) executor).arc_contextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of ClientProxy");
+        }
+    }
+
+    public static SmallRyeThreadContext unwrapThreadContext(ThreadContext executor) {
+        if (executor instanceof ClientProxy) {
+            return (SmallRyeThreadContext) ((ClientProxy) executor).arc_contextualInstance();
+        } else {
+            throw new IllegalStateException("Injected proxies are expected to be instance of ClientProxy");
+        }
+    }
+
+    public static Set<String> providersToStringSet(Set<ThreadContextProvider> providers) {
+        Set<String> result = new HashSet<>();
+        for (ThreadContextProvider provider : providers) {
+            result.add(provider.getThreadContextType());
+        }
+        return result;
+    }
+}

--- a/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
+++ b/extensions/smallrye-context-propagation/runtime/src/main/java/io/quarkus/smallrye/context/runtime/SmallRyeContextPropagationRecorder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.spi.ContextManagerExtension;
 import org.eclipse.microprofile.context.spi.ContextManagerProvider;
@@ -78,6 +79,26 @@ public class SmallRyeContextPropagationRecorder {
                         throw new IllegalStateException("This executor is managed by the container and cannot be shut down.");
                     }
                 };
+            }
+        };
+    }
+
+    public Supplier<Object> initializeConfiguredThreadContext(String[] cleared, String[] propagated, String[] unchanged) {
+        return new Supplier<Object>() {
+            @Override
+            public Object get() {
+                return ThreadContext.builder().propagated(propagated).cleared(cleared).unchanged(unchanged).build();
+            }
+        };
+    }
+
+    public Supplier<Object> initializeConfiguredManagedExecutor(String[] cleared, String[] propagated, int maxAsync,
+            int maxQueued) {
+        return new Supplier<Object>() {
+            @Override
+            public Object get() {
+                return ManagedExecutor.builder().propagated(propagated).cleared(cleared).maxAsync(maxAsync).maxQueued(maxQueued)
+                        .build();
             }
         };
     }


### PR DESCRIPTION
Fixes #22645

This PR ports over a capability that is in SR CP - to create a custom configured `ManagedExecutor` or `ThreadContext` purely via CDI plus the ability to share those executors. There is a lot of tests to go with it that should depict the usage.

Former impl can be seen [here](https://github.com/smallrye/smallrye-context-propagation/blob/main/cdi/src/main/java/io/smallrye/context/inject/SmallryeContextCdiExtension.java).

Note that we already had some existing documentation for this not-so-existing feature, see [here](https://quarkus.io/guides/context-propagation#overriding-the-propagated-contexts-using-cdi-injection). It was pretty brief so I expanded it a little.