### PR TITLE
Close the app bootstrapped in generate-code-tests

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -65,9 +65,10 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
         }
 
         ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        CuratedApplication curatedApplication = null;
         try {
 
-            final CuratedApplication curatedApplication = bootstrapApplication(launchMode);
+            curatedApplication = bootstrapApplication(launchMode);
 
             QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
@@ -85,6 +86,10 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
         } catch (Exception any) {
             throw new MojoExecutionException("Quarkus code generation phase has failed", any);
         } finally {
+            // in case of test mode, we can't share the bootstrapped app with the testing plugins, so we are closing it right away
+            if (test && curatedApplication != null) {
+                curatedApplication.close();
+            }
             Thread.currentThread().setContextClassLoader(originalTccl);
         }
     }

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -306,13 +306,13 @@ public class QuarkusBootstrapProvider implements Closeable {
             final String groupId = coordsArr[0];
             final String artifactId = coordsArr[1];
             String classifier = "";
-            String type = GACTV.TYPE_JAR;
+            String type = ArtifactCoords.TYPE_JAR;
             String version = null;
             if (coordsArr.length == 3) {
                 version = coordsArr[2];
             } else if (coordsArr.length > 3) {
                 classifier = coordsArr[2] == null ? "" : coordsArr[2];
-                type = coordsArr[3] == null ? "jar" : coordsArr[3];
+                type = coordsArr[3] == null ? ArtifactCoords.TYPE_JAR : coordsArr[3];
                 if (coordsArr.length > 4) {
                     version = coordsArr[4];
                 }


### PR DESCRIPTION
Apps bootstrapped in `generate-code-tests` can't be re-used in test plugins, so can be closed right away, instead of waiting for the build to terminate.
This may help with the issue reported in https://github.com/quarkusio/quarkus/issues/23655#issuecomment-1061484895