### PR TITLE
Introduce --link-at-build-time flag for GraalVM 22.1 and later

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/NativeImageAllowIncompleteClasspathBuildItem.java
@@ -4,10 +4,11 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * If any build item of this type is produced, the native-image build tool
- * will run with {@literal --allow-incomplete-classpath} set.
+ * will run with {@literal --allow-incomplete-classpath} set for versions prior to 22.1 or
+ * without {@literal --link-at-build-time} set for versions later than 22.0.
  * <p>
  * This should be strongly discouraged as it makes diagnostics of any issue
- * much more complex, and we have it seen affect error message of code
+ * much more complex, and we have seen it affect error messages of code
  * seemingly unrelated to the code which is having the broken classpath.
  * <p>
  * Use of this build item will trigger a warning during build.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -684,7 +684,11 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:FallbackThreshold=0");
                 }
 
-                if (classpathIsBroken) {
+                // 22.1 removes --allow-incomplete-classpath and makes it the default. --link-at-build-time is now
+                // needed to bring back the old behavior (which requires all classes to be resolvable at build time).
+                if (graalVMVersion.isNewerThan(GraalVM.Version.VERSION_22_0_0_2) && !classpathIsBroken) {
+                    nativeImageArgs.add("--link-at-build-time");
+                } else if (!graalVMVersion.isNewerThan(GraalVM.Version.VERSION_22_0_0_2) && classpathIsBroken) {
                     nativeImageArgs.add("--allow-incomplete-classpath");
                 }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAllowIncompleteClasspathAggregateStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAllowIncompleteClasspathAggregateStep.java
@@ -23,9 +23,9 @@ public final class NativeImageAllowIncompleteClasspathAggregateStep {
             final String extensionsRequiringBrokenClasspath = list.stream()
                     .map(NativeImageAllowIncompleteClasspathBuildItem::getExtensionName)
                     .collect(Collectors.joining(","));
-            log.warn("The following extensions have required the '--allow-incomplete-classpath' flag to be set: {"
+            log.warn("The following extensions have required native-image to allow run-time resolution of classes: {"
                     + extensionsRequiringBrokenClasspath
-                    + "}. This is a global flag which might have unexpected effects on other extensions as well, and is a hint of the library "
+                    + "}. This is a global requirement which might have unexpected effects on other extensions as well, and is a hint of the library "
                     +
                     "needing some additional refactoring to better support GraalVM native-image. In the case of 3rd party dependencies and/or"
                     +


### PR DESCRIPTION
https://github.com/oracle/graal/pull/4305 makes `--allow-incomplete-classpath` the default behavior (removing the flag) and introduces a new flag `--link-at-build-time` which enables us to set which classes/packages we require to be resolvable at build time. Passing `--link-at-build-time` without arguments to `native-image` requires all classes/packages to be resolvable at build time, essentially bringing the pre-22.1 behavior back.