### PR TITLE
Fix NPE when running quartz in database mode and migrating from old versions

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -37,6 +37,7 @@ import org.quartz.SchedulerFactory;
 import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger.TriggerState;
 import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.simpl.InitThreadContextClassLoadHelper;
 import org.quartz.simpl.SimpleJobFactory;
@@ -179,8 +180,10 @@ public class QuartzScheduler implements Scheduler {
                             throw new IllegalArgumentException("Invalid schedule configuration: " + scheduled);
                         }
 
+                        JobDetail jobDetail = jobBuilder.build();
                         TriggerBuilder<?> triggerBuilder = TriggerBuilder.newTrigger()
                                 .withIdentity(identity, Scheduler.class.getName())
+                                .forJob(jobDetail)
                                 .withSchedule(scheduleBuilder);
 
                         Long millisToAdd = null;
@@ -194,18 +197,30 @@ public class QuartzScheduler implements Scheduler {
                                     .plusMillis(millisToAdd).toEpochMilli()));
                         }
 
-                        JobDetail job = jobBuilder.build();
                         org.quartz.Trigger trigger = triggerBuilder.build();
-                        if (!scheduler.checkExists(job.getKey())) {
-                            scheduler.scheduleJob(job, trigger);
-                            LOGGER.debugf("Scheduled business method %s with config %s", method.getMethodDescription(),
-                                    scheduled);
-                        } else {
-                            org.quartz.Trigger oldTrigger = scheduler.getTrigger(trigger.getKey());
+                        org.quartz.Trigger oldTrigger = scheduler.getTrigger(trigger.getKey());
+                        if (oldTrigger != null) {
                             scheduler.rescheduleJob(trigger.getKey(),
                                     triggerBuilder.startAt(oldTrigger.getNextFireTime()).build());
                             LOGGER.debugf("Rescheduled business method %s with config %s", method.getMethodDescription(),
                                     scheduled);
+                        } else if (!scheduler.checkExists(jobDetail.getKey())) {
+                            scheduler.scheduleJob(jobDetail, trigger);
+                            LOGGER.debugf("Scheduled business method %s with config %s", method.getMethodDescription(),
+                                    scheduled);
+                        } else {
+                            // TODO remove this code in 3.0, it is only here to ensure migration after the removal of
+                            // "_trigger" suffix and the need to reschedule jobs due to configuration change between build
+                            // and deploy time
+                            oldTrigger = scheduler.getTrigger(new TriggerKey(identity + "_trigger", Scheduler.class.getName()));
+                            if (oldTrigger != null) {
+                                scheduler.deleteJob(jobDetail.getKey());
+                                scheduler.scheduleJob(jobDetail, triggerBuilder.startAt(oldTrigger.getNextFireTime()).build());
+                                LOGGER.debugf(
+                                        "Rescheduled business method %s with config %s due to Trigger '%s' record being renamed after removal of '_trigger' suffix",
+                                        method.getMethodDescription(),
+                                        scheduled, oldTrigger.getKey().getName());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fix #23457.
Fix #22479

When migrating from versions which are < 2.1 to 2.7, a NPE was produced
due to trigger name renaming to remove the `_trigger` suffix.

The fix in here introduce a migration support to reschedule old triggers.
I went this way to reduce the toil that the user will have to do performing the actions described in our migration documentation.
This is only an exception case where the extension will have to perform the migration.
The temporary code will reschedule the old trigger i.e the one with the _trigger suffix to a new one without the suffix.
This shouldn't impact in any way the application and should be transparent to the user.

I've tested the fix against the reproducer given
https://github.com/quarkusio/quarkus/issues/23457#issuecomment-1035483218
and the verification seemed conclusive to me.

/cc @jendib, do you mind giving this PR a spin to verify if it fixes your issue? 
/cc @mkouba for review and approval