### PR TITLE
Fix setting of JAEGER_SAMPLER_MANAGER_HOST_PORT system property

### DIFF
--- a/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/SamplerManagerConfigurationTest.java
+++ b/extensions/jaeger/deployment/src/test/java/io/quarkus/jaeger/test/SamplerManagerConfigurationTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.jaeger.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.jaegertracing.Configuration.SamplerConfiguration;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests verifying configuration of a remote sampler manager.
+ *
+ */
+public class SamplerManagerConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest().withEmptyApplication()
+            .overrideConfigKey("quarkus.jaeger.service-name", "my-service")
+            .overrideConfigKey("quarkus.jaeger.sampler-manager-host-port", "my-jaeger-host:5778");
+
+    /**
+     * Verifies that the {@code JAEGER_SAMPLER_MANAGER_HOST_PORT} system property is set to the
+     * host name and port specified in the {@code quarkus.jaeger.sampler-manager-host-port} property.
+     */
+    @Test
+    void testSamplerManagerHostIsSetCorrectly() {
+        SamplerConfiguration config = SamplerConfiguration.fromEnv();
+        assertEquals("my-jaeger-host:5778", config.getManagerHostPort());
+    }
+}

--- a/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
+++ b/extensions/jaeger/runtime/src/main/java/io/quarkus/jaeger/runtime/JaegerDeploymentRecorder.java
@@ -16,7 +16,7 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class JaegerDeploymentRecorder {
     private static final Logger log = Logger.getLogger(JaegerDeploymentRecorder.class);
-    private static final Optional UNKNOWN_SERVICE_NAME = Optional.of("quarkus/unknown");
+    private static final Optional<String> UNKNOWN_SERVICE_NAME = Optional.of("quarkus/unknown");
     private static final QuarkusJaegerTracer quarkusTracer = new QuarkusJaegerTracer();
 
     public static String jaegerVersion;
@@ -81,7 +81,8 @@ public class JaegerDeploymentRecorder {
                 duration -> String.valueOf(duration.toMillis()));
         initTracerProperty("JAEGER_SAMPLER_TYPE", jaeger.samplerType, type -> type);
         initTracerProperty("JAEGER_SAMPLER_PARAM", jaeger.samplerParam, param -> NumberFormat.getInstance().format(param));
-        initTracerProperty("JAEGER_SAMPLER_MANAGER_HOST_PORT", jaeger.samplerManagerHostPort, hostPort -> hostPort.toString());
+        initTracerProperty("JAEGER_SAMPLER_MANAGER_HOST_PORT", jaeger.samplerManagerHostPort,
+                hostPort -> String.format("%s:%d", hostPort.getHostString(), hostPort.getPort()));
         initTracerProperty("JAEGER_SERVICE_NAME", jaeger.serviceName, name -> name);
         initTracerProperty("JAEGER_TAGS", jaeger.tags, tags -> tags.toString());
         initTracerProperty("JAEGER_PROPAGATION", jaeger.propagation, format -> format.toString());


### PR DESCRIPTION
Originally, the property had been set to the value returned by
InetAddress.toString(), which always includes the resolved IP address
(or the string "unresolved") in addition to the original host name.
For example, setting "quarkus.jaeger.sampler-manager-host-port" to
"my-jaeger-host:5778" would result in a system property value of
"my-jaeger-host/<unresolved>:5778" which cannot be used by the Jaeger
client to retrieve the sampler strategies.

The property isno set to the original host string + ":" + port instead.

Fixes #23711

Signed-off-by: Kai Hudalla <sophokles.kh@gmail.com>