### PR TITLE
Update Maven to 3.8.5 and maven-invoker to 3.1.0

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -153,7 +153,7 @@
         <kotlin.coroutine.version>1.6.0</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.2</kotlin-serialization.version>
         <dekorate.version>2.9.0</dekorate.version>
-        <maven-invoker.version>3.0.1</maven-invoker.version>
+        <maven-invoker.version>3.1.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
         <flyway.version>8.5.2</flyway.version>
@@ -4967,6 +4967,12 @@
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-invoker</artifactId>
                 <version>${maven-invoker.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -64,7 +64,7 @@
         <supported-maven-versions>[3.6.2,)</supported-maven-versions>
 
         <!-- These 2 properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.8.4</proposed-maven-version>
+        <proposed-maven-version>3.8.5</proposed-maven-version>
         <maven-wrapper.version>3.1.0</maven-wrapper.version>
         <gradle-wrapper.version>7.4.1</gradle-wrapper.version>
         <quarkus-gradle-plugin.version>${project.version}</quarkus-gradle-plugin.version>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -44,7 +44,7 @@
         <version.jta>1.3.3</version.jta>
         <version.jandex>2.4.2.Final</version.jandex>
         <version.junit5>5.8.2</version.junit5>
-        <version.maven>3.8.4</version.maven>
+        <version.maven>3.8.5</version.maven>
         <version.assertj>3.22.0</version.assertj>
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -29,6 +29,7 @@ import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelProblemCollector;
 import org.apache.maven.model.building.ModelProblemCollectorRequest;
 import org.apache.maven.model.path.DefaultPathTranslator;
+import org.apache.maven.model.path.ProfileActivationFilePathInterpolator;
 import org.apache.maven.model.profile.DefaultProfileActivationContext;
 import org.apache.maven.model.profile.DefaultProfileSelector;
 import org.apache.maven.model.profile.activation.FileProfileActivator;
@@ -616,7 +617,8 @@ public class BootstrapMavenContext {
                 .addProfileActivator(new PropertyProfileActivator())
                 .addProfileActivator(new JdkVersionProfileActivator())
                 .addProfileActivator(new OperatingSystemProfileActivator())
-                .addProfileActivator(new FileProfileActivator().setPathTranslator(new DefaultPathTranslator()));
+                .addProfileActivator(new FileProfileActivator().setProfileActivationFilePathInterpolator(
+                        new ProfileActivationFilePathInterpolator().setPathTranslator(new DefaultPathTranslator())));
         modelProfiles = profileSelector.getActiveProfiles(modelProfiles, context, new ModelProblemCollector() {
             public void add(ModelProblemCollectorRequest req) {
                 log.error("Failed to activate a Maven profile: " + req.getMessage());

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -43,12 +43,12 @@
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
         <jsoup.version>1.14.2</jsoup.version> <!-- wagon-http dependency -->
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <maven-core.version>3.8.4</maven-core.version><!-- Keep in sync with sisu.version -->
+        <maven-core.version>3.8.5</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.3.5</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
         <maven-resolver.version>1.6.3</maven-resolver.version>
-        <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- changed from the original version due to https://snyk.io/vuln/maven:org.apache.maven.shared:maven-shared-utils@3.2.1 -->
-        <maven-wagon.version>3.4.3</maven-wagon.version>
+        <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
+        <maven-wagon.version>3.5.1</maven-wagon.version>
         <httpcore.version>4.4.15</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
         <jackson.version>2.13.1</jackson.version>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -37,7 +37,7 @@
 
         <enforcer-api.version>3.0.0-M3</enforcer-api.version>
         <maven-invoker-plugin.version>3.2.2</maven-invoker-plugin.version>
-        <maven-core.version>3.8.4</maven-core.version>
+        <maven-core.version>3.8.5</maven-core.version>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -43,7 +43,7 @@
         <version.cdi>2.0.2</version.cdi>
         <version.jandex>2.4.2.Final</version.jandex>
         <version.junit5>5.8.2</version.junit5>
-        <version.maven>3.8.4</version.maven>
+        <version.maven>3.8.5</version.maven>
         <version.assertj>3.22.0</version.assertj>
         <version.jboss-logging>3.4.3.Final</version.jboss-logging>
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/codestart.yml
@@ -6,7 +6,7 @@ language:
   base:
     data:
       maven:
-        version: 3.8.4
+        version: 3.8.5
         wrapper-version: 3.1.0
     shared-data:
       buildtool:

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -368,7 +368,7 @@
         "gradle-plugin-id": "io.quarkus",
         "gradle-plugin-version": "999-FAKE",
         "supported-maven-versions": "[3.6.2,)",
-        "proposed-maven-version": "3.8.4",
+        "proposed-maven-version": "3.8.5",
         "maven-wrapper-version": "3.1.0",
         "gradle-wrapper-version": "7.4.1"
       }

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <!-- These properties are used by CreateProjectMojo to add the Maven Wrapper -->
-        <proposed-maven-version>3.8.4</proposed-maven-version>
+        <proposed-maven-version>3.8.5</proposed-maven-version>
         <maven-wrapper.version>3.1.0</maven-wrapper.version>
         <gradle-wrapper.version>7.4.1</gradle-wrapper.version>
 
@@ -56,7 +56,7 @@
         <junit.version>5.8.2</junit.version>
         <commons-compress.version>1.21</commons-compress.version>
         <jboss-logging.version>3.4.3.Final</jboss-logging.version>
-        <maven-core.version>3.8.4</maven-core.version>
+        <maven-core.version>3.8.5</maven-core.version>
         <mockito.version>4.4.0</mockito.version>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>

--- a/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
+++ b/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
@@ -7340,7 +7340,7 @@
         "gradle-plugin-id" : "io.quarkus",
         "gradle-plugin-version" : "2.0.3.Final",
         "supported-maven-versions" : "[3.6.2,)",
-        "proposed-maven-version" : "3.8.1",
+        "proposed-maven-version" : "3.8.5",
         "maven-wrapper-version" : "3.1.0",
         "gradle-wrapper-version" : "6.9"
       }


### PR DESCRIPTION
See also:
- https://maven.apache.org/docs/3.8.5/release-notes.html
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12351105

Btw, "CI Friendly Versions" are now "pluggable": https://issues.apache.org/jira/browse/MNG-7407
We might need to adapt to this in the long run...

In passing, I also updated maven-invoker which hasn't been touched for years.