### PR TITLE
Write SSE headers before subscribing

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/SseUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/SseUtil.java
@@ -151,8 +151,6 @@ public class SseUtil extends CommonSseUtil {
 
     public static void setHeaders(ResteasyReactiveRequestContext context, ServerHttpResponse response,
             List<PublisherResponseHandler.StreamingResponseCustomizer> customizers) {
-        // FIXME: spec says we should flush the headers when first message is sent or when the resource method returns, whichever
-        // happens first
         if (!response.headWritten()) {
             response.setStatusCode(Response.Status.OK.getStatusCode());
             response.setResponseHeader(HttpHeaders.CONTENT_TYPE, MediaType.SERVER_SENT_EVENTS);
@@ -164,6 +162,7 @@ public class SseUtil extends CommonSseUtil {
                 customizers.get(i).customize(response);
             }
             // FIXME: other headers?
+
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
@@ -11,7 +11,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 
 public class SseEventSinkImpl implements SseEventSink {
 
-    private static final byte[] EMPTY_BUFFER = new byte[0];
+    public static final byte[] EMPTY_BUFFER = new byte[0];
     private ResteasyReactiveRequestContext context;
     private SseBroadcasterImpl broadcaster;
     private boolean closed;


### PR DESCRIPTION
When using SSE send the headers (and flush them) as soon as we have the Publisher (so before subscription).

Fix #22762
