### PR TITLE
Properly captures and restores the vert.x context in the reactive REST Client

### DIFF
--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -112,7 +112,7 @@ public enum QuarkusContextStorage implements ContextStorage {
      *
      * @return a duplicated Vert.x Context or null.
      */
-    private static io.vertx.core.Context getVertxContext() {
+    public static io.vertx.core.Context getVertxContext() {
         io.vertx.core.Context context = Vertx.currentContext();
         if (context != null) {
             io.vertx.core.Context dc = getOrCreateDuplicatedContext(context);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -14,6 +14,7 @@ import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.ext.web.RoutingContext;
 
 public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactiveRequestContext {
@@ -27,7 +28,9 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
             CurrentIdentityAssociation currentIdentityAssociation) {
         super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
         this.association = currentIdentityAssociation;
-        VertxContextSafetyToggle.setCurrentContextSafe(true);
+        if (VertxContext.isOnDuplicatedContext()) {
+            VertxContextSafetyToggle.setCurrentContextSafe(true);
+        }
     }
 
     protected void handleRequestScopeActivation() {

--- a/independent-projects/resteasy-reactive/client/runtime/pom.xml
+++ b/independent-projects/resteasy-reactive/client/runtime/pom.xml
@@ -44,6 +44,10 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-vertx-context</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
@@ -3,6 +3,8 @@ package org.jboss.resteasy.reactive.client.impl;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -43,7 +45,7 @@ public class ClientRequestContextImpl implements ResteasyReactiveClientRequestCo
     private final ConfigurationImpl configuration;
     private final RestClientRequestContext restClientRequestContext;
     private final ClientRequestHeadersMap headersMap;
-    private OutputStream entityStream;
+    private final Context context;
 
     public ClientRequestContextImpl(RestClientRequestContext restClientRequestContext, ClientImpl client,
             ConfigurationImpl configuration) {
@@ -51,6 +53,16 @@ public class ClientRequestContextImpl implements ResteasyReactiveClientRequestCo
         this.client = client;
         this.configuration = configuration;
         this.headersMap = new ClientRequestHeadersMap(); //restClientRequestContext.requestHeaders.getHeaders()
+
+        // Capture or create a duplicated context, and store it.
+        Context current = client.vertx.getOrCreateContext();
+        this.context = VertxContext.getOrCreateDuplicatedContext(current);
+        restClientRequestContext.properties.put(VERTX_CONTEXT_PROPERTY, context);
+    }
+
+    @Override
+    public Context getContext() {
+        return context;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ResteasyReactiveClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/spi/ResteasyReactiveClientRequestContext.java
@@ -1,12 +1,27 @@
 package org.jboss.resteasy.reactive.client.spi;
 
+import io.vertx.core.Context;
 import javax.ws.rs.client.ClientRequestContext;
 
 public interface ResteasyReactiveClientRequestContext extends ClientRequestContext {
+
+    /**
+     * The property used to store the (duplicated) vert.x context with the request.
+     * This context is captured when the ResteasyReactiveClientRequestContext instance is created.
+     * If, at that moment, there is no context, a new duplicated context is created.
+     * If, we are executed on a root context, it creates a new duplicated context from it.
+     * Otherwise, (we are already on a duplicated context), it captures it.
+     */
+    String VERTX_CONTEXT_PROPERTY = "__context";
 
     void suspend();
 
     void resume();
 
     void resume(Throwable t);
+
+    /**
+     * @return the captured or created duplicated context. See {@link #VERTX_CONTEXT_PROPERTY} for details.
+     */
+    Context getContext();
 }

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
@@ -71,10 +71,8 @@ public class OpenTelemetryReactiveClientTest {
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) server.get("attributes")).get(HTTP_METHOD.getKey()));
 
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        // TODO - radcortez - Requires a fix to pass in the UrlPathTemplate in the Vert.x Context. Check:
-        // io.quarkus.resteasy.reactive.server.runtime.observability.ObservabilityHandler
-        // org.jboss.resteasy.reactive.client.AsyncResultUni
-        //assertEquals("reactive", client.get("name"));
+        assertEquals("/reactive", client.get("name"));
+
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
     }
@@ -107,10 +105,8 @@ public class OpenTelemetryReactiveClientTest {
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) server.get("attributes")).get(HTTP_METHOD.getKey()));
 
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        // TODO - radcortez - Requires a fix to pass in the UrlPathTemplate in the Vert.x Context. Check:
-        // io.quarkus.resteasy.reactive.server.runtime.observability.ObservabilityHandler
-        // org.jboss.resteasy.reactive.client.AsyncResultUni
-        //assertEquals("reactive", client.get("name"));
+        assertEquals("/reactive", client.get("name"));
+
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
     }

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/DefaultCtorTestFilter.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/DefaultCtorTestFilter.java
@@ -7,6 +7,6 @@ public class DefaultCtorTestFilter implements ClientRequestFilter {
 
     @Override
     public void filter(ClientRequestContext requestContext) {
-        System.out.println(requestContext.getMethod());
+        // Do nothing on purpose.
     }
 }

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/NonDefaultCtorTestFilter.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/NonDefaultCtorTestFilter.java
@@ -17,6 +17,5 @@ public class NonDefaultCtorTestFilter implements ClientRequestFilter {
     @Override
     public void filter(ClientRequestContext requestContext) {
         mapper.getFactory();
-        System.out.println(requestContext.getUri());
     }
 }

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -154,15 +154,11 @@ public class BasicTest {
                 Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
                 Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
             } else if (spanData.get("kind").equals(SpanKind.CLIENT.toString())
-                    && spanData.get("name").equals("HTTP POST")) {
+                    && spanData.get("name").equals("/hello")) {
                 clientFound = true;
                 // Client span
+                Assertions.assertEquals("/hello", spanData.get("name"));
 
-                // TODO - radcortez - Requires a fix to pass in the UrlPathTemplate in the Vert.x Context. Check:
-                // io.quarkus.resteasy.reactive.server.runtime.observability.ObservabilityHandler
-                // org.jboss.resteasy.reactive.client.AsyncResultUni
-                //assertEquals("reactive", client.get("name"));
-                Assertions.assertEquals("HTTP POST", spanData.get("name"));
                 Assertions.assertEquals(SpanKind.CLIENT.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
 


### PR DESCRIPTION
This PR handle duplicated context propagation property for the reactive REST Client.

When creating a Client request context, we capture the Vert.x context. If none, or if it's a root context, we create a duplicated context. This duplicated context is stored in the client request context, which allows filters, such as open telemetry to retrieve it. 

Also, it executes the HTTP request/response on the captured context.

It also implement a _trampoline_ to avoid enqueuing actions when we are on the right context.