### PR TITLE
Prepare integration of the next version of reactive messaging

### DIFF
--- a/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
+++ b/extensions/smallrye-reactive-messaging/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/runtime/QuarkusWorkerPoolRegistry.java
@@ -56,7 +56,7 @@ public class QuarkusWorkerPoolRegistry extends WorkerPoolRegistry {
         }
     }
 
-    private WorkerExecutor getWorker(String workerName) {
+    public WorkerExecutor getWorker(String workerName) {
         Objects.requireNonNull(workerName, "Worker Name not specified");
 
         if (workerExecutors.containsKey(workerName)) {


### PR DESCRIPTION
This commit prepares the integration of the next version of reactive messaging without breaking the current integration.
It just makes one method public instead of private. 
