### PR TITLE
Use dev-services in tests and documentation of the Hibernate Search extension

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -536,9 +536,6 @@ Edit `src/main/resources/application.properties` and inject the following config
 quarkus.ssl.native=false <1>
 
 quarkus.datasource.db-kind=postgresql <2>
-quarkus.datasource.username=quarkus_test
-quarkus.datasource.password=quarkus_test
-quarkus.datasource.jdbc.url=jdbc:postgresql:quarkus_test
 
 quarkus.hibernate-orm.database.generation=drop-and-create <3>
 quarkus.hibernate-orm.sql-load-script=import.sql <4>
@@ -547,6 +544,11 @@ quarkus.hibernate-search-orm.elasticsearch.version=7 <5>
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:myAnalysisConfigurer <6>
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8>
+
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test <9>
+%prod.quarkus.datasource.username=quarkus_test
+%prod.quarkus.datasource.password=quarkus_test
+%prod.hibernate-search-orm.elasticsearch.hosts=localhost:9200 <9>
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
 <2> Let's create a PostgreSQL datasource.
@@ -561,6 +563,11 @@ Note that, for OpenSearch, you need to prefix the version with `opensearch:`; se
 <8> This means that we wait for the entities to be searchable before considering a write complete.
 On a production setup, the `write-sync` default will provide better performance.
 Using `sync` is especially important when testing as you need the entities to be searchable immediately.
+<9> For development and tests, we rely on <<dev-services,Dev Services>>,
+which means Quarkus will start a PostgreSQL database and Elasticsearch cluster automatically.
+In production mode, however,
+you will want to start a PostgreSQL database and Elasticsearch cluster manually,
+which is why we provide Quarkus with this connection info in the `prod` profile (`%prod.` prefix).
 
 [TIP]
 For more information about the Hibernate Search extension configuration please refer to the <<configuration-reference, Configuration Reference>>.
@@ -570,7 +577,7 @@ For more information about the Hibernate Search extension configuration please r
 Quarkus supports a feature called Dev Services that allows you to start various containers without any config.
 In the case of Elasticsearch this support extends to the default Elasticsearch connection.
 What that means practically, is that if you have not configured `quarkus.hibernate-search-orm.elasticsearch.hosts` Quarkus will automatically
-start an Elasticsearch container when running tests or dev mode, and automatically configure the connection.
+start an Elasticsearch container when running tests or in xref:dev-mode-differences.adoc[dev mode], and automatically configure the connection.
 
 When running the production version of the application, the Elasticsearch connection needs to be configured as normal,
 so if you want to include a production database config in your `application.properties` and continue to use Dev Services
@@ -578,7 +585,7 @@ we recommend that you use the `%prod.` profile to define your Elasticsearch sett
 
 NOTE: Dev Services for Elasticsearch is currently unable to start multiple clusters concurrently, so it only works with the default backend of the default persistence unit: named persistence units or named backends won't be able to take advantage of Dev Services for Elasticsearch.
 
-For more information you can read the xref:elasticsearch-dev-services.adoc[Dev Services for Elasticsearch].
+For more information you can read the xref:elasticsearch-dev-services.adoc[Dev Services for Elasticsearch guide].
 
 == Creating a frontend
 
@@ -611,22 +618,6 @@ INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'T
 INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Invisible', 2);
 INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), 'Sunset Park', 2);
 INSERT INTO book(id, title, author_id) VALUES (nextval('hibernate_sequence'), '4 3 2 1', 2);
