### PR TITLE
Change protocol name to TLS in QuarkusRestClientBuilder

### DIFF
--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/QuarkusRestClientBuilder.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/QuarkusRestClientBuilder.java
@@ -357,7 +357,7 @@ public class QuarkusRestClientBuilder implements RestClientBuilder {
         if (trustAll.isPresent() && trustAll.get()) {
             clientBuilder.hostnameVerifier(new NoopHostnameVerifier());
             try {
-                SSLContext sslContext = SSLContext.getInstance("SSL");
+                SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, new TrustManager[] { new PassthroughTrustManager() },
                         new SecureRandom());
                 clientBuilder.sslContext(sslContext);


### PR DESCRIPTION
This PR only changes `SSL` to `TLS`; I haven't verified if in fact on Java 11 `SSL` still defaults to `TLSv1.2` but even if does it is better to have `TLS` to avoid various scanners reporting false positives.

I think having `TLS` is the most flexible option because (quoting some lines from Java Crypto docs):
- TLS 1.2 has been the default-enabled TLS protocol since Java 8
- TLS protocols provide a built-in mechanism to negotiate the specific protocol version to use. When a client connects to a server, it announces the highest version it can support

So if we explicitly start with `TLS1.2` then it may fail against the legacy servers which only implement TLS 1.0 or just don't correctly implement TLS version negotiation.

With `TLS` Quarkus client will start with `TLSv1.2` but will be able to drop to `TLSv1.0` if necessary.

Also CC @cescoffier 