### PR TITLE
Document regex capabilities for CORS origins

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/cors/CORSConfig.java
@@ -15,7 +15,9 @@ public class CORSConfig {
     /**
      * Origins allowed for CORS
      *
-     * Comma separated list of valid URLs. ex: http://www.quarkus.io,http://localhost:3000
+     * Comma separated list of valid URLs, e.g.: http://www.quarkus.io,http://localhost:3000
+     * In case an entry of the list is surrounded by forward slashes,
+     * it is interpreted as a regular expression.
      * The filter allows any origin if this is not set.
      *
      * default: returns any requested origin as valid


### PR DESCRIPTION
The current documentation on the CORS filter at https://quarkus.io/guides/http-reference#cors-filter only instructs about the regular expression capabilities for origins in the example, but not in the reference section for available config properties. This commit enhances the javadoc comment to include a hint about the regular expression support.