### PR TITLE
Add config quarkus.security.auth.enabled-in-dev-mode

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -281,7 +281,7 @@ public class SecurityOverrideFilter implements ContainerRequestFilter {
 
 == Disabling Authorization
 
-If you have a good reason to disable the authorization (for example, when testing) then you can register a custom `AuthorizationController`:
+If you have a good reason to disable the authorization then you can register a custom `AuthorizationController`:
 
 [source,java]
 ----
@@ -297,6 +297,13 @@ public class DisabledAuthController extends AuthorizationController {
         return !disableAuthorization;
     }
 }
+----
+
+For manual testing Quarkus provides a convenient config property to disable authorization in dev mode. This property has the exact same effect as the custom `AuthorizationController` shown above, but is only available in dev mode:
+
+[source,properties]
+----
+quarkus.security.auth.enabled-in-dev-mode=false
 ----
 
 Please also see xref:security-testing.adoc#testing-security[TestingSecurity Annotation] section on how to disable the security checks using `TestSecurity` annotation.

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
@@ -14,6 +14,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public final class SecurityConfig {
 
     /**
+     * Whether authorization is enabled in dev mode or not. In other launch modes authorization is always enabled.
+     */
+    @ConfigItem(name = "auth.enabled-in-dev-mode", defaultValue = "true")
+    public boolean authorizationEnabledInDevMode;
+
+    /**
      * List of security providers to enable for reflection
      */
     @ConfigItem

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/DevModeDisabledAuthorizationController.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/DevModeDisabledAuthorizationController.java
@@ -1,0 +1,24 @@
+package io.quarkus.security.spi.runtime;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Singleton;
+import javax.interceptor.Interceptor;
+
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * Controller used in dev mode if {@code quarkus.security.auth.enabled-in-dev-mode=false}.
+ */
+@Alternative
+@Priority(Interceptor.Priority.LIBRARY_AFTER)
+@Singleton
+public final class DevModeDisabledAuthorizationController extends AuthorizationController {
+
+    public boolean isAuthorizationEnabled() {
+        if (LaunchMode.current() != LaunchMode.DEVELOPMENT) {
+            throw new IllegalStateException("This implementation is only available in dev mode");
+        }
+        return false;
+    }
+}

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/security/DisabledAuthorizationTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/security/DisabledAuthorizationTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.security;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import javax.annotation.security.DenyAll;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class DisabledAuthorizationTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(HelloResource.class)
+                    .add(new StringAsset("quarkus.security.auth.enabled-in-dev-mode=false"), "application.properties"));
+
+    @Test
+    void verifyAuthorizationEnablement() {
+        RestAssured.given()
+                .when().get("/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("hello"));
+    }
+
+    @ApplicationScoped
+    @Path("/")
+    @DenyAll
+    public static class HelloResource {
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+}


### PR DESCRIPTION
The new config `quarkus.security.auth.enabled-in-dev-mode` (which defaults to `true`) is read at build-time in dev-mode to control whether authorization should be enabled or not. This can be useful as it makes it easier to manually test secured endpoints when running in dev mode.

Fixes #23254