### PR TITLE
Use a copy of compile classpath for panache annotation processor lookup

### DIFF
--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ApplicationDeploymentClasspathBuilder.java
@@ -70,10 +70,12 @@ public class ApplicationDeploymentClasspathBuilder {
                         configContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
 
         // enable the Panache annotation processor on the classpath, if it's found among the dependencies
-        configContainer.getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME).getIncoming()
-                .beforeResolve(annotationProcessors -> {
-                    Set<ResolvedArtifact> compileClasspathArtifacts = configContainer
-                            .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getResolvedConfiguration()
+        configContainer.getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+                .withDependencies(annotationProcessors -> {
+                    Set<ResolvedArtifact> compileClasspathArtifacts = DependencyUtils
+                            .duplicateConfiguration(project, configContainer
+                                    .getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))
+                            .getResolvedConfiguration()
                             .getResolvedArtifacts();
                     for (ResolvedArtifact artifact : compileClasspathArtifacts) {
                         if ("quarkus-panache-common".equals(artifact.getName())


### PR DESCRIPTION
This change looks for panache dependency on a copy of the compile classpath instead of the real compile classpath.
 
In some case, the `annotationProcessor` configuration is configured to extend `compileOnly` configuration. When looking up for the `quarkus-panache-common` dependency, we resolve the `COMPILE_CLASSPATH` which then make it impossible to add a dependency to the `annotationProcessor` configuration as a part as already been resolved. 

close #23776 