### PR TITLE
Remove @Override annotations from to-be-removed API methods and replace BM#fireEvent calls

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/observer/SyntheticObserverTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/observer/SyntheticObserverTest.java
@@ -65,7 +65,7 @@ public class SyntheticObserverTest {
     @Test
     public void testSyntheticObserver() {
         MyObserver.EVENTS.clear();
-        Arc.container().beanManager().fireEvent("foo");
+        Arc.container().beanManager().getEvent().fire("foo");
         assertEquals(2, MyObserver.EVENTS.size(), "Events: " + MyObserver.EVENTS);
         assertTrue(MyObserver.EVENTS.contains("synthetic"));
         assertTrue(MyObserver.EVENTS.contains("foo_MyObserver"));

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/InjectableBean.java
@@ -90,7 +90,8 @@ public interface InjectableBean<T> extends Bean<T>, InjectableReferenceProvider<
         return Collections.emptySet();
     }
 
-    @Override
+    // Deprecated method which can be safely removed once we use CDI 4.0+
+    @Deprecated
     default boolean isNullable() {
         return false;
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -115,7 +115,8 @@ public class BeanManagerImpl implements BeanManager {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // Deprecated method which can be safely removed once we use CDI 4.0+
+    @Deprecated
     public void fireEvent(Object event, Annotation... qualifiers) {
         Set<Annotation> eventQualifiers = new HashSet<>();
         Collections.addAll(eventQualifiers, qualifiers);
@@ -235,7 +236,8 @@ public class BeanManagerImpl implements BeanManager {
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // Deprecated method which can be safely removed once we use CDI 4.0+
+    @Deprecated
     public <T> InjectionTarget<T> createInjectionTarget(AnnotatedType<T> type) {
         throw new UnsupportedOperationException();
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/SyntheticObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/SyntheticObserverTest.java
@@ -52,13 +52,13 @@ public class SyntheticObserverTest {
     @Test
     public void testSyntheticObserver() {
         MyObserver.EVENTS.clear();
-        Arc.container().beanManager().fireEvent("foo");
+        Arc.container().beanManager().getEvent().fire("foo");
         assertEquals(2, MyObserver.EVENTS.size(), "Events: " + MyObserver.EVENTS);
         assertTrue(MyObserver.EVENTS.contains("foo"));
         assertTrue(MyObserver.EVENTS.contains("foo_MyObserver"));
 
         MyObserver.EVENTS.clear();
-        Arc.container().beanManager().fireEvent("foo", NamedLiteral.of("bla"));
+        Arc.container().beanManager().getEvent().select(String.class, NamedLiteral.of("bla")).fire("foo");
         assertEquals(3, MyObserver.EVENTS.size(), "Events: " + MyObserver.EVENTS);
         assertTrue(MyObserver.EVENTS.contains("foo"));
         assertTrue(MyObserver.EVENTS.contains("foo_MyObserver"));

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/ReceptionIfExistsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/ifexists/ReceptionIfExistsTest.java
@@ -25,14 +25,14 @@ public class ReceptionIfExistsTest {
     @Test
     public void testObserver() {
         ArcContainer container = Arc.container();
-        container.beanManager().fireEvent("foo");
+        container.beanManager().getEvent().fire("foo");
         assertEquals(1, EVENTS.size());
         assertEquals(DependentObserver.class.getName() + "foo", EVENTS.get(0));
 
         // Activate the request context but the instance still does not exist
         EVENTS.clear();
         container.requestContext().activate();
-        container.beanManager().fireEvent("foo");
+        container.beanManager().getEvent().fire("foo");
         assertEquals(1, EVENTS.size());
         assertEquals(DependentObserver.class.getName() + "foo", EVENTS.get(0));
         container.requestContext().deactivate();
@@ -42,7 +42,7 @@ public class ReceptionIfExistsTest {
         container.requestContext().activate();
         // Force bean instance creation
         container.instance(RequestScopedObserver.class).get().ping();
-        container.beanManager().fireEvent("foo");
+        container.beanManager().getEvent().fire("foo");
         assertEquals(2, EVENTS.size());
         assertEquals(RequestScopedObserver.class.getName() + "foo", EVENTS.get(0));
         assertEquals(DependentObserver.class.getName() + "foo", EVENTS.get(1));

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/injection/SimpleObserverInjectionTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/injection/SimpleObserverInjectionTest.java
@@ -14,6 +14,7 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
 import javax.inject.Singleton;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -27,12 +28,14 @@ public class SimpleObserverInjectionTest {
     public void testObserverInjection() {
         AtomicReference<String> msg = new AtomicReference<String>();
         Fool.DESTROYED.set(false);
-        Arc.container().beanManager().fireEvent(msg);
+        Arc.container().beanManager().getEvent().select(new TypeLiteral<AtomicReference<String>>() {
+        }).fire(msg);
         String id1 = msg.get();
         assertNotNull(id1);
         assertTrue(Fool.DESTROYED.get());
         Fool.DESTROYED.set(false);
-        Arc.container().beanManager().fireEvent(msg);
+        Arc.container().beanManager().getEvent().select(new TypeLiteral<AtomicReference<String>>() {
+        }).fire(msg);
         assertNotEquals(id1, msg.get());
         assertTrue(Fool.DESTROYED.get());
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/notification/ObserverNotificationTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/notification/ObserverNotificationTest.java
@@ -19,7 +19,7 @@ public class ObserverNotificationTest {
     public void testContextualInstanceIsUsed() {
         assertEquals(0, StringObserver.CONSTRUCTED.get());
         assertEquals(0, StringObserver.NOTIFIED.get());
-        Arc.container().beanManager().fireEvent("hello");
+        Arc.container().beanManager().getEvent().fire("hello");
         assertEquals(1, StringObserver.CONSTRUCTED.get());
         assertEquals(1, StringObserver.NOTIFIED.get());
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/staticmethods/StaticObserverTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/observers/staticmethods/StaticObserverTest.java
@@ -25,7 +25,7 @@ public class StaticObserverTest {
     public void testObserver() {
         assertEquals(0, StringObserver.EVENTS.size());
         assertFalse(Fool.DESTROYED.get());
-        Arc.container().beanManager().fireEvent("hello");
+        Arc.container().beanManager().getEvent().fire("hello");
         assertEquals(1, StringObserver.EVENTS.size());
         assertEquals("hello", StringObserver.EVENTS.get(0));
         assertTrue(Fool.DESTROYED.get());


### PR DESCRIPTION
This will ease future transition to CDI 4 API. I didn't find any other occurrences of deprecated CDI APIs in Quarkus as such. That being said, external libs may still have them but that's not necessarily for us to fix.

For completeness, the removed methods in CDI 4 can be seen here - https://github.com/eclipse-ee4j/cdi/issues/472
Most of them are not an issue for Quarkus as they are related to portable extensions in some way.