### PR TITLE
Support OIDC form_post response mode

### DIFF
--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -41,6 +41,7 @@ public final class OidcConstants {
 
     public static final String AUTHORIZATION_CODE = "authorization_code";
     public static final String CODE_FLOW_RESPONSE_TYPE = "response_type";
+    public static final String CODE_FLOW_RESPONSE_MODE = "response_mode";
     public static final String CODE_FLOW_CODE = "code";
     public static final String CODE_FLOW_ERROR = "error";
     public static final String CODE_FLOW_ERROR_DESCRIPTION = "error_description";

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -463,6 +463,29 @@ public class OidcTenantConfig extends OidcCommonConfig {
      */
     @ConfigGroup
     public static class Authentication {
+
+        /**
+         * Authorization code flow response mode
+         */
+        public enum ResponseMode {
+            /**
+             * Authorization response parameters are encoded in the query string added to the redirect_uri
+             */
+            QUERY,
+
+            /**
+             * Authorization response parameters are encoded as HTML form values that are auto-submitted in the browser
+             * and transmitted via the HTTP POST method using the application/x-www-form-urlencoded content type
+             */
+            FORM_POST
+        }
+
+        /**
+         * Authorization code flow response mode
+         */
+        @ConfigItem(defaultValueDocumentation = "query")
+        public Optional<ResponseMode> responseMode = Optional.empty();
+
         /**
          * Relative path for calculating a "redirect_uri" query parameter.
          * It has to start from a forward slash and will be appended to the request URI's host and port.
@@ -783,6 +806,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setCookieSuffix(String cookieSuffix) {
             this.cookieSuffix = Optional.of(cookieSuffix);
+        }
+
+        public Optional<ResponseMode> getResponseMode() {
+            return responseMode;
+        }
+
+        public void setResponseMode(ResponseMode responseMode) {
+            this.responseMode = Optional.of(responseMode);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -359,6 +359,9 @@ public final class OidcUtils {
         if (tenant.authentication.forceRedirectHttpsScheme.isEmpty()) {
             tenant.authentication.forceRedirectHttpsScheme = provider.authentication.forceRedirectHttpsScheme;
         }
+        if (tenant.authentication.responseMode.isEmpty()) {
+            tenant.authentication.responseMode = provider.authentication.responseMode;
+        }
 
         // credentials
         if (tenant.credentials.clientSecret.method.isEmpty()) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -3,6 +3,7 @@ package io.quarkus.oidc.runtime.providers;
 import java.util.List;
 
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.OidcTenantConfig.Authentication.ResponseMode;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret.Method;
 import io.smallrye.jwt.algorithm.SignatureAlgorithm;
 
@@ -73,6 +74,7 @@ public class KnownOidcProviders {
         ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
         ret.getAuthentication().setScopes(List.of("openid", "email", "name"));
         ret.getAuthentication().setForceRedirectHttpsScheme(true);
+        ret.getAuthentication().setResponseMode(ResponseMode.FORM_POST);
         ret.getCredentials().getClientSecret().setMethod(Method.POST_JWT);
         ret.getCredentials().getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
         ret.getCredentials().getJwt().setAudience("https://appleid.apple.com/");

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.oidc.OIDCException;
 import io.quarkus.oidc.OidcTenantConfig;
 import io.quarkus.oidc.OidcTenantConfig.ApplicationType;
+import io.quarkus.oidc.OidcTenantConfig.Authentication.ResponseMode;
 import io.quarkus.oidc.OidcTenantConfig.Provider;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig.Credentials.Secret.Method;
 import io.quarkus.oidc.runtime.providers.KnownOidcProviders;
@@ -202,6 +203,7 @@ public class OidcUtilsTest {
         assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
         assertEquals("https://appleid.apple.com/", config.getAuthServerUrl().get());
         assertEquals(List.of("openid", "email", "name"), config.authentication.scopes.get());
+        assertEquals(ResponseMode.FORM_POST, config.authentication.responseMode.get());
         assertEquals(Method.POST_JWT, config.credentials.clientSecret.method.get());
         assertEquals("https://appleid.apple.com/", config.credentials.jwt.audience.get());
         assertEquals(SignatureAlgorithm.ES256.getAlgorithm(), config.credentials.jwt.signatureAlgorithm.get());
@@ -216,7 +218,7 @@ public class OidcUtilsTest {
         tenant.setApplicationType(ApplicationType.HYBRID);
         tenant.setAuthServerUrl("http://localhost/wiremock");
         tenant.authentication.setScopes(List.of("write"));
-
+        tenant.authentication.setResponseMode(ResponseMode.QUERY);
         tenant.credentials.clientSecret.setMethod(Method.POST);
         tenant.credentials.jwt.setAudience("http://localhost/audience");
         tenant.credentials.jwt.setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
@@ -227,7 +229,7 @@ public class OidcUtilsTest {
         assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
         assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
         assertEquals(List.of("write"), config.authentication.scopes.get());
-
+        assertEquals(ResponseMode.QUERY, config.authentication.responseMode.get());
         assertEquals(Method.POST, config.credentials.clientSecret.method.get());
         assertEquals("http://localhost/audience", config.credentials.jwt.audience.get());
         assertEquals(SignatureAlgorithm.ES256.getAlgorithm(), config.credentials.jwt.signatureAlgorithm.get());

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowFormPostResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowFormPostResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/code-flow-form-post")
+public class CodeFlowFormPostResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Authenticated
+    public String access() {
+        return identity.getPrincipal().getName();
+    }
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -17,6 +17,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow") || path.endsWith("code-flow/logout")) {
             return "code-flow";
         }
+        if (path.endsWith("code-flow-form-post")) {
+            return "code-flow-form-post";
+        }
         if (path.endsWith("code-flow-user-info-only")) {
             return "code-flow-user-info-only";
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -20,6 +20,19 @@ quarkus.oidc.code-flow.logout.extra-params.client_id=${quarkus.oidc.code-flow.cl
 quarkus.oidc.code-flow.credentials.secret=secret
 quarkus.oidc.code-flow.application-type=web-app
 
+quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url}/realms/quarkus-form-post/
+quarkus.oidc.code-flow-form-post.client-id=quarkus-web-app
+quarkus.oidc.code-flow-form-post.credentials.secret=secret
+quarkus.oidc.code-flow-form-post.application-type=web-app
+quarkus.oidc.code-flow-form-post.authentication.response-mode=form_post
+quarkus.oidc.code-flow-form-post.discovery-enabled=false
+# redirect the user to ${keycloak.url}/realms/quarkus-form-post/ which will respond with form post data
+quarkus.oidc.code-flow-form-post.authorization-path=/
+# reuse the wiremock access token stub for the `quarkus` realm - it is the same for the query and form post response mode
+quarkus.oidc.code-flow-form-post.token-path=${keycloak.url}/realms/quarkus/token
+# reuse the wiremock JWK endpoint stub for the `quarkus` realm - it is the same for the query and form post response mode
+quarkus.oidc.code-flow-form-post.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
+
 quarkus.oidc.code-flow-user-info-only.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-only.discovery-enabled=false
 quarkus.oidc.code-flow-user-info-only.authorization-path=/

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/CodeFlowAuthorizationTest.java
@@ -58,6 +58,25 @@ public class CodeFlowAuthorizationTest {
     }
 
     @Test
+    public void testCodeFlowFormPost() throws IOException {
+        defineCodeFlowLogoutStub();
+        try (final WebClient webClient = createWebClient()) {
+            webClient.getOptions().setRedirectEnabled(true);
+            HtmlPage page = webClient.getPage("http://localhost:8081/code-flow-form-post");
+
+            HtmlForm form = page.getFormByName("form");
+            form.getInputByName("username").type("alice");
+            form.getInputByName("password").type("alice");
+
+            page = form.getInputByValue("login").click();
+
+            assertEquals("alice", page.getBody().asText());
+            assertNotNull(getSessionCookie(webClient, "code-flow-form-post"));
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
     public void testCodeFlowUserInfo() throws IOException {
         defineCodeFlowAuthorizationOauth2TokenStub();
         doTestCodeFlowUserInfo("code-flow-user-info-only");

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -143,6 +143,26 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                         "</html> ")
                                 .withTransformers("response-template")));
 
+        // Login Page, form_post response mode
+        server.stubFor(
+                get(urlPathMatching("/auth/realms/quarkus-form-post[/]?"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "text/html")
+                                .withBody("<html>\n" +
+                                        "<body>\n" +
+                                        " <form action=\"/login-form-post\" name=\"form\">\n" +
+                                        "  <input type=\"text\" id=\"username\" name=\"username\"/>\n" +
+                                        "  <input type=\"password\" id=\"password\" name=\"password\"/>\n" +
+                                        "  <input type=\"hidden\" id=\"state\" name=\"state\" value=\"{{request.query.state}}\"/>\n"
+                                        +
+                                        "  <input type=\"hidden\" id=\"redirect_uri\" name=\"redirect_uri\" value=\"{{request.query.redirect_uri}}\"/>\n"
+                                        +
+                                        "  <input type=\"submit\" id=\"login\" value=\"login\"/>\n" +
+                                        "</form>\n" +
+                                        "</body>\n" +
+                                        "</html> ")
+                                .withTransformers("response-template")));
+
         // Login Request
         server.stubFor(
                 get(urlPathMatching("/login"))
@@ -150,6 +170,25 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                 .withHeader("Location",
                                         "{{request.query.redirect_uri}}?state={{request.query.state}}&code=58af24f2-9093-4674-a431-4a9d66be719c.50437113-cd78-48a2-838e-b936fe458c5d.0ac5df91-e044-4051-bd03-106a3a5fb9cc")
                                 .withStatus(302)
+                                .withTransformers("response-template")));
+
+        // Login Request, form_post response mode
+        server.stubFor(
+                get(urlPathMatching("/login-form-post"))
+                        .willReturn(aResponse()
+                                .withBody("<html>\n" +
+                                        "   <head><title>Submit This Form</title></head>\n" +
+                                        "   <body onload=\"javascript:document.forms[0].submit()\">\n" +
+                                        "    <form method=\"post\" action=\"{{request.query.redirect_uri}}\">\n" +
+                                        "      <input type=\"hidden\" name=\"state\"\n" +
+                                        "       value=\"{{request.query.state}}\"/>\n" +
+                                        "      <input type=\"hidden\" name=\"code\"\n" +
+                                        "       value=\"58af24f2-9093-4674-a431-4a9d66be719c.50437113-cd78-48a2-838e-b936fe458c5d.0ac5df91-e044-4051-bd03-106a3a5fb9cc\"/>\n"
+                                        +
+                                        "    </form>\n" +
+                                        "   </body>\n" +
+                                        "  </html>\n" +
+                                        "")
                                 .withTransformers("response-template")));
 
         LOG.infof("Keycloak started in mock mode: %s", server.baseUrl());


### PR DESCRIPTION
Fixes #22029 

This PR adds a support for https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html to support `Apple` and other providers which prefer to avoid routing the `code`/`state` via the browser redirect mechanism.

I had to copy Steph's code dealing with reading the form urlencoded data. This is a reactive code, so I had to do a bit of refactoring:
- the current code checking all related to the redirect from OIDC pre-conditioned on the presence of the state cookie has been encapsulated into a function which is called directly if it is not `form_post` or via `Uni` if it is a form_post.

Also now, instead of `quarkus.oidc.authentication.extra-params.response_mode=form_post` one can do a safe `quarkus.oidc.authentication.response-mode=form_post`. 

When the redirect from OIDC is processed, the form post will be processed only if it is POST, the correct content type and this property is set - it is needed to be set anyway to request it.

Test started passing once I saw how Steph did it; I had to tweak the wiremock test support a bit to decide how to process the authorization request - respond with the query or auto-submitted form data.

`apple` provider config has also been updated