### PR TITLE
ArC - never share a generated observer method for multiple beans

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -120,6 +120,7 @@ public class ObserverGenerator extends AbstractGenerator {
             for (org.jboss.jandex.Type paramType : observer.getObserverMethod().parameters()) {
                 sigBuilder.append(paramType.name().toString());
             }
+            sigBuilder.append(observer.getDeclaringBean().getIdentifier());
         }
 
         StringBuilder baseName = new StringBuilder();

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractSharedContext.java
@@ -5,6 +5,7 @@ import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableContext;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -22,7 +23,12 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
     @SuppressWarnings("unchecked")
     @Override
     public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        Objects.requireNonNull(contextual, "Contextual must not be null");
+        Objects.requireNonNull(creationalContext, "CreationalContext must not be null");
         InjectableBean<T> bean = (InjectableBean<T>) contextual;
+        if (!Scopes.scopeMatches(this, bean)) {
+            throw Scopes.scopeDoesNotMatchException(this, bean);
+        }
         return (T) instances.computeIfAbsent(bean.getIdentifier(), new Supplier<ContextInstanceHandle<?>>() {
             @Override
             public ContextInstanceHandle<?> get() {
@@ -34,7 +40,11 @@ abstract class AbstractSharedContext implements InjectableContext, InjectableCon
     @SuppressWarnings("unchecked")
     @Override
     public <T> T get(Contextual<T> contextual) {
+        Objects.requireNonNull(contextual, "Contextual must not be null");
         InjectableBean<T> bean = (InjectableBean<T>) contextual;
+        if (!Scopes.scopeMatches(this, bean)) {
+            throw Scopes.scopeDoesNotMatchException(this, bean);
+        }
         ContextInstanceHandle<?> handle = instances.getValueIfPresent(bean.getIdentifier());
         return handle != null ? (T) handle.get() : null;
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/RequestContext.java
@@ -56,6 +56,10 @@ class RequestContext implements ManagedContext {
     public <T> T getIfActive(Contextual<T> contextual, Function<Contextual<T>, CreationalContext<T>> creationalContextFun) {
         Objects.requireNonNull(contextual, "Contextual must not be null");
         Objects.requireNonNull(creationalContextFun, "CreationalContext supplier must not be null");
+        InjectableBean<T> bean = (InjectableBean<T>) contextual;
+        if (!Scopes.scopeMatches(this, bean)) {
+            throw Scopes.scopeDoesNotMatchException(this, bean);
+        }
         RequestContextState ctxState = currentContext.get();
         if (ctxState == null) {
             // Thread local not set - context is not active!
@@ -88,6 +92,10 @@ class RequestContext implements ManagedContext {
     @Override
     public <T> T get(Contextual<T> contextual) {
         Objects.requireNonNull(contextual, "Contextual must not be null");
+        InjectableBean<T> bean = (InjectableBean<T>) contextual;
+        if (!Scopes.scopeMatches(this, bean)) {
+            throw Scopes.scopeDoesNotMatchException(this, bean);
+        }
         Map<Contextual<?>, ContextInstanceHandle<?>> ctx = currentContext.get().value;
         if (ctx == null) {
             // Thread local not set - context is not active!

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Scopes.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Scopes.java
@@ -1,0 +1,23 @@
+package io.quarkus.arc.impl;
+
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+
+class Scopes {
+
+    private Scopes() {
+    }
+
+    static boolean scopeMatches(InjectableContext context, InjectableBean<?> bean) {
+        return context.getScope().getName().equals(bean.getScope().getName());
+    }
+
+    static IllegalArgumentException scopeDoesNotMatchException(InjectableContext context, InjectableBean<?> bean) {
+        return new IllegalArgumentException(String.format(
+                "The scope of the bean [%s] does not match the scope of the context [%s]:\n\t- %s bean with bean class %s and identifier %s \n\t- context %s",
+                bean.getScope().getName(), context.getScope().getName(), bean.getKind(), bean.getBeanClass().getName(),
+                bean.getIdentifier(),
+                context.getClass().getName()));
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/ApplicationContextGetTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/application/ApplicationContextGetTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.contexts.application;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.impl.CreationalContextImpl;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ApplicationContextGetTest {
+
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Boom.class);
+
+    @Test
+    public void testGet() {
+        InjectableContext appContext = Arc.container().getActiveContext(ApplicationScoped.class);
+        InjectableBean<Boom> boomBean = Arc.container().instance(Boom.class).getBean();
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> appContext.get(boomBean));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> appContext.get(boomBean, new CreationalContextImpl<>(boomBean)));
+    }
+
+    @Singleton
+    public static class Boom {
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/singleton/SingletonContextGetTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/singleton/SingletonContextGetTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.contexts.singleton;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.impl.CreationalContextImpl;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SingletonContextGetTest {
+
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(Boom.class);
+
+    @Test
+    public void testGet() {
+        InjectableContext appContext = Arc.container().getActiveContext(Singleton.class);
+        InjectableBean<Boom> boomBean = Arc.container().instance(Boom.class).getBean();
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> appContext.get(boomBean));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> appContext.get(boomBean, new CreationalContextImpl<>(boomBean)));
+    }
+
+    @RequestScoped
+    public static class Boom {
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/generated/GeneratedObserverClassNotSharedTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/inheritance/generated/GeneratedObserverClassNotSharedTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.arc.test.observers.inheritance.generated;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ClientProxy;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+// see https://github.com/quarkusio/quarkus/issues/23888
+public class GeneratedObserverClassNotSharedTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Alpha.class, Bravo.class);
+
+    static final Set<Alpha> OBSERVING_ALPHAS = new CopyOnWriteArraySet<>();
+
+    @Test
+    public void testBeanInstancesAreShared() {
+        OBSERVING_ALPHAS.clear();
+        Event<Payload> event = Arc.container().beanManager().getEvent().select(Payload.class);
+        // Fire two events and verify that only one instance of Alpha and Bravo was used
+        event.fire(new Payload());
+        event.fire(new Payload());
+        assertEquals(2, OBSERVING_ALPHAS.size());
+        // Also verify that the observing instances are the same as injectable instances
+        for (Alpha alpha : Arc.container().select(Alpha.class)) {
+            if (alpha instanceof ClientProxy) {
+                alpha = (Alpha) ((ClientProxy) alpha).arc_contextualInstance();
+            }
+            assertTrue(OBSERVING_ALPHAS.contains(alpha), alpha + " was not used to observe the event");
+        }
+    }
+
+    @Singleton
+    public static class Alpha {
+
+        void observe(@Observes Payload payload) {
+            OBSERVING_ALPHAS.add(this);
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Bravo extends Alpha {
+
+    }
+
+    public static class Payload {
+
+    }
+
+}


### PR DESCRIPTION
- resolves #23888
- also throw an IAE if a bean with an invalid scope is passed as an
argument to the Context.get() methods (built-in contexts only)