### PR TITLE
Guard against RouteBuildItem$Builder.routeFunction not being set

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -171,6 +171,10 @@ public final class RouteBuildItem extends MultiBuildItem {
         }
 
         public RouteBuildItem build() {
+            if (routeFunction == null) {
+                throw new IllegalStateException(
+                        "'RouteBuildItem$Builder.routeFunction' was not set. Ensure that one of the builder methods that result in it being set is called");
+            }
             return new RouteBuildItem(this, RouteType.APPLICATION_ROUTE);
         }
 


### PR DESCRIPTION
If this field is not set (for example by calling the 'route' method),
then the build proceeds but a NPE is thrown at application boot time
that provides no information about what is going on.