### PR TITLE
Rectify bad class formats in some cases

### DIFF
--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/visitors/KotlinPanacheClassOperationGenerationVisitor.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/visitors/KotlinPanacheClassOperationGenerationVisitor.java
@@ -237,8 +237,7 @@ public class KotlinPanacheClassOperationGenerationVisitor extends ClassVisitor {
 
     private String desc(String name) {
         String s = name.replace(".", "/");
-        s = s.startsWith("L") || s.startsWith("[") ? s : "L" + s + ";";
-        return s;
+        return s.startsWith("[") ? s : "L" + s + ";";
     }
 
     private void descriptors(MethodInfo method, StringJoiner joiner) {


### PR DESCRIPTION
fixes #23727

The checks were a little too defensive coupled with a little too naive and, in practice, ultimately unnecessary as it turns out.