### PR TITLE
Update WebClient used by DevServices for Keycloak to trust Keycloak

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevServicesUtils.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevServicesUtils.java
@@ -8,6 +8,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
@@ -19,7 +20,10 @@ public final class OidcDevServicesUtils {
     }
 
     public static WebClient createWebClient(Vertx vertx) {
-        return WebClient.create(new io.vertx.mutiny.core.Vertx(vertx));
+        WebClientOptions options = new WebClientOptions();
+        options.setTrustAll(true);
+        options.setVerifyHost(false);
+        return WebClient.create(new io.vertx.mutiny.core.Vertx(vertx), options);
     }
 
     public static String getPasswordAccessToken(WebClient client,


### PR DESCRIPTION
Fixes #24130

This PR only makes sure WebClient used by DevServices for Keycloak (and OIDC dev console) trusts the Keycloak server.
Verified with `security-keycloak-authorization-quickstart`.

The use case is when a user does `mvn quarkus:dev` and `quarkus.oidc.auth-server-url` is set up pointing to the existing container