### PR TITLE
Qute loop - treat null as no-op, as it is handled by SingleResultNode

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -391,7 +391,7 @@ NOTE: The current context can be accessed via the implicit binding `this`.
 
 |orEmpty
 |Outputs an empty list if the previous part cannot be resolved or resolves to `null`.
-|`{#for pet in pets.orEmpty}{pet.name}{/for}`
+|`{pets.orEmpty.size}` outputs `0` if `pets` is not resolvable or `null`
 
 |Ternary Operator
 |Shorthand for if-then-else statement. Unlike in <<if_section>> nested operators are not supported.
@@ -597,8 +597,10 @@ A section helper that defines the logic of a section can "execute" any of the bl
 ==== Loop Section
 
 The loop section makes it possible to iterate over an instance of `Iterable`, `Iterator`, array, `Map` (element is a `Map.Entry`), `Stream`, `Integer` and `int` (primitive value).
-It has two flavors.
-The first one is using the `each` name and `it` is an implicit alias for the iteration element.
+A `null` parameter value results in a no-op.
+
+This section has two flavors.
+The first one is using the name `each` and `it` is an implicit alias for the iteration element.
 
 [source]
 ----
@@ -608,7 +610,7 @@ The first one is using the `each` name and `it` is an implicit alias for the ite
 ----
 <1> `name` is resolved against the current iteration element.
 
-The other form is using the `for` name and can specify the alias used to reference the iteration element:
+The other form is using the name `for` and specifies the alias used to reference the iteration element:
 
 [source]
 ----

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/LoopSectionHelper.java
@@ -41,9 +41,8 @@ public class LoopSectionHelper implements SectionHelper {
     public CompletionStage<ResultNode> resolve(SectionResolutionContext context) {
         return context.resolutionContext().evaluate(iterable).thenCompose(it -> {
             if (it == null) {
-                throw new TemplateException(String.format(
-                        "Iteration error in template [%s] on line %s: {%s} resolved to null, use {%<s.orEmpty} to ignore this error",
-                        iterable.getOrigin().getTemplateId(), iterable.getOrigin().getLine(), iterable.toOriginalString()));
+                // Treat null as no-op, as it is handled by SingleResultNode
+                return ResultNode.NOOP;
             }
             // Try to extract the capacity for collections, maps and arrays to avoid resize
             List<CompletionStage<ResultNode>> results = new ArrayList<>(extractSize(it));
@@ -64,7 +63,6 @@ public class LoopSectionHelper implements SectionHelper {
             if (results.size() == 1) {
                 return results.get(0);
             }
-
             return Results.process(results);
         });
     }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/LoopSectionTest.java
@@ -127,9 +127,8 @@ public class LoopSectionTest {
     @Test
     public void testNull() {
         Engine engine = Engine.builder().addDefaults().build();
-        assertThatExceptionOfType(TemplateException.class)
-                .isThrownBy(() -> engine.parse("{#for i in items}{i}:{/for}").data("items", null).render())
-                .withMessageContaining("{items} resolved to null, use {items.orEmpty} to ignore this error");
+        assertEquals("", engine.parse("{#for i in items}{i}:{/for}").data("items", null).render());
+        assertEquals("", engine.parse("{#each foo.bar.baz??}{i}:{/each}").render());
     }
 
     @Test


### PR DESCRIPTION
This is a breaking change in a sense that previously a `null` parameter resulted in a `TemplateException` at runtime. I believe that the new behavior is more practical and also more consistent with how a `null` is handled by an output expression, e.g. `{foo.bar}` is a no-op if bar is resolved to `null`.