### PR TITLE
Mark the HTTP, gRPC and OpenTelemetry DuplicatedContext as 'safe'

### DIFF
--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcDuplicatedContextGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcDuplicatedContextGrpcInterceptor.java
@@ -1,5 +1,7 @@
 package io.quarkus.grpc.runtime.supports.context;
 
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
+
 import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -39,6 +41,7 @@ public class GrpcDuplicatedContextGrpcInterceptor implements ServerInterceptor, 
         if (capturedVertxContext != null) {
             // If we are not on a duplicated context, create and switch.
             Context local = VertxContext.getOrCreateDuplicatedContext(capturedVertxContext);
+            setContextSafe(local, true);
 
             // Must be sure to call next.startCall on the right context
             return new ListenedOnDuplicatedContext<>(() -> next.startCall(call, headers), local);

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/InstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/vertx/InstrumenterVertxTracer.java
@@ -1,5 +1,7 @@
 package io.quarkus.opentelemetry.runtime.tracing.vertx;
 
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
+
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -91,6 +93,7 @@ interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOperation, 
             io.opentelemetry.context.Context spanContext = instrumenter.start(parentContext,
                     writableHeaders((REQ) request, headers));
             Context duplicatedContext = VertxContext.getOrCreateDuplicatedContext(context);
+            setContextSafe(duplicatedContext, true);
             Scope scope = QuarkusContextStorage.INSTANCE.attach(duplicatedContext, spanContext);
             return spanOperation(duplicatedContext, (REQ) request, toMultiMap(headers), spanContext, scope);
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -1,5 +1,8 @@
 package io.quarkus.vertx.http.runtime;
 
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setCurrentContextSafe;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -488,6 +491,7 @@ public class VertxHttpRecorder {
         root = new Handler<HttpServerRequest>() {
             @Override
             public void handle(HttpServerRequest event) {
+                setCurrentContextSafe(true);
                 delegate.handle(new ResumingRequestWrapper(event));
             }
         };
@@ -1209,7 +1213,12 @@ public class VertxHttpRecorder {
                         VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
 
                             Http1xServerConnection conn = new Http1xServerConnection(
-                                    () -> (ContextInternal) VertxContext.getOrCreateDuplicatedContext(context),
+                                    () -> {
+                                        ContextInternal internal = (ContextInternal) VertxContext
+                                                .getOrCreateDuplicatedContext(context);
+                                        setContextSafe(internal, true);
+                                        return internal;
+                                    },
                                     null,
                                     new HttpServerOptions(),
                                     chctx,


### PR DESCRIPTION
Fix #24037 
