### PR TITLE
Fix Jandex Type parsing for array of primitive

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/AsmUtil.java
@@ -61,11 +61,16 @@ public class AsmUtil {
             getType(Long.class),
             getType(Double.class));
     public static final Map<org.objectweb.asm.Type, org.objectweb.asm.Type> WRAPPER_TO_PRIMITIVE = new HashMap<>();
+    public static final Map<Character, String> PRIMITIVE_DESCRIPTOR_TO_PRIMITIVE_CLASS_LITERAL;
 
     static {
         for (int i = 0; i < AsmUtil.PRIMITIVES.size(); i++) {
             AsmUtil.WRAPPER_TO_PRIMITIVE.put(AsmUtil.WRAPPERS.get(i), AsmUtil.PRIMITIVES.get(i));
         }
+        PRIMITIVE_DESCRIPTOR_TO_PRIMITIVE_CLASS_LITERAL = Map.of(
+                'Z', "boolean", 'B', "byte", 'C', "char",
+                'D', "double", 'F', "float", 'I', "int",
+                'J', "long", 'S', "short");
     }
 
     public static org.objectweb.asm.Type autobox(org.objectweb.asm.Type primitive) {
@@ -698,50 +703,22 @@ public class AsmUtil {
             char c = chars[i];
             switch (c) {
                 case 'Z':
-                    args.add(Type.create(DotName.createSimple("boolean"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'B':
-                    args.add(Type.create(DotName.createSimple("byte"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'C':
-                    args.add(Type.create(DotName.createSimple("char"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'D':
-                    args.add(Type.create(DotName.createSimple("double"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'F':
-                    args.add(Type.create(DotName.createSimple("float"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'I':
-                    args.add(Type.create(DotName.createSimple("int"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'J':
-                    args.add(Type.create(DotName.createSimple("long"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
-                    dimensions = 0;
-                    start = i + 1;
-                    break;
                 case 'S':
-                    args.add(Type.create(DotName.createSimple("short"),
-                            dimensions > 0 ? Kind.ARRAY : Kind.PRIMITIVE));
+                    final Type type;
+                    if (dimensions == 0) {
+                        type = Type.create(DotName.createSimple(PRIMITIVE_DESCRIPTOR_TO_PRIMITIVE_CLASS_LITERAL.get(c)),
+                                Kind.PRIMITIVE);
+                    } else {
+                        DotName dotName = DotName.createSimple("[".repeat(dimensions) + c);
+                        type = Type.create(dotName, Kind.ARRAY);
+                    }
+                    args.add(type);
                     dimensions = 0;
                     start = i + 1;
                     break;

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/AsmUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/AsmUtilTest.java
@@ -1,0 +1,41 @@
+package io.quarkus.deployment.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.Type;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AsmUtilTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void testGetParameterTypes(String methodDescriptor, String... expected) {
+        assertArrayEquals(expected,
+                Stream.of(AsmUtil.getParameterTypes(methodDescriptor)).map(Type::toString).toArray(String[]::new));
+    }
+
+    private static final Stream<Arguments> testGetParameterTypes() {
+        List<Arguments> arguments = new ArrayList<>();
+        final var array1 = new StringBuilder();
+        final var array2 = new StringBuilder();
+        for (int i = 0; i < 5; i++) {
+            for (Character c : AsmUtil.PRIMITIVE_DESCRIPTOR_TO_PRIMITIVE_CLASS_LITERAL.keySet()) {
+                arguments.add(Arguments.of("(" + array2 + c + ")V",
+                        toArray(AsmUtil.PRIMITIVE_DESCRIPTOR_TO_PRIMITIVE_CLASS_LITERAL.get(c) + array1)));
+            }
+            array1.append("[]");
+            array2.append('[');
+        }
+        return arguments.stream();
+    }
+
+    private static String[] toArray(String... values) {
+        return values;
+    }
+}


### PR DESCRIPTION
I wrote test only for broken code in core-deployment, not for Panache module where the error was found. 
Just ran tests for code-deployment and test on reproducer project because I can't do a full build with tests due to QuarkusBindException.

Fix #24228