### PR TITLE
Update resteasy-reactive-kotlin w/ capabilities

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin/runtime/pom.xml
@@ -46,6 +46,10 @@
                     <dependencyCondition>
                         <artifact>io.quarkus:quarkus-kotlin</artifact>
                     </dependencyCondition>
+                    <capabilities>
+                        <provides>io.quarkus.rest.kotlinx-serialization</provides>
+                        <provides>io.quarkus.resteasy.reactive.json.kotlinx-serialization</provides>
+                    </capabilities>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
> NOTE: I didn't test this, it seemed straightforward so I filed the PR in the browser just to get things moving

Currently Quarkus issues a warning when using Kotlinx Serialization with RESTEasy Reactive at startup:

```
2022-03-09 09:45:38,116 WARN  [io.qua.res.rea.ser.dep.QuarkusServerEndpointIndexer] (build-9)
Quarkus detected the use of JSON in JAX-RS method 'com.example.ReactiveGreetingResource#helloJson'
but no JSON extension has been added. Consider adding 'quarkus-resteasy-reactive-jackson' or 'quarkus-resteasy-reactive-jsonb'.
```

This is because of `QuarkusServerEndpointIndexer#warnAboutMissingJsonProviderIfNeeded()`:

https://github.com/quarkusio/quarkus/blob/39f9d05f695d3aef99755f3f347f7f5142b7537d/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/QuarkusServerEndpointIndexer.java#L168-L177

This fixes the warning (I think) by adding the capabilities.