### PR TITLE
Don't list quarkus-jaxrs-client-reactive

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,7 @@ metadata:
   categories:
   - "web"
   status: "stable"
+  unlisted: true
   codestart:
     name: "resteasy-reactive"
     kind: "core"


### PR DESCRIPTION
We don't mention this in the guides anywhere, nor
do we have any real use cases for using this
other than a dependency of the quarkus-rest-client-reactive
and in the RESTEasy Reactive TCK

Closes: #19860