### PR TITLE
Update SmallRye OpenAPI to 2.1.20

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -42,7 +42,7 @@
         <smallrye-config.version>2.9.0</smallrye-config.version>
         <smallrye-health.version>3.2.0</smallrye-health.version>
         <smallrye-metrics.version>3.0.4</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.17</smallrye-open-api.version>
+        <smallrye-open-api.version>2.1.20</smallrye-open-api.version>
         <smallrye-graphql.version>1.4.3</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.3.1</smallrye-fault-tolerance.version>


### PR DESCRIPTION
Because of https://github.com/smallrye/smallrye-open-api/pull/1070. To use an MP OpenAPI dependency which is not an RC.