### PR TITLE
Clarify error message when trying to retrieve SearchMapping/SearchSession while Hibernate Search is disabled

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/configuration/ConfigDisabledAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/elasticsearch/test/configuration/ConfigDisabledAndIndexedEntityTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.inject.Inject;
 
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.SearchException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -30,11 +32,23 @@ public class ConfigDisabledAndIndexedEntityTest {
     @Test
     public void testDisabled() {
         assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
-                .isInstanceOf(SearchException.class)
-                .hasMessageContaining("Hibernate Search was not initialized");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "Cannot retrieve the SearchMapping: Hibernate Search was disabled through configuration properties");
 
         assertThatThrownBy(() -> Search.mapping(sessionFactory))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContaining("Hibernate Search was not initialized");
+                .hasMessageContaining("Hibernate Search was not initialized.");
+
+        assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties");
+
+        try (Session session = sessionFactory.openSession()) {
+            assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))
+                    .isInstanceOf(SearchException.class)
+                    .hasMessageContaining("Hibernate Search was not initialized.");
+        }
     }
 }


### PR DESCRIPTION
This probably should **not** be backported, as it slightly changes the behavior when using `@Inject SearchSession`:

* Before this patch, the injection would work fine, but attempting to use the session would fail with an unclear message ("Hibernate Search was not initialized")
* After this patch, the injection will likely fail (so the bean with the injection point won't be instantiated), but with a somewhat clearer message ("Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties").