### PR TITLE
Add Dekorate helm annotations to the dependency management

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -2772,6 +2772,12 @@
                 <classifier>noapt</classifier>
             </dependency>
             <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>helm-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>${jboss-logging.version}</version>


### PR DESCRIPTION
This is a new feature introduced in Dekorate 2.9.0.