### PR TITLE
Fix typo in JSON snippet

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1018,7 +1018,7 @@ The full source of the `knative.json` file looks something like this:
         "app.kubernetes.io/name" : "test-quarkus-app",
         "app.kubernetes.io/version" : "1.0.0-SNAPSHOT"
       },
-      "name" : "knative.
+      "name" : "knative"
     },
     "spec" : {
       "runLatest" : {


### PR DESCRIPTION
it ain't much, but I hope appreciated to fix syntax highlight on the website:

<img width="1915" alt="Screenshot 2022-02-12 at 10 08 28" src="https://user-images.githubusercontent.com/1699252/153705109-b1e10c23-3d6b-4c7f-a3e3-b855aea7e408.png">
