### PR TITLE
Support for required capabilities

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CapabilityAggregationStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CapabilityAggregationStep.java
@@ -106,8 +106,7 @@ public class CapabilityAggregationStep {
             final Object previous = providedCapabilities.put(capability, provider);
             if (previous != null) {
                 if (previous instanceof String) {
-                    capabilityErrors = capabilityErrors == null ? capabilityErrors = new CapabilityErrors()
-                            : capabilityErrors;
+                    capabilityErrors = createIfNull(capabilityErrors);
                     capabilityErrors.addConflict(capability, previous.toString());
                     providedCapabilities.put(capability, capabilityErrors);
                 } else {
@@ -122,6 +121,18 @@ public class CapabilityAggregationStep {
                     capsProvidedByBuildSteps = new HashMap<>();
                 }
                 capsProvidedByBuildSteps.computeIfAbsent(provider, k -> new ArrayList<>(1)).add(capability);
+            }
+        }
+
+        for (ExtensionCapabilities extCap : curateOutcomeBuildItem.getApplicationModel().getExtensionCapabilities()) {
+            if (extCap.getRequiresCapabilities().isEmpty()) {
+                continue;
+            }
+            for (String required : extCap.getRequiresCapabilities()) {
+                if (!providedCapabilities.containsKey(required)) {
+                    capabilityErrors = createIfNull(capabilityErrors);
+                    capabilityErrors.addMissing(required, extCap.getExtension());
+                }
             }
         }
 
@@ -148,5 +159,9 @@ public class CapabilityAggregationStep {
         }
 
         return new Capabilities(providedCapabilities.keySet());
+    }
+
+    private static CapabilityErrors createIfNull(CapabilityErrors capabilityErrors) {
+        return capabilityErrors == null ? capabilityErrors = new CapabilityErrors() : capabilityErrors;
     }
 }

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/GradleApplicationModelBuilder.java
@@ -440,7 +440,7 @@ public class GradleApplicationModelBuilder implements ParameterizedToolingModelB
         final String providesCapabilities = extProps.getProperty(BootstrapConstants.PROP_PROVIDES_CAPABILITIES);
         if (providesCapabilities != null) {
             modelBuilder
-                    .addExtensionCapabilities(CapabilityContract.providesCapabilities(extensionCoords, providesCapabilities));
+                    .addExtensionCapabilities(CapabilityContract.of(extensionCoords, providesCapabilities, null));
         }
         return true;
     }

--- a/docs/src/main/asciidoc/capabilities.adoc
+++ b/docs/src/main/asciidoc/capabilities.adoc
@@ -7,15 +7,21 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-Quarkus extensions may declare in their descriptors (`META-INF/quarkus-extension.properties` found in the runtime extension JAR artifact) that they provide certain capabilities. A capability represents a technical aspect, e.g. an implementation of some functionality or a specification. Each capability has a name which should follow the Java package naming convention, e.g. `io.quarkus.rest`.
+Quarkus extensions may provide certain capabilities and require certain capabilities to be provided by other extensions in an application to function properly.
+
+A capability represents a technical aspect, for example, it could be an implementation of some functionality, a contract or a specification. Each capability has a name which should follow the Java package naming convention, e.g. `io.quarkus.rest`.
+
+Capability promises and requirements are described in Quarkus extension descriptors - `META-INF/quarkus-extension.properties` entries of the runtime extension JAR artifacts.
 
 IMPORTANT: Only a single provider of any given capability is allowed in an application. If more than one provider of a capability is detected, the application build will fail with the corresponding error message.
+
+If one extension requires a certain capability, there must be another one among the application dependencies that provides that capability, otherwise the build will fail with the corresponding error message.
 
 At build time all the capabilities found in the application will be aggregated in an instance of the `io.quarkus.deployment.Capabilities` build item that extension build steps can inject to check whether a given capability is available or not.
 
 == Declaring capabilities
 
