### PR TITLE
Detect container runtime when using Jib

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -2,10 +2,10 @@ package io.quarkus.deployment.pkg;
 
 import java.io.File;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -229,7 +229,7 @@ public class NativeConfig {
      * a container build is always done.
      */
     @ConfigItem
-    public Optional<ContainerRuntime> containerRuntime;
+    public Optional<ContainerRuntimeUtil.ContainerRuntime> containerRuntime;
 
     /**
      * Options to pass to the container runtime
@@ -440,18 +440,6 @@ public class NativeConfig {
          */
         @ConfigItem
         public Optional<List<String>> additionalArgs;
-    }
-
-    /**
-     * Supported Container runtimes
-     */
-    public static enum ContainerRuntime {
-        DOCKER,
-        PODMAN;
-
-        public String getExecutableName() {
-            return this.name().toLowerCase();
-        }
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.apache.commons.lang3.SystemUtils;
 
 import io.quarkus.deployment.pkg.NativeConfig;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.FileUtil;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
@@ -23,7 +24,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
             String gid = getLinuxID("-gr");
             if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
                 Collections.addAll(containerRuntimeArgs, "--user", uid + ":" + gid);
-                if (containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
+                if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN) {
                     // Needed to avoid AccessDeniedExceptions
                     containerRuntimeArgs.add("--userns=keep-id");
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -20,6 +20,7 @@ import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.deployment.util.ProcessUtil;
 
@@ -99,8 +100,8 @@ public class UpxCompressionBuildStep {
         List<String> extraArgs = nativeConfig.compression.additionalArgs.orElse(Collections.emptyList());
 
         List<String> commandLine = new ArrayList<>();
-        NativeConfig.ContainerRuntime containerRuntime = nativeConfig.containerRuntime
-                .orElseGet(NativeImageBuildContainerRunner::detectContainerRuntime);
+        ContainerRuntimeUtil.ContainerRuntime containerRuntime = nativeConfig.containerRuntime
+                .orElseGet(ContainerRuntimeUtil::detectContainerRuntime);
         commandLine.add(containerRuntime.getExecutableName());
 
         commandLine.add("run");
@@ -121,7 +122,7 @@ public class UpxCompressionBuildStep {
             String gid = getLinuxID("-gr");
             if (uid != null && gid != null && !uid.isEmpty() && !gid.isEmpty()) {
                 Collections.addAll(commandLine, "--user", uid + ":" + gid);
-                if (containerRuntime == NativeConfig.ContainerRuntime.PODMAN) {
+                if (containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN) {
                     // Needed to avoid AccessDeniedExceptions
                     commandLine.add("--userns=keep-id");
                 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ContainerRuntimeUtil.java
@@ -1,0 +1,73 @@
+package io.quarkus.deployment.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.logging.Logger;
+
+public final class ContainerRuntimeUtil {
+
+    private static final Logger log = Logger.getLogger(ContainerRuntimeUtil.class);
+
+    private ContainerRuntimeUtil() {
+    }
+
+    /**
+     * @return {@link ContainerRuntime#DOCKER} if it's available, or {@link ContainerRuntime#PODMAN}
+     *         if the podman
+     *         executable exists in the environment or if the docker executable is an alias to podman
+     * @throws IllegalStateException if no container runtime was found to build the image
+     */
+    public static ContainerRuntime detectContainerRuntime() {
+        // Docker version 19.03.14, build 5eb3275d40
+        String dockerVersionOutput = getVersionOutputFor(ContainerRuntime.DOCKER);
+        boolean dockerAvailable = dockerVersionOutput.contains("Docker version");
+        // Check if Podman is installed
+        // podman version 2.1.1
+        String podmanVersionOutput = getVersionOutputFor(ContainerRuntime.PODMAN);
+        boolean podmanAvailable = podmanVersionOutput.startsWith("podman version");
+        if (dockerAvailable) {
+            // Check if "docker" is an alias to "podman"
+            if (dockerVersionOutput.equals(podmanVersionOutput)) {
+                return ContainerRuntime.PODMAN;
+            }
+            return ContainerRuntime.DOCKER;
+        } else if (podmanAvailable) {
+            return ContainerRuntime.PODMAN;
+        } else {
+            throw new IllegalStateException("No container runtime was found to. "
+                    + "Make sure you have Docker or Podman installed in your environment.");
+        }
+    }
+
+    private static String getVersionOutputFor(ContainerRuntime containerRuntime) {
+        Process versionProcess = null;
+        try {
+            ProcessBuilder pb = new ProcessBuilder(containerRuntime.getExecutableName(), "--version")
+                    .redirectErrorStream(true);
+            versionProcess = pb.start();
+            versionProcess.waitFor();
+            return new String(FileUtil.readFileContents(versionProcess.getInputStream()), StandardCharsets.UTF_8);
+        } catch (IOException | InterruptedException e) {
+            // If an exception is thrown in the process, just return an empty String
+            log.debugf(e, "Failure to read version output from %s", containerRuntime.getExecutableName());
+            return "";
+        } finally {
+            if (versionProcess != null) {
+                versionProcess.destroy();
+            }
+        }
+    }
+
+    /**
+     * Supported Container runtimes
+     */
+    public enum ContainerRuntime {
+        DOCKER,
+        PODMAN;
+
+        public String getExecutableName() {
+            return this.name().toLowerCase();
+        }
+    }
+}

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -69,6 +69,7 @@ import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
 import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
+import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.dependency.ResolvedDependency;
 
@@ -266,6 +267,11 @@ public class JibProcessor {
                 dockerDaemonImage.setDockerExecutable(Paths.get(jibConfigExecutableName.get()));
             } else if (dockerConfigExecutableName.isPresent()) {
                 dockerDaemonImage.setDockerExecutable(Paths.get(dockerConfigExecutableName.get()));
+            } else {
+                // detect the container runtime instead of falling back to 'docker' as the default
+                ContainerRuntimeUtil.ContainerRuntime detectedContainerRuntime = ContainerRuntimeUtil.detectContainerRuntime();
+                log.infof("Using %s to run the native image builder", detectedContainerRuntime.getExecutableName());
+                dockerDaemonImage.setDockerExecutable(Paths.get(detectedContainerRuntime.getExecutableName()));
             }
             containerizer = Containerizer.to(dockerDaemonImage);
         }


### PR DESCRIPTION
The detection uses the same method Quarkus already
used when building the native binary using a container build

Fixes: #24231