### PR TITLE
Disable `MultiSourceProjectDevModeTest` on Java 18

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/MultiSourceProjectDevModeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 
+@org.junit.jupiter.api.Tag("failsOnJDK18")
 public class MultiSourceProjectDevModeTest extends QuarkusDevGradleTestBase {
 
     @Override


### PR DESCRIPTION
```
2022-02-14T02:15:30.2416958Z 2022-02-14 02:14:28,798 INFO  [io.qua.dep.dev.RuntimeUpdatesProcessor] (vert.x-worker-thread-0) Live reload total time: 0.671s 
2022-02-14T02:15:30.2417984Z Compilation failed. Unknown JVM target version: 18
2022-02-14T02:15:30.2418376Z Supported versions: 1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17
2022-02-14T02:15:30.2503738Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 108.077 s <<< FAILURE! - in io.quarkus.gradle.devmode.MultiSourceProjectDevModeTest
2022-02-14T02:15:30.2507332Z [ERROR] io.quarkus.gradle.devmode.MultiSourceProjectDevModeTest.main  Time elapsed: 108.071 s  <<< ERROR!
```

See also: #22742