### PR TITLE
Exclude some more JTA API variations

### DIFF
--- a/extensions/narayana-jta/runtime/pom.xml
+++ b/extensions/narayana-jta/runtime/pom.xml
@@ -72,10 +72,15 @@
                         <provides>io.quarkus.transactions</provides>
                     </capabilities>
                     <excludedArtifacts>
+                        <!-- Reference JTA API du jour is jakarta.transaction:jakarta.transaction-api: all other variants need to be exiled -->
                         <excludedArtifact>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</excludedArtifact>
                         <excludedArtifact>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</excludedArtifact>
                         <excludedArtifact>javax.transaction:jta</excludedArtifact>
                         <excludedArtifact>javax.transaction:javax.transaction-api</excludedArtifact>
+                        <excludedArtifact>org.apache.geronimo.specs:geronimo-jta_1.0.1B_spec</excludedArtifact>
+                        <excludedArtifact>org.apache.geronimo.specs:geronimo-jta_1.1_spec</excludedArtifact>
+                        <excludedArtifact>org.apache.geronimo.specs:geronimo-jta_1.2_spec</excludedArtifact>
+                        <excludedArtifact>org.glassfish.main.transaction:javax.transaction</excludedArtifact>
                     </excludedArtifacts>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fix #23660

Might need some care: Camel Quarkus was using Geronimo APIs in some dependencies; users currently need an explicit exclusion according to #23660 but it's possible it was a silent issue in other cases.

So let's not backport unless @ppalaga or team can check it out :)

