### PR TITLE
Allow Jackson configuration through properties

### DIFF
--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonFeaturesTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonFeaturesTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonFeaturesTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-serialization-properties.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void objectMapperConfigCorrect() {
+        assertThat(this.objectMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)).isTrue();
+        assertThat(this.objectMapper.isEnabled(SerializationFeature.WRAP_ROOT_VALUE)).isTrue();
+        assertThat(this.objectMapper.isEnabled(DeserializationFeature.UNWRAP_ROOT_VALUE)).isTrue();
+        assertThat(this.objectMapper.isEnabled(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)).isTrue();
+        assertThat(this.objectMapper.isEnabled(JsonParser.Feature.ALLOW_COMMENTS)).isTrue();
+        assertThat(this.objectMapper.isEnabled(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION)).isTrue();
+    }
+
+    @Test
+    public void objectToJsonDoesntContainEmptyValue() throws JsonProcessingException {
+        assertThat(this.objectMapper.writeValueAsString(new Pojo("", 1, "value // This is a comment")))
+                .isEqualTo("{\"Pojo\":{\"anotherField\":\"value // This is a comment\",\"order\":1}}");
+    }
+
+    @Test
+    public void objectToJsonPropertyOrderingCorrect() throws JsonProcessingException {
+        assertThat(this.objectMapper.writeValueAsString(new Pojo("Darth Vader", 1, "value // This is a comment")))
+                .isEqualTo("{\"Pojo\":{\"anotherField\":\"value // This is a comment\",\"name\":\"Darth Vader\",\"order\":1}}");
+    }
+
+    @Test
+    public void jsonToObjectContainsEmptyValue() throws JsonProcessingException {
+        assertThat(this.objectMapper.readValue("{\"Pojo\":{\"anotherField\":\"value // This is a comment\",\"order\":1}}",
+                Pojo.class))
+                        .isNotNull()
+                        .extracting(Pojo::getName, Pojo::getOrder, Pojo::getAnotherField)
+                        .containsExactly(null, 1, "value // This is a comment");
+    }
+
+    @Test
+    public void jsonToObjectFailsOnUnknownProperty() {
+        assertThatExceptionOfType(UnrecognizedPropertyException.class)
+                .isThrownBy(() -> this.objectMapper.readValue("{\"Pojo\":{\"unknownProperty\":1}}", Pojo.class))
+                .extracting(UnrecognizedPropertyException::getPropertyName)
+                .isEqualTo("unknownProperty");
+    }
+
+    public static class Pojo {
+        private String name;
+        private int order;
+        private String anotherField;
+
+        public Pojo() {
+        }
+
+        public Pojo(String name, int order, String anotherField) {
+            this.name = name;
+            this.order = order;
+            this.anotherField = anotherField;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getOrder() {
+            return order;
+        }
+
+        public void setOrder(int order) {
+            this.order = order;
+        }
+
+        public String getAnotherField() {
+            return anotherField;
+        }
+
+        public void setAnotherField(String anotherField) {
+            this.anotherField = anotherField;
+        }
+    }
+}

