### PR TITLE
Add ability to set extension capability from gradle plugin

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -2,7 +2,11 @@ package io.quarkus.extension.gradle;
 
 import java.util.List;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
+
+import io.quarkus.extension.gradle.dsl.Capabilities;
+import io.quarkus.extension.gradle.dsl.Capability;
 
 public class QuarkusExtensionConfiguration {
 
@@ -15,6 +19,7 @@ public class QuarkusExtensionConfiguration {
     private List<String> lesserPriorityArtifacts;
     private List<String> conditionalDependencies;
     private List<String> dependencyCondition;
+    private Capabilities capabilities = new Capabilities();
 
     private Project project;
 
@@ -92,6 +97,14 @@ public class QuarkusExtensionConfiguration {
 
     public void setDependencyConditions(List<String> dependencyCondition) {
         this.dependencyCondition = dependencyCondition;
+    }
+
+    public List<Capability> getCapabilities() {
+        return capabilities.getCapabilities();
+    }
+
+    public void capabilities(Action<Capabilities> capabilitiesAction) {
+        capabilitiesAction.execute(this.capabilities);
     }
 
     public String getDefaultDeployementArtifactName() {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capabilities.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capabilities.java
@@ -1,0 +1,19 @@
+package io.quarkus.extension.gradle.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Capabilities {
+
+    private List<Capability> capabilities = new ArrayList<>(0);
+
+    public Capability capability(String name) {
+        Capability capability = new Capability(name);
+        capabilities.add(capability);
+        return capability;
+    }
+
+    public List<Capability> getCapabilities() {
+        return capabilities;
+    }
+}

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capability.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capability.java
@@ -1,0 +1,39 @@
+package io.quarkus.extension.gradle.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Capability {
+
+    private String name;
+
+    private List<String> onlyIf = new ArrayList<>(0);
+
+    private List<String> onlyIfNot = new ArrayList<>(0);
+
+    public Capability(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Capability onlyIf(List<String> conditions) {
+        onlyIf.addAll(conditions);
+        return this;
+    }
+
+    public List<String> getOnlyIf() {
+        return onlyIf;
+    }
+
+    public Capability onlyIfNot(List<String> conditions) {
+        onlyIfNot.addAll(conditions);
+        return this;
+    }
+
+    public List<String> getOnlyIfNot() {
+        return onlyIfNot;
+    }
+}

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/QuarkusExtensionPluginTest.java
@@ -37,7 +37,7 @@ public class QuarkusExtensionPluginTest {
 
     @Test
     public void jarShouldContainsExtensionPropertiesFile() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
 
         BuildResult jarResult = GradleRunner.create()
                 .withPluginClasspath()

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/TestUtils.java
@@ -25,7 +25,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class TestUtils {
 
-    public static String getDefaultGradleBuildFileContent(boolean disableValidation, List<String> implementationDependencies)
+    public static String getDefaultGradleBuildFileContent(boolean disableValidation, List<String> implementationDependencies,
+            String customPluginConfiguration)
             throws IOException {
         StringBuilder implementationBuilder = new StringBuilder();
         for (String implementationDependency : implementationDependencies) {
@@ -43,7 +44,7 @@ public class TestUtils {
                 "}\n" +
                 QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { \n" +
                 "disableValidation = " + disableValidation + "\n" +
-
+                customPluginConfiguration +
                 "}\n" +
                 "dependencies { \n" +
                 "implementation enforcedPlatform(\"io.quarkus:quarkus-bom:" + getCurrentQuarkusVersion() + "\")\n" +
@@ -93,7 +94,7 @@ public class TestUtils {
         File runtimeModule = new File(testProjectDir, "runtime");
         runtimeModule.mkdir();
         writeFile(new File(runtimeModule, "build.gradle"),
-                getDefaultGradleBuildFileContent(disableValidation, runtimeDependencies));
+                getDefaultGradleBuildFileContent(disableValidation, runtimeDependencies, ""));
         File runtimeTestFile = new File(runtimeModule, "src/main/java/runtime/Test.java");
         runtimeTestFile.getParentFile().mkdirs();
         writeFile(runtimeTestFile, "package runtime; public class Test {}");

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.quarkus.extension.gradle.QuarkusExtensionPlugin;
 import io.quarkus.extension.gradle.TestUtils;
 
 public class ExtensionDescriptorTaskTest {
@@ -37,7 +36,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldCreateFilesWithDefaultValues() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
         TestUtils.runExtensionDescriptorTask(testProjectDir);
 
         File extensionPropertiesFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.properties");
@@ -75,10 +74,8 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldUseCustomDeploymentArtifactName() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
-                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
-                "deploymentArtifact = 'custom.group:custom-deployment-artifact:0.1.0'" +
-                "}";
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "deploymentArtifact = 'custom.group:custom-deployment-artifact:0.1.0'");
         TestUtils.writeFile(buildFile, buildFileContent);
         TestUtils.runExtensionDescriptorTask(testProjectDir);
 
@@ -91,10 +88,8 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldContainsConditionalDependencies() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
-                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
-                "conditionalDependencies= ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
-                "}";
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "conditionalDependencies= ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']");
         TestUtils.writeFile(buildFile, buildFileContent);
         TestUtils.runExtensionDescriptorTask(testProjectDir);
 
@@ -109,10 +104,9 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldContainsParentFirstArtifacts() throws IOException {
-        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList())
-                + QuarkusExtensionPlugin.EXTENSION_CONFIGURATION_NAME + " { " +
-                "parentFirstArtifacts = ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']" +
-                "}";
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "parentFirstArtifacts = ['org.acme:ext-a:0.1.0', 'org.acme:ext-b:0.1.0']");
+
         TestUtils.writeFile(buildFile, buildFileContent);
         TestUtils.runExtensionDescriptorTask(testProjectDir);
 
@@ -126,7 +120,7 @@ public class ExtensionDescriptorTaskTest {
 
     @Test
     public void shouldGenerateDescriptorBasedOnExistingFile() throws IOException {
-        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList()));
+        TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
         File metaInfDir = new File(testProjectDir, "src/main/resources/META-INF");
         metaInfDir.mkdirs();
         String description = "name: extension-name\n" +
@@ -142,5 +136,25 @@ public class ExtensionDescriptorTaskTest {
         assertThat(extensionDescriptor.get("name").asText()).isEqualTo("extension-name");
         assertThat(extensionDescriptor.has("description")).isTrue();
         assertThat(extensionDescriptor.get("description").asText()).isEqualTo("this is a sample extension");
+    }
+
+    @Test
+    public void shouldGenerateDescriptorWithCapabilities() throws IOException {
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "capabilities { \n" +
+                        "   capability 'org.acme:ext-a:0.1.0' \n" +
+                        "   capability 'org.acme:ext-b:0.1.0' onlyIf(['org.acme:ext-b:0.1.0']) onlyIfNot(['org.acme:ext-c:0.1.0']) \n"
+                        +
+                        "}\n");
+
+        TestUtils.writeFile(buildFile, buildFileContent);
+        TestUtils.runExtensionDescriptorTask(testProjectDir);
+
+        File extensionPropertiesFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.properties");
+        assertThat(extensionPropertiesFile).exists();
+
+        Properties extensionProperty = TestUtils.readPropertyFile(extensionPropertiesFile.toPath());
+        assertThat(extensionProperty).containsEntry("provides-capabilities",
+                "org.acme:ext-a:0.1.0,org.acme:ext-b:0.1.0?org.acme:ext-b:0.1.0?!org.acme:ext-c:0.1.0");
     }
 }


### PR DESCRIPTION
This adds the ability to set `capabilities` from within the gradle extension plugin. 

Capabilities can be used as such: 
````
quarkusExtension {
  capabilities {
    capability 'org.acme:ext-z'
    capability 'org.acme:ext-a' onlyIf ['org.acme:ext-b', 'org.acme:ext-y']
    capability 'org.acme:ext-c' onlyIfNot ['org.acme:ext-d']
    capability 'org.acme:ext-g' onlyIf ['org.acme:ext-b'] onlyIfNot ['org.acme:ext-d']
  }
}
````
