### PR TITLE
Update working directory for Jib created images

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -342,7 +342,7 @@ public class JibProcessor {
         Path componentsPath = sourceJarBuildItem.getPath().getParent();
         Path appLibDir = componentsPath.resolve(JarResultBuildStep.LIB).resolve(JarResultBuildStep.MAIN);
 
-        AbsoluteUnixPath workDirInContainer = AbsoluteUnixPath.get("/work");
+        AbsoluteUnixPath workDirInContainer = AbsoluteUnixPath.get("/home/jboss");
 
         List<String> entrypoint;
         if (jibConfig.jvmEntrypoint.isPresent()) {


### PR DESCRIPTION
With the use of ubi8/openjdk base images as the default,
we now also update the working directory to avoid
any permissions issues (as the containers are run by a
non-root image).

This change is compatible with the pre Quarkus 2.7
base images as well (for those users who wish to continue
using that base image).

Fixes: #23665