### PR TITLE
Improving docs for `@QuarkusIntegrationTest`

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -155,7 +155,7 @@ If you want to hand code raw events for the AWS REST API, Quarkus has its own im
 and `io.quarkus.amazon.lambda.http.model.AwsProxyResponse`.  This corresponds
 to `quarkus-amazon-lambda-rest` extension and the AWS REST API.
 
-The mock event server is also started for `@NativeImageTest` unit tests so will work
+The mock event server is also started for `@NativeImageTest` and `@QuarkusIntegrationTest` tests so will work
 with native binaries too.  All this provides similar functionality to the SAM CLI local testing, without the overhead of Docker.
 
 Finally, if port 8080 or port 8081 is not available on your computer, you can modify the dev

--- a/docs/src/main/asciidoc/amazon-lambda.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda.adoc
@@ -347,7 +347,7 @@ public class LambdaHandlerTest {
 }
 ----
 
-The mock event server is also started for `@NativeImageTest` unit tests so will work
+The mock event server is also started for `@NativeImageTest` and `@QuarkusIntegrationTest` tests so will work
 with native binaries too.  All this provides similar functionality to the SAM CLI local testing, without the overhead of Docker.
 
 Finally, if port 8080 or port 8081 is not available on your computer, you can modify the dev

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -259,17 +259,17 @@ In the `pom.xml` file, the `native` profile contains:
 
 This instructs the failsafe-maven-plugin to run integration-test and indicates the location of the produced native executable.
 
-Then, open the `src/test/java/org/acme/quickstart/NativeGreetingResourceIT.java`. It contains:
+Then, open the `src/test/java/org/acme/quickstart/GreetingResourceIT.java`. It contains:
 
 [source,java]
 ----
 package org.acme.quickstart;
 
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest // <1>
-public class NativeGreetingResourceIT extends GreetingResourceTest { // <2>
+@QuarkusIntegrationTest // <1>
+public class GreetingResourceIT extends GreetingResourceTest { // <2>
 
     // Run the same tests
 
@@ -279,7 +279,7 @@ public class NativeGreetingResourceIT extends GreetingResourceTest { // <2>
 The executable is retrieved using the `native.image.path` system property configured in the _Failsafe Maven Plugin_.
 <2> We extend our previous tests, but you can also implement your tests
 
-To see the `NativeGreetingResourceIT` run against the native executable, use `./mvnw verify -Pnative`:
+To see the `GreetingResourceIT` run against the native executable, use `./mvnw verify -Pnative`:
 [source,shell]
 ----
 $ ./mvnw verify -Pnative
@@ -298,11 +298,11 @@ $ ./mvnw verify -Pnative
 [INFO] -------------------------------------------------------
 [INFO]  T E S T S
 [INFO] -------------------------------------------------------
-[INFO] Running org.acme.quickstart.NativeGreetingResourceIT
+[INFO] Running org.acme.quickstart.GreetingResourceIT
 Executing [/data/home/gsmet/git/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-runner, -Dquarkus.http.port=8081, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=build/quarkus.log]
 2019-04-15 11:33:20,348 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT started in 0.002s. Listening on: http://[::]:8081
 2019-04-15 11:33:20,348 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
-[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s - in org.acme.quickstart.NativeGreetingResourceIT
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s - in org.acme.quickstart.GreetingResourceIT
 ...
 ----
 
@@ -315,11 +315,11 @@ to 300 seconds, use: `./mvnw verify -Pnative -Dquarkus.test.wait-time=300`.
 
 [WARNING]
 ====
-In the future, `@NativeImageTest` will be deprecated in favor of `@QuarkusIntegrationTest` which provides a superset of the testing
+This procedure was formerly accomplished using the `@NativeImageTest` annotation. `@NativeImageTest` is considered deprecated in favor of `@QuarkusIntegrationTest` which provides a superset of the testing
 capabilities of `@NativeImageTest`. More information about `@QuarkusIntegrationTest` can be found in the xref:getting-started-testing.adoc#quarkus-integration-test[Testing Guide].
 ====
 
-By default, native tests runs using the `prod` profile.
+By default, integration tests runs using the `prod` profile.
 This can be overridden using the `quarkus.test.native-image-profile` property.
 For example, in your `application.properties` file, add: `quarkus.test.native-image-profile=test`.
 Alternatively, you can run your tests with: `./mvnw verify -Pnative -Dquarkus.test.native-image-profile=test`.

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1181,17 +1181,11 @@ be read until Quarkus has started, so the timeout for Quarkus start will be the 
 
 == Native Executable Testing
 
-It is also possible to test native executables using `@NativeImageTest`. This supports all the features mentioned in this
+It is also possible to test native executables using `@QuarkusIntegrationTest`. This supports all the features mentioned in this
 guide except injecting into tests (and the native executable runs in a separate non-JVM process this is not really possible).
 
 
 This is covered in the xref:building-native-image.adoc[Native Executable Guide].
-
-[WARNING]
-====
-Although `@NativeImageTest` is not yet deprecated, it will be in the future as its functionality is covered by `@QuarkusIntegrationTest`
-which is described in the following section.
-====
 
 [#quarkus-integration-test]
 == Using @QuarkusIntegrationTest

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -532,7 +532,7 @@ If you have not used <<project-creation,project scaffolding>>, add the following
 `maven.home` is only required if you have custom configuration in `${maven.home}/conf/settings.xml`.
 <5> Use a specific `native` profile for native executable building.
 <6> Enable the `native` package type. The build will therefore produce a native executable.
-<7> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` will be run against the native executable. See the xref:building-native-image.adoc[Native executable guide] for more info.
+<7> If you want to test your native executable with Integration Tests, add the following plugin configuration. Test names `*IT` and annotated `@NativeImageTest` or `@QuarkusIntegrationTest` will be run against the native executable. See the xref:building-native-image.adoc[Native executable guide] for more info.
 
 [[fast-jar]]
 === Using fast-jar

--- a/docs/src/main/asciidoc/security-testing.adoc
+++ b/docs/src/main/asciidoc/security-testing.adoc
@@ -86,7 +86,7 @@ See xref:security-openid-connect.adoc#integration-testing-security-annotation[Op
 
 [WARNING]
 ====
-The feature is only available for `@QuarkusTest` and will **not** work on a `@NativeImageTest`.
+The feature is only available for `@QuarkusTest` and will **not** work on a `@NativeImageTest` or `@QuarkusIntegrationTest`.
 ====
 
 === Mixing security tests


### PR DESCRIPTION
Improving docs now that code.quarkus.io will generate projects using `@QuarkusIntegrationTest` instead of `@NativeImageTest`.

This probably should have been part of #23488 but was missed.