### PR TITLE
Update netty to version 4.1.74

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -129,7 +129,7 @@
         <infinispan.version>13.0.5.Final</infinispan.version>
         <infinispan.protostream.version>4.4.1.Final</infinispan.protostream.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <netty.version>4.1.73.Final</netty.version>
+        <netty.version>4.1.74.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
         <mutiny.version>1.3.1</mutiny.version>


### PR DESCRIPTION
See: https://netty.io/news/2022/02/08/4-1-74-Final.html

Vert.x already updated, and we cannot integrate the snapshot version of Vert.x until this PR goes in (Vert.x core uses a new API).