### PR TITLE
Close bootstrapped apps at the end of mojo execution if Maven extensions are disabled

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -54,7 +54,7 @@ public class QuarkusBootstrapProvider implements Closeable {
     @Requirement(role = RemoteRepositoryManager.class, optional = false)
     protected RemoteRepositoryManager remoteRepoManager;
 
-    private final Cache<String, QuarkusAppBootstrapProvider> appBootstrapProviders = CacheBuilder.newBuilder()
+    private final Cache<String, QuarkusMavenAppBootstrap> appBootstrapProviders = CacheBuilder.newBuilder()
             .concurrencyLevel(4).softValues().initialCapacity(10).build();
 
     static ArtifactKey getProjectId(MavenProject project) {
@@ -69,25 +69,26 @@ public class QuarkusBootstrapProvider implements Closeable {
         return remoteRepoManager;
     }
 
-    private QuarkusAppBootstrapProvider provider(ArtifactKey projectId, String executionId) {
+    public QuarkusMavenAppBootstrap bootstrapper(QuarkusBootstrapMojo mojo) {
         try {
-            return appBootstrapProviders.get(String.format("%s-%s", projectId, executionId), QuarkusAppBootstrapProvider::new);
+            return appBootstrapProviders.get(String.format("%s-%s", mojo.projectId(), mojo.executionId()),
+                    QuarkusMavenAppBootstrap::new);
         } catch (ExecutionException e) {
-            throw new IllegalStateException("Failed to cache a new instance of " + QuarkusAppBootstrapProvider.class.getName(),
+            throw new IllegalStateException("Failed to cache a new instance of " + QuarkusMavenAppBootstrap.class.getName(),
                     e);
         }
     }
 
     public CuratedApplication bootstrapApplication(QuarkusBootstrapMojo mojo, LaunchMode mode)
             throws MojoExecutionException {
-        return provider(mojo.projectId(), mojo.executionId()).bootstrapApplication(mojo, mode);
+        return bootstrapper(mojo).bootstrapApplication(mojo, mode);
     }
 
     public ApplicationModel getResolvedApplicationModel(ArtifactKey projectId, LaunchMode mode) {
         if (appBootstrapProviders.size() == 0) {
             return null;
         }
-        final QuarkusAppBootstrapProvider provider = appBootstrapProviders.getIfPresent(projectId + "-null");
+        final QuarkusMavenAppBootstrap provider = appBootstrapProviders.getIfPresent(projectId + "-null");
         if (provider == null) {
             return null;
         }
@@ -105,7 +106,7 @@ public class QuarkusBootstrapProvider implements Closeable {
         if (appBootstrapProviders.size() == 0) {
             return;
         }
-        for (QuarkusAppBootstrapProvider p : appBootstrapProviders.asMap().values()) {
+        for (QuarkusMavenAppBootstrap p : appBootstrapProviders.asMap().values()) {
             try {
                 p.close();
             } catch (Exception e) {
@@ -114,7 +115,7 @@ public class QuarkusBootstrapProvider implements Closeable {
         }
     }
 
-    private class QuarkusAppBootstrapProvider implements Closeable {
+    public class QuarkusMavenAppBootstrap implements Closeable {
 
         private CuratedApplication prodApp;
         private CuratedApplication devApp;
@@ -137,7 +138,7 @@ public class QuarkusBootstrapProvider implements Closeable {
             }
         }
 
-        protected CuratedApplication doBootstrap(QuarkusBootstrapMojo mojo, LaunchMode mode)
+        private CuratedApplication doBootstrap(QuarkusBootstrapMojo mojo, LaunchMode mode)
                 throws MojoExecutionException {
             final Properties projectProperties = mojo.mavenProject().getProperties();
             final Properties effectiveProperties = new Properties();

--- a/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -16,6 +16,8 @@ public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant 
     @Requirement(optional = false)
     protected QuarkusBootstrapProvider bootstrapProvider;
 
+    private boolean enabled;
+
     @Override
     public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
         try {
@@ -23,5 +25,16 @@ public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant 
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public void afterProjectsRead(MavenSession session)
+            throws MavenExecutionException {
+        // if this method is called then Maven plugin extensions are enabled
+        enabled = true;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }


### PR DESCRIPTION
This should help with #23655

@Postremus I am on vacation currently and can't verify whether this fixes the issue. What this change does is it makes every mojo that bootstraps an app to close it in case Maven extensions are disabled.