### PR TITLE
Remove dependencies on GraalVM's SVM internal packages other than com.oracle.svm.core.annotate

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/Substitutions.java
@@ -1,59 +1,25 @@
 package io.quarkus.runtime.configuration;
 
-import java.util.function.Supplier;
-
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 
 import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
-import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
-import com.oracle.svm.core.threadlocal.FastThreadLocalInt;
 
 import io.smallrye.common.constraint.Assert;
 import io.smallrye.config.ConfigMappingMetadata;
-import io.smallrye.config.Expressions;
 
 /**
  */
 final class Substitutions {
-    // 0 = expand so that the default value is to expand
-    static final FastThreadLocalInt notExpanding = FastThreadLocalFactory.createInt();
-
     @TargetClass(ConfigProviderResolver.class)
     static final class Target_ConfigurationProviderResolver {
 
         @Alias
         @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
         private static volatile ConfigProviderResolver instance;
-    }
-
-    @TargetClass(Expressions.class)
-    static final class Target_Expressions {
-        @Delete
-        private static ThreadLocal<Boolean> ENABLE;
-
-        @Substitute
-        private static boolean isEnabled() {
-            return notExpanding.get() == 0;
-        }
-
-        @Substitute
-        public static <T> T withoutExpansion(Supplier<T> supplier) {
-            if (isEnabled()) {
-                notExpanding.set(1);
-                try {
-                    return supplier.get();
-                } finally {
-                    notExpanding.set(0);
-                }
-            } else {
-                return supplier.get();
-            }
-        }
     }
 
     @TargetClass(className = "io.smallrye.config.ConfigMappingLoader")

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/CidrAddressSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/CidrAddressSubstitutions.java
@@ -5,7 +5,6 @@ import java.net.InetAddress;
 import org.wildfly.common.net.CidrAddress;
 import org.wildfly.common.net.Inet;
 
-import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -33,19 +32,18 @@ final class Target_org_wildfly_common_net_CidrAddress {
     public static CidrAddress INET6_ANY_CIDR;
 
     static class CidrAddressUtil {
-        static CidrAddress newInstance(InetAddress networkAddress, int netmaskBits) {
-            return SubstrateUtil.cast(new Target_org_wildfly_common_net_CidrAddress(networkAddress, netmaskBits),
-                    CidrAddress.class);
+        static Target_org_wildfly_common_net_CidrAddress newInstance(InetAddress networkAddress, int netmaskBits) {
+            return new Target_org_wildfly_common_net_CidrAddress(networkAddress, netmaskBits);
         }
     }
 }
 
 class Inet4AnyCidrAccessor {
 
-    private static volatile CidrAddress INET4_ANY_CIDR;
+    private static volatile Target_org_wildfly_common_net_CidrAddress INET4_ANY_CIDR;
 
-    static CidrAddress get() {
-        CidrAddress result = INET4_ANY_CIDR;
+    static Target_org_wildfly_common_net_CidrAddress get() {
+        Target_org_wildfly_common_net_CidrAddress result = INET4_ANY_CIDR;
         if (result == null) {
             // Lazy initialization on first access.
             result = initializeOnce();
@@ -53,8 +51,8 @@ class Inet4AnyCidrAccessor {
         return result;
     }
 
-    private static synchronized CidrAddress initializeOnce() {
-        CidrAddress result = INET4_ANY_CIDR;
+    private static synchronized Target_org_wildfly_common_net_CidrAddress initializeOnce() {
+        Target_org_wildfly_common_net_CidrAddress result = INET4_ANY_CIDR;
         if (result != null) {
             // Double-checked locking is OK because INSTANCE is volatile.
             return result;
@@ -67,10 +65,10 @@ class Inet4AnyCidrAccessor {
 
 class Inet6AnyCidrAccessor {
 
-    private static volatile CidrAddress INET6_ANY_CIDR;
+    private static volatile Target_org_wildfly_common_net_CidrAddress INET6_ANY_CIDR;
 
-    static CidrAddress get() {
-        CidrAddress result = INET6_ANY_CIDR;
+    static Target_org_wildfly_common_net_CidrAddress get() {
+        Target_org_wildfly_common_net_CidrAddress result = INET6_ANY_CIDR;
         if (result == null) {
             // Lazy initialization on first access.
             result = initializeOnce();
@@ -78,8 +76,8 @@ class Inet6AnyCidrAccessor {
         return result;
     }
 
-    private static synchronized CidrAddress initializeOnce() {
-        CidrAddress result = INET6_ANY_CIDR;
+    private static synchronized Target_org_wildfly_common_net_CidrAddress initializeOnce() {
+        Target_org_wildfly_common_net_CidrAddress result = INET6_ANY_CIDR;
         if (result != null) {
             // Double-checked locking is OK because INSTANCE is volatile.
             return result;

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/JDK17OrLater.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/JDK17OrLater.java
@@ -1,0 +1,12 @@
+package io.quarkus.runtime.graal;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.runtime.util.JavaVersionUtil;
+
+public class JDK17OrLater implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.isJava17OrHigher();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/Target_sun_security_jca_JCAUtil.java
@@ -5,7 +5,6 @@ import java.security.SecureRandom;
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrLater;
 
 @TargetClass(className = "sun.security.jca.JCAUtil", onlyWith = JDK17OrLater.class)
 public final class Target_sun_security_jca_JCAUtil {

--- a/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/graal/AvroSubstitutions.java
+++ b/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/graal/AvroSubstitutions.java
@@ -16,7 +16,8 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrLater;
+
+import io.quarkus.runtime.graal.JDK17OrLater;
 
 @TargetClass(className = "org.apache.avro.generic.GenericDatumReader")
 final class Target_org_apache_avro_generic_GenericDatumReader {

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/Engine.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/Engine.java
@@ -3,7 +3,6 @@ package io.quarkus.jdbc.h2.runtime.graal;
 import org.h2.engine.ConnectionInfo;
 import org.h2.engine.Session;
 
-import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
@@ -12,8 +11,8 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class Engine {
 
     @Substitute
-    public static org.h2.engine.Engine getInstance() {
-        return SubstrateUtil.cast(new Engine(), org.h2.engine.Engine.class);
+    public static Engine getInstance() {
+        return new Engine();
     }
 
     @Substitute


### PR DESCRIPTION
This PR removes all Quarkus dependencies on GraalVM's SVM internal packages other than `com.oracle.svm.core.annotate`. As discussed in https://github.com/oracle/graal/discussions/4146 there is the desire to deprecate the maven package `org.graalvm.nativeimage:svm`with the ultimate goal of not shipping it in future releases. 

Note that this maven package also contains the annotations API (`com.oracle.svm.core.annotate`) which enables Quarkus to work around issues with libraries that are not native-ready and to perform optimizations by reducing the reachable classes/objects in certain cases, etc.

Since that API is crucial to Quarkus and other frameworks, it's confirmed that it is not going away, instead it might get moved to a different module and become a public API.