--- a/extensions/jackson/deployment/src/test/resources/application-serialization-properties.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-serialization-properties.properties
@@ -1,0 +1,13 @@
+quarkus.jackson.serialization-inclusion=non-empty
+quarkus.jackson.fail-on-unknown-properties=true
+
+# Want to make sure this does not override quarkus.jackson.fail-on-unknown-properties
+quarkus.jackson.deserialization.FAIL_ON_UNKNOWN_PROPERTIES=false
+
+# Some are ALL_UPPERCASE_WITH_UNDERSCORES and some are all-lowercase-with-hypens on purpose
+# to show that either is fine
+quarkus.jackson.serialization.WRAP_ROOT_VALUE=true
+quarkus.jackson.deserialization.unwrap-root-value=true
+quarkus.jackson.mapper.SORT_PROPERTIES_ALPHABETICALLY=true
+quarkus.jackson.parser.allow-comments=true
+quarkus.jackson.generator.STRICT_DUPLICATE_DETECTION=true

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.jackson.runtime;
 
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -52,4 +53,34 @@ public class JacksonBuildTimeConfig {
      */
     @ConfigItem
     public Optional<JsonInclude.Include> serializationInclusion;
+
+    /**
+     * Enable/disable Jackson serialization ({@code com.fasterxml.jackson.databind.SerializationFeature}) features.
+     */
+    @ConfigItem
+    public Map<String, Boolean> serialization;
+
+    /**
+     * Enable/disable Jackson deserialization ({@code com.fasterxml.jackson.databind.DeserializationFeature}) features.
+     */
+    @ConfigItem
+    public Map<String, Boolean> deserialization;
+
+    /**
+     * Enable/disable Jackson general purpose mapping ({@code com.fasterxml.jackson.databind.MapperFeature}) features.
+     */
+    @ConfigItem
+    public Map<String, Boolean> mapper;
+
+    /**
+     * Enable/disable Jackson parser ({@code com.fasterxml.jackson.core.JsonParser.Feature}) features.
+     */
+    @ConfigItem
+    public Map<String, Boolean> parser;
+
+    /**
+     * Enable/disable Jackson generator ({@code com.fasterxml.jackson.core.JsonGenerator.Feature}) features.
+     */
+    @ConfigItem
+    public Map<String, Boolean> generator;
 }

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -1,9 +1,9 @@
 package io.quarkus.jackson.runtime;
 
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -11,7 +11,8 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,33 +30,56 @@ public class ObjectMapperProducer {
     public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers,
             JacksonBuildTimeConfig jacksonBuildTimeConfig) {
         ObjectMapper objectMapper = new ObjectMapper();
-        if (!jacksonBuildTimeConfig.failOnUnknownProperties) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        }
-        if (!jacksonBuildTimeConfig.failOnEmptyBeans) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-        }
-        if (!jacksonBuildTimeConfig.writeDatesAsTimestamps) {
-            // this feature is enabled by default, so we disable it
-            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        }
-        if (jacksonBuildTimeConfig.acceptCaseInsensitiveEnums) {
-            objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
-        }
-        JsonInclude.Include serializationInclusion = jacksonBuildTimeConfig.serializationInclusion.orElse(null);
-        if (serializationInclusion != null) {
-            objectMapper.setSerializationInclusion(serializationInclusion);
-        }
-        ZoneId zoneId = jacksonBuildTimeConfig.timezone.orElse(null);
-        if ((zoneId != null) && !zoneId.getId().equals("UTC")) { // Jackson uses UTC as the default, so let's not reset it
-            objectMapper.setTimeZone(TimeZone.getTimeZone(zoneId));
-        }
-        List<ObjectMapperCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
-        for (ObjectMapperCustomizer customizer : sortedCustomizers) {
-            customizer.customize(objectMapper);
-        }
+
+        // These are done first so that the other boolean properties will take precedence over them
+        jacksonBuildTimeConfig.serialization.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> Map.entry(SerializationFeature.valueOf(entry.getKey().toUpperCase().replace('-', '_')),
+                        entry.getValue()))
+                .forEach(entry -> objectMapper.configure(entry.getKey(), entry.getValue()));
+
+        jacksonBuildTimeConfig.deserialization.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> Map.entry(DeserializationFeature.valueOf(entry.getKey().toUpperCase().replace('-', '_')),
+                        entry.getValue()))
+                .forEach(entry -> objectMapper.configure(entry.getKey(), entry.getValue()));
+
+        jacksonBuildTimeConfig.mapper.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> Map.entry(MapperFeature.valueOf(entry.getKey().toUpperCase().replace('-', '_')),
+                        entry.getValue()))
+                .forEach(entry -> objectMapper.configure(entry.getKey(), entry.getValue()));
+
+        jacksonBuildTimeConfig.parser.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> Map.entry(JsonParser.Feature.valueOf(entry.getKey().toUpperCase().replace('-', '_')),
+                        entry.getValue()))
+                .forEach(entry -> objectMapper.configure(entry.getKey(), entry.getValue()));
+
+        jacksonBuildTimeConfig.generator.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> Map.entry(JsonGenerator.Feature.valueOf(entry.getKey().toUpperCase().replace('-', '_')),
+                        entry.getValue()))
+                .forEach(entry -> objectMapper.configure(entry.getKey(), entry.getValue()));
+
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                jacksonBuildTimeConfig.failOnUnknownProperties);
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, jacksonBuildTimeConfig.failOnEmptyBeans);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
+                jacksonBuildTimeConfig.writeDatesAsTimestamps);
+        objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS,
+                jacksonBuildTimeConfig.acceptCaseInsensitiveEnums);
+
+        jacksonBuildTimeConfig.serializationInclusion.ifPresent(objectMapper::setSerializationInclusion);
+
+        jacksonBuildTimeConfig.timezone
+                .filter(zoneId -> !zoneId.getId().equals("UTC")) // Jackson uses UTC as the default, so let's not reset it
+                .map(TimeZone::getTimeZone)
+                .ifPresent(objectMapper::setTimeZone);
+
+        sortCustomizersInDescendingPriorityOrder(customizers)
+                .forEach(customizer -> customizer.customize(objectMapper));
+
         return objectMapper;
     }
 


### PR DESCRIPTION
Allow Jackson configuration through properties.

**NOTE:** This does not require #24214. That could make this simpler. 

Closes #18572