### PR TITLE
Change RotationConfig defualtmax file size in FileConfig.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ ObjectStore
 .gradle
 docker/distroless/bazel-*
 /.apt_generated_tests/
-quarkus.log
+quarkus.log*
 replay_*.logß
 nbactions.xml
 nb-configuration.xml

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -58,7 +58,7 @@ public class FileConfig {
         /**
          * The maximum file size of the log file after which a rotation is executed.
          */
-        @ConfigItem(defaultValueDocumentation = "10")
+        @ConfigItem(defaultValue = "10M")
         Optional<MemorySize> maxFileSize;
 
         /**

--- a/core/test-extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
+++ b/core/test-extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
@@ -3,11 +3,15 @@ package io.quarkus.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
-import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.FileHandler;
+import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,7 +43,7 @@ public class CategoryConfiguredHandlerTest {
         Logger categoryLogger = logManager.getLogger("io.quarkus.category");
         assertThat(categoryLogger).isNotNull();
         assertThat(categoryLogger.getHandlers()).hasSize(2).extracting("class").containsExactlyInAnyOrder(ConsoleHandler.class,
-                FileHandler.class);
+                SizeRotatingFileHandler.class);
 
         Logger otherCategoryLogger = logManager.getLogger("io.quarkus.othercategory");
         assertThat(otherCategoryLogger).isNotNull();


### PR DESCRIPTION
This is a continuation of #24060 as I accidentally removed the fork, which closed the pr.

###Change RotationConfig default max file size in FileConfig.java
___

In FileConfig.java RotationConfig the default value for Max Size of the log file after which a rotation is executed was set incorrectly.
___

Fixes https://github.com/quarkusio/quarkus/issues/24041