### PR TITLE
Move all MongoDB Panache common classes to the common root package

### DIFF
--- a/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
+++ b/extensions/panache/mongodb-panache-common/deployment/src/main/java/io/quarkus/mongodb/panache/deployment/BasePanacheMongoResourceProcessor.java
@@ -51,8 +51,8 @@ import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.mongodb.deployment.MongoClientNameBuildItem;
 import io.quarkus.mongodb.deployment.MongoUnremovableClientsBuildItem;
 import io.quarkus.mongodb.panache.common.PanacheMongoRecorder;
-import io.quarkus.mongodb.panache.jackson.ObjectIdDeserializer;
-import io.quarkus.mongodb.panache.jackson.ObjectIdSerializer;
+import io.quarkus.mongodb.panache.common.jackson.ObjectIdDeserializer;
+import io.quarkus.mongodb.panache.common.jackson.ObjectIdSerializer;
 import io.quarkus.panache.common.deployment.EntityField;
 import io.quarkus.panache.common.deployment.EntityModel;
 import io.quarkus.panache.common.deployment.MetamodelInfo;
@@ -400,9 +400,11 @@ public abstract class BasePanacheMongoResourceProcessor {
     protected void registerJsonbSerDeser(BuildProducer<JsonbSerializerBuildItem> jsonbSerializers,
             BuildProducer<JsonbDeserializerBuildItem> jsonbDeserializers) {
         jsonbSerializers
-                .produce(new JsonbSerializerBuildItem(io.quarkus.mongodb.panache.jsonb.ObjectIdSerializer.class.getName()));
+                .produce(new JsonbSerializerBuildItem(
+                        io.quarkus.mongodb.panache.common.jsonb.ObjectIdSerializer.class.getName()));
         jsonbDeserializers
-                .produce(new JsonbDeserializerBuildItem(io.quarkus.mongodb.panache.jsonb.ObjectIdDeserializer.class.getName()));
+                .produce(new JsonbDeserializerBuildItem(
+                        io.quarkus.mongodb.panache.common.jsonb.ObjectIdDeserializer.class.getName()));
     }
 
     @BuildStep

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/CommonQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/CommonQueryBinder.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.binder;
+package io.quarkus.mongodb.panache.common.binder;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/MongoParserVisitor.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.binder;
+package io.quarkus.mongodb.panache.common.binder;
 
 import java.util.Map;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/NativeQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/NativeQueryBinder.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.binder;
+package io.quarkus.mongodb.panache.common.binder;
 
 import java.util.Map;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/PanacheQlQueryBinder.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/binder/PanacheQlQueryBinder.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.binder;
+package io.quarkus.mongodb.panache.common.binder;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jackson/ObjectIdDeserializer.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jackson/ObjectIdDeserializer.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.jackson;
+package io.quarkus.mongodb.panache.common.jackson;
 
 import java.io.IOException;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jackson/ObjectIdSerializer.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jackson/ObjectIdSerializer.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.jackson;
+package io.quarkus.mongodb.panache.common.jackson;
 
 import java.io.IOException;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jsonb/ObjectIdDeserializer.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jsonb/ObjectIdDeserializer.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.jsonb;
+package io.quarkus.mongodb.panache.common.jsonb;
 
 import java.lang.reflect.Type;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jsonb/ObjectIdSerializer.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/jsonb/ObjectIdSerializer.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.jsonb;
+package io.quarkus.mongodb.panache.common.jsonb;
 
 import javax.json.bind.serializer.JsonbSerializer;
 import javax.json.bind.serializer.SerializationContext;

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
@@ -27,9 +27,9 @@ import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
-import io.quarkus.mongodb.panache.binder.NativeQueryBinder;
-import io.quarkus.mongodb.panache.binder.PanacheQlQueryBinder;
 import io.quarkus.mongodb.panache.common.MongoEntity;
+import io.quarkus.mongodb.panache.common.binder.NativeQueryBinder;
+import io.quarkus.mongodb.panache.common.binder.PanacheQlQueryBinder;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
 import io.quarkus.mongodb.reactive.ReactiveMongoDatabase;

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -36,10 +36,10 @@ import com.mongodb.client.result.DeleteResult;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
-import io.quarkus.mongodb.panache.binder.NativeQueryBinder;
-import io.quarkus.mongodb.panache.binder.PanacheQlQueryBinder;
 import io.quarkus.mongodb.panache.common.MongoEntity;
-import io.quarkus.mongodb.panache.transaction.MongoTransactionException;
+import io.quarkus.mongodb.panache.common.binder.NativeQueryBinder;
+import io.quarkus.mongodb.panache.common.binder.PanacheQlQueryBinder;
+import io.quarkus.mongodb.panache.common.transaction.MongoTransactionException;
 import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/transaction/MongoTransactionException.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/transaction/MongoTransactionException.java
@@ -1,4 +1,4 @@
-package io.quarkus.mongodb.panache.transaction;
+package io.quarkus.mongodb.panache.common.transaction;
 
 public class MongoTransactionException extends RuntimeException {
     public MongoTransactionException(Exception cause) {


### PR DESCRIPTION
This is a leftover from the housekeeping done on split packages.