-----
-
-== Preparing the infrastructure
-
-We need a PostgreSQL instance and an Elasticsearch cluster.
-
-Let's use Docker to start one of each:
-
-[source,bash,subs=attributes+]
-----
-docker run -it --rm=true --name elasticsearch_quarkus_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:{elasticsearch-version}
-----
-
-[source,bash]
-----
-docker run -it --rm=true --name postgresql_quarkus_test -e POSTGRES_USER=quarkus_test -e POSTGRES_PASSWORD=quarkus_test -e POSTGRES_DB=quarkus_test -p 5432:5432 postgres:14.1
 ----
 
 == Time to play with your application

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchDevServicesTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchDevServicesTestResource.java
@@ -1,0 +1,61 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+@Path("/test/dev-services")
+public class HibernateSearchDevServicesTestResource {
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Inject
+    Session session;
+
+    @Inject
+    SearchSession searchSession;
+
+    @GET
+    @Path("/hosts")
+    @Transactional
+    @SuppressWarnings("unchecked")
+    public String hosts() {
+        return ((List<String>) sessionFactory.getProperties().get("hibernate.search.backend.hosts")).iterator().next();
+    }
+
+    @PUT
+    @Path("/init-data")
+    @Transactional
+    public void initData() {
+        IndexedEntity entity = new IndexedEntity("John Irving");
+        session.persist(entity);
+    }
+
+    @PUT
+    @Path("/refresh")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String refresh() {
+        searchSession.workspace().refresh();
+        return "OK";
+    }
+
+    @GET
+    @Path("/count")
+    @Produces(MediaType.TEXT_PLAIN)
+    public long count() {
+        return searchSession.search(IndexedEntity.class)
+                .where(f -> f.matchAll())
+                .fetchTotalHitCount();
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/IndexedEntity.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/IndexedEntity.java
@@ -1,0 +1,47 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class IndexedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "personSeq")
+    private Long id;
+
+    @FullTextField(analyzer = "standard")
+    @KeywordField(name = "name_sort", normalizer = "lowercase", sortable = Sortable.YES)
+    private String name;
+
+    public IndexedEntity() {
+    }
+
+    public IndexedEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
@@ -8,8 +8,6 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 quarkus.hibernate-search-orm.elasticsearch.version=7
-quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
-quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:backend-analysis
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis1TestingEntity.analysis.configurer=class:io.quarkus.it.hibernate.search.elasticsearch.analysis.IndexAnalysis1Configurer
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis2TestingEntity.analysis.configurer=bean:index-analysis-2
@@ -18,3 +16,6 @@ quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis4TestingEntity.analys
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis5TestingEntity.analysis.configurer=io.quarkus.it.hibernate.search.elasticsearch.analysis.IndexAnalysis5Configurer
 quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
+
+%test.quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
+%test.quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/DevServicesContextSpy.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/DevServicesContextSpy.java
@@ -1,0 +1,32 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class DevServicesContextSpy implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    DevServicesContext devServicesContext;
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.devServicesContext = context;
+    }
+
+    @Override
+    public Map<String, String> start() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(devServicesContext, f -> f.getType().isAssignableFrom(DevServicesContext.class));
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesDisabledExplicitlyTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            Map<String, String> config = new HashMap<>(); // Cannot use Map.of, we need nulls
+            // Even if quarkus.hibernate-search-orm.elasticsearch.hosts is not set,
+            // Quarkus won't start Elasticsearch dev-services because of this explicit setting:
+            config.put("quarkus.elasticsearch.devservices.enabled", "false");
+            // Ensure we can work offline, because without dev-services,
+            // we won't have an Elasticsearch instance to talk to.
+            config.putAll(Map.of(
+                    "quarkus.hibernate-search-orm.schema-management.strategy", "none",
+                    // This version does not matter as long as it's supported by Hibernate Search:
+                    // it won't be checked in this test anyway.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "7.5",
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false"));
+            return config;
+        }
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .doesNotContainKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is("localhost:9200")); // This is the default
+
+        // We don't test Hibernate Search features (indexing, search) here,
+        // because we're not sure that there is a host that Hibernate Search can talk to.
+        // It's fine, though: we checked that Hibernate Search is configured as intended.
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesDisabledImplicitlyTest {
+    private static final String EXPLICIT_HOSTS = "mycompany.com:4242";
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    // Make sure quarkus.hibernate-search-orm.elasticsearch.hosts is set,
+                    // so that Quarkus detects disables Elasticsearch dev-services implicitly.
+                    "quarkus.hibernate-search-orm.elasticsearch.hosts", EXPLICIT_HOSTS,
+                    // Ensure we can work offline, because the host we set just above does not actually exist.
+                    "quarkus.hibernate-search-orm.schema-management.strategy", "none",
+                    // This version does not matter as long as it's supported by Hibernate Search:
+                    // it won't be checked in this test anyway.
+                    "quarkus.hibernate-search-orm.elasticsearch.version", "7.6",
+                    "quarkus.hibernate-search-orm.elasticsearch.version-check.enabled", "false");
+        }
+
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we DO set quarkus.hibernate-search-orm.elasticsearch.hosts (see above).
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .doesNotContainKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is(EXPLICIT_HOSTS));
+
+        // We don't test Hibernate Search features (indexing, search) here,
+        // because we're not sure that there is a host that Hibernate Search can talk to.
+        // It's fine, though: we checked that Hibernate Search is configured as intended.
+    }
+}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.hibernate.search.elasticsearch.devservices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+@TestProfile(HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.Profile.class)
+public class HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            // Don't use %test properties;
+            // that way, we can control whether quarkus.hibernate-search-orm.elasticsearch.hosts is set or not.
+            // In this test, we do NOT set quarkus.hibernate-search-orm.elasticsearch.hosts.
+            return "someotherprofile";
+        }
+
+        @Override
+        public List<TestResourceEntry> testResources() {
+            // Enables injection of DevServicesContext
+            return List.of(new TestResourceEntry(DevServicesContextSpy.class));
+        }
+    }
+
+    DevServicesContext context;
+
+    @Test
+    public void testDevServicesProperties() {
+        assertThat(context.devServicesProperties())
+                .containsKey("quarkus.hibernate-search-orm.elasticsearch.hosts");
+        assertThat(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts"))
+                .isNotEmpty()
+                .isNotEqualTo("localhost:9200");
+    }
+
+    @Test
+    public void testHibernateSearch() {
+        RestAssured.when().get("/test/dev-services/hosts").then()
+                .statusCode(200)
+                .body(is(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts")));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("0"));
+
+        RestAssured.when().put("/test/dev-services/init-data").then()
+                .statusCode(204);
+
+        RestAssured.when().put("/test/hibernate-search/refresh").then()
+                .statusCode(200)
+                .body(is("OK"));
+
+        RestAssured.when().get("/test/dev-services/count").then()
+                .statusCode(200)
+                .body(is("1"));
+    }
+}


### PR DESCRIPTION
Fixes #23878 

~Creating as draft, because we need to merge #23753 first.~ => Done

Goes hand-to-hand with the quickstart update https://github.com/quarkusio/quarkus-quickstarts/pull/1064