### PR TITLE
OpenShift: Fix image pull policy property

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -22,6 +22,7 @@ import io.dekorate.kubernetes.config.ImageConfigurationBuilder;
 import io.dekorate.kubernetes.decorator.AddEnvVarDecorator;
 import io.dekorate.kubernetes.decorator.AddLabelDecorator;
 import io.dekorate.kubernetes.decorator.ApplicationContainerDecorator;
+import io.dekorate.kubernetes.decorator.ApplyImagePullPolicyDecorator;
 import io.dekorate.kubernetes.decorator.RemoveFromSelectorDecorator;
 import io.dekorate.kubernetes.decorator.RemoveLabelDecorator;
 import io.dekorate.openshift.decorator.ApplyReplicasDecorator;
@@ -220,6 +221,7 @@ public class OpenshiftProcessor {
         image.ifPresent(i -> {
             result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyContainerImageDecorator(name, i.getImage())));
         });
+        result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyImagePullPolicyDecorator(name, config.getImagePullPolicy())));
         result.add(new DecoratorBuildItem(OPENSHIFT, new AddLabelDecorator(name, OPENSHIFT_APP_RUNTIME, QUARKUS)));
 
         Stream.concat(config.convertToBuildItems().stream(),

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VanillaKubernetesProcessor.java
@@ -141,8 +141,7 @@ public class VanillaKubernetesProcessor {
             result.add(new DecoratorBuildItem(KUBERNETES, new ApplyContainerImageDecorator(name, i.getImage())));
         });
 
-        result
-                .add(new DecoratorBuildItem(KUBERNETES, new ApplyImagePullPolicyDecorator(name, config.getImagePullPolicy())));
+        result.add(new DecoratorBuildItem(KUBERNETES, new ApplyImagePullPolicyDecorator(name, config.getImagePullPolicy())));
         result.add(new DecoratorBuildItem(KUBERNETES, new AddSelectorToDeploymentDecorator(name)));
 
         Stream.concat(config.convertToBuildItems().stream(),

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicOpenshiftTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/BasicOpenshiftTest.java
@@ -6,14 +6,13 @@ import static org.assertj.core.api.Assertions.entry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
-import org.assertj.core.api.AbstractObjectAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -41,16 +40,21 @@ public class BasicOpenshiftTest {
                 .deserializeAsList(kubernetesDir.resolve("openshift.yml"));
 
         assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
-            assertThat(h.getMetadata()).satisfies(m -> {
-                assertThat(m.getName()).isEqualTo("basic-openshift");
-                assertThat(m.getLabels().get("app.openshift.io/runtime")).isEqualTo("quarkus");
-                assertThat(m.getNamespace()).isNull();
-            });
-            AbstractObjectAssert<?, ?> specAssert = assertThat(h).extracting("spec");
-            specAssert.extracting("replicas").isEqualTo(1);
-            specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {
-                assertThat(selectorsMap).containsOnly(entry("app.kubernetes.io/name", "basic-openshift"),
-                        entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+            DeploymentConfig deployment = (DeploymentConfig) h;
+
+            // metadata assertions
+            assertThat(deployment.getMetadata().getName()).isEqualTo("basic-openshift");
+            assertThat(deployment.getMetadata().getLabels().get("app.openshift.io/runtime")).isEqualTo("quarkus");
+            assertThat(deployment.getMetadata().getNamespace()).isNull();
+
+            // spec assertions
+            assertThat(deployment.getSpec().getReplicas()).isEqualTo(1);
+            assertThat(deployment.getSpec().getSelector()).containsOnly(entry("app.kubernetes.io/name", "basic-openshift"),
+                    entry("app.kubernetes.io/version", "0.1-SNAPSHOT"));
+
+            // containers assertions
+            assertThat(deployment.getSpec().getTemplate().getSpec().getContainers()).satisfiesExactly(container -> {
+                assertThat(container.getImagePullPolicy()).isEqualTo("Always"); // expect the default value
             });
         });
 

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithApplicationPropertiesTest.java
@@ -55,6 +55,7 @@ public class OpenshiftWithApplicationPropertiesTest {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getEnv()).extracting("name", "value")
                                     .contains(tuple("MY_ENV_VAR", "SOMEVALUE"));
+                            assertThat(container.getImagePullPolicy()).isEqualTo("IfNotPresent");
                         });
                     });
             specAssert.extracting("selector").isInstanceOfSatisfying(Map.class, selectorsMap -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-application.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-application.properties
@@ -8,5 +8,6 @@ quarkus.openshift.env-vars.my-env-var.value=SOMEVALUE
 quarkus.openshift.group=grp
 quarkus.openshift.route.expose=true
 quarkus.s2i.registry=quay.io
+quarkus.openshift.image-pull-policy=IfNotPresent
 quarkus.openshift.replicas=3
 quarkus.openshift.add-version-to-label-selectors=false


### PR DESCRIPTION
The property `quarkus.openshift.image-pull-policy` was being ignored and the default value was `IfNotPresent` instead of `Always`.
This PR fixes both issues and covers these two scenarios (default setting ++ using he property to use an image pull policy).

Fix https://github.com/quarkusio/quarkus/issues/23492