### PR TITLE
Fix SmallRye GraphQL Client dependencies

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/pom.xml
+++ b/extensions/smallrye-graphql-client/deployment/pom.xml
@@ -27,6 +27,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql-client</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-graphql-client/runtime/pom.xml
+++ b/extensions/smallrye-graphql-client/runtime/pom.xml
@@ -26,6 +26,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye</groupId>


### PR DESCRIPTION
It depends on Vert.x but we don't depend on quarkus-vertx.
You only have the issue when you don't have quarkus-vertx brought by
other dependencies, which is the case for most applications but not
for command mode apps.

With this change, you can compile command mode apps including the SmallRye GraphQL Client in native.