### PR TITLE
Deprecate the quarkus-resteasy-mutiny extension

### DIFF
--- a/extensions/resteasy-classic/resteasy-mutiny/deployment/src/main/java/io/quarkus/resteasy/mutiny/deployment/ResteasyMutinyProcessor.java
+++ b/extensions/resteasy-classic/resteasy-mutiny/deployment/src/main/java/io/quarkus/resteasy/mutiny/deployment/ResteasyMutinyProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.resteasy.mutiny.deployment;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -8,7 +10,16 @@ public class ResteasyMutinyProcessor {
 
     @BuildStep
     FeatureBuildItem feature() {
+        warn();
         return new FeatureBuildItem(Feature.RESTEASY_MUTINY);
+    }
+
+    void warn() {
+        Logger.getLogger(ResteasyMutinyProcessor.class).warn("The quarkus-resteasy-mutiny extension is deprecated. " +
+                "Switch to RESTEasy Reactive instead.\n" +
+                "This extension adds support for Uni and Multi to RESTEasy 'classic', without using the reactive execution model,"
+                +
+                " as RESTEasy classic does not use it. To properly integrate Mutiny and RESTEasy, use RESTEasy Reactive. See https://quarkus.io/guides/getting-started-reactive for detailed instructions");
     }
 
 }

--- a/extensions/resteasy-classic/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,4 +10,4 @@ metadata:
   categories:
     - "web"
     - "reactive"
-  status: "preview"
+  status: "deprecated"


### PR DESCRIPTION
Also added a warning explaining why it's deprecated.

