### PR TITLE
Prevent NoSuchElementException in MockSupport after earlier error

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/MockSupport.java
@@ -18,6 +18,9 @@ class MockSupport {
     }
 
     static void popContext() {
+        if (contexts.isEmpty()) {
+            return; // can happen on error in QuarkusTestResourceLifecycleManagers etc.
+        }
         List<Object> val = contexts.pop();
         for (Object i : val) {
             try {


### PR DESCRIPTION
Saw a `NoSuchElementException` (as suppressed exception) when I had an error in a custom `QuarkusTestResourceLifecycleManager`.