### PR TITLE
Fix multi-module Hot-Code-Replacement

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -213,8 +213,8 @@ public class DevModeContext implements Serializable {
 
     public List<ModuleInfo> getAllModules() {
         List<ModuleInfo> ret = new ArrayList<>();
-        ret.add(applicationRoot);
         ret.addAll(additionalModules);
+        ret.add(applicationRoot);
         return ret;
     }
 


### PR DESCRIPTION
* [Here](https://github.com/quarkusio/quarkus/blob/e8b0c1e02b7eab0fda93fe476b15839eb1051c97/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java#L656) the `applicationRoot` will always be traversed first. Thus, any incompatible change in any other module will always result in a compile error https://github.com/quarkusio/quarkus/blob/e8b0c1e02b7eab0fda93fe476b15839eb1051c97/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java#L708
* Furthermore this will always result in `restartNeeded = false`
https://github.com/quarkusio/quarkus/blob/e8b0c1e02b7eab0fda93fe476b15839eb1051c97/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java#L525
* resolves [#23164](https://github.com/quarkusio/quarkus/issues/23164)
