### PR TITLE
Leverage tabs for kotlin DSL in gradle documentation

### DIFF
--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -67,6 +67,9 @@ It is however possible to use a custom configuration profile for your tests with
 This can be useful if you need for example to run some tests using a specific database which is not your default testing
 database.
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy,subs=attributes+]
 ----
 test {
@@ -74,8 +77,12 @@ test {
 }
 ----
 
-or, if you use the Gradle Kotlin DSL:
+<1> The `foo` configuration profile will be used to run the tests.
+****
 
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
 [source,kotlin,subs=attributes+]
 ----
 tasks.test {
@@ -84,6 +91,7 @@ tasks.test {
 ----
 
 <1> The `foo` configuration profile will be used to run the tests.
+****
 
 [WARNING]
 ====
@@ -164,12 +172,27 @@ Hit `CTRL+C` to stop the application.
 
 You can change the working directory the development environment runs on:
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy]
 ----
 quarkusDev {
     workingDir = rootProject.projectDir
 }
 ----
+****
+
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
+[source,kotlin]
+----
+tasks.quarkusDev {
+    workingDir = rootProject.projectDir.toString()
+}
+----
+****
 
 [TIP]
 ====
@@ -187,12 +210,27 @@ include::includes/devtools/dev-parameters.adoc[]
 The plugin also exposes a `quarkusDev` configuration. Using this configuration to declare a dependency will restrict the usage of that dependency to development mode.
 The `quarkusDev` configuration can be used as following:
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy]
 ----
 dependencies {
     quarkusDev 'io.quarkus:quarkus-jdbc-h2'
 }
 ----
+****
+
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
+[source,kotlin]
+----
+dependencies {
+    quarkusDev("io.quarkus:quarkus-jdbc-h2")
+}
+----
+****
 
 === Remote Development Mode
 
@@ -357,6 +395,9 @@ A native executable will be present in `build/`.
 Native related properties can either be added in `application.properties` file, as command line arguments or in the `quarkusBuild` task.
 Configuring the `quarkusBuild` task can be done as following:
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy,subs=attributes+]
 ----
 quarkusBuild {
@@ -367,21 +408,26 @@ quarkusBuild {
 }
 ----
 
-or if you are using the Gradle Kotlin DSL:
+<1> Set `quarkus.native.container-build` property to `true`
+<2> Set `quarkus.native.build-image` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
+****
 
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
 [source,kotlin,subs=attributes+]
 ----
 tasks.quarkusBuild {
     nativeArgs {
         "container-build" to true <1>
         "build-image" to "quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}" <2>
-        "java-home" to "/opt/java-11/"
     }
 }
 ----
 
 <1> Set `quarkus.native.container-build` property to `true`
 <2> Set `quarkus.native.build-image` property to `quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor}`
+****
 
 [WARNING]
 ====
@@ -427,6 +473,9 @@ This task depends on `quarkusBuild`, so it will generate the native image before
 ====
 By default, the `native-test` source set is based on `main` and `test` source sets. It is possible to add an extra source set. For example, if your integration tests are located in an `integrationTest` source set, you can specify it as:
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy]
 ----
 quarkus {
@@ -435,6 +484,20 @@ quarkus {
     }
 }
 ----
+****
+
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
+[source,kotlin]
+----
+quarkus {
+    sourceSets {
+        setExtraNativeTest(sourceSets["integrationTest"])
+    }
+}
+----
+****
 
 ====
 
@@ -485,11 +548,26 @@ More information on this topic can be found on the xref:cdi-reference.adoc#bean_
 
 In order to make sure the right dependency versions are being used by Gradle, the BOM is declared as an `enforcedPlatform` in your build file.
 By default, the `maven-publish` plugin will prevent you from publishing your application due to this `enforcedPlatform`.
-This validation can be skipped by adding the following configuration in your `build.gradle` file:
+This validation can be skipped by adding the following configuration in your build file:
 
+[role="primary asciidoc-tabs-sync-groovy"]
+.Groovy DSL
+****
 [source,groovy]
 ----
 tasks.withType(GenerateModuleMetadata).configureEach {
     suppressedValidationErrors.add('enforced-platform')
 }
 ----
+****
+
+[role="secondary asciidoc-tabs-sync-kotlin"]
+.Kotlin DSL
+****
+[source,kotlin]
+----
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    suppressedValidationErrors.add("enforced-platform")
+}
+----
+****


### PR DESCRIPTION
This leverage tabs in gradle documentation and add kotlin dsl example.