### PR TITLE
Ensure that remote-dev works with containers created by Jib

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -12,6 +12,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class JibConfig {
 
+    public static final String DEFAULT_WORKING_DIR = "/home/jboss";
     /**
      * The base image to be used when a container image is being produced for the jar build.
      *
@@ -127,7 +128,7 @@ public class JibConfig {
      * The working directory to use in the generated image.
      * The default value is chosen to work in accordance with the default base image.
      */
-    @ConfigItem(defaultValue = "/home/jboss")
+    @ConfigItem(defaultValue = DEFAULT_WORKING_DIR)
     public String workingDirectory;
 
     /**


### PR DESCRIPTION
The issue without this is that Jib overwrites the owner
of the working directory and sets it to root.
With this fix, we add a faux layer that simply
reverts the owner back to the default when the
default base image is used.

Originally discussed at: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/remote.20dev.20in.202.2E7/near/273449615