### PR TITLE
Make formatter and impsort cache version-specific

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -697,7 +697,7 @@
                       </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                         <configFile>eclipse-format.xml</configFile>
                         <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
@@ -709,7 +709,7 @@
                     <version>${impsort-maven-plugin.version}</version>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <groups>java.,javax.,org.,com.</groups>
                         <staticGroups>*</staticGroups>
                         <skip>${format.skip}</skip>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -283,7 +283,7 @@
                       </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                         <configFile>eclipse-format.xml</configFile>
                         <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
@@ -295,7 +295,7 @@
                     <version>1.6.2</version>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <removeUnused>true</removeUnused>
                         <skip>${format.skip}</skip>
                     </configuration>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -203,7 +203,7 @@
                     </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                         <configFile>eclipse-format.xml</configFile>
                         <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
@@ -215,7 +215,7 @@
                     <version>1.6.2</version>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <removeUnused>true</removeUnused>
                         <skip>${format.skip}</skip>
                     </configuration>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -113,7 +113,7 @@
                   </dependencies>
                 <configuration>
                     <!-- store outside of target to speed up formatting when mvn clean is used -->
-                    <cachedir>.cache</cachedir>
+                    <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                     <configFile>eclipse-format.xml</configFile>
                     <lineEnding>LF</lineEnding>
                     <skip>${format.skip}</skip>
@@ -125,7 +125,7 @@
                 <version>1.6.2</version>
                 <configuration>
                     <!-- store outside of target to speed up formatting when mvn clean is used -->
-                    <cachedir>.cache</cachedir>
+                    <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                     <removeUnused>true</removeUnused>
                     <skip>${format.skip}</skip>
                 </configuration>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -217,7 +217,7 @@
                       </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                         <configFile>eclipse-format.xml</configFile>
                         <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
@@ -229,7 +229,7 @@
                     <version>1.6.2</version>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <removeUnused>true</removeUnused>
                         <skip>${format.skip}</skip>
                     </configuration>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -464,7 +464,7 @@
                       </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                         <configFile>eclipse-format.xml</configFile>
                         <lineEnding>LF</lineEnding>
                         <skip>${format.skip}</skip>
@@ -476,7 +476,7 @@
                     <version>1.6.2</version>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
-                        <cachedir>.cache</cachedir>
+                        <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                         <removeUnused>true</removeUnused>
                         <skip>${format.skip}</skip>
                     </configuration>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -348,7 +348,7 @@
                   </dependencies>
                 <configuration>
                     <!-- store outside of target to speed up formatting when mvn clean is used -->
-                    <cachedir>.cache</cachedir>
+                    <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
                     <configFile>eclipse-format.xml</configFile>
                     <lineEnding>LF</lineEnding>
                     <skip>${format.skip}</skip>
@@ -360,7 +360,7 @@
                 <version>1.6.2</version>
                 <configuration>
                     <!-- store outside of target to speed up formatting when mvn clean is used -->
-                    <cachedir>.cache</cachedir>
+                    <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                     <removeUnused>true</removeUnused>
                     <skip>${format.skip}</skip>
                 </configuration>


### PR DESCRIPTION
Avoids inconsistencies like this one: https://github.com/quarkusio/quarkus/pull/23944#issuecomment-1061644655

The obvious downside is that on plugin update, obsolete cache files of the older version remain present.
But then again those plugins are updated only rarely. Btw, formatter cache file for core-deployment is ~88k.