### PR TITLE
OIDC: Allow authenticating AccessTokenCredential without routing context

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -124,6 +124,10 @@ public class DefaultTenantConfigResolver {
 
     private TenantConfigContext getStaticTenantContext(RoutingContext context) {
 
+        if (context == null) {
+            return tenantConfigBean.getDefaultTenant();
+        }
+
         String tenantId = context.get(CURRENT_STATIC_TENANT_ID);
 
         if (tenantId == null && context.get(CURRENT_STATIC_TENANT_ID_NULL) == null) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -62,7 +62,11 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
             return Uni.createFrom().nullItem();
         }
         RoutingContext vertxContext = HttpSecurityUtils.getRoutingContextAttribute(request);
-        vertxContext.put(AuthenticationRequestContext.class.getName(), context);
+        if (vertxContext == null && request.getToken() instanceof IdTokenCredential) {
+            return Uni.createFrom().failure(new AuthenticationFailedException());
+        } else if (vertxContext != null) {
+            vertxContext.put(AuthenticationRequestContext.class.getName(), context);
+        }
 
         Uni<TenantConfigContext> tenantConfigContext = tenantResolver.resolveContext(vertxContext);
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -230,7 +230,9 @@ public final class OidcUtils {
     }
 
     public static void setRoutingContextAttribute(QuarkusSecurityIdentity.Builder builder, RoutingContext routingContext) {
-        builder.addAttribute(RoutingContext.class.getName(), routingContext);
+        if (routingContext != null) {
+            builder.addAttribute(RoutingContext.class.getName(), routingContext);
+        }
     }
 
     public static void setSecurityIdentityUserInfo(QuarkusSecurityIdentity.Builder builder, UserInfo userInfo) {

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
@@ -1,15 +1,21 @@
 package io.quarkus.it.keycloak;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.SecurityIdentityAssociation;
 
 @Path("/web-app")
 @Authenticated
@@ -24,6 +30,13 @@ public class ProtectedJwtResource {
     @Context
     SecurityContext securityContext;
 
+    @Inject
+    SecurityIdentityAssociation identityAssociation;
+    @Inject
+    SecurityContextExecutor securityContextExecutor;
+
+    ManagedExecutor executor = ManagedExecutor.builder().cleared(ThreadContext.SECURITY).build();
+
     @GET
     @Path("test-security")
     public String testSecurity() {
@@ -35,5 +48,18 @@ public class ProtectedJwtResource {
     public String testSecurityJwt() {
         return accessToken.getName() + ":" + accessToken.getGroups().iterator().next()
                 + ":" + accessToken.getClaim("email");
+    }
+
+    @GET
+    @Path("test-security-propagation")
+    public String testSecurityPropagation() {
+        CompletableFuture<SecurityIdentity> future = executor.supplyAsync(
+                () -> securityContextExecutor.executeUsingIdentity(accessToken.getRawToken(),
+                        identityAssociation::getIdentity));
+        try {
+            return future.get().getPrincipal().getName();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/SecurityContextExecutor.java
+++ b/integration-tests/oidc/src/main/java/io/quarkus/it/keycloak/SecurityContextExecutor.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.keycloak;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.inject.Inject;
+
+import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.TokenAuthenticationRequest;
+import io.quarkus.security.runtime.SecurityIdentityAssociation;
+
+@ApplicationScoped
+public class SecurityContextExecutor {
+    @Inject
+    SecurityIdentityAssociation identityAssociation;
+    @Inject
+    IdentityProviderManager identityProviderManager;
+
+    @ActivateRequestContext
+    public <T> T executeUsingIdentity(String token, Supplier<T> supplier) {
+        SecurityIdentity originalIdentity = identityAssociation.getIdentity();
+        try {
+            SecurityIdentity identity = identityProviderManager.authenticateBlocking(
+                    new TokenAuthenticationRequest(new AccessTokenCredential(token, null)));
+            identityAssociation.setIdentity(identity);
+            return supplier.get();
+        } finally {
+            identityAssociation.setIdentity(originalIdentity);
+        }
+    }
+}

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -23,6 +23,13 @@ public class TestSecurityLazyAuthTest {
     }
 
     @Test
+    @TestSecurity(user = "user1", roles = "viewer")
+    public void testPropagation() {
+        RestAssured.when().get("test-security-propagation").then()
+                .body(is("user1"));
+    }
+
+    @Test
     @TestSecurity(user = "userJwt", roles = "viewer")
     @OidcSecurity(claims = {
             @Claim(key = "email", value = "user@gmail.com")


### PR DESCRIPTION
The `quarkus-oidc` extension should allow the user to perform a programmatic authentication using the `IdentityProviderManager#authenticate()` and `IdentityProviderManager#authenticateBlocking()` APIs. One use case for this is when the application temporarily stores a given token and uses it later (possibly in a different thread outside of the scope of the original request) to perform some action.