### PR TITLE
Add initial support of Project CRaC

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -198,6 +198,7 @@
         <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.22</strimzi-oauth.nimbus.version>
         <java-buildpack-client.version>0.0.6</java-buildpack-client.version>
+        <org-crac.version>0.1.1</org-crac.version>
     </properties>
 
     <dependencyManagement>
@@ -5543,6 +5544,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-awt-deployment</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.crac</groupId>
+                <artifactId>org-crac</artifactId>
+                <version>${org-crac.version}</version>
             </dependency>
 
             <!-- Relocations -->

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -223,6 +223,8 @@
                         <runnerParentFirstArtifact>org.wildfly.common:wildfly-common</runnerParentFirstArtifact>
                         <!-- This is needed because it contains some jar handling classes -->
                         <runnerParentFirstArtifact>io.smallrye.common:smallrye-common-io</runnerParentFirstArtifact>
+                        <!-- QuarkusEntryPoint needs org-crac class definition -->
+                        <runnerParentFirstArtifact>io.github.crac:org-crac</runnerParentFirstArtifact>
                     </runnerParentFirstArtifacts>
                     <excludedArtifacts>
                         <excludedArtifact>io.smallrye:smallrye-config</excludedArtifact>

--- a/extensions/vertx-http/runtime/pom.xml
+++ b/extensions/vertx-http/runtime/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.crac</groupId>
+            <artifactId>org-crac</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -343,6 +343,11 @@
                 <artifactId>jsoup</artifactId>
                 <version>${jsoup.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.github.crac</groupId>
+                <artifactId>org-crac</artifactId>
+                <version>${org-crac.version}</version>
+            </dependency>
             <!-- Smallrye Common dependencies, imported as a BOM -->
             <dependency>
                 <groupId>io.smallrye.common</groupId>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -67,6 +67,7 @@
         <smallrye-common.version>1.11.0</smallrye-common.version>
         <gradle-tooling.version>7.4.2</gradle-tooling.version>
         <quarkus-fs-util.version>0.0.9</quarkus-fs-util.version>
+        <org-crac.version>0.1.1</org-crac.version>
     </properties>
     <modules>
         <module>bom</module>

--- a/independent-projects/bootstrap/runner/pom.xml
+++ b/independent-projects/bootstrap/runner/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.crac</groupId>
+            <artifactId>org-crac</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
There is a project CRaC in OpenJDK: https://openjdk.java.net/projects/crac/. A bit more verbose description is at https://github.com/crac/docs#readme. The idea of the project is to allow creating image (checkpoint) of an application and JVM state, and then start new instances from the image to reduce start-up and warm-up time. Applications are allowed to manage their state on the checkpoint and restore. Apps are also obligated to take care of external resources such as file handles and network connections. Such care naturally resides in frameworks, so from the very start, we pay special attention to popular ones, including Quarkus.

This change provides initial CRaC support to Quarkus, making an unmodified app https://github.com/CRaC/example-quarkus/tree/dev-quarkus to start on CRaC JDK in a matter of tenth of milliseconds. To avoid a hard dependency on the new features provided by CRaC, applications are suggested to use org-crac package https://github.com/CRaC/org.crac. So the new code should not harm the compatibility with existing runtimes.

However, I'm totally lost about how to document and provide tests. Could someone point or describe how it would need to look like? Native image mode seems to require passing all of the tests. Would a similar way of testing be sufficient for CRaC, in theory?