### PR TITLE
Merge multiple Gradle project classes dirs into one for quarkusDev

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -404,16 +404,18 @@ public class QuarkusDev extends QuarkusTask {
         Set<Path> sourcePaths = new LinkedHashSet<>();
         Set<Path> sourceParentPaths = new LinkedHashSet<>();
 
-        Path classesDir = null;
+        final Set<Path> classesDirs = new HashSet<>(sources.getSourceDirs().size());
         for (SourceDir src : sources.getSourceDirs()) {
             if (Files.exists(src.getDir())) {
                 sourcePaths.add(src.getDir());
                 sourceParentPaths.add(src.getDir().getParent());
-                if (classesDir == null) {
-                    classesDir = src.getOutputDir();
+                if (src.getOutputDir() != null) {
+                    classesDirs.add(src.getOutputDir());
                 }
             }
         }
+        Path classesDir = classesDirs.isEmpty() ? null
+                : QuarkusGradleUtils.mergeClassesDirs(classesDirs, project.getWorkspaceModule().getBuildDir(), root, root);
 
         final Set<Path> resourcesSrcDirs = new LinkedHashSet<>();
         // resourcesSrcDir may exist but if it's empty the resources output dir won't be created
@@ -458,17 +460,20 @@ public class QuarkusDev extends QuarkusTask {
         if (testSources != null) {
             Set<Path> testSourcePaths = new LinkedHashSet<>();
             Set<Path> testSourceParentPaths = new LinkedHashSet<>();
-            Path testClassesDir = null;
 
+            final Set<Path> testClassesDirs = new HashSet<>(testSources.getSourceDirs().size());
             for (SourceDir src : testSources.getSourceDirs()) {
                 if (Files.exists(src.getDir())) {
                     testSourcePaths.add(src.getDir());
                     testSourceParentPaths.add(src.getDir().getParent());
-                    if (testClassesDir == null && src.getOutputDir() != null) {
-                        testClassesDir = src.getOutputDir();
+                    if (src.getOutputDir() != null) {
+                        testClassesDirs.add(src.getOutputDir());
                     }
                 }
             }
+            Path testClassesDir = testClassesDirs.isEmpty() ? null
+                    : QuarkusGradleUtils.mergeClassesDirs(testClassesDirs, project.getWorkspaceModule().getBuildDir(), root,
+                            root);
 
             final Set<Path> testResourcesSrcDirs = new LinkedHashSet<>();
             // resourcesSrcDir may exist but if it's empty the resources output dir won't be created

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
@@ -4,6 +4,7 @@ public interface ArtifactCoords {
 
     String TYPE_JAR = "jar";
     String TYPE_POM = "pom";
+    String DEFAULT_CLASSIFIER = "";
 
     String getGroupId();
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACT.java
@@ -34,7 +34,7 @@ public class GACT implements ArtifactKey, Serializable {
                     "One of groupId or artifactId is missing from '" + str.substring(0, fromIndex) + "'");
         }
         if (i == fromIndex - 1) {
-            parts[2] = "";
+            parts[2] = ArtifactCoords.DEFAULT_CLASSIFIER;
         } else {
             parts[2] = str.substring(i + 1, fromIndex);
         }
@@ -69,15 +69,32 @@ public class GACT implements ArtifactKey, Serializable {
     protected final String type;
 
     public GACT(String[] parts) {
+        if (parts == null || parts.length < 2 || parts.length > 4) {
+            final StringBuilder sb = new StringBuilder().append("Artifact key ");
+            if (parts == null) {
+                sb.append("null");
+            } else {
+                sb.append('\'');
+                if (parts.length > 0) {
+                    sb.append(parts[0]);
+                    for (int i = 1; i < parts.length; ++i) {
+                        sb.append(':').append(parts[i]);
+                    }
+                }
+                sb.append('\'');
+            }
+            throw new IllegalArgumentException(
+                    sb.append(" does not follow format <groupId>:<artifactId>[:<classifier>[:<type>]]").toString());
+        }
         this.groupId = parts[0];
         this.artifactId = parts[1];
         if (parts.length == 2 || parts[2] == null) {
-            this.classifier = "";
+            this.classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
         } else {
             this.classifier = parts[2];
         }
         if (parts.length <= 3 || parts[3] == null) {
-            this.type = "jar";
+            this.type = ArtifactCoords.TYPE_JAR;
         } else {
             this.type = parts[3];
         }
@@ -94,7 +111,7 @@ public class GACT implements ArtifactKey, Serializable {
     public GACT(String groupId, String artifactId, String classifier, String type) {
         this.groupId = groupId;
         this.artifactId = artifactId;
-        this.classifier = classifier == null ? "" : classifier;
+        this.classifier = classifier == null ? ArtifactCoords.DEFAULT_CLASSIFIER : classifier;
         this.type = type;
     }
 

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MultiSourceProjectDevModeTest extends QuarkusDevGradleTestBase {
+
+    @Override
+    protected String projectDirectoryName() {
+        return "multi-source-project";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "quarkusDev", "-s" };
+    }
+
+    protected void testDevMode() throws Exception {
+
+        assertThat(getHttpResponse("/hello")).contains("hello from JavaComponent");
+        replace("src/main/java/org/acme/service/SimpleService.java",
+                ImmutableMap.of("return \"hello from JavaComponent\";", "return \"hi\";"));
+
+        assertUpdatedResponseContains("/hello", "hi");
+
+        replace("src/main/kotlin/org/acme/ExampleResource.kt",
+                ImmutableMap.of("fun hello(): String = service.hello()", "fun hello(): String = service.hello() + \"!\""));
+
+        assertUpdatedResponseContains("/hello", "hi!");
+    }
+}


### PR DESCRIPTION
Fix #23591

This fixes a regression in 2.7.1.Final. This change is merging multiple classes dirs into a single one for `quarkusDev` the way it is done in 2.7.0.Final.