### PR TITLE
Add FrameworkEndpointsBuildStep for OTel Sampler

### DIFF
--- a/extensions/opentelemetry/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/deployment/pom.xml
@@ -17,7 +17,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core-deployment</artifactId>
@@ -26,7 +25,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-deployment</artifactId>
@@ -40,12 +38,7 @@
             <artifactId>quarkus-datasource-deployment-spi</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
@@ -73,11 +66,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
             <scope>test</scope>
@@ -85,6 +73,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,19 +106,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/NonAppEndpointsEqualRootPath.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/NonAppEndpointsEqualRootPath.java
@@ -1,0 +1,47 @@
+package io.quarkus.opentelemetry.deployment;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class NonAppEndpointsEqualRootPath {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TracerRouter.class)
+                    .addClass(TestSpanExporter.class))
+            .overrideConfigKey("quarkus.http.root-path", "/app")
+            .overrideConfigKey("quarkus.http.non-application-root-path", "/app");
+
+    @Inject
+    TestSpanExporter testSpanExporter;
+
+    @Test
+    void testHealthEndpointNotTraced() {
+        // Generates 2 Spans
+        RestAssured.when().get("/tracer").then()
+                .statusCode(200)
+                .body(is("Hello Tracer!"));
+
+        RestAssured.when().get("/health").then()
+                .statusCode(200)
+                .body(containsString("\"status\": \"UP\""));
+
+        RestAssured.when().get("/health/live").then()
+                .statusCode(200)
+                .body(containsString("\"status\": \"UP\""));
+
+        RestAssured.when().get("/health/ready").then()
+                .statusCode(200)
+                .body(containsString("\"status\": \"UP\""));
+
+        testSpanExporter.assertSpanCount(2);
+    }
+}

--- a/extensions/opentelemetry/opentelemetry/runtime/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/runtime/pom.xml
@@ -26,13 +26,17 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-vertx-context</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
 
+        <!-- Optional Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client</artifactId>
@@ -44,10 +48,7 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>io.smallrye.common</groupId>
-            <artifactId>smallrye-common-vertx-context</artifactId>
-        </dependency>
+        <!-- OpenTelemetry Dependencies -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
@@ -91,6 +92,7 @@
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
 
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>

