### PR TITLE
Use StringTokenizer to parse OIDC cookies

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 import org.jose4j.jwt.consumer.ErrorCodes;
@@ -57,8 +56,6 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
     static final String AMP = "&";
     static final String EQ = "=";
     static final String UNDERSCORE = "_";
-    static final String COOKIE_DELIM = "|";
-    static final Pattern COOKIE_PATTERN = Pattern.compile("\\" + COOKIE_DELIM);
     static final String SESSION_MAX_AGE_PARAM = "session-max-age";
     static final String STATE_COOKIE_RESTORE_PATH = "restore-path";
     static final Uni<Void> VOID_UNI = Uni.createFrom().voidItem();
@@ -137,7 +134,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
 
     private Uni<SecurityIdentity> processRedirectFromOidc(RoutingContext context, OidcTenantConfig oidcTenantConfig,
             IdentityProviderManager identityProviderManager, Cookie stateCookie, MultiMap requestParams) {
-        String[] parsedStateCookieValue = COOKIE_PATTERN.split(stateCookie.getValue());
+        String[] parsedStateCookieValue = OidcUtils.parseCookieValue(stateCookie.getValue());
         OidcUtils.removeCookie(context, oidcTenantConfig, stateCookie.getName());
 
         if (!isStateValid(requestParams, parsedStateCookieValue[0])) {
@@ -657,7 +654,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             }
             extraStateValue.setCodeVerifier(pkceCodeVerifier);
             if (!extraStateValue.isEmpty()) {
-                cookieValue += (COOKIE_DELIM + encodeExtraStateValue(extraStateValue, configContext));
+                cookieValue += (OidcUtils.COOKIE_DELIM + encodeExtraStateValue(extraStateValue, configContext));
             }
         }
         createCookie(context, configContext.oidcConfig, getStateCookieName(configContext.oidcConfig), cookieValue, 60 * 30);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTokenStateManager.java
@@ -25,9 +25,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
         sb.append(encryptToken(tokens.getIdToken(), routingContext, oidcConfig));
         if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.KEEP_ALL_TOKENS) {
             if (!oidcConfig.tokenStateManager.splitTokens) {
-                sb.append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                sb.append(OidcUtils.COOKIE_DELIM)
                         .append(encryptToken(tokens.getAccessToken(), routingContext, oidcConfig))
-                        .append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                        .append(OidcUtils.COOKIE_DELIM)
                         .append(encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
             } else {
                 CodeAuthenticationMechanism.createCookie(routingContext,
@@ -45,9 +45,9 @@ public class DefaultTokenStateManager implements TokenStateManager {
             }
         } else if (oidcConfig.tokenStateManager.strategy == OidcTenantConfig.TokenStateManager.Strategy.ID_REFRESH_TOKENS) {
             if (!oidcConfig.tokenStateManager.splitTokens) {
-                sb.append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                sb.append(OidcUtils.COOKIE_DELIM)
                         .append("")
-                        .append(CodeAuthenticationMechanism.COOKIE_DELIM)
+                        .append(OidcUtils.COOKIE_DELIM)
                         .append(encryptToken(tokens.getRefreshToken(), routingContext, oidcConfig));
             } else {
                 if (tokens.getRefreshToken() != null) {
@@ -65,7 +65,7 @@ public class DefaultTokenStateManager implements TokenStateManager {
     @Override
     public Uni<AuthorizationCodeTokens> getTokens(RoutingContext routingContext, OidcTenantConfig oidcConfig, String tokenState,
             OidcRequestContext<AuthorizationCodeTokens> requestContext) {
-        String[] tokens = CodeAuthenticationMechanism.COOKIE_PATTERN.split(tokenState);
+        String[] tokens = OidcUtils.parseCookieValue(tokenState);
         String idToken = decryptToken(tokens[0], routingContext, oidcConfig);
 
         String accessToken = null;

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -412,4 +412,42 @@ public class OidcUtilsTest {
         }
     }
 
+    @Test
+    public void testParseCookieValueOneToken() throws Exception {
+        String[] values = OidcUtils.parseCookieValue("1");
+        assertEquals(1, values.length);
+        assertEquals("1", values[0]);
+    }
+
+    @Test
+    public void testParseCookieValueTwoTokens() throws Exception {
+        String[] values = OidcUtils.parseCookieValue("1|2");
+        assertEquals(2, values.length);
+        assertEquals("1", values[0]);
+        assertEquals("2", values[1]);
+    }
+
+    @Test
+    public void testParseCookieValueThreeTokensOneEmpty() throws Exception {
+        String[] values = OidcUtils.parseCookieValue("1||3");
+        assertEquals(3, values.length);
+        assertEquals("1", values[0]);
+        assertEquals("", values[1]);
+        assertEquals("3", values[2]);
+    }
+
+    @Test
+    public void testParseCookieValueThreeTokens() throws Exception {
+        String[] values = OidcUtils.parseCookieValue("1|2|3");
+        assertEquals(3, values.length);
+        assertEquals("1", values[0]);
+        assertEquals("2", values[1]);
+        assertEquals("3", values[2]);
+    }
+
+    @Test
+    public void testParseEmptyCookieValue() throws Exception {
+        String[] values = OidcUtils.parseCookieValue("");
+        assertEquals(0, values.length);
+    }
 }


### PR DESCRIPTION
OIDC `session cookie` can have 2 or 3 tokens, example, `IDToken|AccessToken|RefreshToken` or only two: `IDToken||RefreshToken` (when keeping access token is not required).
OIDC state cookie has a similar format (keeps the state used during the redirect to OIDC) with an optional extra data also separated by `|`.

Right now a split is done using a RegEx pattern. It is faster and safer to use a simple `StringTokenizer`