### PR TITLE
Use project's compile root dirs instead of hardcoded source dirs

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
@@ -1,8 +1,5 @@
 package io.quarkus.maven;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -13,8 +10,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class GenerateCodeTestsMojo extends GenerateCodeMojo {
     @Override
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
-        String projectDir = mavenProject().getBasedir().getAbsolutePath();
-        Path testSources = Paths.get(projectDir, "src", "test");
-        generateCode(testSources, path -> mavenProject().addTestCompileSourceRoot(path.toString()), true);
+        generateCode(getParentDirs(mavenProject().getTestCompileSourceRoots()),
+                path -> mavenProject().addTestCompileSourceRoot(path.toString()), true);
     }
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/BootstrapAppModelFactory.java
@@ -146,7 +146,7 @@ public class BootstrapAppModelFactory {
                 if (mavenArtifactResolver == null) {
                     final BootstrapMavenContext mvnCtx = createBootstrapMavenContext();
                     if (managingProject == null) {
-                        managingProject = mvnCtx.getCurrentProjectArtifact("pom");
+                        managingProject = mvnCtx.getCurrentProjectArtifact(ArtifactCoords.TYPE_POM);
                     }
                     mvn = new MavenArtifactResolver(mvnCtx);
                 } else {


### PR DESCRIPTION
It's a minor change but it's better use the actual source dirs instead of the hardcoded ones.