### PR TITLE
Fixed otel-collector configuration

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -133,11 +133,10 @@ receivers:
         endpoint: otel-collector:55680
 
 exporters:
-  logging:
-
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
- Removed unused logging exporter
- corrected tls configuration for jaeger exporter (see sample configuration at https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/examples/demo/otel-collector-config.yaml#L18)