### PR TITLE
Bump Gson from 2.8.6 to 2.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -157,6 +157,7 @@ updates:
       # Others
       - dependency-name: com.puppycrawl.tools:checkstyle
       - dependency-name: com.google.cloud.functions:*
+      - dependency-name: com.google.code.gson:gson
       - dependency-name: com.google.errorprone:*
       - dependency-name: com.google.http-client:*
       - dependency-name: io.dekorate:servicebinding-annotations

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -182,7 +182,7 @@
         <picocli.version>4.6.3</picocli.version>
         <google-cloud-functions.version>1.0.4</google-cloud-functions.version>
         <commons-compress.version>1.21</commons-compress.version>
-        <gson.version>2.8.6</gson.version>
+        <gson.version>2.9.0</gson.version>
         <log4j2-jboss-logmanager.version>1.1.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.17.1</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.0.Final</log4j-jboss-logmanager.version>


### PR DESCRIPTION
Upgrade due to CVE WS-2021-0419 (see also https://github.com/protocolbuffers/protobuf/issues/9457 and https://github.com/google/gson/pull/1991).