### PR TITLE
Set target dir in QuarkusUnitTest

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/PathTestHelper.java
@@ -258,4 +258,24 @@ public final class PathTestHelper {
     private static Path toPath(URL resource) {
         return ClassPathUtils.toLocalPath(resource);
     }
+
+    /**
+     * Returns the build directory of the project given its base dir and the test classes dir.
+     * 
+     * @param projectRoot project dir
+     * @param testClassLocation test dir
+     * 
+     * @return project build dir
+     */
+    public static Path getProjectBuildDir(Path projectRoot, Path testClassLocation) {
+        Path outputDir;
+        try {
+            // this should work for both maven and gradle
+            outputDir = projectRoot.resolve(projectRoot.relativize(testClassLocation).getName(0));
+        } catch (Exception e) {
+            // this shouldn't happen since testClassLocation is usually found under the project dir
+            outputDir = projectRoot;
+        }
+        return outputDir;
+    }
 }

--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusUnitTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -540,6 +541,8 @@ public class QuarkusUnitTest
                         .setMode(QuarkusBootstrap.Mode.TEST)
                         .addExcludedPath(testLocation)
                         .setProjectRoot(testLocation)
+                        .setTargetDirectory(
+                                PathTestHelper.getProjectBuildDir(Paths.get("").normalize().toAbsolutePath(), testLocation))
                         .setFlatClassPath(flatClassPath)
                         .setForcedDependencies(forcedDependencies);
                 for (JavaArchive dependency : additionalDependencies) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -104,14 +104,7 @@ public class AbstractJvmQuarkusTestExtension {
         }
 
         final Path projectRoot = Paths.get("").normalize().toAbsolutePath();
-        Path outputDir;
-        try {
-            // this should work for both maven and gradle
-            outputDir = projectRoot.resolve(projectRoot.relativize(testClassLocation).getName(0));
-        } catch (Exception e) {
-            // this shouldn't happen since testClassLocation is usually found under the project dir
-            outputDir = projectRoot;
-        }
+        final Path outputDir = PathTestHelper.getProjectBuildDir(projectRoot, testClassLocation);
 
         rootBuilder.add(appClassLocation);
         final Path appResourcesLocation = PathTestHelper.getResourcesForClassesDirOrNull(appClassLocation, "main");

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -220,15 +220,7 @@ public final class IntegrationTestUtil {
 
         final Path projectRoot = Paths.get("").normalize().toAbsolutePath();
         runnerBuilder.setProjectRoot(projectRoot);
-        Path outputDir;
-        try {
-            // this should work for both maven and gradle
-            outputDir = projectRoot.resolve(projectRoot.relativize(testClassLocation).getName(0));
-        } catch (Exception e) {
-            // this shouldn't happen since testClassLocation is usually found under the project dir
-            outputDir = projectRoot;
-        }
-        runnerBuilder.setTargetDirectory(outputDir);
+        runnerBuilder.setTargetDirectory(PathTestHelper.getProjectBuildDir(projectRoot, testClassLocation));
 
         rootBuilder.add(appClassLocation);
         final Path appResourcesLocation = PathTestHelper.getResourcesForClassesDirOrNull(appClassLocation, "main");


### PR DESCRIPTION
It looks the target dir is missing in QuarkusUnitTest.
This is related to https://github.com/quarkusio/quarkus/issues/23759 and https://github.com/quarkusio/quarkus/pull/23856