### PR TITLE
Fix DirectoryPathTree allowing to escape the tree when passing absolute paths

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -43,8 +43,13 @@ public class HibernateOrmConfigPersistenceUnit {
 
     // @formatter:off
     /**
-     * Name of the file containing the SQL statements to execute when Hibernate ORM starts.
-     * Its default value differs depending on the Quarkus launch mode:
+     * Path to a file containing the SQL statements to execute when Hibernate ORM starts.
+     *
+     * The file is retrieved from the classpath resources,
+     * so it must be located in the resources directory (e.g. `src/main/resources`)
+     * or in a JAR the application depends on.
+     *
+     * The default value for this setting differs depending on the Quarkus launch mode:
      *
      * * In dev and test modes, it defaults to `import.sql`.
      *   Simply add an `import.sql` file in the root of your resources directory

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/AbsoluteFileSystemPathSqlLoadScriptTestCase.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/sql_load_script/AbsoluteFileSystemPathSqlLoadScriptTestCase.java
@@ -1,0 +1,58 @@
+package io.quarkus.hibernate.orm.sql_load_script;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that setting {@code quarkus.hibernate-orm.sql-load-script}
+ * to the absolute path to a resource file on the filesystem
+ * makes the build fail.
+ *
+ * The build used to run just fine because we were interpreting the "absolute" path
+ * as relative to the FS root rather than relative to the classpath root,
+ * and ended up deciding that it does exist... only to not be able to find it later and ignoring it.
+ *
+ * See https://github.com/quarkusio/quarkus/issues/23574
+ */
+public class AbsoluteFileSystemPathSqlLoadScriptTestCase {
+    private static final String sqlLoadScriptAbsolutePath;
+    static {
+        // For this reproducer, we need the absolute path to a file
+        // that actually exists in src/test/resources
+        URL resource = AbsoluteFileSystemPathSqlLoadScriptTestCase.class.getResource("/import.sql");
+        try {
+            sqlLoadScriptAbsolutePath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.sql-load-script", sqlLoadScriptAbsolutePath)
+            .assertException(t -> assertThat(t)
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContainingAll("Unable to find file referenced in '"
+                            + "quarkus.hibernate-orm.sql-load-script=" + sqlLoadScriptAbsolutePath
+                            + "'. Remove property or add file to your path."));
+
+    @Test
+    public void testSqlLoadScriptFileAbsentTest() {
+        // deployment exception should happen first
+        Assertions.fail();
+    }
+}


### PR DESCRIPTION
Fixes #23574