### PR TITLE
Allow passing a string to QuarkusApplicationClassBuildItem

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusApplicationClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/QuarkusApplicationClassBuildItem.java
@@ -10,6 +10,10 @@ public final class QuarkusApplicationClassBuildItem extends SimpleBuildItem {
         this.className = quarkusApplicationClass.getName();
     }
 
+    public QuarkusApplicationClassBuildItem(String quarkusApplicationClassName) {
+        this.className = quarkusApplicationClassName;
+    }
+
     public String getClassName() {
         return className;
     }


### PR DESCRIPTION
This is especially useful when you generate the @QuarkusMain class.
The @QuarkusMain annotations are looked for in the combined index,
thus not taking into account generated classes.
The only way to push a generated class as @QuarkusMain is to use
QuarkusApplicationClassBuildItem and obviously, in this case, you don't
have a Class handy.

Asking for a friend who has a tendency to use bytecode generation for his extensions :).