### PR TITLE
Forbid using '..' in paths passed to PathTree

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/ArchivePathTree.java
@@ -49,9 +49,13 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
         }
     }
 
+    private void ensureResourcePath(String path) {
+        DirectoryPathTree.ensureResourcePath(archive.getFileSystem(), path);
+    }
+
     @Override
     protected <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled) {
-        DirectoryPathTree.ensureRelativePath(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             return func.apply(null);
         }
@@ -74,7 +78,7 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     @Override
     public void accept(String relativePath, Consumer<PathVisit> consumer) {
-        DirectoryPathTree.ensureRelativePath(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             consumer.accept(null);
             return;
@@ -99,7 +103,7 @@ public class ArchivePathTree extends PathTreeWithManifest implements PathTree {
 
     @Override
     public boolean contains(String relativePath) {
-        DirectoryPathTree.ensureRelativePath(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             return false;
         }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/DirectoryPathTree.java
@@ -80,22 +80,21 @@ public class DirectoryPathTree extends PathTreeWithManifest implements OpenPathT
         PathTreeVisit.walk(dir, dir, pathFilter, getMultiReleaseMapping(), visitor);
     }
 
-    private String normalize(String path) {
+    private void ensureResourcePath(String path) {
         ensureRelativePath(path);
         // this is to disallow reading outside the path tree root
         if (path != null && path.contains("..")) {
-            final Path absolutePath = dir.resolve(path).normalize().toAbsolutePath();
-            if (absolutePath.startsWith(dir)) {
-                return dir.relativize(absolutePath).toString();
+            for (Path pathElement : dir.getFileSystem().getPath(path)) {
+                if (pathElement.toString().equals("..")) {
+                    throw new IllegalArgumentException("'..' cannot be used in resource paths, but got " + path);
+                }
             }
-            return null;
         }
-        return path;
     }
 
     @Override
     protected <T> T apply(String relativePath, Function<PathVisit, T> func, boolean manifestEnabled) {
-        relativePath = normalize(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             return func.apply(null);
         }
@@ -108,7 +107,7 @@ public class DirectoryPathTree extends PathTreeWithManifest implements OpenPathT
 
     @Override
     public void accept(String relativePath, Consumer<PathVisit> consumer) {
-        relativePath = normalize(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             consumer.accept(null);
             return;
@@ -123,7 +122,7 @@ public class DirectoryPathTree extends PathTreeWithManifest implements OpenPathT
 
     @Override
     public boolean contains(String relativePath) {
-        relativePath = normalize(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             return false;
         }
@@ -133,7 +132,7 @@ public class DirectoryPathTree extends PathTreeWithManifest implements OpenPathT
 
     @Override
     public Path getPath(String relativePath) {
-        relativePath = normalize(relativePath);
+        ensureResourcePath(relativePath);
         if (!PathFilter.isVisible(pathFilter, relativePath)) {
             return null;
         }

--- a/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/DirectoryPathTreeTest.java
+++ b/independent-projects/bootstrap/app-model/src/test/java/io/quarkus/paths/DirectoryPathTreeTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -89,26 +90,39 @@ public class DirectoryPathTreeTest {
     public void acceptExistingRelativeNonNormalizedPath() throws Exception {
         final Path root = resolveTreeRoot("root");
         final PathTree tree = PathTree.ofDirectoryOrArchive(root);
-        tree.accept("../root/./other/../README.md", visit -> {
-            assertThat(visit).isNotNull();
-            assertThat(visit.getRelativePath("/")).isEqualTo("README.md");
-            assertThat(visit.getPath()).exists();
-            assertThat(visit.getRoot()).isEqualTo(root);
-            try {
-                assertThat(Files.readString(visit.getPath())).isEqualTo("test readme");
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        });
+        assertThatThrownBy(() -> {
+            tree.accept("other/../README.md", visit -> {
+                fail("'..' should lead to an exception that prevents the visitor from being called");
+            });
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'..' cannot be used in resource paths");
     }
 
     @Test
-    public void acceptNonExistentRelativeNonNormalizedPath() throws Exception {
+    public void acceptExistingRelativeNonNormalizedPathOutsideTree() throws Exception {
         final Path root = resolveTreeRoot("root");
         final PathTree tree = PathTree.ofDirectoryOrArchive(root);
-        tree.accept("../root/./README.md/../non-existent.txt", visit -> {
-            assertThat(visit).isNull();
-        });
+        assertThatThrownBy(() -> {
+            tree.accept("../root/./other/../README.md", visit -> {
+                fail("'..' should lead to an exception that prevents the visitor from being called");
+            });
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'..' cannot be used in resource paths");
+    }
+
+    @Test
+    public void acceptNonExistentRelativeNonNormalizedPathOutsideTree() throws Exception {
+        final Path root = resolveTreeRoot("root");
+        final PathTree tree = PathTree.ofDirectoryOrArchive(root);
+        assertThatThrownBy(() -> {
+            tree.accept("../root/./README.md/../non-existent.txt", visit -> {
+                fail("'..' should lead to an exception that prevents the visitor from being called");
+            });
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'..' cannot be used in resource paths");
     }
 
     @Test


### PR DESCRIPTION
@aloubyansky as you requested [here](https://github.com/quarkusio/quarkus/pull/23692#discussion_r811669052).

If you meant to do this for `DirectoryPathTree` only, we can drop the second commit.