### PR TITLE
Support custom fields in JSON logging

### DIFF
--- a/extensions/logging-json/deployment/pom.xml
+++ b/extensions/logging-json/deployment/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>quarkus-arc-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterCustomConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterCustomConfigTest.java
@@ -4,12 +4,19 @@ import static io.quarkus.logging.json.JsonFormatterDefaultConfigTest.getJsonForm
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZoneId;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
-import org.jboss.logmanager.formatters.JsonFormatter;
+import org.assertj.core.api.Assertions;
 import org.jboss.logmanager.formatters.StructuredFormatter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.logging.json.runtime.AdditionalFieldConfig;
+import io.quarkus.logging.json.runtime.JsonFormatter;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class JsonFormatterCustomConfigTest {
@@ -30,5 +37,36 @@ public class JsonFormatterCustomConfigTest {
                 .isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED);
         assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n;");
         assertThat(jsonFormatter.isPrintDetails()).isTrue();
+        assertThat(jsonFormatter.getExcludedKeys()).containsExactly("timestamp", "sequence");
+        assertThat(jsonFormatter.getAdditionalFields().size()).isEqualTo(2);
+        assertThat(jsonFormatter.getAdditionalFields().containsKey("foo")).isTrue();
+        assertThat(jsonFormatter.getAdditionalFields().get("foo").type).isEqualTo(AdditionalFieldConfig.Type.INT);
+        assertThat(jsonFormatter.getAdditionalFields().get("foo").value).isEqualTo("42");
+        assertThat(jsonFormatter.getAdditionalFields().containsKey("bar")).isTrue();
+        assertThat(jsonFormatter.getAdditionalFields().get("bar").type).isEqualTo(AdditionalFieldConfig.Type.STRING);
+        assertThat(jsonFormatter.getAdditionalFields().get("bar").value).isEqualTo("baz");
+    }
+
+    @Test
+    public void jsonFormatterOutputTest() throws Exception {
+        JsonFormatter jsonFormatter = getJsonFormatter();
+        String line = jsonFormatter.format(new LogRecord(Level.INFO, "Hello, World!"));
+
+        JsonNode node = new ObjectMapper().readTree(line);
+        // "level" has been renamed to HEY
+        Assertions.assertThat(node.has("level")).isFalse();
+        Assertions.assertThat(node.has("HEY")).isTrue();
+        Assertions.assertThat(node.get("HEY").asText()).isEqualTo("INFO");
+
+        // excluded fields
+        Assertions.assertThat(node.has("timestamp")).isFalse();
+        Assertions.assertThat(node.has("sequence")).isFalse();
+
+        // additional fields
+        Assertions.assertThat(node.has("foo")).isTrue();
+        Assertions.assertThat(node.get("foo").asInt()).isEqualTo(42);
+        Assertions.assertThat(node.has("bar")).isTrue();
+        Assertions.assertThat(node.get("bar").asText()).isEqualTo("baz");
+        Assertions.assertThat(node.get("message").asText()).isEqualTo("Hello, World!");
     }
 }

