### PR TITLE
Update Keycloak AdminClientTest

### DIFF
--- a/integration-tests/keycloak-authorization/pom.xml
+++ b/integration-tests/keycloak-authorization/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -93,7 +93,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/AdminClientResource.java
@@ -1,33 +1,119 @@
 package io.quarkus.it.keycloak;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 
 @Path("/admin-client")
 public class AdminClientResource {
-
-    private static final Logger LOG = Logger.getLogger(AdminClientResource.class);
 
     @ConfigProperty(name = "admin-url")
     String url;
 
     @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public String hello() {
-        LOG.info("Hello invoked");
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("realm")
+    public RealmRepresentation getRealm() {
+        try (Keycloak keycloak = keycloak()) {
+            return keycloak.realm("quarkus").toRepresentation();
+        }
+    }
 
-        Keycloak keycloak = KeycloakBuilder.builder().serverUrl(url)
-                .realm("master")
-                .clientId("admin-cli")
-                .username("admin")
-                .password("admin").build();
-        return keycloak.realm("quarkus").toRepresentation().getRealm();
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("newrealm")
+    public RealmRepresentation createRealm() {
+        RealmRepresentation newRealm = createRealm("quarkus2");
+
+        newRealm.getClients().add(createClient("quarkus-app2"));
+        newRealm.getUsers().add(createUser("alice", "user"));
+
+        try (Keycloak keycloak = keycloak()) {
+            keycloak.realms().create(newRealm);
+        }
+
+        try (Keycloak keycloak = keycloak()) {
+            return keycloak.realm("quarkus2").toRepresentation();
+        }
+    }
+
+    private Keycloak keycloak() {
+        try {
+            return KeycloakBuilder.builder()
+                    .serverUrl(url)
+                    .realm("master")
+                    .clientId("admin-cli")
+                    .username("admin")
+                    .password("admin")
+                    .build();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static RealmRepresentation createRealm(String name) {
+        RealmRepresentation realm = new RealmRepresentation();
+
+        realm.setRealm(name);
+        realm.setEnabled(true);
+        realm.setUsers(new ArrayList<>());
+        realm.setClients(new ArrayList<>());
+
+        RolesRepresentation roles = new RolesRepresentation();
+        List<RoleRepresentation> realmRoles = new ArrayList<>();
+
+        roles.setRealm(realmRoles);
+        realm.setRoles(roles);
+
+        realm.getRoles().getRealm().add(new RoleRepresentation("user", null, false));
+
+        return realm;
+    }
+
+    private static ClientRepresentation createClient(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+
+        client.setClientId(clientId);
+        client.setRedirectUris(Arrays.asList("*"));
+        client.setPublicClient(false);
+        client.setSecret("secret");
+        client.setDirectAccessGrantsEnabled(true);
+        client.setEnabled(true);
+
+        return client;
+    }
+
+    private static UserRepresentation createUser(String username, String... realmRoles) {
+        UserRepresentation user = new UserRepresentation();
+
+        user.setUsername(username);
+        user.setEnabled(true);
+        user.setCredentials(new ArrayList<>());
+        user.setRealmRoles(Arrays.asList(realmRoles));
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(username);
+        credential.setTemporary(false);
+
+        user.getCredentials().add(credential);
+
+        return user;
     }
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AdminClientTestCase.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/AdminClientTestCase.java
@@ -1,9 +1,10 @@
 package io.quarkus.it.keycloak;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -11,12 +12,16 @@ import io.quarkus.test.junit.QuarkusTest;
 public class AdminClientTestCase {
 
     @Test
-    public void testHelloEndpoint() {
-        given()
-                .when().get("/admin-client")
-                .then()
-                .statusCode(200)
-                .body(is("quarkus"));
+    public void testGetExistingRealm() {
+        RealmRepresentation realm = given()
+                .when().get("/admin-client/realm").as(RealmRepresentation.class);
+        assertEquals("quarkus", realm.getRealm());
     }
 
+    @Test
+    public void testGetNewRealm() {
+        RealmRepresentation realm = given()
+                .when().get("/admin-client/newrealm").as(RealmRepresentation.class);
+        assertEquals("quarkus2", realm.getRealm());
+    }
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -4,11 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
-
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessTokenResponse;
 
@@ -31,14 +27,6 @@ public class PolicyEnforcerTest {
 
     private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");
     private static final String KEYCLOAK_REALM = "quarkus";
-
-    @BeforeAll
-    public static void configureKeycloakRealm() throws IOException {
-    }
-
-    @AfterAll
-    public static void removeKeycloakRealm() {
-    }
 
     @Test
     public void testUserHasAdminRoleServiceTenant() {


### PR DESCRIPTION
This PR updates `AdminClientTest` to use Jackson to return `RealmRepresentation` and also adds a new test to add a realm directly from the Quarkus endpoint and then retrieves that realm from the same endpoint.
Looks like ClientRepresentation is not returned though when a realm is retrieved, I believe it is controlled as the Keycloak UI where one can chose between partial and complete realm export - but it is not possible at the admin API level, CC @pedroigor 

These updated tests reflect my level of experience with Admin API. But we can use it as a base and keep adding more tests going forward

thanks