### PR TITLE
In Resteasy Reactive, fix line separator for "x-ndjson" and "stream+json".

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/sse/SseTestCase.java
@@ -119,8 +119,8 @@ public class SseTestCase {
         when().get(uri.toString() + "sse/ndjson/multi")
                 .then().statusCode(HttpStatus.SC_OK)
                 // @formatter:off
-                .body(is("{\"name\":\"hello\"}/n"
-                            + "{\"name\":\"stef\"}/n"))
+                .body(is("{\"name\":\"hello\"}\n"
+                            + "{\"name\":\"stef\"}\n"))
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE, containsString(RestMediaType.APPLICATION_NDJSON));
     }
@@ -130,8 +130,8 @@ public class SseTestCase {
         when().get(uri.toString() + "sse/stream-json/multi")
                 .then().statusCode(HttpStatus.SC_OK)
                 // @formatter:off
-                .body(is("{\"name\":\"hello\"}/n"
-                        + "{\"name\":\"stef\"}/n"))
+                .body(is("{\"name\":\"hello\"}\n"
+                        + "{\"name\":\"stef\"}\n"))
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE, containsString(RestMediaType.APPLICATION_STREAM_JSON));
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/sse/SseTestCase.java
@@ -117,8 +117,8 @@ public class SseTestCase {
         when().get(uri.toString() + "sse/ndjson/multi")
                 .then().statusCode(HttpStatus.SC_OK)
                 // @formatter:off
-                .body(is("{\"name\":\"hello\"}/n"
-                            + "{\"name\":\"stef\"}/n"))
+                .body(is("{\"name\":\"hello\"}\n"
+                            + "{\"name\":\"stef\"}\n"))
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE, containsString(RestMediaType.APPLICATION_NDJSON));
     }
@@ -128,8 +128,8 @@ public class SseTestCase {
         when().get(uri.toString() + "sse/stream-json/multi")
                 .then().statusCode(HttpStatus.SC_OK)
                 // @formatter:off
-                .body(is("{\"name\":\"hello\"}/n"
-                        + "{\"name\":\"stef\"}/n"))
+                .body(is("{\"name\":\"hello\"}\n"
+                        + "{\"name\":\"stef\"}\n"))
                 // @formatter:on
                 .header(HttpHeaders.CONTENT_TYPE, containsString(RestMediaType.APPLICATION_STREAM_JSON));
     }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/PublisherResponseHandler.java
@@ -66,7 +66,7 @@ public class PublisherResponseHandler implements ServerRestHandler {
 
     private static class ChunkedStreamingMultiSubscriber extends StreamingMultiSubscriber {
 
-        private static final String LINE_SEPARATOR = "/n";
+        private static final String LINE_SEPARATOR = "\n";
 
         private boolean isFirstItem = true;
 


### PR DESCRIPTION
We're wrongly using `/n` instead of `\n`.
This was done in https://github.com/quarkusio/quarkus/pull/20908