### PR TITLE
Resteasy Reactive: Support use of optional with list/set/sortedset

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/QueryParamTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/QueryParamTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.resteasy.test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class QueryParamTest {
+
+    private static final String HELLO = "hello ";
+    private static final String NOBODY = "nobody";
+    private static final String ALBERT = "albert";
+    private static final String AND = " and ";
+    private static final String JOSE = "jose";
+    private static final String NAME = "name";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MyResource.class));
+
+    @Test
+    public void testWithSomeNames() {
+        Assertions.assertEquals(HELLO + ALBERT + AND + JOSE,
+                RestAssured.given().queryParam(NAME, ALBERT, JOSE).get("/greetings").asString());
+    }
+
+    @Path("/greetings")
+    public static class MyResource {
+
+        @GET
+        public String sayHello(@QueryParam("name") final Optional<List<String>> names) {
+            return HELLO + names.map(l -> l.stream().collect(Collectors.joining(AND)))
+                    .orElse(NOBODY);
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/OptionalQueryParamResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/OptionalQueryParamResource.java
@@ -1,0 +1,49 @@
+package io.quarkus.resteasy.reactive.server.test.simple;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("/optional-query/greetings")
+public class OptionalQueryParamResource {
+
+    public static final String HELLO = "hello ";
+    public static final String NOBODY = "nobody";
+    public static final String AND = " and ";
+
+    @Path("/one")
+    @GET
+    public String sayHelloToValue(@QueryParam("name") final Optional<String> name) {
+        return HELLO + name.orElse(NOBODY);
+    }
+
+    @Path("/list")
+    @GET
+    public String sayHelloToList(@QueryParam("name") final Optional<List<String>> names) {
+        return doSayHelloToCollection(names);
+    }
+
+    @Path("/set")
+    @GET
+    public String sayHelloToSet(@QueryParam("name") final Optional<Set<String>> names) {
+        return doSayHelloToCollection(names);
+    }
+
+    @Path("/sortedset")
+    @GET
+    public String sayHelloToSortedSet(@QueryParam("name") final Optional<SortedSet<String>> names) {
+        return doSayHelloToCollection(names);
+    }
+
+    private String doSayHelloToCollection(final Optional<? extends Collection<String>> names) {
+        return HELLO + names.map(l -> l.stream().collect(Collectors.joining(AND)))
+                .orElse(NOBODY);
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -1,5 +1,8 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
+import static io.quarkus.resteasy.reactive.server.test.simple.OptionalQueryParamResource.AND;
+import static io.quarkus.resteasy.reactive.server.test.simple.OptionalQueryParamResource.HELLO;
+import static io.quarkus.resteasy.reactive.server.test.simple.OptionalQueryParamResource.NOBODY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 
@@ -8,6 +11,7 @@ import java.util.function.Supplier;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -38,7 +42,7 @@ public class SimpleQuarkusRestTestCase {
                                     FeatureResponseFilter.class, DynamicFeatureRequestFilterWithLowPriority.class,
                                     TestFeature.class, TestDynamicFeature.class,
                                     SubResource.class, RootAResource.class, RootBResource.class,
-                                    QueryParamResource.class, HeaderParamResource.class,
+                                    QueryParamResource.class, HeaderParamResource.class, OptionalQueryParamResource.class,
                                     TestWriter.class, TestClass.class,
                                     SimpleBeanParam.class, OtherBeanParam.class, FieldInjectedResource.class,
                                     ParameterWithFromString.class, BeanParamSubClass.class, FieldInjectedSubClassResource.class,
@@ -431,5 +435,41 @@ public class SimpleQuarkusRestTestCase {
     public void testInterfaceResource() {
         RestAssured.get("/iface")
                 .then().statusCode(200).body(Matchers.equalTo("Hello"));
+    }
+
+    @Test
+    public void testQueryParamWithOptionalSingleValue() {
+        // verify with empty
+        Assertions.assertEquals(HELLO + NOBODY, RestAssured.get("/optional-query/greetings/one").asString());
+        // verify with values
+        Assertions.assertEquals(HELLO + "albert", RestAssured.given().queryParam("name", "albert")
+                .get("/optional-query/greetings/one").asString());
+    }
+
+    @Test
+    public void testQueryParamWithOptionalList() {
+        // verify with empty
+        Assertions.assertEquals(HELLO + NOBODY, RestAssured.get("/optional-query/greetings/list").asString());
+        // verify with values
+        Assertions.assertEquals(HELLO + "albert" + AND + "jose", RestAssured.given().queryParam("name", "albert", "jose")
+                .get("/optional-query/greetings/list").asString());
+    }
+
+    @Test
+    public void testQueryParamWithOptionalSet() {
+        // verify with empty
+        Assertions.assertEquals(HELLO + NOBODY, RestAssured.get("/optional-query/greetings/set").asString());
+        // verify with values
+        Assertions.assertEquals(HELLO + "albert" + AND + "jose", RestAssured.given().queryParam("name", "albert", "jose")
+                .get("/optional-query/greetings/set").asString());
+    }
+
+    @Test
+    public void testQueryParamWithOptionalSortedSet() {
+        // verify with empty
+        Assertions.assertEquals(HELLO + NOBODY, RestAssured.get("/optional-query/greetings/sortedset").asString());
+        // verify with values
+        Assertions.assertEquals(HELLO + "albert" + AND + "jose", RestAssured.given().queryParam("name", "albert", "jose")
+                .get("/optional-query/greetings/sortedset").asString());
     }
 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -1136,7 +1136,14 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 typeHandled = true;
                 elementType = toClassName(pt.arguments().get(0), currentClassInfo, actualEndpointInfo, index);
                 if (convertible) {
-                    handleOptionalParam(existingConverters, errorLocation, hasRuntimeConverters, builder, elementType);
+                    String genericElementType = null;
+                    if (pt.arguments().get(0).kind() == Kind.PARAMETERIZED_TYPE) {
+                        genericElementType = toClassName(pt.arguments().get(0).asParameterizedType().arguments().get(0),
+                                currentClassInfo, actualEndpointInfo, index);
+                    }
+
+                    handleOptionalParam(existingConverters, errorLocation, hasRuntimeConverters, builder, elementType,
+                            genericElementType);
                 }
                 builder.setOptional(true);
             } else if (convertible) {
@@ -1227,7 +1234,7 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     }
 
     protected void handleOptionalParam(Map<String, String> existingConverters, String errorLocation,
-            boolean hasRuntimeConverters, PARAM builder, String elementType) {
+            boolean hasRuntimeConverters, PARAM builder, String elementType, String genericElementType) {
     }
 
     protected void handleSetParam(Map<String, String> existingConverters, String errorLocation, boolean hasRuntimeConverters,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/OptionalConverter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/parameters/converters/OptionalConverter.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.reactive.server.core.parameters.converters;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.Optional;
 import org.jboss.resteasy.reactive.server.model.ParamConverterProviders;
 
@@ -18,7 +19,14 @@ public class OptionalConverter implements ParameterConverter {
         if (parameter == null) {
             return Optional.empty();
         } else if (delegate != null) {
-            return Optional.ofNullable(delegate.convert(parameter));
+            Object converted = delegate.convert(parameter);
+            if (converted != null
+                    && converted instanceof Collection
+                    && ((Collection) converted).isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.ofNullable(converted);
+            }
         } else {
             return Optional.of(parameter);
         }


### PR DESCRIPTION
Support use when using query params with some collections. Example:

```java
@Path("/list")
    @GET
    public String sayHelloToList(@QueryParam("name") final Optional<List<String>> names) {
        return doSayHelloToCollection(names);
    }
```

fix https://github.com/quarkusio/quarkus/issues/23898