--- a/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/FrameworkEndpointsBuildItem.java
+++ b/extensions/vertx-http/deployment-spi/src/main/java/io/quarkus/vertx/http/deployment/spi/FrameworkEndpointsBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.http.deployment.spi;
+
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class FrameworkEndpointsBuildItem extends SimpleBuildItem {
+    private final List<String> endpoints;
+
+    public FrameworkEndpointsBuildItem(final List<String> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    public List<String> getEndpoints() {
+        return endpoints;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/HttpRootPathBuildItem.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 import io.quarkus.deployment.util.UriNormalizationUtil;
+import io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.console.ConfiguredPathInfo;
 import io.quarkus.vertx.http.runtime.BasicRoute;
@@ -99,7 +100,8 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
 
     public static class Builder extends RouteBuildItem.Builder {
         private final HttpRootPathBuildItem buildItem;
-        private RouteBuildItem.RouteType routeType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
+        private RouteType routeType = RouteType.APPLICATION_ROUTE;
+        private RouteType routerType = RouteType.APPLICATION_ROUTE;
         private String path;
 
         private Builder(HttpRootPathBuildItem buildItem) {
@@ -118,11 +120,11 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
             if (route.startsWith(buildItem.getRootPath())) {
                 // relative to http root (leading slash for vert.x route)
                 this.path = "/" + UriNormalizationUtil.relativize(buildItem.getRootPath(), route);
-                this.routeType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
+                this.routerType = RouteType.APPLICATION_ROUTE;
             } else if (route.startsWith("/")) {
                 // absolute path
                 this.path = route;
-                this.routeType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
+                this.routerType = RouteType.ABSOLUTE_ROUTE;
             }
 
             BasicRoute basicRoute = new BasicRoute(this.path, -1);
@@ -137,11 +139,11 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
             if (route.startsWith(buildItem.getRootPath())) {
                 // relative to http root (leading slash for vert.x route)
                 this.path = "/" + UriNormalizationUtil.relativize(buildItem.getRootPath(), route);
-                this.routeType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
+                this.routerType = RouteType.APPLICATION_ROUTE;
             } else if (route.startsWith("/")) {
                 // absolute path
                 this.path = route;
-                this.routeType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
+                this.routerType = RouteType.ABSOLUTE_ROUTE;
             }
             super.routeFunction(this.path, routeFunction);
             return this;
@@ -208,7 +210,7 @@ public final class HttpRootPathBuildItem extends SimpleBuildItem {
 
         @Override
         public RouteBuildItem build() {
-            return new RouteBuildItem(this, routeType);
+            return new RouteBuildItem(this, routeType, routerType);
         }
 
         @Override

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/NonApplicationRootPathBuildItem.java
@@ -180,6 +180,7 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
     public static class Builder extends RouteBuildItem.Builder {
         private final NonApplicationRootPathBuildItem buildItem;
         private RouteBuildItem.RouteType routeType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
+        private RouteBuildItem.RouteType routerType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
         private String path;
 
         Builder(NonApplicationRootPathBuildItem buildItem) {
@@ -201,15 +202,15 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
             if (isFrameworkRoute) {
                 // relative non-application root (leading slash for vert.x)
                 this.path = "/" + UriNormalizationUtil.relativize(buildItem.getNonApplicationRootPath(), route);
-                this.routeType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
+                this.routerType = RouteBuildItem.RouteType.FRAMEWORK_ROUTE;
             } else if (route.startsWith(buildItem.httpRootPath.getPath())) {
                 // relative to http root (leading slash for vert.x route)
                 this.path = "/" + UriNormalizationUtil.relativize(buildItem.httpRootPath.getPath(), route);
-                this.routeType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
+                this.routerType = RouteBuildItem.RouteType.APPLICATION_ROUTE;
             } else if (route.startsWith("/")) {
                 // absolute path
                 this.path = route;
-                this.routeType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
+                this.routerType = RouteBuildItem.RouteType.ABSOLUTE_ROUTE;
             }
 
             super.routeFunction(this.path, routeFunction);
@@ -277,7 +278,7 @@ public final class NonApplicationRootPathBuildItem extends SimpleBuildItem {
 
         @Override
         public RouteBuildItem build() {
-            return new RouteBuildItem(this, routeType);
+            return new RouteBuildItem(this, routeType, routerType);
         }
 
         @Override

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.http.deployment;
 
+import static io.quarkus.vertx.http.deployment.RouteBuildItem.RouteType.APPLICATION_ROUTE;
+
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -23,16 +25,18 @@ public final class RouteBuildItem extends MultiBuildItem {
     private final Handler<RoutingContext> handler;
     private final HandlerType type;
     private final RouteType routeType;
+    private final RouteType routerType;
     private final NotFoundPageDisplayableEndpointBuildItem notFoundPageDisplayableEndpoint;
-    private final ConfiguredPathInfo devConsoleResolvedPathBuildItem;
+    private final ConfiguredPathInfo configuredPathInfo;
 
-    RouteBuildItem(Builder builder, RouteType routeType) {
+    RouteBuildItem(Builder builder, RouteType routeType, RouteType routerType) {
         this.routeFunction = builder.routeFunction;
         this.handler = builder.handler;
         this.type = builder.type;
         this.routeType = routeType;
+        this.routerType = routerType;
         this.notFoundPageDisplayableEndpoint = builder.getNotFoundEndpoint();
-        this.devConsoleResolvedPathBuildItem = builder.getRouteConfigInfo();
+        this.configuredPathInfo = builder.getRouteConfigInfo();
     }
 
     public Handler<RoutingContext> getHandler() {
@@ -47,24 +51,32 @@ public final class RouteBuildItem extends MultiBuildItem {
         return routeFunction;
     }
 
-    public boolean isFrameworkRoute() {
-        return routeType.equals(RouteType.FRAMEWORK_ROUTE);
+    public RouteType getRouteType() {
+        return routeType;
     }
 
-    public boolean isApplicationRoute() {
-        return routeType.equals(RouteType.APPLICATION_ROUTE);
+    public RouteType getRouterType() {
+        return routerType;
     }
 
-    public boolean isAbsoluteRoute() {
-        return routeType.equals(RouteType.ABSOLUTE_ROUTE);
+    public boolean isRouterFramework() {
+        return routerType.equals(RouteType.FRAMEWORK_ROUTE);
+    }
+
+    public boolean isRouterApplication() {
+        return routerType.equals(APPLICATION_ROUTE);
+    }
+
+    public boolean isRouterAbsolute() {
+        return routerType.equals(RouteType.ABSOLUTE_ROUTE);
     }
 
     public NotFoundPageDisplayableEndpointBuildItem getNotFoundPageDisplayableEndpoint() {
         return notFoundPageDisplayableEndpoint;
     }
 
-    public ConfiguredPathInfo getDevConsoleResolvedPath() {
-        return devConsoleResolvedPathBuildItem;
+    public ConfiguredPathInfo getConfiguredPathInfo() {
+        return configuredPathInfo;
     }
 
     public enum RouteType {
@@ -175,7 +187,7 @@ public final class RouteBuildItem extends MultiBuildItem {
                 throw new IllegalStateException(
                         "'RouteBuildItem$Builder.routeFunction' was not set. Ensure that one of the builder methods that result in it being set is called");
             }
-            return new RouteBuildItem(this, RouteType.APPLICATION_ROUTE);
+            return new RouteBuildItem(this, APPLICATION_ROUTE, APPLICATION_ROUTE);
         }
 
         protected ConfiguredPathInfo getRouteConfigInfo() {

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -565,7 +565,7 @@ public class DevConsoleProcessor {
         // Create map of resolved paths
         Map<String, String> resolvedPaths = new HashMap<>();
         for (RouteBuildItem item : allRoutes) {
-            ConfiguredPathInfo resolvedPathBuildItem = item.getDevConsoleResolvedPath();
+            ConfiguredPathInfo resolvedPathBuildItem = item.getConfiguredPathInfo();
             if (resolvedPathBuildItem != null) {
                 resolvedPaths.put(resolvedPathBuildItem.getName(),
                         resolvedPathBuildItem.getEndpointPath(nonApplicationRootPathBuildItem));


### PR DESCRIPTION
The purpose of this PR is to collect all framework endpoints paths, so we can distinguish them from user endpoints, even if they share the same base root. This will allow extensions like OTel and Metrics to ignore these specific endpoints. Right now we rely on the base path, but if the base path is the same we cannot do it.