### PR TITLE
Close opened ZipFileSystems during generate-code goal execution

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -67,21 +67,22 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
         ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         try {
 
-            final CuratedApplication curatedApplication = bootstrapApplication(launchMode);
+            try (final CuratedApplication curatedApplication = bootstrapApplication(launchMode)) {
 
-            QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
-            Thread.currentThread().setContextClassLoader(deploymentClassLoader);
+                QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
+                Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
-            final Class<?> codeGenerator = deploymentClassLoader.loadClass("io.quarkus.deployment.CodeGenerator");
-            final Method initAndRun = codeGenerator.getMethod("initAndRun", ClassLoader.class, PathCollection.class,
-                    Path.class, Path.class,
-                    Consumer.class, ApplicationModel.class, Properties.class, String.class,
-                    boolean.class);
-            initAndRun.invoke(null, deploymentClassLoader, PathList.of(sourcesDir),
-                    generatedSourcesDir(test), buildDir().toPath(),
-                    sourceRegistrar, curatedApplication.getApplicationModel(), mavenProject().getProperties(),
-                    launchMode.name(),
-                    test);
+                final Class<?> codeGenerator = deploymentClassLoader.loadClass("io.quarkus.deployment.CodeGenerator");
+                final Method initAndRun = codeGenerator.getMethod("initAndRun", ClassLoader.class, PathCollection.class,
+                        Path.class, Path.class,
+                        Consumer.class, ApplicationModel.class, Properties.class, String.class,
+                        boolean.class);
+                initAndRun.invoke(null, deploymentClassLoader, PathList.of(sourcesDir),
+                        generatedSourcesDir(test), buildDir().toPath(),
+                        sourceRegistrar, curatedApplication.getApplicationModel(), mavenProject().getProperties(),
+                        launchMode.name(),
+                        test);
+            }
         } catch (Exception any) {
             throw new MojoExecutionException("Quarkus code generation phase has failed", any);
         } finally {


### PR DESCRIPTION
This will close all opened zip file systems of dependencies. These files where still locked during mojo execution by m2e, since the mojo is never destroyed.

This is basicly the same way the gradle plugin does it already.
https://github.com/quarkusio/quarkus/blob/main/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java#L97

Fixes #23655