### PR TITLE
Enable info logs on gradle tests

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -33,6 +33,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         command.add(getGradleWrapperCommand());
         command.addAll(getSytemProperties());
         command.add("--stacktrace");
+        command.add("--info");
         command.addAll(Arrays.asList(args));
 
         File logOutput = new File(projectDir, "command-output.log");


### PR DESCRIPTION
This enable info logs. It will provide more info on test failure. 

The CI is ok on my fork.