### PR TITLE
Hibernate Validator - Allow setting the expression language feature level

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ConstraintExpressionLanguageFeatureLevelTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ConstraintExpressionLanguageFeatureLevelTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.hibernate.validator.test;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+import javax.validation.Payload;
+import javax.validation.Validator;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConstraintExpressionLanguageFeatureLevelTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(BeanMethodsConstraint.class, BeanMethodsConstraintStringValidator.class, BeanMethodsBean.class)
+            .add(new StringAsset(
+                    "quarkus.hibernate-validator.expression-language.constraint-expression-feature-level=bean-methods"),
+                    "application.properties"));
+
+    @Inject
+    Validator validator;
+
+    @Test
+    public void testConstraintExpressionFeatureLevel() {
+        Set<ConstraintViolation<BeanMethodsBean>> violations = validator.validate(new BeanMethodsBean());
+        assertEquals("Method execution: a", violations.iterator().next().getMessage());
+    }
+
+    @Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+    @Retention(RUNTIME)
+    @Documented
+    @Constraint(validatedBy = { BeanMethodsConstraintStringValidator.class })
+    private @interface BeanMethodsConstraint {
+        String message() default "Method execution: ${'aaaa'.substring(0, 1)}";
+
+        Class<?>[] groups() default {};
+
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    public static class BeanMethodsConstraintStringValidator implements ConstraintValidator<BeanMethodsConstraint, String> {
+
+        @Override
+        public boolean isValid(String value, ConstraintValidatorContext context) {
+            return false;
+        }
+    }
+
+    public static class BeanMethodsBean {
+
+        @BeanMethodsConstraint
+        public String value;
+    }
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorBuildTimeConfig.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorBuildTimeConfig.java
@@ -1,5 +1,9 @@
 package io.quarkus.hibernate.validator.runtime;
 
+import java.util.Optional;
+
+import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel;
+
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -21,6 +25,12 @@ public class HibernateValidatorBuildTimeConfig {
      */
     @ConfigDocSection
     public HibernateValidatorMethodBuildTimeConfig methodValidation;
+
+    /**
+     * Expression Language.
+     */
+    @ConfigDocSection
+    public HibernateValidatorExpressionLanguageBuildTimeConfig expressionLanguage;
 
     @ConfigGroup
     public static class HibernateValidatorMethodBuildTimeConfig {
@@ -71,5 +81,23 @@ public class HibernateValidatorBuildTimeConfig {
          */
         @ConfigItem(defaultValue = "false")
         public boolean allowMultipleCascadedValidationOnReturnValues;
+    }
+
+    @ConfigGroup
+    public static class HibernateValidatorExpressionLanguageBuildTimeConfig {
+
+        /**
+         * Configure the Expression Language feature level for constraints, allowing the selection of
+         * Expression Language features available for message interpolation.
+         * <p>
+         * This property only affects the EL feature level of "static" constraint violation messages set through the
+         * <code>message</code> attribute of constraint annotations.
+         * <p>
+         * In particular, it doesn't affect the default EL feature level for custom violations
+         * created programmatically in validator implementations.
+         * The feature level for those can only be configured directly in the validator implementation.
+         */
+        @ConfigItem(defaultValueDocumentation = "bean-properties")
+        public Optional<ExpressionLanguageFeatureLevel> constraintExpressionFeatureLevel;
     }
 }

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -68,6 +68,11 @@ public class HibernateValidatorRecorder {
                         .defaultLocale(localesBuildTimeConfig.defaultLocale)
                         .beanMetaDataClassNormalizer(new ArcProxyBeanMetaDataClassNormalizer());
 
+                if (hibernateValidatorBuildTimeConfig.expressionLanguage.constraintExpressionFeatureLevel.isPresent()) {
+                    configuration.constraintExpressionLanguageFeatureLevel(
+                            hibernateValidatorBuildTimeConfig.expressionLanguage.constraintExpressionFeatureLevel.get());
+                }
+
                 InstanceHandle<ConstraintValidatorFactory> configuredConstraintValidatorFactory = Arc.container()
                         .instance(ConstraintValidatorFactory.class);
                 if (configuredConstraintValidatorFactory.isAvailable()) {


### PR DESCRIPTION
I only exposed the constraint one and not the custom violation one as I
think it is bad practice to globally change the custom violation one.

Fix #23838