### PR TITLE
Arc - mention that decorating built-in types is not supported; log a warning if we detect such case

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -214,6 +214,7 @@ public class CounterBean {
 * Passivation and passivating scopes are not supported
 * Interceptor methods on superclasses are not implemented yet
 * `@Interceptors` is not supported
+* Decoration of built-in beans, such as `Event`, is not supported
 
 [[nonstandard_features]]
 == Non-standard Features

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Decorators.java
@@ -80,6 +80,16 @@ final class Decorators {
                 throw new DefinitionException("The delegate type " + delegateInjectionPoint.getRequiredType()
                         + " does not implement the decorated type: " + decoratedType);
             }
+            for (BuiltinBean bean : BuiltinBean.values()) {
+                if (bean.equals(BuiltinBean.RESOURCE)) {
+                    // do not take Resource into consideration
+                    continue;
+                }
+                if (bean.hasRawTypeDotName(decoratedType.name())) {
+                    throw new UnsupportedOperationException("Decorating built-in bean types is not supported! " +
+                            "Decorator " + decoratorClass + " is attempting to decorate " + decoratedType.name());
+                }
+            }
         }
 
         if (priority == null) {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorForBuiltInEventTypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/validation/DecoratorForBuiltInEventTypeTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.arc.test.decorators.validation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Priority;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.Annotation;
+import java.util.concurrent.CompletionStage;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class DecoratorForBuiltInEventTypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(BadDecorator.class)
+            .shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        assertNotNull(container.getFailure());
+        assertTrue(
+                container.getFailure().getMessage().contains("Decorating built-in bean types is not supported!"),
+                container.getFailure().getMessage());
+    }
+
+    @Decorator
+    @Priority(1)
+    static class BadDecorator<T> implements Event<T> {
+
+        @Delegate
+        @Inject
+        Event<T> delegate;
+
+        @Override
+        public void fire(T event) {
+
+        }
+
+        @Override
+        public Event<T> select(Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public <U extends T> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public <U extends T> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            return null;
+        }
+
+        @Override
+        public <U extends T> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+            return null;
+        }
+
+        @Override
+        public <U extends T> CompletionStage<U> fireAsync(U event) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Note that in this PR I choose to skip the creation of decorator component with this delegate injection point type.
Instead, we could throw an error.

I tried this with a test but didn't include it here since it is just a log message.

Fixes #23713 