### PR TITLE
Check FormAuthentication location cookie

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthParametersTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthParametersTestCase.java
@@ -116,7 +116,7 @@ public class FormAuthParametersTestCase {
     }
 
     @Test
-    public void testFormAuthFailure() {
+    public void testFormAuthFailureWrongPassword() {
         CookieFilter cookies = new CookieFilter();
         RestAssured
                 .given()
@@ -131,5 +131,21 @@ public class FormAuthParametersTestCase {
                 .statusCode(302)
                 .header("location", containsString("/error"));
 
+    }
+
+    @Test
+    public void testFormAuthFailureWrongRedirect() {
+        CookieFilter cookies = new CookieFilter();
+        RestAssured
+                .given()
+                .filter(cookies)
+                .when()
+                .cookies("redirect-location", "http://localhost")
+                .formParam("username", "admin")
+                .formParam("password", "admin")
+                .post("/auth")
+                .then()
+                .assertThat()
+                .statusCode(401);
     }
 }


### PR DESCRIPTION
A check is added verifying that the location cookie, once converted to URI, has the same host and port as the current authentication request URI 