### PR TITLE
Add the ability to specify additional exposed ports for @QuarkusIntegrationTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.deployment.dev.testing;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -244,11 +245,16 @@ public class TestConfig {
         /**
          * Controls the container network to be used when @QuarkusIntegration needs to launch the application in a container.
          * This setting only applies if Quarkus does not need to use a shared network - which is the case if DevServices are
-         * used
-         * when running the test.
+         * used when running the test.
          */
         @ConfigItem
         Optional<String> network;
+
+        /**
+         * Set additional ports to be exposed when @QuarkusIntegration needs to launch the application in a container.
+         */
+        @ConfigItem
+        Map<String, String> additionalExposedPorts;
     }
 
     public enum Mode {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -34,6 +34,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult;
     private String containerImage;
     private boolean pullRequired;
+    private Map<Integer, Integer> additionalExposedPorts;
 
     private final Map<String, String> systemProps = new HashMap<>();
 
@@ -51,6 +52,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         this.devServicesLaunchResult = initContext.getDevServicesLaunchResult();
         this.containerImage = initContext.containerImage();
         this.pullRequired = initContext.pullRequired();
+        this.additionalExposedPorts = initContext.additionalExposedPorts();
     }
 
     @Override
@@ -97,6 +99,10 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         args.add(httpPort + ":" + httpPort);
         args.add("-p");
         args.add(httpsPort + ":" + httpsPort);
+        for (var entry : additionalExposedPorts.entrySet()) {
+            args.add("-p");
+            args.add(entry.getKey() + ":" + entry.getValue());
+        }
         // if the dev services resulted in creating a dedicated network, then use it
         if (devServicesLaunchResult.networkId() != null) {
             args.add("--net=" + devServicesLaunchResult.networkId());

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DockerContainerArtifactLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DockerContainerArtifactLauncher.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.common;
 
+import java.util.Map;
+
 public interface DockerContainerArtifactLauncher extends ArtifactLauncher<DockerContainerArtifactLauncher.DockerInitContext> {
 
     interface DockerInitContext extends InitContext {
@@ -7,5 +9,7 @@ public interface DockerContainerArtifactLauncher extends ArtifactLauncher<Docker
         String containerImage();
 
         boolean pullRequired();
+
+        Map<Integer, Integer> additionalExposedPorts();
     }
 }


### PR DESCRIPTION
Originally mentioned in https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/QuarkusIntegrationTest.2C.20container.20config

Resolves; #23722 23722