### PR TITLE
Fix JSON Serialization for multipart data containing emoji

### DIFF
--- a/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
+++ b/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
@@ -55,7 +55,7 @@ public final class JacksonMessageBodyWriterUtil {
                     }
                 }
             }
-            entityStream.write(defaultWriter.writeValueAsBytes(o));
+            entityStream.write(defaultWriter.writeValueAsString(o).getBytes(StandardCharsets.UTF_8));
         }
     }
 


### PR DESCRIPTION
Reason for the change:
- While using `defaultWriter.writeValueAsBytes(o)` we convert our emoji to UTF-16 bytes that which cannot be converted to Unicode character again.
- Using `writeValueAsString(o)` allows us to not change the convert the string to bytes preserving our Unicode characters.

Fixes #23756 
