### PR TITLE
Use -H:PrintAnalysisCallTreeType=CSV to generate csv call tree files

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -24,6 +24,7 @@ final class GraalVM {
         static final Version VERSION_21_2 = new Version("GraalVM 21.2", "21.2", Distribution.ORACLE);
         static final Version VERSION_21_3 = new Version("GraalVM 21.3", "21.3", Distribution.ORACLE);
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
+        static final Version VERSION_21_3_2 = new Version("GraalVM 21.3.2", "21.3.2", Distribution.ORACLE);
         static final Version VERSION_22_0_0_2 = new Version("GraalVM 22.0.0.2", "22.0.0.2", Distribution.ORACLE);
 
         static final Version MINIMUM = VERSION_21_2;

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -665,6 +665,19 @@ public class NativeImageBuildStep {
                 //address https://github.com/quarkusio/quarkus-quickstarts/issues/993
                 nativeImageArgs.add("-J--add-opens=java.base/java.text=ALL-UNNAMED");
 
+                if (nativeConfig.enableReports) {
+                    if (graalVMVersion.isOlderThan(GraalVM.Version.VERSION_21_3_2)) {
+                        nativeImageArgs.add("-H:+PrintAnalysisCallTree");
+                    } else {
+                        nativeImageArgs.add("-H:PrintAnalysisCallTreeType=CSV");
+                    }
+                }
+
+                /*
+                 * Any parameters following this call are forced over the user provided parameters in
+                 * quarkus.native.additional-build-args. So if you need a parameter to be overridable through
+                 * quarkus.native.additional-build-args please make sure to add it before this call.
+                 */
                 handleAdditionalProperties(nativeImageArgs);
 
                 nativeImageArgs.add(
@@ -712,9 +725,6 @@ public class NativeImageBuildStep {
                     nativeImageArgs
                             .add("-J-Xrunjdwp:transport=dt_socket,address=" + debugBuildProcessHost + ":"
                                     + DEBUG_BUILD_PROCESS_PORT + ",server=y,suspend=y");
-                }
-                if (nativeConfig.enableReports) {
-                    nativeImageArgs.add("-H:+PrintAnalysisCallTree");
                 }
                 if (nativeConfig.dumpProxies) {
                     nativeImageArgs.add("-Dsun.misc.ProxyGenerator.saveGeneratedFiles=true");


### PR DESCRIPTION
Fixes #20733

~Marking this as draft till I learn [whether the parameter will be backported to 21.3 as well or not](https://github.com/oracle/graal/pull/3861#issuecomment-1064307037).~