### PR TITLE
Fix typo in OpenshiftConfig

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -7,6 +7,8 @@ import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_CONFIG_GROUP
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_CONFIG_VERSION;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_GROUP;
 import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_VERSION;
+import static io.quarkus.kubernetes.deployment.Constants.OPENSHIFT;
+import static io.quarkus.kubernetes.deployment.Constants.S2I;
 import static io.quarkus.kubernetes.deployment.Constants.STATEFULSET;
 
 import java.util.List;
@@ -510,8 +512,8 @@ public class OpenshiftConfig implements PlatformConfiguration {
 
     public static boolean isOpenshiftBuildEnabled(ContainerImageConfig containerImageConfig, Capabilities capabilities) {
         boolean implictlyEnabled = ContainerImageCapabilitiesUtil.getActiveContainerImageCapability(capabilities)
-                .filter(c -> c.contains("openshift") || c.contains("s2i")).isPresent();
-        return containerImageConfig.builder.map(b -> b.equals("openshfit") || b.equals("s2i")).orElse(implictlyEnabled);
+                .filter(c -> c.contains(OPENSHIFT) || c.contains(S2I)).isPresent();
+        return containerImageConfig.builder.map(b -> b.equals(OPENSHIFT) || b.equals(S2I)).orElse(implictlyEnabled);
     }
 
     public DeploymentResourceKind getDeploymentResourceKind() {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
@@ -58,6 +58,20 @@ public class OpenshiftWithS2iTest {
                 });
 
         assertThat(openshiftList).filteredOn(h -> "BuildConfig".equals(h.getKind())).hasSize(1);
+        // Has output image stream
+        assertThat(openshiftList)
+                .filteredOn(h -> "ImageStream".equals(h.getKind()) && h.getMetadata().getName().equals("openshift-s2i"))
+                .hasSize(1);
+
+        // Has builder image stream 
+        assertThat(openshiftList)
+                .filteredOn(h -> "ImageStream".equals(h.getKind()) && !h.getMetadata().getName().equals("openshift-s2i"))
+                .singleElement().satisfies(r -> {
+                    assertThat(r).isInstanceOfSatisfying(ImageStream.class, i -> {
+                        assertThat(i.getSpec()).isNotNull();
+                        assertThat(i.getSpec().getDockerImageRepository()).isNotNull();
+                    });
+                });
 
         assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
             assertThat(h.getMetadata()).satisfies(m -> {


### PR DESCRIPTION
Resolves: #23788

It seems that a typo prevented it us to correctly handle the case where users explicitly specified: `quarkus.container-image.builder=openshift`.