### PR TITLE
Upgrade to Hibernate Search 6.1.1.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -90,7 +90,7 @@
         <bytebuddy.version>1.12.7</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.2.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.2.Final</hibernate-validator.version>
-        <hibernate-search.version>6.1.0.Final</hibernate-search.version>
+        <hibernate-search.version>6.1.1.Final</hibernate-search.version>
         <narayana.version>5.12.4.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.14</agroal.version>


### PR DESCRIPTION
See https://in.relation.to/2022/02/08/hibernate-search-6-1-1-Final/ ; nothing much worth mentioning here. I'm just upgrading so that we can say we're using the latest version.