### PR TITLE
Fix typo in Quarkus-cli documentation example

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -19,7 +19,7 @@ To scaffold a Gradle project you can either use the xref:cli-tooling.adoc[Quarku
 [source, bash]
 ----
 quarkus create app my-groupId:my-artifactId \
-    --extensions=resteasy,resteasy-jackson \
+    --extension=resteasy,resteasy-jackson \
     --gradle
 ----
 


### PR DESCRIPTION
The following [site](https://quarkus.io/guides/gradle-tooling) has a typo in the Quarkus-cli create example