### PR TITLE
Fix Arc NPE if `quarkus.arc.remove-unused-beans` is false

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.deployment.devconsole;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,14 +109,20 @@ public class ArcDevConsoleProcessor {
         for (InterceptorInfo interceptor : validationContext.get(BuildExtension.Key.INTERCEPTORS)) {
             beanInfos.addInterceptor(DevInterceptorInfo.from(interceptor, predicate));
         }
-        for (InterceptorInfo interceptor : validationContext.get(BuildExtension.Key.REMOVED_INTERCEPTORS)) {
-            beanInfos.addRemovedInterceptor(DevInterceptorInfo.from(interceptor, predicate));
+        Collection<InterceptorInfo> removedInterceptors = validationContext.get(BuildExtension.Key.REMOVED_INTERCEPTORS);
+        if (removedInterceptors != null) {
+            for (InterceptorInfo interceptor : removedInterceptors) {
+                beanInfos.addRemovedInterceptor(DevInterceptorInfo.from(interceptor, predicate));
+            }
         }
         for (DecoratorInfo decorator : validationContext.get(BuildExtension.Key.DECORATORS)) {
             beanInfos.addDecorator(DevDecoratorInfo.from(decorator, predicate));
         }
-        for (DecoratorInfo decorator : validationContext.get(BuildExtension.Key.REMOVED_DECORATORS)) {
-            beanInfos.addRemovedDecorator(DevDecoratorInfo.from(decorator, predicate));
+        Collection<DecoratorInfo> removedDecorators = validationContext.get(BuildExtension.Key.REMOVED_DECORATORS);
+        if (removedDecorators != null) {
+            for (DecoratorInfo decorator : removedDecorators) {
+                beanInfos.addRemovedDecorator(DevDecoratorInfo.from(decorator, predicate));
+            }
         }
         beanInfos.sort();
         return new DevConsoleTemplateInfoBuildItem("devBeanInfos", beanInfos);

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.deployment.devmode;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -12,6 +13,8 @@ import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
+import io.quarkus.arc.processor.DecoratorInfo;
+import io.quarkus.arc.processor.InterceptorInfo;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -34,8 +37,15 @@ public class ArcDevProcessor {
             BuildProducer<ValidationErrorBuildItem> errors) {
 
         List<BeanInfo> removed = new ArrayList<>();
-        removed.addAll(validationPhase.getContext().get(BuildExtension.Key.REMOVED_INTERCEPTORS));
-        removed.addAll(validationPhase.getContext().get(BuildExtension.Key.REMOVED_DECORATORS));
+        Collection<InterceptorInfo> removedInterceptors = validationPhase.getContext()
+                .get(BuildExtension.Key.REMOVED_INTERCEPTORS);
+        if (removedInterceptors != null) {
+            removed.addAll(removedInterceptors);
+        }
+        Collection<DecoratorInfo> removedDecorators = validationPhase.getContext().get(BuildExtension.Key.REMOVED_DECORATORS);
+        if (removedDecorators != null) {
+            removed.addAll(removedDecorators);
+        }
         List<String[]> removedInterceptorsDecorators;
         if (removed.isEmpty()) {
             removedInterceptorsDecorators = Collections.emptyList();


### PR DESCRIPTION
If `quarkus.arc.remove-unused-beans` is false, it originates NPEs when retrieving the removed interceptors / decorators (because they were never added to the context)