### PR TITLE
Cosmetic change in Results.asMessage()

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Results.java
@@ -150,7 +150,7 @@ public final class Results {
                 builder.append("\"").append(name);
                 if (!params.isEmpty()) {
                     builder.append("(");
-                    builder.append(getParams().stream().map(Expression::toOriginalString).collect(Collectors.joining(",")));
+                    builder.append(params.stream().map(Expression::toOriginalString).collect(Collectors.joining(",")));
                     builder.append(")");
                 }
                 builder.append("\" not found");


### PR DESCRIPTION
No need to call getParams() when we already have a non-null reference to params