### PR TITLE
Update OpenApiRecorder to recommend using quarkus.http.cors

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -524,6 +524,10 @@ rather than `style.css`.
 
 For more information on styling, read this blog entry: https://quarkus.io/blog/stylish-api/
 
+=== Cross Origin Resource Sharing
+
+If you plan to consume this application from a Single Page Application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). Please read the xref:http-reference.adoc#cors-filter[HTTP CORS documentation] for more details.
+
 == Configuration Reference
 
 === OpenAPI

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -8,7 +8,9 @@ import java.util.function.Supplier;
 
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
+import org.jboss.logging.Logger;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
@@ -18,6 +20,7 @@ import io.vertx.ext.web.RoutingContext;
 
 @Recorder
 public class OpenApiRecorder {
+    private static final Logger log = Logger.getLogger(OpenApiRecorder.class);
     final RuntimeValue<HttpConfiguration> configuration;
 
     public OpenApiRecorder(RuntimeValue<HttpConfiguration> configuration) {
@@ -26,6 +29,9 @@ public class OpenApiRecorder {
 
     public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig) {
         if (runtimeConfig.enable) {
+            if (!configuration.getValue().corsEnabled && LaunchMode.NORMAL == LaunchMode.current()) {
+                log.info("Default CORS properties will be used, please use 'quarkus.http.cors' properties instead");
+            }
             return new OpenApiHandler(configuration.getValue().corsEnabled);
         } else {
             return new OpenApiNotFoundHandler();


### PR DESCRIPTION
This PR adds a log info message to `OpenApiRecorder` to recommend using `quarkus.http.cors` in the production mode and update the docs with a link to HTTP CORS section