### PR TITLE
Add `TestEngine` filters to continuous testing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/JunitTestRunner.java
@@ -53,6 +53,7 @@ import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -105,6 +106,8 @@ public class JunitTestRunner {
     private final Set<String> excludeTags;
     private final Pattern include;
     private final Pattern exclude;
+    private final List<String> includeEngines;
+    private final List<String> excludeEngines;
     private final boolean failingTestsOnly;
     private final TestType testType;
 
@@ -124,6 +127,8 @@ public class JunitTestRunner {
         this.excludeTags = new HashSet<>(builder.excludeTags);
         this.include = builder.include;
         this.exclude = builder.exclude;
+        this.includeEngines = builder.includeEngines;
+        this.excludeEngines = builder.excludeEngines;
         this.failingTestsOnly = builder.failingTestsOnly;
         this.testType = builder.testType;
     }
@@ -167,6 +172,11 @@ public class JunitTestRunner {
                 launchBuilder.filters(new RegexFilter(false, include));
             } else if (exclude != null) {
                 launchBuilder.filters(new RegexFilter(true, exclude));
+            }
+            if (!includeEngines.isEmpty()) {
+                launchBuilder.filters(EngineFilter.includeEngines(includeEngines));
+            } else if (!excludeEngines.isEmpty()) {
+                launchBuilder.filters(EngineFilter.excludeEngines(excludeEngines));
             }
             if (!additionalFilters.isEmpty()) {
                 launchBuilder.filters(additionalFilters.toArray(new PostDiscoveryFilter[0]));
@@ -744,6 +754,8 @@ public class JunitTestRunner {
         private List<String> excludeTags = Collections.emptyList();
         private Pattern include;
         private Pattern exclude;
+        private List<String> includeEngines = Collections.emptyList();
+        private List<String> excludeEngines = Collections.emptyList();
         private boolean failingTestsOnly;
 
         public Builder setRunId(long runId) {
@@ -813,6 +825,16 @@ public class JunitTestRunner {
 
         public Builder setExclude(Pattern exclude) {
             this.exclude = exclude;
+            return this;
+        }
+
+        public Builder setIncludeEngines(List<String> includeEngines) {
+            this.includeEngines = includeEngines;
+            return this;
+        }
+
+        public Builder setExcludeEngines(List<String> excludeEngines) {
+            this.excludeEngines = excludeEngines;
             return this;
         }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/ModuleTestRunner.java
@@ -59,6 +59,8 @@ public class ModuleTestRunner {
                         .setExcludeTags(testSupport.excludeTags)
                         .setInclude(testSupport.include)
                         .setExclude(testSupport.exclude)
+                        .setIncludeEngines(testSupport.includeEngines)
+                        .setExcludeEngines(testSupport.excludeEngines)
                         .setTestType(testSupport.testType)
                         .setModuleInfo(moduleInfo)
                         .addListener(listener)

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -74,6 +74,20 @@ public class TestConfig {
     public Optional<String> excludePattern;
 
     /**
+     * Test engine ids that should be included for continuous testing.
+     */
+    @ConfigItem
+    public Optional<List<String>> includeEngines;
+
+    /**
+     * Test engine ids that should be excluded by default with continuous testing.
+     *
+     * This is ignored if include-engines has been set.
+     */
+    @ConfigItem
+    public Optional<List<String>> excludeEngines;
+
+    /**
      * Disable the testing status/prompt message at the bottom of the console
      * and log these messages to STDOUT instead.
      *

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -56,6 +56,8 @@ public class TestSupport implements TestController {
     volatile List<String> excludeTags = Collections.emptyList();
     volatile Pattern include = null;
     volatile Pattern exclude = null;
+    volatile List<String> includeEngines = Collections.emptyList();
+    volatile List<String> excludeEngines = Collections.emptyList();
     volatile boolean displayTestOutput;
     volatile Boolean explicitDisplayTestOutput;
     volatile boolean brokenOnlyMode;
@@ -71,6 +73,8 @@ public class TestSupport implements TestController {
     String appPropertiesExcludeTags;
     String appPropertiesIncludePattern;
     String appPropertiesExcludePattern;
+    String appPropertiesIncludeEngines;
+    String appPropertiesExcludeEngines;
     String appPropertiesTestType;
     private TestConfig config;
     private volatile boolean closed;
@@ -442,6 +446,8 @@ public class TestSupport implements TestController {
                 String excludeTags = p.getProperty("quarkus.test.exclude-tags");
                 String includePattern = p.getProperty("quarkus.test.include-pattern");
                 String excludePattern = p.getProperty("quarkus.test.exclude-pattern");
+                String includeEngines = p.getProperty("quarkus.test.include-engines");
+                String excludeEngines = p.getProperty("quarkus.test.exclude-engines");
                 String testType = p.getProperty("quarkus.test.type");
                 if (!firstRun) {
                     if (!Objects.equals(includeTags, appPropertiesIncludeTags)) {
@@ -474,6 +480,22 @@ public class TestSupport implements TestController {
                             exclude = Pattern.compile(excludePattern);
                         }
                     }
+                    if (!Objects.equals(includeEngines, appPropertiesIncludeEngines)) {
+                        if (includeEngines == null) {
+                            this.includeEngines = Collections.emptyList();
+                        } else {
+                            this.includeEngines = Arrays.stream(includeEngines.split(",")).map(String::trim)
+                                    .collect(Collectors.toList());
+                        }
+                    }
+                    if (!Objects.equals(excludeEngines, appPropertiesExcludeEngines)) {
+                        if (excludeEngines == null) {
+                            this.excludeEngines = Collections.emptyList();
+                        } else {
+                            this.excludeEngines = Arrays.stream(excludeEngines.split(",")).map(String::trim)
+                                    .collect(Collectors.toList());
+                        }
+                    }
                     if (!Objects.equals(testType, appPropertiesTestType)) {
                         if (testType == null) {
                             this.testType = TestType.ALL;
@@ -486,6 +508,8 @@ public class TestSupport implements TestController {
                 appPropertiesExcludeTags = excludeTags;
                 appPropertiesIncludePattern = includePattern;
                 appPropertiesExcludePattern = excludePattern;
+                appPropertiesIncludeEngines = includeEngines;
+                appPropertiesExcludeEngines = excludeEngines;
                 appPropertiesTestType = testType;
                 break;
             }
@@ -527,6 +551,11 @@ public class TestSupport implements TestController {
     public void setPatterns(String include, String exclude) {
         this.include = include == null ? null : Pattern.compile(include);
         this.exclude = exclude == null ? null : Pattern.compile(exclude);
+    }
+
+    public void setEngines(List<String> includeEngines, List<String> excludeEngines) {
+        this.includeEngines = includeEngines;
+        this.excludeEngines = excludeEngines;
     }
 
     public TestSupport setConfiguredDisplayTestOutput(boolean displayTestOutput) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestTracingProcessor.java
@@ -96,6 +96,8 @@ public class TestTracingProcessor {
                 config.excludeTags.orElse(Collections.emptyList()));
         testSupport.setPatterns(config.includePattern.orElse(null),
                 config.excludePattern.orElse(null));
+        testSupport.setEngines(config.includeEngines.orElse(Collections.emptyList()),
+                config.excludeEngines.orElse(Collections.emptyList()));
         testSupport.setConfiguredDisplayTestOutput(config.displayTestOutput);
         testSupport.setTestType(config.type);
         if (!liveReloadBuildItem.isLiveReload()) {


### PR DESCRIPTION
Resolves #23929

Tested in my project (exclude `archunit`).

Not sure about a test for this (effort/benefit ratio). I could try to implement a custom engine that throws an exception, set the exclude and expect no failure.