### PR TITLE
Add misfireThreshold default to QuartzRuntimeConfig.java

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.quartz.runtime;
 
+import java.time.Duration;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -24,6 +26,12 @@ public class QuartzRuntimeConfig {
      */
     @ConfigItem(defaultValue = "5")
     public int threadPriority;
+
+    /**
+     * Defines how late the schedulers should be to be considered misfired.
+     */
+    @ConfigItem(defaultValue = "60")
+    public Duration misfireThreshold;
 
     /**
      * Scheduler can be started in different modes: normal, forced or halted.

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -437,7 +437,8 @@ public class QuartzScheduler implements Scheduler {
             String dataSource = buildTimeConfig.dataSourceName.orElse("QUARKUS_QUARTZ_DEFAULT_DATASOURCE");
             QuarkusQuartzConnectionPoolProvider.setDataSourceName(dataSource);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".useProperties", "true");
-            props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".misfireThreshold", "60000");
+            props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".misfireThreshold",
+                    "" + quartzSupport.getRuntimeConfig().misfireThreshold.toMillis());
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".tablePrefix", buildTimeConfig.tablePrefix);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".dataSource", dataSource);
             props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".driverDelegateClass",


### PR DESCRIPTION
### Add misfireThreshold default to QuartzRuntimeConfig.java

This enables the misfireThreshold configuration to be overridden by the user.

Fixes https://github.com/quarkusio/quarkus/issues/24105.