### PR TITLE
Support multiple levels of JUnit Nested with QuarkusTest

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -35,6 +36,8 @@ public class QuarkusTestNestedTestCase {
     private static final AtomicInteger COUNT_AFTER_ALL = new AtomicInteger(0);
     private static final String EXPECTED_OUTER_VALUE = "set from outer";
     private static final String EXPECTED_INNER_VALUE = "set from inner";
+    private static final String EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE = "set from second level first inner";
+    private static final String EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE = "set from second level second inner";
 
     String outerValue;
 
@@ -74,9 +77,9 @@ public class QuarkusTestNestedTestCase {
         @Order(1)
         void testOne() {
             assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
-            assertEquals(5, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(7, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
             assertEquals(2, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
-            assertEquals(3, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(5, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
             assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
         }
 
@@ -84,9 +87,9 @@ public class QuarkusTestNestedTestCase {
         @Order(2)
         void testTwo() {
             assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
-            assertEquals(7, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(9, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
             assertEquals(3, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
-            assertEquals(5, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(7, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
             assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
         }
 
@@ -99,6 +102,38 @@ public class QuarkusTestNestedTestCase {
         @AfterEach
         void afterEach() {
             COUNT_AFTER_EACH.incrementAndGet();
+        }
+
+        @Nested
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        @TestMethodOrder(OrderAnnotation.class)
+        class SecondLevelInnerNested {
+
+            private final AtomicInteger SECOND_LEVEL_COUNTER = new AtomicInteger(0);
+
+            String secondLevelInnerValue;
+
+            @BeforeEach
+            void beforeEach() {
+                SECOND_LEVEL_COUNTER.incrementAndGet();
+                secondLevelInnerValue = EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE;
+            }
+
+            @Test
+            @Order(1)
+            void testOne() {
+                // assertEquals(1, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
+                assertEquals(1, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
+            }
+
+            @Test
+            @Order(2)
+            void testSecondLevelAndInnerAndOuterValues() {
+                assertEquals(2, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
+                assertEquals(EXPECTED_INNER_VALUE, innerValue);
+                assertEquals(EXPECTED_OUTER_VALUE, outerValue);
+                assertEquals(EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE, secondLevelInnerValue);
+            }
         }
     }
 
@@ -123,6 +158,23 @@ public class QuarkusTestNestedTestCase {
         void afterEach() {
             COUNT_AFTER_EACH.incrementAndGet();
         }
+
+        @Nested
+        class SecondLevelInnerNested {
+
+            String secondLevelInnerValue;
+
+            @BeforeEach
+            void beforeEach() {
+                secondLevelInnerValue = EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE;
+            }
+
+            @Test
+            void testSecondLevelAndInnerAndOuterValues() {
+                assertEquals(EXPECTED_OUTER_VALUE, outerValue);
+                assertEquals(EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE, secondLevelInnerValue);
+            }
+        }
     }
 
     @AfterEach
@@ -133,9 +185,9 @@ public class QuarkusTestNestedTestCase {
     @AfterAll
     static void afterAll() {
         assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
-        assertEquals(9, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(15, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
         assertEquals(4, COUNT_TEST.get(), "COUNT_TEST");
-        assertEquals(9, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(15, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
         assertEquals(0, COUNT_AFTER_ALL.getAndIncrement(), "COUNT_AFTER_ALL");
     }
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetOuterMockitoMocksCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/ResetOuterMockitoMocksCallback.java
@@ -7,8 +7,10 @@ public class ResetOuterMockitoMocksCallback implements QuarkusTestAfterAllCallba
 
     @Override
     public void afterAll(QuarkusTestContext context) {
-        if (context.getOuterInstance() != null) {
-            MockitoMocksTracker.reset(context.getOuterInstance());
+        if (context.getOuterInstances() != null) {
+            for (Object outerInstance : context.getOuterInstances()) {
+                MockitoMocksTracker.reset(outerInstance);
+            }
         }
     }
 }

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/internal/SetMockitoMockAsBeanMockCallback.java
@@ -9,8 +9,10 @@ public class SetMockitoMockAsBeanMockCallback implements QuarkusTestBeforeEachCa
     @Override
     public void beforeEach(QuarkusTestMethodContext context) {
         MockitoMocksTracker.getMocks(context.getTestInstance()).forEach(this::installMock);
-        if (context.getOuterInstance() != null) {
-            MockitoMocksTracker.getMocks(context.getOuterInstance()).forEach(this::installMock);
+        if (context.getOuterInstances() != null) {
+            for (Object outerInstance : context.getOuterInstances()) {
+                MockitoMocksTracker.getMocks(outerInstance).forEach(this::installMock);
+            }
         }
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestContext.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestContext.java
@@ -1,23 +1,25 @@
 package io.quarkus.test.junit.callback;
 
+import java.util.List;
+
 /**
  * Context object passed to {@link QuarkusTestAfterAllCallback}
  */
 public class QuarkusTestContext {
 
     private final Object testInstance;
-    private final Object outerInstance;
+    private final List<Object> outerInstances;
 
-    public QuarkusTestContext(Object testInstance, Object outerInstance) {
+    public QuarkusTestContext(Object testInstance, List<Object> outerInstances) {
         this.testInstance = testInstance;
-        this.outerInstance = outerInstance;
+        this.outerInstances = outerInstances;
     }
 
     public Object getTestInstance() {
         return testInstance;
     }
 
-    public Object getOuterInstance() {
-        return outerInstance;
+    public List<Object> getOuterInstances() {
+        return outerInstances;
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestMethodContext.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestMethodContext.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.junit.callback;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 /**
  * Context object passed to {@link QuarkusTestBeforeEachCallback} and {@link QuarkusTestAfterEachCallback}
@@ -9,8 +10,8 @@ public final class QuarkusTestMethodContext extends QuarkusTestContext {
 
     private final Method testMethod;
 
-    public QuarkusTestMethodContext(Object testInstance, Object outerInstance, Method testMethod) {
-        super(testInstance, outerInstance);
+    public QuarkusTestMethodContext(Object testInstance, List<Object> outerInstances, Method testMethod) {
+        super(testInstance, outerInstances);
         this.testMethod = testMethod;
     }
 


### PR DESCRIPTION
The initTestState is being called each time there is a Nested class, so we need to keep the previous reference in the outerInstances list. 
Only the last class (the one that has no more enclosing classes) is the actual test instance and the one that can be resolved using CDI (runningQuarkusApplication.instance(outerClass)).

Fix https://github.com/quarkusio/quarkus/issues/19845