### PR TITLE
Kubernetes: Expose Dekorate output and allow to supply configurators

### DIFF
--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/ConfigurationSupplierBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/ConfigurationSupplierBuildItem.java
@@ -1,0 +1,27 @@
+package io.quarkus.kubernetes.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that wraps around ConfigurationSupplier objects.
+ * The purpose of those build items is influence the configuration that will be feed to the generator process.
+ */
+public final class ConfigurationSupplierBuildItem extends MultiBuildItem {
+
+    /**
+     * The configuration supplier
+     */
+    private final Object configurationSupplier;
+
+    public ConfigurationSupplierBuildItem(Object configurationSupplier) {
+        this.configurationSupplier = configurationSupplier;
+    }
+
+    public Object getConfigurationSupplier() {
+        return this.configurationSupplier;
+    }
+
+    public boolean matches(Class type) {
+        return type.isInstance(configurationSupplier);
+    }
+}

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/ConfiguratorBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/ConfiguratorBuildItem.java
@@ -1,7 +1,5 @@
 package io.quarkus.kubernetes.spi;
 
-import java.util.Optional;
-
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -26,13 +24,5 @@ public final class ConfiguratorBuildItem extends MultiBuildItem {
 
     public boolean matches(Class type) {
         return type.isInstance(configurator);
-
-    }
-
-    public <C> Optional<C> getConfigurator(Class<C> type) {
-        if (matches(type)) {
-            return Optional.<C> of((C) configurator);
-        }
-        return Optional.empty();
     }
 }

--- a/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/DekorateOutputBuildItem.java
+++ b/extensions/kubernetes/spi/src/main/java/io/quarkus/kubernetes/spi/DekorateOutputBuildItem.java
@@ -1,0 +1,33 @@
+package io.quarkus.kubernetes.spi;
+
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Produce this build item to expose the Dekorate project and Dekorate session.
+ */
+public final class DekorateOutputBuildItem extends SimpleBuildItem {
+
+    private final Object project;
+    private final Object session;
+    private final List<String> generatedFiles;
+
+    public DekorateOutputBuildItem(Object project, Object session, List<String> generatedFiles) {
+        this.project = project;
+        this.session = session;
+        this.generatedFiles = generatedFiles;
+    }
+
+    public Object getProject() {
+        return project;
+    }
+
+    public Object getSession() {
+        return session;
+    }
+
+    public List<String> getGeneratedFiles() {
+        return generatedFiles;
+    }
+}


### PR DESCRIPTION
This change would help to expose the Dekorate project and session to later usage by other extensions.