### PR TITLE
Improve the DNS lookup support in native mode for the Mongo connection using mongo:srv://

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongodbConfig.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/MongodbConfig.java
@@ -71,11 +71,17 @@ public class MongodbConfig {
     @ConfigItem(name = "native.dns.server-port", defaultValue = "53")
     public OptionalInt dnsServerPortInNativeMode;
 
-    // mongo.dns.lookup-timeout
     /**
      * If {@code native.dns.use-vertx-dns-resolver} is set to {@code true}, this property configures the DNS lookup timeout
      * duration.
      */
     @ConfigItem(name = "native.dns.lookup-timeout", defaultValue = "5s")
     public Duration dnsLookupTimeoutInNativeMode;
+
+    /**
+     * If {@code native.dns.use-vertx-dns-resolver} is set to {@code true}, this property enables the logging ot the
+     * DNS lookup. It can be useful to understand why the lookup fails.
+     */
+    @ConfigItem(name = "native.dns.log-activity", defaultValue = "false")
+    public Optional<Boolean> dnsLookupLogActivityInNativeMode;
 }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/DnsClientProducer.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/DnsClientProducer.java
@@ -14,8 +14,10 @@ import java.util.StringTokenizer;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
+import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.core.dns.DnsClient;
 
@@ -29,6 +31,7 @@ public abstract class DnsClientProducer {
 
     private static final String DNS_SERVER = "quarkus.mongodb.native.dns.server-host";
     private static final String DNS_SERVER_PORT = "quarkus.mongodb.native.dns.server-port";
+    private static final String DNS_SERVER_ACTIVITY = "quarkus.mongodb.native.dns.log-activity";
 
     public static final String LOOKUP_TIMEOUT = "quarkus.mongodb.native.dns.lookup-timeout";
 
@@ -38,6 +41,8 @@ public abstract class DnsClientProducer {
         Config config = ConfigProvider.getConfig();
         if (client == null) {
             Vertx vertx = Arc.container().instance(Vertx.class).get();
+
+            boolean activity = config.getOptionalValue(DNS_SERVER_ACTIVITY, Boolean.class).orElse(false);
 
             // If the server is not set, we attempt to read the /etc/resolv.conf. If it does not exist, we use the default
             // configuration.
@@ -50,9 +55,9 @@ public abstract class DnsClientProducer {
             });
             if (server != null) {
                 int port = config.getOptionalValue(DNS_SERVER_PORT, Integer.class).orElse(53);
-                client = vertx.createDnsClient(port, server);
+                client = vertx.createDnsClient(new DnsClientOptions().setLogActivity(activity).setPort(port).setHost(server));
             } else {
-                client = vertx.createDnsClient();
+                client = vertx.createDnsClient(new DnsClientOptions().setLogActivity(activity));
             }
         }
 
@@ -64,19 +69,23 @@ public abstract class DnsClientProducer {
         if (!new File(file).isFile()) {
             return Collections.emptyList();
         }
-
         Path p = Paths.get(file);
         List<String> nameServers = new ArrayList<>();
         String line;
         try (BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(p)))) {
             while ((line = br.readLine()) != null) {
                 StringTokenizer st = new StringTokenizer(line);
-                if (st.nextToken().startsWith("nameserver")) {
-                    nameServers.add(st.nextToken());
+                if (st.hasMoreTokens()) {
+                    String token = st.nextToken();
+                    if (token.startsWith("nameserver")) {
+                        // If we do not have another token it means that the line is not formatted correctly.
+                        // So, throwing an exception is ok.
+                        nameServers.add(st.nextToken().trim());
+                    }
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            Logger.getLogger(DnsClientProducer.class).error("Unable to read the /etc/resolv.conf file", e);
         }
         return nameServers;
     }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
@@ -116,7 +116,7 @@ final class CompressorSubstitute {
 }
 
 @TargetClass(InternalStreamConnection.class)
-final class InternalStreamConnectionSubtitution {
+final class InternalStreamConnectionSubstitution {
     @Substitute
     private CompressorSubstitute createCompressor(final MongoCompressor mongoCompressor) {
         throw new UnsupportedOperationException("Unsupported compressor in native mode");
@@ -179,7 +179,6 @@ final class DefaultDnsResolverSubstitution {
             if (srvRecords.isEmpty()) {
                 throw new MongoConfigurationException("No SRV records available for host " + "_mongodb._tcp." + srvHost);
             }
-
             for (SrvRecord srvRecord : srvRecords) {
                 String resolvedHost = srvRecord.target().endsWith(".")
                         ? srvRecord.target().substring(0, srvRecord.target().length() - 1)


### PR DESCRIPTION
Fix #23548 

NOTE: I was unable to test against a serverless instance. 