### PR TITLE
Oracle Dev Service - Fix shared network JDBC URL

### DIFF
--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -104,7 +104,7 @@ public class OracleDevServicesProcessor {
                 // in this case we expose the URL using the network alias we created in 'configure'
                 // and the container port since the application communicating with this container
                 // won't be doing port mapping
-                return "jdbc:oracle:thin//" + hostName + ":" + PORT + ":" + getDatabaseName();
+                return "jdbc:oracle:thin:" + "@" + hostName + ":" + PORT + "/" + getDatabaseName();
             } else {
                 return super.getJdbcUrl();
             }


### PR DESCRIPTION
Use a JDBC URL that is consistent with the one used when we don't use a
shared network (i.e. exactly the same as generated by the container
getJdbcUrl() method except for the host and port).
At the moment, it is using a SID URL, which is inconsistent and looks
incorrect to me.