-The `quarkus-bootstrap-maven-plugin:extension-descriptor` Maven goal and the `extensionDescriptor` Gradle task, generating the extension descriptor, allows to declare provided capabilities in the following way:
+The `quarkus-bootstrap-maven-plugin:extension-descriptor` Maven goal and the `extensionDescriptor` Gradle task, that generate extension descriptors, allow configuring provided and required capabilities in the following way:
 
 [role="primary asciidoc-tabs-sync-maven"]
 .Maven
@@ -27,12 +33,15 @@ The `quarkus-bootstrap-maven-plugin:extension-descriptor` Maven goal and the `ex
     <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
     <configuration>
         <capabilities>
-            <provides>io.quarkus.rest</provides>
-            <provides>io.quarkus.resteasy</provides>
+            <provides>io.quarkus.hibernate.orm</provides> <1>
+            <requires>io.quarkus.agroal</requires> <2>
         </capabilities>
     </configuration>
 </plugin>
 ----
+<1> the extension provides the `io.quarkus.hibernate.orm` capability (multiple `provides` elements are allowed)
+<2> the extension requires the `io.quarkus.agroal` capability to be provided to function properly (multiple `requires` elements are allowed)
+
 ****
 
 [role="secondary asciidoc-tabs-sync-gradle-groovy"]
@@ -67,13 +76,9 @@ quarkusExtension {
 NOTE: The Gradle extension plugin is still experimental and may change in the future.
 ****
 
-In this case, the extension is declaring two capabilities.
+=== Conditional capability promises and requirements
 
-
-
-=== Declaring conditional capabilities
-
-A capability may be provided only if a certain condition is satisfied, e.g. if a certain configuration option is enabled or based on some other condition. This could be expressed in the following way:
+A capability may be provided or required only if a certain condition is satisfied, for example, if a certain configuration option is enabled or based on some other condition. Here is how a conditional capability promise can be configured:
 
 [role="primary asciidoc-tabs-sync-maven"]
 .Maven
@@ -98,6 +103,8 @@ A capability may be provided only if a certain condition is satisfied, e.g. if a
 <3> provided capability name
 
 NOTE: `providesIf` allows listing multiple `<positive>` as well as `<negative>` elements.
+
+The corresponding `requiresIf` element is also supported.
 
 ****
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/BootstrapConstants.java
@@ -32,6 +32,7 @@ public interface BootstrapConstants {
 
     String PROP_DEPLOYMENT_ARTIFACT = "deployment-artifact";
     String PROP_PROVIDES_CAPABILITIES = "provides-capabilities";
+    String PROP_REQUIRES_CAPABILITIES = "requires-capabilities";
     String PARENT_FIRST_ARTIFACTS = "parent-first-artifacts";
     String EXCLUDED_ARTIFACTS = "excluded-artifacts";
     String LESSER_PRIORITY_ARTIFACTS = "lesser-priority-artifacts";

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityContract.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityContract.java
@@ -2,30 +2,74 @@ package io.quarkus.bootstrap.model;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class CapabilityContract implements ExtensionCapabilities, Serializable {
 
     private static final long serialVersionUID = -2817736967526011849L;
 
+    private static final Pattern capabilitiesPattern = Pattern.compile("\\s*,\\s*");
+
+    /**
+     * @deprecated in favor of {@link #of(String, String, String)}
+     *
+     * @param extension extension id
+     * @param commaSeparatedList provided capabilities as a command-separated string
+     * @return capability contract
+     */
+    @Deprecated(forRemoval = true)
     public static CapabilityContract providesCapabilities(String extension, String commaSeparatedList) {
-        final List<String> list = Arrays.asList(commaSeparatedList.split("\\s*,\\s*"));
-        for (String provided : list) {
-            if (provided.isEmpty()) {
+        return of(extension, commaSeparatedList, null);
+    }
+
+    public static CapabilityContract of(String extension, String providesStr, String requiresStr) {
+
+        final Collection<String> provides = parseCapabilities(providesStr);
+        for (String name : provides) {
+            if (name.isEmpty()) {
                 throw new IllegalArgumentException("Extension " + extension
-                        + " was configured to provide a capability with an empty name: " + commaSeparatedList);
+                        + " was configured to provide a capability with an empty name: " + providesStr);
             }
         }
-        return new CapabilityContract(extension, list);
+        final Collection<String> requires = parseCapabilities(requiresStr);
+        for (String name : requires) {
+            if (name.isEmpty()) {
+                throw new IllegalArgumentException("Extension " + extension
+                        + " was configured to require a capability with an empty name: " + requiresStr);
+            }
+        }
+
+        return new CapabilityContract(extension, provides, requires);
+    }
+
+    private static Collection<String> parseCapabilities(String s) {
+        return s == null || s.isBlank() ? List.of() : Arrays.asList(capabilitiesPattern.split(s));
     }
 
     private final String extension;
-    private final List<String> providesCapabilities;
+    private final Collection<String> providesCapabilities;
+    private final Collection<String> requiresCapabilities;
 
-    public CapabilityContract(String extension, List<String> providesCapabilities) {
+    /**
+     * @deprecated in favor of {@link #CapabilityContract(String, Collection, Collection)}
+     *
+     * @param extension extension id, typically its artifact coordinates but could also potentially be "unknown", currently used
+     *        for display purposes.
+     * @param providesCapabilities provided capabilities
+     */
+    @Deprecated(forRemoval = true)
+    public CapabilityContract(String extension, Collection<String> providesCapabilities) {
+        this(extension, providesCapabilities, List.of());
+    }
+
+    public CapabilityContract(String extension, Collection<String> providesCapabilities,
+            Collection<String> requiresCapabilities) {
         this.extension = Objects.requireNonNull(extension, "extension can't be null");
         this.providesCapabilities = Objects.requireNonNull(providesCapabilities, "providesCapabilities can't be null");
+        this.requiresCapabilities = Objects.requireNonNull(requiresCapabilities, "requiresCapabilities can't be null");
     }
 
     @Override
@@ -34,7 +78,12 @@ public class CapabilityContract implements ExtensionCapabilities, Serializable {
     }
 
     @Override
-    public List<String> getProvidesCapabilities() {
+    public Collection<String> getProvidesCapabilities() {
         return providesCapabilities;
+    }
+
+    @Override
+    public Collection<String> getRequiresCapabilities() {
+        return requiresCapabilities;
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityErrors.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/CapabilityErrors.java
@@ -12,36 +12,57 @@ import java.util.Map;
 public class CapabilityErrors {
 
     private final Map<String, List<String>> conflicts = new HashMap<>();
+    private final Map<String, List<String>> missing = new HashMap<>();
 
     public void addConflict(String capability, String provider) {
         conflicts.computeIfAbsent(capability, k -> new ArrayList<>()).add(provider);
     }
 
+    public void addMissing(String capability, String consumer) {
+        missing.computeIfAbsent(capability, k -> new ArrayList<>()).add(consumer);
+    }
+
     public boolean isEmpty() {
-        return conflicts.isEmpty();
+        return conflicts.isEmpty() && missing.isEmpty();
     }
 
     public String report() {
         final StringWriter sw = new StringWriter();
         try (BufferedWriter writer = new BufferedWriter(sw)) {
-            writer.write("Please make sure there is only one provider of the following capabilities:");
-            // To have a consistent report over multiple builds, the capabilities and providers are ordered alphabetically
-            final List<String> capabilities = new ArrayList<>(conflicts.size());
-            capabilities.addAll(conflicts.keySet());
-            Collections.sort(capabilities);
-            for (String capability : capabilities) {
-                writer.newLine();
-                writer.append("capability ").append(capability).append(" is provided by:");
-                final List<String> providers = conflicts.get(capability);
-                Collections.sort(providers);
-                for (String provider : providers) {
-                    writer.newLine();
-                    writer.append("  - ").append(provider);
-                }
-            }
+            reportProblems(conflicts, false, writer);
+            reportProblems(missing, true, writer);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to generate the capability conflicts report out of " + conflicts, e);
+            throw new RuntimeException("Failed to generate the capability error report out of conflicts " + conflicts
+                    + " and unsatisfied " + missing, e);
         }
         return sw.getBuffer().toString();
+    }
+
+    private static void reportProblems(Map<String, List<String>> problems, boolean missing, BufferedWriter writer)
+            throws IOException {
+        if (problems.isEmpty()) {
+            return;
+        }
+        if (missing) {
+            writer.write(
+                    "The following capability requirements aren't satisfied by the Quarkus extensions present on the classpath:");
+        } else {
+            writer.write("Please make sure there is only one provider of the following capabilities:");
+        }
+        // To have a consistent report over multiple builds, the capabilities and providers are ordered alphabetically
+        final List<String> capabilities = new ArrayList<>(problems.size());
+        capabilities.addAll(problems.keySet());
+        Collections.sort(capabilities);
+        for (String capability : capabilities) {
+            writer.newLine();
+            writer.append("capability ").append(capability).append(missing ? " is required by:" : " is provided by:");
+            final List<String> extensions = problems.get(capability);
+            Collections.sort(extensions);
+            for (String extension : extensions) {
+                writer.newLine();
+                writer.append("  - ").append(extension);
+            }
+        }
+        writer.newLine();
     }
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ExtensionCapabilities.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ExtensionCapabilities.java
@@ -7,4 +7,6 @@ public interface ExtensionCapabilities {
     String getExtension();
 
     Collection<String> getProvidesCapabilities();
+
+    Collection<String> getRequiresCapabilities();
 }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -65,7 +65,8 @@ public class BootstrapUtils {
         }
         builder.setAppArtifact(appArtifact);
         builder.setCapabilitiesContracts(appModel.getExtensionCapabilities().stream()
-                .map(c -> new CapabilityContract(c.getExtension(), new ArrayList<>(c.getProvidesCapabilities())))
+                .map(c -> new CapabilityContract(c.getExtension(), new ArrayList<>(c.getProvidesCapabilities()),
+                        new ArrayList<>(c.getRequiresCapabilities())))
                 .collect(Collectors.toMap(CapabilityContract::getExtension, Function.identity())));
         builder.setPlatformImports(appModel.getPlatforms());
         appModel.getDependencies().forEach(d -> {

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/capabilities/CapabilitiesConfig.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/capabilities/CapabilitiesConfig.java
@@ -1,0 +1,35 @@
+package io.quarkus.maven.capabilities;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CapabilitiesConfig {
+
+    private List<CapabilityConfig> provides = new ArrayList<>(0);
+    private List<CapabilityConfig> requires = new ArrayList<>(0);
+
+    public void addProvides(CapabilityConfig capability) {
+        provides.add(capability);
+    }
+
+    public void addProvidesIf(CapabilityConfig capability) {
+        provides.add(capability);
+    }
+
+    public Collection<CapabilityConfig> getProvides() {
+        return provides;
+    }
+
+    public void addRequires(CapabilityConfig capability) {
+        requires.add(capability);
+    }
+
+    public void addRequiresIf(CapabilityConfig capability) {
+        requires.add(capability);
+    }
+
+    public Collection<CapabilityConfig> getRequires() {
+        return requires;
+    }
+}

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/DeploymentInjectingDependencyVisitor.java
@@ -539,9 +539,10 @@ public class DeploymentInjectingDependencyVisitor {
             appBuilder.handleExtensionProperties(props, runtimeArtifact.toString());
 
             final String providesCapabilities = props.getProperty(BootstrapConstants.PROP_PROVIDES_CAPABILITIES);
-            if (providesCapabilities != null) {
+            final String requiresCapabilities = props.getProperty(BootstrapConstants.PROP_REQUIRES_CAPABILITIES);
+            if (providesCapabilities != null || requiresCapabilities != null) {
                 appBuilder.addExtensionCapabilities(
-                        CapabilityContract.providesCapabilities(toGactv(runtimeArtifact), providesCapabilities));
+                        CapabilityContract.of(toCompactCoords(runtimeArtifact), providesCapabilities, requiresCapabilities));
             }
         }
     }
@@ -661,8 +662,16 @@ public class DeploymentInjectingDependencyVisitor {
                 .setResolvedPaths(artifact.getFile() == null ? PathList.empty() : PathList.of(artifact.getFile().toPath()));
     }
 
-    private static String toGactv(Artifact a) {
-        return a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getClassifier() + ":" + a.getExtension() + ":"
-                + a.getVersion();
+    private static String toCompactCoords(Artifact a) {
+        final StringBuilder b = new StringBuilder();
+        b.append(a.getGroupId()).append(':').append(a.getArtifactId()).append(':');
+        if (!a.getClassifier().isEmpty()) {
+            b.append(a.getClassifier()).append(':');
+        }
+        if (!ArtifactCoords.TYPE_JAR.equals(a.getExtension())) {
+            b.append(a.getExtension()).append(':');
+        }
+        b.append(a.getVersion());
+        return b.toString();
     }
 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>acme-quarkus-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>acme-quarkus-ext-deployment</artifactId>
+    <name>Acme Quarkus Ext - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>acme-quarkus-ext</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>\${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/deployment/src/main/java/org/acme/quarkus/ext/deployment/AcmeQuarkusExtProcessor.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/deployment/src/main/java/org/acme/quarkus/ext/deployment/AcmeQuarkusExtProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.quarkus.ext.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class AcmeQuarkusExtProcessor {
+
+    private static final String FEATURE = "acme-quarkus-ext";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>acme-quarkus-ext-parent</artifactId>
+    <name>Acme Quarkus Ext - Parent</name>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <quarkus.version>@project.version@</quarkus.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    </properties>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/acme-ext/runtime/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>acme-quarkus-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>acme-quarkus-ext</artifactId>
+    <name>Acme Quarkus Ext - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>\${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>org.acme:acme-quarkus-ext-deployment:1.0-SNAPSHOT</deployment>
+                            <capabilities>
+                                <requires>sunshine</requires>
+                            </capabilities>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>\${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/deployment/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>alt-quarkus-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alt-quarkus-ext-deployment</artifactId>
+    <name>Alt Quarkus Ext - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>alt-quarkus-ext</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>\${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/deployment/src/main/java/org/acme/quarkus/ext/deployment/AcmeQuarkusExtProcessor.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/deployment/src/main/java/org/acme/quarkus/ext/deployment/AcmeQuarkusExtProcessor.java
@@ -1,0 +1,15 @@
+package org.acme.quarkus.ext.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class AltQuarkusExtProcessor {
+
+    private static final String FEATURE = "alt-quarkus-ext";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alt-quarkus-ext-parent</artifactId>
+    <name>Alt Quarkus Ext - Parent</name>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <quarkus.version>@project.version@</quarkus.version>
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    </properties>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>\${compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/alt-ext/runtime/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>alt-quarkus-ext-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alt-quarkus-ext</artifactId>
+    <name>Alt Quarkus Ext - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>\${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>org.acme:alt-quarkus-ext-deployment:1.0-SNAPSHOT</deployment>
+                            <capabilities>
+                                <provides>sunshine</provides>
+                            </capabilities>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>\${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.version>@project.version@</quarkus.platform.version>
+        <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <modules>
+        <module>acme-ext</module>
+        <module>alt-ext</module>
+        <module>runner</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>\${quarkus-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>acme-quarkus-ext</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.acme</groupId>
+                <artifactId>alt-quarkus-ext</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/runner/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/runner/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acme</groupId>
+        <artifactId>quarkus-quickstart-multimodule-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.acme</groupId>
+    <artifactId>quarkus-quickstart-multimodule-main</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>acme-quarkus-ext</artifactId>
+        </dependency>
+        <!-- missing -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>\${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>\${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>\${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${surefire-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>\${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/runner/src/main/java/org/acme/HelloResource.java
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/runner/src/main/java/org/acme/HelloResource.java
@@ -1,0 +1,17 @@
+package org.acme;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}


### PR DESCRIPTION
This PR adds support for extensions to declare capability requirements that must be satisfied for the application build to succeed.

The Quarkus Gradle extension plugin still needs to be enhanced to allow configuring capability requirements. @glefloch would you be interested in completing that part? I just noticed you used `capability` in the DSL instead of the `provides` (or something) unlike in the Maven plugin config. We'll probably need to re-work that.