### PR TITLE
Introduce distinct ObjectMappers for RestEasy Reactive / RestEasy Reactive Client

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -246,15 +246,15 @@ public class CustomObjectMapper {
 ----
 
 There is one unqualified `ObjectMapper` instance provided by the quarkus-jackson extension.  Your code may produce two additional
-`ObjectMapper` instances. The client `ObjectMapper` instance is qualified by the `@RestClientObjectMapper` annotation. The server
+`ObjectMapper` instances. The REST client `ObjectMapper` instance is qualified by the `@RestClientObjectMapper` annotation. The REST server
 `ObjectMapper` instance is qualified by the `@RestServerObjectMapper` annotation.
 
-If the client `ObjectMapper` instance is available, it is used by the quarkus-jaxrs-client-reactive extension for serialization
-and deserialization.  If the client instance is not provided, then quarkus-resteasy-reactive uses the unqualified `ObjectMapper`
+If the REST client `ObjectMapper` instance is available, it is used by the quarkus-rest-client-reactive extension for serialization
+and deserialization.  If the REST client instance is not provided, then quarkus-rest-client-reactive uses the unqualified `ObjectMapper`
 instance.
 
-If the server `ObjectMapper` is available, it is used by the quarkus-resteasy-reactive extension for serialization and
-deserialization.  If the server instance is not provided, then quarkus-resteasy-reactive uses the unqualified `ObjectMapper`
+If the REST server `ObjectMapper` is available, it is used by the quarkus-resteasy-reactive extension for serialization and
+deserialization.  If the REST server instance is not provided, then quarkus-resteasy-reactive uses the unqualified `ObjectMapper`
 instance.
 
 You can produce, inject, and customize each of these instances independently.  The following snippet demonstrates how to inject

--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -245,6 +245,151 @@ public class CustomObjectMapper {
 }
 ----
 
+There is one unqualified `ObjectMapper` instance provided by the quarkus-jackson extension.  Your code may produce two additional
+`ObjectMapper` instances. The client `ObjectMapper` instance is qualified by the `@RestClientObjectMapper` annotation. The server
+`ObjectMapper` instance is qualified by the `@RestServerObjectMapper` annotation.
+
+If the client `ObjectMapper` instance is available, it is used by the quarkus-jaxrs-client-reactive extension for serialization
+and deserialization.  If the client instance is not provided, then quarkus-resteasy-reactive uses the unqualified `ObjectMapper`
+instance.
+
+If the server `ObjectMapper` is available, it is used by the quarkus-resteasy-reactive extension for serialization and
+deserialization.  If the server instance is not provided, then quarkus-resteasy-reactive uses the unqualified `ObjectMapper`
+instance.
+
+You can produce, inject, and customize each of these instances independently.  The following snippet demonstrates how to inject
+each instance using the `@RestClientObjectMapper` and `@RestServerObjectMapper` annotations.
+
+[source,java]
+----
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+
+import javax.inject.Inject;
+
+public class UseFallback {
+
+    private final ObjectMapper serializer;
+
+    @Inject
+    public UseFallback(ObjectMapper mapper,
+            @RestClientObjectMapper Instance<ObjectMapper> clientInstance) {
+        serializer = clientInstance.isUnsatisfied() ? mapper : clientInstance.get();
+    }
+
+}
+----
+
+If you want to customize the unqualified, client, and server instances differently, you can use the `@RestClientObjectMapper` and
+`@RestServerObjectMapper` annotations on your `ObjectMapperCustomizer`.  `ObjectMapperCustomizer` instances without any
+qualifier will customize all three `ObjectMapper`s. `ObjectMapperCustomizer` annotated with `@RestClientObjectMapper` will customize
+only the client instance.  `ObjectMapperCustomizer` annotated with `@RestServerObjectMapper` will customize only the server instance.
+
+[source,java]
+----
+package io.quarkus.jackson.deployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+
+import javax.inject.Singleton;
+
+public class DistinctObjectMapperCustomizers {
+    @Singleton
+    static class UnqualifiedCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            // customize ObjectMappers for unqualified, client, and server use
+        }
+    }
+
+    @Singleton
+    @RestClientObjectMapper
+    static class ClientCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            // customize ObjectMapper for client use
+        }
+    }
+
+    @Singleton
+    @RestServerObjectMapper
+    static class ServerCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            // customize ObjectMapper for server use
+        }
+    }
+}
+----
+
+If you want to provide an alternate `ObjectMapper` bean instance, you can use the `@RestClientObjectMapper` and `@RestServerObjectMapper`
+annotations on the producer method.  Again, it is important to apply all appropriate `ObjectMapperCustomizer` beans in the CDI
+producer.
+
+[source,java]
+----
+package io.quarkus.jackson.deployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class DistinctObjectMapperProducer {
+
+    // This producer overrides the default producer provided by resteasy-jackson extension
+    @Singleton
+    @Produces
+    public ObjectMapper unqualifiedObjectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers) {
+        return objectMapper(unqualifiedCustomizers, null);
+    }
+
+    @RestClientObjectMapper
+    @Singleton
+    @Produces
+    public ObjectMapper clientObjectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+            @RestClientObjectMapper Instance<ObjectMapperCustomizer> clientCustomizers) {
+        return objectMapper(unqualifiedCustomizers, clientCustomizers);
+    }
+
+    @RestServerObjectMapper
+    @Singleton
+    @Produces
+    public ObjectMapper serverObjectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+            @RestServerObjectMapper Instance<ObjectMapperCustomizer> serverCustomizers) {
+        return objectMapper(unqualifiedCustomizers, serverCustomizers);
+    }
+
+    private ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+            Instance<ObjectMapperCustomizer> qualifiedCustomizers) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        // apply base configuration here ...
+
+        // concat all customizers
+        Stream<ObjectMapperCustomizer> customizers = unqualifiedCustomizers.stream();
+        if (qualifiedCustomizers != null) {
+            customizers = Stream.concat(customizers, qualifiedCustomizers.stream());
+        }
+
+        // apply customizers in priority order
+        customizers.sorted().forEach(c -> c.customize(objectMapper));
+        return objectMapper;
+    }
+}
+----
+
 ==== JSON-B
 
 As stated above, Quarkus provides the option of using JSON-B instead of Jackson via the use of the `quarkus-resteasy-jsonb` extension.

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestClientObjectMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestClientObjectMapper.java
@@ -9,9 +9,9 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
- * Qualifier Annotation that specializes production, customization, and injection of `client` ObjectMapper. If an ObjectMapper
- * is produced with this qualifier, it is used by the quarkus-jaxrs-client-reactive extension for serialization and
- * deserialization. Otherwise, quarkus-resteasy-reactive uses the unqualified `ObjectMapper` instance.
+ * Qualifier Annotation that specializes production, customization, and injection of the REST Client ObjectMapper. If an ObjectMapper
+ * is produced with this qualifier, it is used by the quarkus-rest-client-reactive extension for serialization and
+ * deserialization. Otherwise, quarkus-rest-client-reactive uses the unqualified `ObjectMapper` instance.
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestClientObjectMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestClientObjectMapper.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.jackson.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier Annotation that specializes production, customization, and injection of `client` ObjectMapper. If an ObjectMapper
+ * is produced with this qualifier, it is used by the quarkus-jaxrs-client-reactive extension for serialization and
+ * deserialization. Otherwise, quarkus-resteasy-reactive uses the unqualified `ObjectMapper` instance.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface RestClientObjectMapper {
+    final class Literal extends AnnotationLiteral<RestClientObjectMapper> implements RestClientObjectMapper {
+        public static final RestClientObjectMapper.Literal INSTANCE = new Literal();
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestServerObjectMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestServerObjectMapper.java
@@ -1,0 +1,24 @@
+package io.quarkus.resteasy.reactive.jackson.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier Annotation that specializes production, customization, and injection of `server` ObjectMapper. If an ObjectMapper
+ * is produced with this qualifier, it is used by the quarkus-resteasy-reactive extension for serialization and deserialization.
+ * Otherwise, quarkus-resteasy-reactive uses the unqualified `ObjectMapper` instance.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface RestServerObjectMapper {
+    final class Literal extends AnnotationLiteral<RestServerObjectMapper> implements RestServerObjectMapper {
+        public static final RestServerObjectMapper.Literal INSTANCE = new Literal();
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestServerObjectMapper.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/common/RestServerObjectMapper.java
@@ -9,7 +9,7 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
- * Qualifier Annotation that specializes production, customization, and injection of `server` ObjectMapper. If an ObjectMapper
+ * Qualifier Annotation that specializes production, customization, and injection of the REST server ObjectMapper. If an ObjectMapper
  * is produced with this qualifier, it is used by the quarkus-resteasy-reactive extension for serialization and deserialization.
  * Otherwise, quarkus-resteasy-reactive uses the unqualified `ObjectMapper` instance.
  */

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DefaultObjectMappersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DefaultObjectMappersTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.serializers;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DefaultObjectMappersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    @RestClientObjectMapper
+    Instance<ObjectMapper> clientObjectMapper;
+
+    @Inject
+    @RestServerObjectMapper
+    Instance<ObjectMapper> serverObjectMapper;
+
+    @Test
+    public void noClientObjectMapper() {
+        Assertions.assertTrue(clientObjectMapper.isUnsatisfied());
+    }
+
+    @Test
+    public void noServerObjectMapper() {
+        Assertions.assertTrue(serverObjectMapper.isUnsatisfied());
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DistinctObjectMappersCustomizerTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DistinctObjectMappersCustomizerTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.serializers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DistinctObjectMappersCustomizerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    @RestClientObjectMapper
+    ObjectMapper clientObjectMapper;
+
+    @Inject
+    @RestServerObjectMapper
+    ObjectMapper serverObjectMapper;
+
+    @Inject
+    ObjectMapper unqualifiedObjectMapper;
+
+    private static AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> assertionList(ObjectMapper mapper) {
+        return assertThat((List<?>) new ArrayList<>(mapper.getRegisteredModuleIds())).asList();
+    }
+
+    @Test
+    public void unqualifiedObjectMapperCustomized() {
+        assertionList(unqualifiedObjectMapper).contains("unqualified").doesNotContain("client").doesNotContain("server");
+    }
+
+    @Test
+    public void clientObjectMapperCustomized() {
+        assertionList(clientObjectMapper).contains("unqualified").contains("client").doesNotContain("server");
+    }
+
+    @Test
+    public void serverObjectMapperCustomized() {
+        assertionList(serverObjectMapper).contains("unqualified").doesNotContain("client").contains("server");
+    }
+
+    @Singleton
+    static class DefaultCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            objectMapper.registerModule(new SimpleModule("unqualified"));
+        }
+    }
+
+    @Singleton
+    @RestClientObjectMapper
+    static class ClientCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            objectMapper.registerModule(new SimpleModule("client"));
+        }
+    }
+
+    @Singleton
+    @RestServerObjectMapper
+    static class ServerCustomizer implements ObjectMapperCustomizer {
+        @Override
+        public void customize(ObjectMapper objectMapper) {
+            objectMapper.registerModule(new SimpleModule("server"));
+        }
+    }
+
+    @Singleton
+    public static class Factory {
+
+        private ObjectMapper createMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+                Instance<ObjectMapperCustomizer> qualifiedCustomizers) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            // apply customizers in priority order
+            Stream.concat(unqualifiedCustomizers.stream(), qualifiedCustomizers.stream())
+                    .sorted()
+                    .forEach(c -> c.customize(objectMapper));
+            return objectMapper;
+        }
+
+        @Produces
+        @RestClientObjectMapper
+        ObjectMapper clientObjectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+                @RestClientObjectMapper Instance<ObjectMapperCustomizer> clientCustom) {
+            return createMapper(unqualifiedCustomizers, clientCustom);
+        }
+
+        @Produces
+        @RestServerObjectMapper
+        ObjectMapper serverObjectMapper(Instance<ObjectMapperCustomizer> unqualifiedCustomizers,
+                @RestServerObjectMapper Instance<ObjectMapperCustomizer> serverCustom) {
+            return createMapper(unqualifiedCustomizers, serverCustom);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DistinctObjectMappersProducerTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/serializers/DistinctObjectMappersProducerTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test.serializers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DistinctObjectMappersProducerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest();
+
+    @Inject
+    @RestClientObjectMapper
+    ObjectMapper clientObjectMapper;
+
+    @Inject
+    @RestServerObjectMapper
+    ObjectMapper serverObjectMapper;
+
+    @Inject
+    ObjectMapper unqualifiedObjectMapper;
+
+    private static AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> assertionList(ObjectMapper mapper) {
+        return assertThat((List<?>) new ArrayList<>(mapper.getRegisteredModuleIds())).asList();
+    }
+
+    @Test
+    public void unqualifiedObjectMapper() {
+        assertionList(unqualifiedObjectMapper).contains("unqualified").doesNotContain("client").doesNotContain("server");
+    }
+
+    @Test
+    public void clientObjectMapper() {
+        assertionList(clientObjectMapper).doesNotContain("unqualified").contains("client").doesNotContain("server");
+    }
+
+    @Test
+    public void serverObjectMapper() {
+        assertionList(serverObjectMapper).doesNotContain("unqualified").doesNotContain("client").contains("server");
+    }
+
+    @Singleton
+    public static class Factory {
+        private ObjectMapper createObjectMapper(String moduleName) {
+            return new ObjectMapper().registerModule(new SimpleModule(moduleName));
+        }
+
+        @Produces
+        ObjectMapper unqualifiedObjectMapper() {
+            return createObjectMapper("unqualified");
+        }
+
+        @Produces
+        @RestClientObjectMapper
+        ObjectMapper clientObjectMapper() {
+            return createObjectMapper("client");
+        }
+
+        @Produces
+        @RestServerObjectMapper
+        ObjectMapper serverObjectMapper() {
+            return createObjectMapper("server");
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/BasicServerJacksonMessageBodyWriter.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -21,13 +22,16 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
+
 public class BasicServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
     private final ObjectWriter defaultWriter;
 
     @Inject
-    public BasicServerJacksonMessageBodyWriter(ObjectMapper mapper) {
-        this.defaultWriter = createDefaultWriter(mapper);
+    public BasicServerJacksonMessageBodyWriter(ObjectMapper mapper,
+            @RestServerObjectMapper Instance<ObjectMapper> serverInstance) {
+        this.defaultWriter = createDefaultWriter(serverInstance.isUnsatisfied() ? mapper : serverInstance.get());
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/FullyFeaturedServerJacksonMessageBodyWriter.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -27,6 +28,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.quarkus.resteasy.reactive.jackson.common.RestServerObjectMapper;
 import io.quarkus.resteasy.reactive.jackson.runtime.ResteasyReactiveServerJacksonRecorder;
 
 public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
@@ -36,9 +38,10 @@ public class FullyFeaturedServerJacksonMessageBodyWriter extends ServerMessageBo
     private final ConcurrentMap<String, ObjectWriter> perMethodWriter = new ConcurrentHashMap<>();
 
     @Inject
-    public FullyFeaturedServerJacksonMessageBodyWriter(ObjectMapper mapper) {
-        this.originalMapper = mapper;
-        this.defaultWriter = createDefaultWriter(mapper);
+    public FullyFeaturedServerJacksonMessageBodyWriter(ObjectMapper mapper,
+            @RestServerObjectMapper Instance<ObjectMapper> serverInstance) {
+        this.originalMapper = serverInstance.isUnsatisfied() ? mapper : serverInstance.get();
+        this.defaultWriter = createDefaultWriter(originalMapper);
     }
 
     @Override

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyWriter.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -17,15 +18,18 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.quarkus.resteasy.reactive.jackson.common.RestClientObjectMapper;
+
 public class ClientJacksonMessageBodyWriter implements MessageBodyWriter<Object> {
 
     protected final ObjectMapper originalMapper;
     protected final ObjectWriter defaultWriter;
 
     @Inject
-    public ClientJacksonMessageBodyWriter(ObjectMapper mapper) {
-        this.originalMapper = mapper;
-        this.defaultWriter = createDefaultWriter(mapper);
+    public ClientJacksonMessageBodyWriter(ObjectMapper mapper,
+            @RestClientObjectMapper Instance<ObjectMapper> clientInstance) {
+        this.originalMapper = clientInstance.isUnsatisfied() ? mapper : clientInstance.get();
+        this.defaultWriter = createDefaultWriter(originalMapper);
     }
 
     @Override


### PR DESCRIPTION
Closes #23979

Provide three ObjectMappers: unqualified, client, and server that can be independently produced, customized, and injected.  This allows different behaviors for the different uses.