### PR TITLE
Support Stork configuration under the quarkus namespace

### DIFF
--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -49,8 +49,8 @@ For each service expected to be exposed as a Kubernetes Service, configure the l
 
 [source, properties]
 ----
-stork.my-service.service-discovery=kubernetes
-stork.my-service.service-discovery.k8s-namespace=my-namespace
+quarkus.stork.my-service.service-discovery.type=kubernetes
+quarkus.stork.my-service.service-discovery.params.k8s-namespace=my-namespace
 ----
 
 Stork looks for the Kubernetes Service with the given name (`my-service` in the previous example) in the specified namespace.
@@ -110,7 +110,7 @@ This type is used in the configuration to reference the provider:
 
 [source, properties]
 ----
-stork.my-service.service-discovery=acme
+quarkus.stork.my-service.service-discovery.type=acme
 ----
 
 The first step consists of implementing the `io.smallrye.stork.spi.ServiceDiscoveryProvider` interface:
@@ -148,7 +148,7 @@ public class AcmeServiceDiscoveryProvider // <3>
 This implementation is straightforward.
 
 <1> `@ServiceDiscoveryType` annotation defines the type of the service discovery provider. For each `ServiceDiscoveryProvider` annotated with this annotation, a configuration class will be generated. The name of the configuration class is constructed by appending `Configuration` to the name of the provider.
-<2> Use `@ServiceDiscoveryAttribute` to define configuration properties for services configured with this service discovery provider. Configuration properties are gathered from all properties of a form: `stork.my-service.service-discovery.attr=value`.
+<2> Use `@ServiceDiscoveryAttribute` to define configuration properties for services configured with this service discovery provider. Configuration properties are gathered from all properties of a form: `quarkus.stork.my-service.service-discovery.params.attr=value`.
 <3> The provider needs to implement `ServiceDiscoveryType` typed by the configuration class.
 <4> `createServiceDiscovery` method is the factory method. It receives the configuration and access to the name of the service and available infrastructure.
 
@@ -201,9 +201,9 @@ Then, in the configuration, just add:
 
 [source, properties]
 ----
-stork.my-service.service-discovery=acme
-stork.my-service.service-discovery.host=localhost
-stork.my-service.service-discovery.port=1234
+quarkus.stork.my-service.service-discovery.type=acme
+quarkus.stork.my-service.service-discovery.params.host=localhost
+quarkus.stork.my-service.service-discovery.params.port=1234
 ----
 
 Then, Stork will use your implementation to locate the `my-service` service.
@@ -256,7 +256,7 @@ This _type_ is used in the configuration to reference the provider:
 
 [source, properties]
 ----
