### PR TITLE
Only start Elasticsearch Dev Services for Hibernate Search if the default backend is in use

### DIFF
--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItem.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevservicesElasticsearchBuildItem.java
@@ -8,8 +8,8 @@ public final class DevservicesElasticsearchBuildItem extends MultiBuildItem {
     private final String version;
     private final Distribution distribution;
 
-    public DevservicesElasticsearchBuildItem(String configItemName) {
-        this.hostsConfigProperty = configItemName;
+    public DevservicesElasticsearchBuildItem(String hostsConfigProperty) {
+        this.hostsConfigProperty = hostsConfigProperty;
         this.version = null;
         this.distribution = Distribution.ELASTIC;
     }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/HibernateSearchElasticsearchProcessor.java
@@ -342,12 +342,16 @@ class HibernateSearchElasticsearchProcessor {
     @BuildStep
     DevservicesElasticsearchBuildItem devServices(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
         if (buildTimeConfig.defaultPersistenceUnit != null && buildTimeConfig.defaultPersistenceUnit.defaultBackend != null
+        // If the version is not set, the default backend is not in use.
                 && buildTimeConfig.defaultPersistenceUnit.defaultBackend.version.isPresent()) {
             ElasticsearchVersion version = buildTimeConfig.defaultPersistenceUnit.defaultBackend.version.get();
             return new DevservicesElasticsearchBuildItem("quarkus.hibernate-search-orm.elasticsearch.hosts",
                     version.versionString(),
                     DevservicesElasticsearchBuildItem.Distribution.valueOf(version.distribution().toString().toUpperCase()));
+        } else {
+            // Currently we only start dev-services for the default backend of the default persistence unit.
+            // See https://github.com/quarkusio/quarkus/issues/24011
+            return null;
         }
-        return new DevservicesElasticsearchBuildItem("quarkus.hibernate-search-orm.elasticsearch.hosts");
     }
 }


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/23974#issuecomment-1054334955