### PR TITLE
Support required capability in gradle extension plugin

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -99,8 +99,12 @@ public class QuarkusExtensionConfiguration {
         this.dependencyCondition = dependencyCondition;
     }
 
-    public List<Capability> getCapabilities() {
-        return capabilities.getCapabilities();
+    public List<Capability> getProvidedCapabilities() {
+        return capabilities.getProvidedCapabilities();
+    }
+
+    public List<Capability> getRequiredCapabilities() {
+        return capabilities.getRequiredCapabilities();
     }
 
     public void capabilities(Action<Capabilities> capabilitiesAction) {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capabilities.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/Capabilities.java
@@ -5,15 +5,26 @@ import java.util.List;
 
 public class Capabilities {
 
-    private List<Capability> capabilities = new ArrayList<>(0);
+    private List<Capability> provided = new ArrayList<>(0);
+    private List<Capability> required = new ArrayList<>(0);
 
-    public Capability capability(String name) {
+    public Capability provides(String name) {
         Capability capability = new Capability(name);
-        capabilities.add(capability);
+        provided.add(capability);
         return capability;
     }
 
-    public List<Capability> getCapabilities() {
-        return capabilities;
+    public Capability requires(String name) {
+        Capability capability = new Capability(name);
+        required.add(capability);
+        return capability;
+    }
+
+    public List<Capability> getProvidedCapabilities() {
+        return provided;
+    }
+
+    public List<Capability> getRequiredCapabilities() {
+        return required;
     }
 }

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -8,6 +8,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -141,14 +142,24 @@ public class ExtensionDescriptorTask extends DefaultTask {
             props.put(AppModel.LESSER_PRIORITY_ARTIFACTS, val);
         }
 
-        List<Capability> capabilities = quarkusExtensionConfiguration.getCapabilities();
-        if (!capabilities.isEmpty()) {
+        if (!quarkusExtensionConfiguration.getProvidedCapabilities().isEmpty()) {
             final StringBuilder buf = new StringBuilder();
-            appendCapability(capabilities.get(0), buf);
-            for (int i = 1; i < capabilities.size(); ++i) {
-                appendCapability(capabilities.get(i), buf.append(','));
+            final Iterator<Capability> i = quarkusExtensionConfiguration.getProvidedCapabilities().iterator();
+            appendCapability(i.next(), buf);
+            while (i.hasNext()) {
+                appendCapability(i.next(), buf.append(','));
             }
             props.setProperty(BootstrapConstants.PROP_PROVIDES_CAPABILITIES, buf.toString());
+        }
+
+        if (!quarkusExtensionConfiguration.getRequiredCapabilities().isEmpty()) {
+            final StringBuilder buf = new StringBuilder();
+            final Iterator<Capability> i = quarkusExtensionConfiguration.getRequiredCapabilities().iterator();
+            appendCapability(i.next(), buf);
+            while (i.hasNext()) {
+                appendCapability(i.next(), buf.append(','));
+            }
+            props.setProperty(BootstrapConstants.PROP_REQUIRES_CAPABILITIES, buf.toString());
         }
 
         try {

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -142,9 +142,10 @@ public class ExtensionDescriptorTaskTest {
     public void shouldGenerateDescriptorWithCapabilities() throws IOException {
         String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
                 "capabilities { \n" +
-                        "   capability 'org.acme:ext-a:0.1.0' \n" +
-                        "   capability 'org.acme:ext-b:0.1.0' onlyIf(['org.acme:ext-b:0.1.0']) onlyIfNot(['org.acme:ext-c:0.1.0']) \n"
+                        "   provides 'org.acme:ext-a:0.1.0' \n" +
+                        "   provides 'org.acme:ext-b:0.1.0' onlyIf(['org.acme:ext-b:0.1.0']) onlyIfNot(['org.acme:ext-c:0.1.0']) \n"
                         +
+                        "   requires 'sunshine' onlyIf(['org.acme:ext-b:0.1.0']) \n" +
                         "}\n");
 
         TestUtils.writeFile(buildFile, buildFileContent);
@@ -156,5 +157,7 @@ public class ExtensionDescriptorTaskTest {
         Properties extensionProperty = TestUtils.readPropertyFile(extensionPropertiesFile.toPath());
         assertThat(extensionProperty).containsEntry("provides-capabilities",
                 "org.acme:ext-a:0.1.0,org.acme:ext-b:0.1.0?org.acme:ext-b:0.1.0?!org.acme:ext-c:0.1.0");
+        assertThat(extensionProperty).containsEntry("requires-capabilities",
+                "sunshine?org.acme:ext-b:0.1.0");
     }
 }

--- a/docs/src/main/asciidoc/capabilities.adoc
+++ b/docs/src/main/asciidoc/capabilities.adoc
@@ -51,11 +51,13 @@ The `quarkus-bootstrap-maven-plugin:extension-descriptor` Maven goal and the `ex
 ----
 quarkusExtension {
     capabilities {
-        capability 'io.quarkus.rest'
-        capability 'io.quarkus.resteasy'
+        provides 'io.quarkus.rest' <1>
+        requires 'io.quarkus.resteasy' <2>
     }
 }
 ----
+<1> the extension provides the `io.quarkus.hibernate.orm` capability (multiple `provides` elements are allowed)
+<2> the extension requires the `io.quarkus.agroal` capability to be provided to function properly (multiple `requires` elements are allowed)
 
 NOTE: The Gradle extension plugin is still experimental and may change in the future.
 
@@ -68,11 +70,14 @@ NOTE: The Gradle extension plugin is still experimental and may change in the fu
 ----
 quarkusExtension {
     capabilities {
-        capability("io.quarkus.rest")
-        capability("io.quarkus.resteasy")
+        provides("io.quarkus.rest") <1>
+        requires("io.quarkus.resteasy") <2>
     }
 }
 ----
+<1> the extension provides the `io.quarkus.hibernate.orm` capability (multiple `provides` elements are allowed)
+<2> the extension requires the `io.quarkus.agroal` capability to be provided to function properly (multiple `requires` elements are allowed)
+
 NOTE: The Gradle extension plugin is still experimental and may change in the future.
 ****
 
@@ -115,13 +120,13 @@ The corresponding `requiresIf` element is also supported.
 ----
 quarkusExtension {
     capabilities {
-        capability 'io.quarkus.container.image.openshift' onlyIf ['io.quarkus.container.image.openshift.deployment.OpenshiftBuild'] <1>
+        provides 'io.quarkus.container.image.openshift' onlyIf ['io.quarkus.container.image.openshift.deployment.OpenshiftBuild'] <1>
     }
 }
 ----
 <1> condition that must be resolved to `true` by a class implementing `java.util.function.BooleanSupplier`
 
-NOTE: It is possible to specify `onlyIfNot` conditions as well.
+NOTE: It is possible to specify `onlyIfNot` conditions as well. Conditions can also be set for required capabilities.
 ****
 
 [role="secondary asciidoc-tabs-sync-gradle-kotlin"]
@@ -131,13 +136,13 @@ NOTE: It is possible to specify `onlyIfNot` conditions as well.
 ----
 quarkusExtension {
     capabilities {
-        capability("io.quarkus.container.image.openshift").onlyIf(["io.quarkus.container.image.openshift.deployment.OpenshiftBuild"]) <1>
+        provides("io.quarkus.container.image.openshift").onlyIf(["io.quarkus.container.image.openshift.deployment.OpenshiftBuild"]) <1>
     }
 }
 ----
 <1> condition that must be resolved to `true` by a class implementing `java.util.function.BooleanSupplier`
 
-NOTE: It is possible to specify `onlyIfNot` conditions as well.
+NOTE: It is possible to specify `onlyIfNot` conditions as well. . Conditions can also be set for required capabilities.
 ****
 
 In this case, `io.quarkus.container.image.openshift.deployment.OpenshiftBuild` should be included in one of the extension deployment dependencies and implement `java.util.function.BooleanSupplier`. At build time, the Quarkus bootstrap will create an instance of it and register `io.quarkus.container.image.openshift` capability only if its `getAsBoolean()` method returns true. 


### PR DESCRIPTION
This adds support for required capabilities through a `requires` method. Also, it rename the `capability` method into `provides`. 