### PR TITLE
Close Liquibase `ClassLoaderResourceAccessor` and update liquibase-mongodb to 4.8.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -153,7 +153,6 @@
         <flyway.version>8.5.0</flyway.version>
         <yasson.version>1.0.11</yasson.version>
         <liquibase.version>4.8.0</liquibase.version>
-        <liquibase-mongodb.version>4.7.1</liquibase-mongodb.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>4.3.4</mongo-client.version>
@@ -4963,7 +4962,7 @@
             <dependency>
                 <groupId>org.liquibase.ext</groupId>
                 <artifactId>liquibase-mongodb</artifactId>
-                <version>${liquibase-mongodb.version}</version>
+                <version>${liquibase.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -179,6 +179,7 @@ class LiquibaseMongodbProcessor {
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.7.xsd",
+                "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd",
@@ -191,6 +192,7 @@ class LiquibaseMongodbProcessor {
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.5.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.6.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.7.xsd",
+                "www.liquibase.org/xml/ns/pro/liquibase-pro-4.8.xsd",
                 "liquibase.build.properties"));
 
         // liquibase resource bundles
@@ -248,19 +250,29 @@ class LiquibaseMongodbProcessor {
      */
     private List<String> getChangeLogs(LiquibaseMongodbBuildTimeConfig liquibaseBuildConfig) {
         ChangeLogParameters changeLogParameters = new ChangeLogParameters();
-        ClassLoaderResourceAccessor classLoaderResourceAccessor = new ClassLoaderResourceAccessor(
-                Thread.currentThread().getContextClassLoader());
 
         ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
 
         Set<String> resources = new LinkedHashSet<>();
 
-        resources.addAll(findAllChangeLogFiles(liquibaseBuildConfig.changeLog, changeLogParserFactory,
-                classLoaderResourceAccessor, changeLogParameters));
+        ClassLoaderResourceAccessor classLoaderResourceAccessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader());
 
-        LOGGER.debugf("Liquibase changeLogs: %s", resources);
+        try {
+            resources.addAll(findAllChangeLogFiles(liquibaseBuildConfig.changeLog, changeLogParserFactory,
+                    classLoaderResourceAccessor, changeLogParameters));
 
-        return new ArrayList<>(resources);
+            LOGGER.debugf("Liquibase changeLogs: %s", resources);
+
+            return new ArrayList<>(resources);
+
+        } finally {
+            try {
+                classLoaderResourceAccessor.close();
+            } catch (Exception ignored) {
+                // close() really shouldn't declare that exception, see also https://github.com/liquibase/liquibase/pull/2576
+            }
+        }
     }
 
     /**

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -12,7 +12,6 @@ import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.ResourceAccessor;
 
 public class LiquibaseMongodbFactory {
 
@@ -31,8 +30,8 @@ public class LiquibaseMongodbFactory {
     }
 
     public Liquibase createLiquibase() {
-        try {
-            ResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader());
+        try (ClassLoaderResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader())) {
             String connectionString = this.mongoClientConfig.connectionString.orElse("mongodb://localhost:27017");
             if (!HAS_DB.matcher(connectionString).matches()) {
                 connectionString += "/" + this.mongoClientConfig.database.orElseThrow(

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -221,6 +221,7 @@ class LiquibaseProcessor {
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.7.xsd",
+                "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd",
                 "www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd",
@@ -233,6 +234,7 @@ class LiquibaseProcessor {
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.5.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.6.xsd",
                 "www.liquibase.org/xml/ns/pro/liquibase-pro-4.7.xsd",
+                "www.liquibase.org/xml/ns/pro/liquibase-pro-4.8.xsd",
                 "liquibase.build.properties"));
 
         // liquibase resource bundles
@@ -323,35 +325,45 @@ class LiquibaseProcessor {
         }
 
         ChangeLogParameters changeLogParameters = new ChangeLogParameters();
-        ClassLoaderResourceAccessor classLoaderResourceAccessor = new ClassLoaderResourceAccessor(
-                Thread.currentThread().getContextClassLoader());
 
         ChangeLogParserFactory changeLogParserFactory = ChangeLogParserFactory.getInstance();
 
         Set<String> resources = new LinkedHashSet<>();
 
-        // default datasource
-        if (DataSourceUtil.hasDefault(dataSourceNames)) {
-            resources.addAll(findAllChangeLogFiles(liquibaseBuildConfig.defaultDataSource.changeLog, changeLogParserFactory,
-                    classLoaderResourceAccessor, changeLogParameters));
+        ClassLoaderResourceAccessor classLoaderResourceAccessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader());
+
+        try {
+            // default datasource
+            if (DataSourceUtil.hasDefault(dataSourceNames)) {
+                resources.addAll(findAllChangeLogFiles(liquibaseBuildConfig.defaultDataSource.changeLog, changeLogParserFactory,
+                        classLoaderResourceAccessor, changeLogParameters));
+            }
+
+            // named datasources
+            Collection<String> namedDataSourceChangeLogs = dataSourceNames.stream()
+                    .filter(n -> !DataSourceUtil.isDefault(n))
+                    .map(liquibaseBuildConfig::getConfigForDataSourceName)
+                    .map(c -> c.changeLog)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            for (String namedDataSourceChangeLog : namedDataSourceChangeLogs) {
+                resources.addAll(
+                        findAllChangeLogFiles(namedDataSourceChangeLog, changeLogParserFactory, classLoaderResourceAccessor,
+                                changeLogParameters));
+            }
+
+            LOGGER.debugf("Liquibase changeLogs: %s", resources);
+
+            return new ArrayList<>(resources);
+
+        } finally {
+            try {
+                classLoaderResourceAccessor.close();
+            } catch (Exception ignored) {
+                // close() really shouldn't declare that exception, see also https://github.com/liquibase/liquibase/pull/2576
+            }
         }
-
-        // named datasources
-        Collection<String> namedDataSourceChangeLogs = dataSourceNames.stream()
-                .filter(n -> !DataSourceUtil.isDefault(n))
-                .map(liquibaseBuildConfig::getConfigForDataSourceName)
-                .map(c -> c.changeLog)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        for (String namedDataSourceChangeLog : namedDataSourceChangeLogs) {
-            resources.addAll(
-                    findAllChangeLogFiles(namedDataSourceChangeLog, changeLogParserFactory, classLoaderResourceAccessor,
-                            changeLogParameters));
-        }
-
-        LOGGER.debugf("Liquibase changeLogs: %s", resources);
-
-        return new ArrayList<>(resources);
     }
 
     /**

--- a/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/LiquibaseFactory.java
+++ b/extensions/liquibase/runtime/src/main/java/io/quarkus/liquibase/LiquibaseFactory.java
@@ -12,7 +12,6 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.ResourceAccessor;
 
 public class LiquibaseFactory {
 
@@ -29,8 +28,8 @@ public class LiquibaseFactory {
     }
 
     public Liquibase createLiquibase() {
-        try {
-            ResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader());
+        try (ClassLoaderResourceAccessor resourceAccessor = new ClassLoaderResourceAccessor(
+                Thread.currentThread().getContextClassLoader())) {
 
             Database database = DatabaseFactory.getInstance()
                     .findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));


### PR DESCRIPTION
See also: https://github.com/quarkusio/quarkus/pull/23891#issuecomment-1049044266

Also checked the quickstarts.

PS: Exception handling can be cleaned up again after https://github.com/liquibase/liquibase/pull/2576