### PR TITLE
Document toggle for disabling K8s version label generation

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -241,6 +241,16 @@ The labels in generated resources will look like:
   }
 ----
 
+[NOTE]
+====
+You can also remove the `app.kubernetes.io/version` label by applying the following configuration:
+
+[source,properties]
+----
+quarkus.kubernetes.add-version-to-label-selectors=false
+----
+====
+
 ==== Custom Labels
 
 To add additional custom labels, for example `foo=bar` just apply the following configuration:


### PR DESCRIPTION
Document configuration property for disabling K8s version label generation (selector), as discussed in [this Zulip topic](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Documentation.20for.20K8s.20extension.20config.20addVersionToLabelS.2E.2E.2E/near/271801408).

FYI @geoand 