### PR TITLE
Upgrade to Hibernate Validator 6.2.2.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <hibernate-orm.version>5.6.5.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.2.Final</hibernate-reactive.version>
-        <hibernate-validator.version>6.2.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.2.2.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.0.Final</hibernate-search.version>
         <narayana.version>5.12.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>


### PR DESCRIPTION
Let's merge this one rather than the potential Dependabot PR as it needs the backport label.