### PR TITLE
Fix example for `GeneratedResourceBuildItem`

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -735,8 +735,8 @@ public void produceServiceFiles(
                     w.write(implName);
                     w.write(System.lineSeparator());
                 }
+                w.flush();
             }
-            w.flush();
             resourceProducer.produce(
                 new GeneratedResourceBuildItem(
                     "META-INF/services/" + serviceName,


### PR DESCRIPTION
The flush of the writer was out of scope.