### PR TITLE
Implement Context Poisoning for Vert.x contexts, and related validations in Hibernate Reactive

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/ContextFruitResource.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/ContextFruitResource.java
@@ -1,0 +1,38 @@
+package io.quarkus.hibernate.reactive.context;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.mutiny.Uni;
+
+@Path("contextTest")
+@ApplicationScoped
+@Produces("application/json")
+@Consumes("application/json")
+public class ContextFruitResource {
+
+    @Inject
+    Mutiny.SessionFactory sf;
+
+    @GET
+    @Path("valid")
+    public Uni<Fruit> get() {
+        return sf.withTransaction((s, t) -> s.find(Fruit.class, 1));
+    }
+
+    @GET
+    @Path("invalid")
+    public Uni<Fruit> getSingle(@RestPath Integer id) {
+        VertxContextSafetyToggle.setCurrentContextSafe(false);
+        return get();
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/ContextValidationTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/ContextValidationTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.reactive.context;
+
+import static io.restassured.RestAssured.given;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+/**
+ * Checks that Hibernate Reactive will refuse to store a contextual Session into
+ * a Vert.x session which has been explicitly disabled by using
+ * {@link io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle#setCurrentContextSafe(boolean)}.
+ */
+public class ContextValidationTest {
+
+    @RegisterExtension
+    static QuarkusDevModeTest runner = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Fruit.class, ContextFruitResource.class).addAsResource("application.properties")
+                    .addAsResource(new StringAsset("INSERT INTO context_fruits(id, name) VALUES (1, 'Mango');\n"),
+                            "import.sql"));
+
+    @Test
+    public void testListAllFruits() {
+        //This should work fine:
+        given()
+                .when()
+                .get("/contextTest/valid")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .extract().response();
+
+        //This should throw an exception (status code 500):
+        given()
+                .when()
+                .get("/contextTest/invalid")
+                .then()
+                .statusCode(500)
+                .contentType("application/json")
+                .extract().response();
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/Fruit.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/context/Fruit.java
@@ -1,0 +1,13 @@
+package io.quarkus.hibernate.reactive.context;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "context_fruits")
+public class Fruit {
+
+    @Id
+    Integer id;
+    String name;
+
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/boot/registry/PreconfiguredReactiveServiceRegistryBuilder.java
@@ -20,7 +20,6 @@ import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
-import org.hibernate.reactive.context.impl.VertxContextInitiator;
 import org.hibernate.reactive.id.impl.ReactiveIdentifierGeneratorFactoryInitiator;
 import org.hibernate.reactive.provider.service.NoJtaPlatformInitiator;
 import org.hibernate.reactive.provider.service.ReactiveMarkerServiceInitiator;
@@ -43,6 +42,7 @@ import io.quarkus.hibernate.orm.runtime.service.DisabledJMXInitiator;
 import io.quarkus.hibernate.orm.runtime.service.FlatClassLoaderService;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusImportSqlCommandExtractorInitiator;
 import io.quarkus.hibernate.orm.runtime.service.QuarkusRegionFactoryInitiator;
+import io.quarkus.hibernate.reactive.runtime.customized.CheckingVertxContextInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcConnectionProviderInitiator;
 import io.quarkus.hibernate.reactive.runtime.customized.QuarkusNoJdbcEnvironmentInitiator;
 
@@ -138,7 +138,9 @@ public class PreconfiguredReactiveServiceRegistryBuilder {
 
         // Definitely exclusive to Hibernate Reactive, as it marks the registry as Reactive:
         serviceInitiators.add(ReactiveMarkerServiceInitiator.INSTANCE);
-        serviceInitiators.add(VertxContextInitiator.INSTANCE);
+
+        // Custom to Quarkus: Hibernate Reactive upstream would use org.hibernate.reactive.context.impl.VertxContextInitiator
+        serviceInitiators.add(CheckingVertxContextInitiator.INSTANCE);
 
         //Custom for Hibernate Reactive:
         serviceInitiators.add(ReactiveSessionFactoryBuilderInitiator.INSTANCE);

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContext.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContext.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import org.hibernate.reactive.context.impl.VertxContext;
+
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+
+/**
+ * The {@link VertxContext} in Hibernate Reactive is accessing the
+ * Vert.x context directly, assuming this is the correct context as
+ * intended by the developer, as Hibernate Reactive has no opinion in
+ * regards to how Vert.x is integrated with other components.
+ * The precise definition of "correct context" will most likely depend
+ * on the runtime model and how other components are integrated with Vert.x;
+ * in particular the lifecycle of the context needs to be specified.
+ * For example in Quarkus's RestEasy Reactive we ensure that each request
+ * will run on a separate context; this ensures operations relating to
+ * different web requests are isolated among each other.
+ * To ensure that Quarkus users are using Hibernate Reactive on a context
+ * which is compatible with its expectations, this alternative implementation
+ * of {@link VertxContext} actually checks on each context access if it's safe
+ * to use by invoking {@link VertxContextSafetyToggle#validateContextIfExists(String, String)}.
+ *
+ * @see VertxContextSafetyToggle
+ */
+public final class CheckingVertxContext extends VertxContext {
+
+    private static final String ERROR_MSG_ON_PROHIBITED_CONTEXT;
+    private static final String ERROR_MSG_ON_UNKNOWN_CONTEXT;
+
+    static {
+        final String sharedmsg = " You can still use Hibernate Reactive, you just need to avoid using the methods which implicitly require accessing the stateful context, such as MutinySessionFactory#withTransaction and #withSession.";
+        ERROR_MSG_ON_UNKNOWN_CONTEXT = "The current operation requires a safe (isolated) Vert.x sub-context, but the current context hasn't been flagged as such."
+                + sharedmsg;
+        ERROR_MSG_ON_PROHIBITED_CONTEXT = "The current Hibernate Reactive operation requires a safe (isolated) Vert.x sub-context, while the current context has been explicitly flagged as not compatible for this purpose."
+                + sharedmsg;
+    }
+
+    @Override
+    public <T> void put(Key<T> key, T instance) {
+        VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG_ON_PROHIBITED_CONTEXT, ERROR_MSG_ON_UNKNOWN_CONTEXT);
+        super.put(key, instance);
+    }
+
+    @Override
+    public <T> T get(Key<T> key) {
+        VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG_ON_PROHIBITED_CONTEXT, ERROR_MSG_ON_UNKNOWN_CONTEXT);
+        return super.get(key);
+    }
+
+    @Override
+    public void remove(Key<?> key) {
+        VertxContextSafetyToggle.validateContextIfExists(ERROR_MSG_ON_PROHIBITED_CONTEXT, ERROR_MSG_ON_UNKNOWN_CONTEXT);
+        super.remove(key);
+    }
+
+}

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContextInitiator.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/customized/CheckingVertxContextInitiator.java
@@ -1,0 +1,27 @@
+package io.quarkus.hibernate.reactive.runtime.customized;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.reactive.context.Context;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * Custom Quarkus initiator for the {@link Context} service; this
+ * one creates instances of {@link CheckingVertxContext}.
+ */
+public class CheckingVertxContextInitiator implements StandardServiceInitiator<Context> {
+
+    public static final CheckingVertxContextInitiator INSTANCE = new CheckingVertxContextInitiator();
+
+    @Override
+    public Context initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+        return new CheckingVertxContext();
+    }
+
+    @Override
+    public Class<Context> getServiceInitiated() {
+        return Context.class;
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -12,6 +12,7 @@ import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 import io.quarkus.arc.Arc;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.ext.web.RoutingContext;
 
@@ -26,6 +27,7 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
             CurrentIdentityAssociation currentIdentityAssociation) {
         super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
         this.association = currentIdentityAssociation;
+        VertxContextSafetyToggle.setCurrentContextSafe(true);
     }
 
     protected void handleRequestScopeActivation() {

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/context/VertxContextSafetyToggle.java
@@ -1,0 +1,96 @@
+package io.quarkus.vertx.core.runtime.context;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * This is meant for other extensions to integrate with, to help
+ * identify which {@link Context}s are isolated and guaranteeing
+ * access by a unique thread or event chain; for example it's
+ * used by Hibernate Reactive to check if the current context is safe
+ * for it to store the currently opened session, to protect users
+ * from mistakenly interleaving multiple reactive operations which
+ * could unintentionally share the same session.
+ * Vert.x web will create a new context for each http web
+ * request; Quarkus RestEasy Reactive will mark such contexts as
+ * safe. Other extensions should follow a similar pattern when they
+ * are setting up a new context which is safe to be used for the purposes
+ * of a local context guaranteeing sequential use, non concurrent access
+ * and scoped to the current reactive chain as a convenience to not
+ * have to pass a "context" object along explicitly.
+ * In other cases it might be useful to explicitly mark the current
+ * context as not safe instead; for example if an existing context needs
+ * to be shared across multiple workers to process some operations
+ * in parallel: by marking and un-marking appropriately the same
+ * context can have spans in which it's safe, followed by spans
+ * in which it's not safe.
+ * Normally we would expect the user to know and follow the caveats
+ * expressed in the documentation of each project, but this additional
+ * facility helps to catch errors.
+ * The current context can be explicitly marked as safe, or it can
+ * be explicitly marked as unsafe; there's a third state which is
+ * the default of any new context: unmarked.
+ * At this time the default is to consider a {@link Context} to be safe
+ * unless the system property {@link #RESTRICT_BY_DEFAULT_PROPERTY} is
+ * set to "true"; this is useful to allow gradually expanding the checks
+ * and it's likely that we might flip this default in the future,
+ * or even remove the system property eventually.
+ */
+public final class VertxContextSafetyToggle {
+
+    private static final Object ACCESS_TOGGLE_KEY = new Object();
+    public static final String RESTRICT_BY_DEFAULT_PROPERTY = "io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.RESTRICT_BY_DEFAULT";
+    private static final boolean RESTRICT_BY_DEFAULT = Boolean.getBoolean(RESTRICT_BY_DEFAULT_PROPERTY);
+
+    /**
+     * Verifies if the current Vert.x context was flagged as safe
+     * to be accessed by components which expect non-concurrent
+     * access to the current context, and its state isolated to the
+     * current stream.
+     * For example, it checks if it's suitable to store a Session
+     * for Hibernate Reactive.
+     *
+     * @param errorMessageOnVeto the message to use for an {@link IllegalStateException}, should the context be
+     *        explicitly marked as unsafe.
+     * @param errorMessageOnDoubt the message to use for an {@link IllegalStateException}, in case the current
+     *        context has no markers and flag RESTRICT_BY_DEFAULT has been set.
+     * @throws IllegalStateException if the context exists and it failed to be validated
+     */
+    public static void validateContextIfExists(final String errorMessageOnVeto, final String errorMessageOnDoubt) {
+        final io.vertx.core.Context context = Vertx.currentContext();
+        if (context != null) {
+            checkIsSafe(context, errorMessageOnVeto, errorMessageOnDoubt);
+        }
+    }
+
+    private static void checkIsSafe(final Context context, final String errorMessageOnVeto, final String errorMessageOnDoubt) {
+        final Object safeFlag = context.getLocal(ACCESS_TOGGLE_KEY);
+        if (safeFlag == Boolean.TRUE) {
+            return;
+        } else if (safeFlag == null && !RESTRICT_BY_DEFAULT) {
+            //flag was not set, and we're instructed to consider the undefined safeFlag as safe
+            return;
+        } else {
+            if (safeFlag == null) {
+                throw new IllegalStateException(errorMessageOnDoubt);
+            } else {
+                throw new IllegalStateException(errorMessageOnVeto);
+            }
+        }
+    }
+
+    /**
+     * @param safe set to {@code true} to explicitly mark the current context as safe, or {@code false} to explicitly mark it as
+     *        unsafe.
+     * @throws IllegalStateException if there is no current context!
+     */
+    public static void setCurrentContextSafe(boolean safe) {
+        final io.vertx.core.Context context = Vertx.currentContext();
+        if (context == null) {
+            throw new IllegalStateException("Can't set the context safety flag: no Vert.x context found");
+        } else {
+            context.putLocal(ACCESS_TOGGLE_KEY, Boolean.valueOf(safe));
+        }
+    }
+
+}


### PR DESCRIPTION
I'd suggest to reviewers to look at it in commit order.

N.B. by default at this stage we'll assume all unmarked contexts are "ok to be used" by Hibernate Reactive.

This should really be changed, but I'd prefer these APIs to be integrated already so that people can start marking each context suitably before we need to enforce such checks.