### PR TITLE
Bump microprofile-metrics to 3.0.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -31,7 +31,7 @@
         <micrometer.version>1.8.2</micrometer.version>
         <google-auth.version>0.22.0</google-auth.version>
         <microprofile-config-api.version>2.0</microprofile-config-api.version>
-        <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
+        <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
         <microprofile-context-propagation.version>1.2</microprofile-context-propagation.version>
         <microprofile-opentracing-api.version>2.0</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>

--- a/tcks/microprofile-metrics/pom.xml
+++ b/tcks/microprofile-metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <microprofile-metrics-tck.version>3.0</microprofile-metrics-tck.version>
+        <microprofile-metrics-tck.version>3.0.1</microprofile-metrics-tck.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
replaces https://github.com/quarkusio/quarkus/pull/23689 