-stork.my-service.load-balancer=acme
+quarkus.stork.my-service.load-balancer.type=acme
 ----
 
 Similarly to `ServiceDiscoveryProvider, a `LoadBalancerProvider` implementation needs to be annotated with `@LoadBalancerType` that defines the _type_.
@@ -336,8 +336,8 @@ Then, in the configuration, just add:
 
 [source, properties]
 ----
-stork.my-service.service-discovery=...
-stork.my-service.load-balancer=acme
+quarkus.stork.my-service.service-discovery.type=...
+quarkus.stork.my-service.load-balancer.type=acme
 ----
 
 Then, Stork will use your implementation to select the `my-service` service instance.

--- a/docs/src/main/asciidoc/stork.adoc
+++ b/docs/src/main/asciidoc/stork.adoc
@@ -307,10 +307,10 @@ In the `src/main/resources/application.properties`, add:
 consul.host=localhost
 consul.port=8500
 
-stork.my-service.service-discovery=consul
-stork.my-service.service-discovery.consul-host=localhost
-stork.my-service.service-discovery.consul-port=8500
-stork.my-service.load-balancer=round-robin
+quarkus.stork.my-service.service-discovery.type=consul
+quarkus.stork.my-service.service-discovery.params.consul-host=localhost
+quarkus.stork.my-service.service-discovery.params.consul-port=8500
+quarkus.stork.my-service.load-balancer.type=round-robin
 ----
 
 The first two lines provide the Consul location used by the `Registration` bean.
@@ -318,8 +318,8 @@ The first two lines provide the Consul location used by the `Registration` bean.
 The other properties are related to Stork.
 `stork.my-service.service-discovery` indicates which type of service discovery we will be using to locate the `my-service` service.
 In our case, it's `consul`.
-`stork.my-service.service-discovery.consul-host` and `stork.my-service.service-discovery.consul-port` configures the access to Consul.
-Finally, `stork.my-service.load-balancer` configures the service selection.
+`quarkus.stork.my-service.service-discovery.params.consul-host` and `quarkus.stork.my-service.service-discovery.params.consul-port` configures the access to Consul.
+Finally, `quarkus.stork.my-service.load-balancer.type` configures the service selection.
 In our case, we use a `round-robin`.
 
 == Running the application

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkDevModeTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkDevModeTest.java
@@ -57,8 +57,8 @@ public class StorkDevModeTest {
         // @formatter:on
 
         TEST.modifyResourceFile("application.properties",
-                v -> v.replaceAll("stork.hello-service.service-discovery.address-list=.*",
-                        "stork.hello-service.service-discovery.address-list=localhost:8766"));
+                v -> v.replaceAll("quarkus.stork.hello-service.service-discovery.params.address-list=.*",
+                        "quarkus.stork.hello-service.service-discovery.params.address-list=localhost:8766"));
         // @formatter:off
         when()
                 .get("/helper")

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-application.properties
@@ -1,5 +1,5 @@
-stork.hello-service.service-discovery=static
-stork.hello-service.service-discovery.address-list=${quarkus.http.host}:${quarkus.http.test-port}
-stork.hello-service.load-balancer=least-response-time
+quarkus.stork.hello-service.service-discovery.type=static
+quarkus.stork.hello-service.service-discovery.params.address-list=${quarkus.http.host}:${quarkus.http.test-port}
+quarkus.stork.hello-service.load-balancer.type=least-response-time
 
 hello2/mp-rest/url=stork://hello-service/hello

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-dev-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-dev-application.properties
@@ -1,5 +1,5 @@
-stork.hello-service.service-discovery=static
-stork.hello-service.service-discovery.address-list=${quarkus.http.host}:${quarkus.http.port}
-stork.hello-service.load-balancer=least-response-time
+quarkus.stork.hello-service.service-discovery.type=static
+quarkus.stork.hello-service.service-discovery.params.address-list=${quarkus.http.host}:${quarkus.http.port}
+quarkus.stork.hello-service.load-balancer.type=least-response-time
 
 hello2/mp-rest/url=stork://hello-service/hello

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-stat-lb.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/stork-stat-lb.properties
@@ -1,4 +1,4 @@
-stork.hello-service.service-discovery=static
-stork.hello-service.service-discovery.address-list=${quarkus.http.host}:${quarkus.http.test-port},localhost:8766
-stork.hello-service.load-balancer=least-response-time
+quarkus.stork.hello-service.service-discovery.type=static
+quarkus.stork.hello-service.service-discovery.params.address-list=${quarkus.http.host}:${quarkus.http.test-port},localhost:8766
+quarkus.stork.hello-service.load-balancer.type=least-response-time
 hello2/mp-rest/url=stork://hello-service/hello

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
@@ -28,8 +28,16 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-microprofile-config</artifactId>
+            <artifactId>stork-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>io.smallrye.stork</groupId>-->
+<!--            <artifactId>stork-microprofile-config</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>

--- a/extensions/smallrye-stork/deployment/src/main/java/io/quarkus/stork/deployment/SmallRyeStorkProcessor.java
+++ b/extensions/smallrye-stork/deployment/src/main/java/io/quarkus/stork/deployment/SmallRyeStorkProcessor.java
@@ -12,8 +12,9 @@ import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.stork.SmallRyeStorkRecorder;
+import io.quarkus.stork.StorkConfigProvider;
+import io.quarkus.stork.StorkConfiguration;
 import io.quarkus.vertx.deployment.VertxBuildItem;
-import io.smallrye.stork.microprofile.MicroProfileConfigProvider;
 import io.smallrye.stork.spi.internal.LoadBalancerLoader;
 import io.smallrye.stork.spi.internal.ServiceDiscoveryLoader;
 
@@ -22,7 +23,7 @@ public class SmallRyeStorkProcessor {
     @BuildStep
     void registerServiceProviders(BuildProducer<ServiceProviderBuildItem> services) {
         services.produce(new ServiceProviderBuildItem(io.smallrye.stork.spi.config.ConfigProvider.class.getName(),
-                MicroProfileConfigProvider.class.getName()));
+                StorkConfigProvider.class.getName()));
 
         for (Class<?> providerClass : asList(LoadBalancerLoader.class, ServiceDiscoveryLoader.class)) {
             services.produce(ServiceProviderBuildItem.allProvidersFromClassPath(providerClass.getName()));
@@ -33,7 +34,9 @@ public class SmallRyeStorkProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
-    void initializeStork(SmallRyeStorkRecorder storkRecorder, ShutdownContextBuildItem shutdown, VertxBuildItem vertx) {
-        storkRecorder.initialize(shutdown, vertx.getVertx());
+    void initializeStork(SmallRyeStorkRecorder storkRecorder, ShutdownContextBuildItem shutdown, VertxBuildItem vertx,
+            StorkConfiguration configuration) {
+        storkRecorder.initialize(shutdown, vertx.getVertx(), configuration);
     }
+
 }

--- a/extensions/smallrye-stork/runtime/pom.xml
+++ b/extensions/smallrye-stork/runtime/pom.xml
@@ -16,7 +16,11 @@
     <dependencies>
         <dependency>
             <groupId>io.smallrye.stork</groupId>
-            <artifactId>stork-microprofile-config</artifactId>
+            <artifactId>stork-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/ServiceConfiguration.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/ServiceConfiguration.java
@@ -1,0 +1,19 @@
+package io.quarkus.stork;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ServiceConfiguration {
+    /**
+     * ServiceDiscovery configuration for the service
+     */
+    @ConfigItem
+    public StorkServiceDiscoveryConfiguration serviceDiscovery;
+
+    /**
+     * LoadBalancer configuration for the service
+     */
+    @ConfigItem
+    public StorkLoadBalancerConfiguration loadBalancer;
+}

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/SmallRyeStorkRecorder.java
@@ -1,15 +1,20 @@
 package io.quarkus.stork;
 
+import java.util.List;
+
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.smallrye.stork.Stork;
+import io.smallrye.stork.api.config.ServiceConfig;
 import io.vertx.core.Vertx;
 
 @Recorder
 public class SmallRyeStorkRecorder {
 
-    public void initialize(ShutdownContext shutdown, RuntimeValue<Vertx> vertx) {
+    public void initialize(ShutdownContext shutdown, RuntimeValue<Vertx> vertx, StorkConfiguration configuration) {
+        List<ServiceConfig> serviceConfigs = StorkConfigUtil.toStorkServiceConfig(configuration);
+        StorkConfigProvider.init(serviceConfigs);
         Stork.initialize(new QuarkusStorkInfrastructure(vertx.getValue()));
         shutdown.addShutdownTask(new Runnable() {
             @Override

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigProvider.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigProvider.java
@@ -1,0 +1,27 @@
+package io.quarkus.stork;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.spi.config.ConfigProvider;
+
+public class StorkConfigProvider implements ConfigProvider {
+
+    private static final List<ServiceConfig> serviceConfigs = new ArrayList<>();
+
+    public static void init(List<ServiceConfig> configs) {
+        serviceConfigs.addAll(configs);
+    }
+
+    @Override
+    public List<ServiceConfig> getConfigs() {
+        return serviceConfigs;
+    }
+
+    @Override
+    public int priority() {
+        return 150;
+    }
+
+}

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigUtil.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfigUtil.java
@@ -1,0 +1,30 @@
+package io.quarkus.stork;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import io.smallrye.stork.api.config.ServiceConfig;
+import io.smallrye.stork.spi.config.SimpleServiceConfig;
+
+public class StorkConfigUtil {
+
+    public static List<ServiceConfig> toStorkServiceConfig(StorkConfiguration storkConfiguration) {
+        List<ServiceConfig> storkServicesConfigs = new ArrayList<>();
+        Set<String> servicesConfigs = storkConfiguration.serviceConfiguration.keySet();
+        SimpleServiceConfig.Builder builder = new SimpleServiceConfig.Builder();
+        for (String serviceName : servicesConfigs) {
+            builder.setServiceName(serviceName);
+            ServiceConfiguration serviceConfiguration = storkConfiguration.serviceConfiguration.get(serviceName);
+            SimpleServiceConfig.SimpleServiceDiscoveryConfig storkServiceDiscoveryConfig = new SimpleServiceConfig.SimpleServiceDiscoveryConfig(
+                    serviceConfiguration.serviceDiscovery.type, serviceConfiguration.serviceDiscovery.params);
+            builder.setServiceDiscovery(storkServiceDiscoveryConfig);
+            SimpleServiceConfig.SimpleLoadBalancerConfig loadBalancerConfig = new SimpleServiceConfig.SimpleLoadBalancerConfig(
+                    serviceConfiguration.loadBalancer.type, serviceConfiguration.loadBalancer.parameters);
+            builder.setLoadBalancer(loadBalancerConfig);
+            storkServicesConfigs.add(builder.build());
+        }
+        return storkServicesConfigs;
+    }
+
+}

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfiguration.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkConfiguration.java
@@ -1,0 +1,25 @@
+package io.quarkus.stork;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Stork configuration root.
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class StorkConfiguration {
+
+    /**
+     * ServiceDiscovery configuration for the service
+     */
+    @ConfigItem(name = ConfigItem.PARENT)
+    @ConfigDocSection
+    @ConfigDocMapKey("service-name")
+    public Map<String, ServiceConfiguration> serviceConfiguration;
+
+}

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkLoadBalancerConfiguration.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkLoadBalancerConfiguration.java
@@ -1,0 +1,27 @@
+package io.quarkus.stork;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class StorkLoadBalancerConfiguration {
+
+    /**
+     * Configures load balancer type, e.g. "round-robin".
+     * A LoadBalancerProvider for the type has to be available
+     *
+     */
+    @ConfigItem(defaultValue = "round-robin")
+    public String type;
+
+    /**
+     * Load Balancer parameters.
+     * Check the documentation of the selected load balancer type for available parameters
+     *
+     */
+    @ConfigItem
+    public Map<String, String> parameters;
+
+}

--- a/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkServiceDiscoveryConfiguration.java
+++ b/extensions/smallrye-stork/runtime/src/main/java/io/quarkus/stork/StorkServiceDiscoveryConfiguration.java
@@ -1,0 +1,27 @@
+package io.quarkus.stork;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class StorkServiceDiscoveryConfiguration {
+
+    /**
+     * Configures the service discovery type, e.g. "consul".
+     * ServiceDiscoveryProvider for the type has to be available
+     *
+     */
+    @ConfigItem
+    public String type;
+
+    /**
+     * ServiceDiscovery parameters.
+     * Check the documentation of the selected service discovery type for available parameters.
+     *
+     */
+    @ConfigItem
+    public Map<String, String> params;
+
+}

--- a/extensions/smallrye-stork/runtime/src/main/resources/META-INF/services/io.smallrye.stork.spi.config.ConfigProvider
+++ b/extensions/smallrye-stork/runtime/src/main/resources/META-INF/services/io.smallrye.stork.spi.config.ConfigProvider
@@ -1,0 +1,1 @@
+io.quarkus.stork.StorkConfigProvider

--- a/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
+++ b/integration-tests/grpc-mutual-auth/src/main/resources/application.properties
@@ -2,10 +2,10 @@ quarkus.grpc.clients.hello.host=hello-service
 quarkus.grpc.clients.hello.override-authority=localhost
 quarkus.grpc.clients.hello.name-resolver=stork
 
-stork."hello-service".service-discovery=static
-stork."hello-service".service-discovery.address-list=${quarkus.http.host}:9000
-%test.stork."hello-service".service-discovery.address-list=${quarkus.http.host}:9001
-stork."hello-service".load-balancer=round-robin
+quarkus.stork."hello-service".service-discovery.type=static
+quarkus.stork."hello-service".service-discovery.params.address-list=${quarkus.http.host}:9000
+%test.quarkus.stork."hello-service".service-discovery.params.address-list=${quarkus.http.host}:9001
+quarkus.stork."hello-service".load-balancer.type=round-robin
 
 quarkus.grpc.clients.hello.ssl.certificate=src/main/resources/tls/client.pem
 quarkus.grpc.clients.hello.ssl.key=src/main/resources/tls/client.key

--- a/integration-tests/grpc-plain-text-mutiny/src/main/resources/application.properties
+++ b/integration-tests/grpc-plain-text-mutiny/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.grpc.clients.hello.host=hello-service
 
 quarkus.grpc.clients.hello.name-resolver=stork
 
-stork.hello-service.service-discovery=static
-%test.stork.hello-service.service-discovery.address-list=badd-url:9001,${quarkus.http.host}:9001
-stork.hello-service.service-discovery.address-list=badd-url:9000,${quarkus.http.host}:9000
-stork.hello-service.load-balancer=round-robin
+quarkus.stork.hello-service.service-discovery.type=static
+%test.quarkus.stork.hello-service.service-discovery.params.address-list=badd-url:9001,${quarkus.http.host}:9001
+quarkus.stork.hello-service.service-discovery.params.address-list=badd-url:9000,${quarkus.http.host}:9000
+quarkus.stork.hello-service.load-balancer.type=round-robin

--- a/integration-tests/grpc-stork-response-time/src/main/resources/application.properties
+++ b/integration-tests/grpc-stork-response-time/src/main/resources/application.properties
@@ -4,12 +4,12 @@ quarkus.grpc.clients.hello2.host=hello-service2
 quarkus.grpc.clients.hello1.name-resolver=stork
 quarkus.grpc.clients.hello2.name-resolver=stork
 
-stork.hello-service1.service-discovery=static
-stork.hello-service1.service-discovery.address-list=localhost:9013,localhost:9012
-stork.hello-service1.load-balancer=least-response-time
+quarkus.stork.hello-service1.service-discovery.type=static
+quarkus.stork.hello-service1.service-discovery.params.address-list=localhost:9013,localhost:9012
+quarkus.stork.hello-service1.load-balancer.type=least-response-time
 
-stork.hello-service2.service-discovery=static
-stork.hello-service2.service-discovery.address-list=localhost:9013,localhost:9012
-stork.hello-service2.load-balancer=least-response-time
+quarkus.stork.hello-service2.service-discovery.type=static
+quarkus.stork.hello-service2.service-discovery.params.address-list=localhost:9013,localhost:9012
+quarkus.stork.hello-service2.load-balancer.type=least-response-time
 
 #quarkus.log.category."io.quarkus.grpc.runtime.stork".level=DEBUG

--- a/integration-tests/rest-client-reactive-stork/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive-stork/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-stork.hello-service.service-discovery=my
-stork.hello-service.load-balancer=least-response-time
+quarkus.stork.hello-service.service-discovery.type=my
+quarkus.stork.hello-service.load-balancer.type=least-response-time
 hello/mp-rest/url=stork://hello-service/hello
 # slow-service and fast-service come from Slow- and FastWiremockServer
-stork.hello-service.service-discovery.address-list=${slow-service},${fast-service}
+quarkus.stork.hello-service.service-discovery.params.address-list=${slow-service},${fast-service}


### PR DESCRIPTION
Fixes #23942

This allows align the stork extension config with the others. With this PR the config should be something like:

```
quarkus.stork.my-service.service-discovery.type=consul
quarkus.stork.my-service.service-discovery.params.consul-host=localhost
quarkus.stork.my-service.service-discovery.params.consul-port=8500

quarkus.stork.my-service.load-balancer.type=least-random
...

```