--- a/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
+++ b/extensions/logging-json/deployment/src/test/java/io/quarkus/logging/json/JsonFormatterDefaultConfigTest.java
@@ -11,7 +11,6 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import org.jboss.logmanager.formatters.JsonFormatter;
 import org.jboss.logmanager.formatters.StructuredFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.logging.json.runtime.JsonFormatter;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class JsonFormatterDefaultConfigTest {
@@ -37,6 +37,8 @@ public class JsonFormatterDefaultConfigTest {
         assertThat(jsonFormatter.getExceptionOutputType()).isEqualTo(StructuredFormatter.ExceptionOutputType.DETAILED);
         assertThat(jsonFormatter.getRecordDelimiter()).isEqualTo("\n");
         assertThat(jsonFormatter.isPrintDetails()).isFalse();
+        assertThat(jsonFormatter.getExcludedKeys()).isEmpty();
+        assertThat(jsonFormatter.getAdditionalFields().entrySet()).isEmpty();
     }
 
     public static JsonFormatter getJsonFormatter() {

--- a/extensions/logging-json/deployment/src/test/resources/application-json-formatter-custom.properties
+++ b/extensions/logging-json/deployment/src/test/resources/application-json-formatter-custom.properties
@@ -8,4 +8,9 @@ quarkus.log.console.json.record-delimiter=\n;
 quarkus.log.console.json.zone-id=UTC+05:00
 quarkus.log.console.json.exception-output-type=DETAILED_AND_FORMATTED
 quarkus.log.console.json.print-details=true
-
+quarkus.log.console.json.key-overrides=level=HEY
+quarkus.log.console.json.excluded-keys=timestamp,sequence
+quarkus.log.console.json.additional-field.foo.value=42
+quarkus.log.console.json.additional-field.foo.type=int
+quarkus.log.console.json.additional-field.bar.value=baz
+quarkus.log.console.json.additional-field.bar.type=string

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/AdditionalFieldConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/AdditionalFieldConfig.java
@@ -1,0 +1,30 @@
+package io.quarkus.logging.json.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Post additional fields. E.g. `fieldName1=value1,fieldName2=value2`.
+ */
+@ConfigGroup
+public class AdditionalFieldConfig {
+    /**
+     * Additional field value.
+     */
+    @ConfigItem
+    public String value;
+
+    /**
+     * Additional field type specification.
+     * Supported types: string, int, long
+     * String is the default if not specified.
+     */
+    @ConfigItem(defaultValue = "string")
+    public Type type;
+
+    public enum Type {
+        STRING,
+        INT,
+        LONG,
+    }
+}

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonConfig.java
@@ -1,9 +1,12 @@
 package io.quarkus.logging.json.runtime;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jboss.logmanager.formatters.StructuredFormatter;
 
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -51,4 +54,22 @@ public class JsonConfig {
      */
     @ConfigItem
     boolean printDetails;
+    /**
+     * Override keys with custom values. Omitting this value indicates that no key overrides will be applied.
+     */
+    @ConfigItem
+    Optional<String> keyOverrides;
+
+    /**
+     * Keys to be excluded from the Json output.
+     */
+    @ConfigItem
+    Optional<Set<String>> excludedKeys;
+
+    /**
+     * Additional fields to be appended in the json logs.
+     */
+    @ConfigItem
+    @ConfigDocMapKey("field-name")
+    Map<String, AdditionalFieldConfig> additionalField;
 }

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/JsonFormatter.java
@@ -1,0 +1,171 @@
+package io.quarkus.logging.json.runtime;
+
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+public class JsonFormatter extends org.jboss.logmanager.formatters.JsonFormatter {
+
+    private Set<String> excludedKeys;
+    private Map<String, AdditionalFieldConfig> additionalFields;
+
+    /**
+     * Creates a new JSON formatter.
+     *
+     */
+    public JsonFormatter() {
+        super();
+        this.excludedKeys = new HashSet<>();
+        this.additionalFields = new HashMap<>();
+    }
+
+    /**
+     * Creates a new JSON formatter.
+     *
+     * @param keyOverrides a string representation of a map to override keys
+     *
+     *        "@see org.jboss.logmanager.ext.PropertyValues#stringToEnumMap(Class, String)"
+     */
+    public JsonFormatter(final String keyOverrides) {
+        super(keyOverrides);
+        this.excludedKeys = new HashSet<>();
+        this.additionalFields = new HashMap<>();
+    }
+
+    /**
+     * Creates a new JSON formatter.
+     *
+     * @param keyOverrides a string representation of a map to override keys
+     *
+     *        "@see org.jboss.logmanager.ext.PropertyValues#stringToEnumMap(Class, String)"
+     * @param excludedKeys a list of keys to be excluded when writing the output
+     * @param additionalFields additionalFields to be added to the output
+     */
+    public JsonFormatter(final String keyOverrides, final Set<String> excludedKeys,
+            final Map<String, AdditionalFieldConfig> additionalFields) {
+        super(keyOverrides);
+        this.excludedKeys = excludedKeys;
+        this.additionalFields = additionalFields;
+    }
+
+    public Set<String> getExcludedKeys() {
+        return this.excludedKeys;
+    }
+
+    public void setExcludedKeys(Set<String> excludedKeys) {
+        this.excludedKeys = excludedKeys;
+    }
+
+    public Map<String, AdditionalFieldConfig> getAdditionalFields() {
+        return this.additionalFields;
+    }
+
+    public void setAdditionalFields(Map<String, AdditionalFieldConfig> additionalFields) {
+        this.additionalFields = additionalFields;
+    }
+
+    @Override
+    protected Generator createGenerator(final Writer writer) {
+        Generator superGenerator = super.createGenerator(writer);
+        return new FormatterJsonGenerator(superGenerator, this.excludedKeys);
+    }
+
+    @Override
+    protected void after(final Generator generator, final ExtLogRecord record) throws Exception {
+        for (var entry : this.additionalFields.entrySet()) {
+            switch (entry.getValue().type) {
+                case STRING:
+                    generator.add(entry.getKey(), entry.getValue().value);
+                    break;
+                case INT:
+                    generator.add(entry.getKey(), Integer.valueOf(entry.getValue().value));
+                    break;
+                case LONG:
+                    generator.add(entry.getKey(), Long.valueOf(entry.getValue().value));
+                    break;
+            }
+        }
+    }
+
+    private static class FormatterJsonGenerator implements Generator {
+        private final Generator generator;
+        private final Set<String> excludedKeys;
+
+        private FormatterJsonGenerator(final Generator generator, final Set<String> excludedKeys) {
+            this.generator = generator;
+            this.excludedKeys = excludedKeys;
+        }
+
+        @Override
+        public Generator begin() throws Exception {
+            generator.begin();
+            return this;
+        }
+
+        @Override
+        public Generator add(final String key, final int value) throws Exception {
+            if (!excludedKeys.contains(key)) {
+                generator.add(key, value);
+            }
+            return this;
+        }
+
+        @Override
+        public Generator add(final String key, final long value) throws Exception {
+            if (!excludedKeys.contains(key)) {
+                generator.add(key, value);
+            }
+            return this;
+        }
+
+        @Override
+        public Generator add(final String key, final Map<String, ?> value) throws Exception {
+            if (!excludedKeys.contains(key)) {
+                generator.add(key, value);
+            }
+            return this;
+        }
+
+        @Override
+        public Generator add(final String key, final String value) throws Exception {
+            if (!excludedKeys.contains(key)) {
+                generator.add(key, value);
+            }
+            return this;
+        }
+
+        @Override
+        public Generator startObject(final String key) throws Exception {
+            generator.startObject(key);
+            return this;
+        }
+
+        @Override
+        public Generator endObject() throws Exception {
+            generator.endObject();
+            return this;
+        }
+
+        @Override
+        public Generator startArray(final String key) throws Exception {
+            generator.startArray(key);
+            return this;
+        }
+
+        @Override
+        public Generator endArray() throws Exception {
+            generator.endArray();
+            return this;
+        }
+
+        @Override
+        public Generator end() throws Exception {
+            generator.end();
+            return this;
+        }
+    }
+}

--- a/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
+++ b/extensions/logging-json/runtime/src/main/java/io/quarkus/logging/json/runtime/LoggingJsonRecorder.java
@@ -3,8 +3,6 @@ package io.quarkus.logging.json.runtime;
 import java.util.Optional;
 import java.util.logging.Formatter;
 
-import org.jboss.logmanager.formatters.JsonFormatter;
-
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -14,7 +12,9 @@ public class LoggingJsonRecorder {
         if (!config.enable) {
             return new RuntimeValue<>(Optional.empty());
         }
-        final JsonFormatter formatter = new JsonFormatter();
+        final JsonFormatter formatter = config.keyOverrides.map(ko -> new JsonFormatter(ko)).orElse(new JsonFormatter());
+        config.excludedKeys.ifPresent(ek -> formatter.setExcludedKeys(ek));
+        Optional.ofNullable(config.additionalField).ifPresent(af -> formatter.setAdditionalFields(af));
         formatter.setPrettyPrint(config.prettyPrint);
         final String dateFormat = config.dateFormat;
         if (!dateFormat.equals("default")) {


### PR DESCRIPTION
This is a way to support some of the use cases described in #7451

Here we introduce 3 new features:
- expose `keyOverrides`(already available from jboss logging) give the possibility to rename a key
- implement `excludedKeys` to exclude unused/undesired fields
- implement `additionalField` to include custom keys with a fixed value

This should be completely backward compatible (all the additions are optional).
The implementation is heavily based on the original `org.jboss.logmanager.JsonFormatter` and delegates to it whenever possible, if it's required I can try to push those changes to the original [repo](https://github.com/jboss-logging/jboss-logmanager).

Additional context:
In the Keycloak project we want to use the Quarkus "official" Json logging, but we are not entirely satisfied by the limited number of "knobs" it offers (refernce [issue](https://github.com/keycloak/keycloak/issues/10415))
With this PR we are integrating enough features from the [Quarkiverse Extension quarkus-logging-json](https://github.com/quarkiverse/quarkus-logging-json) to make it fit but building directly on top of the original `jboss` library.
