### PR TITLE
Arc - Introduce separate assignability rules for delegate injection points as per CDI specification

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -76,6 +76,7 @@ public class BeanDeployment {
     private final List<ObserverInfo> observers;
 
     final BeanResolverImpl beanResolver;
+    final DelegateInjectionPointResolverImpl delegateInjectionPointResolver;
     private final AssignabilityCheck assignabilityCheck;
 
     private final InterceptorResolver interceptorResolver;
@@ -190,6 +191,7 @@ public class BeanDeployment {
 
         this.assignabilityCheck = new AssignabilityCheck(beanArchiveIndex, applicationIndex);
         this.beanResolver = new BeanResolverImpl(this);
+        this.delegateInjectionPointResolver = new DelegateInjectionPointResolverImpl(this);
         this.interceptorResolver = new InterceptorResolver(this);
         this.transformUnproxyableClasses = builder.transformUnproxyableClasses;
         this.failOnInterceptedPrivateMethod = builder.failOnInterceptedPrivateMethod;
@@ -520,6 +522,10 @@ public class BeanDeployment {
         return beanResolver;
     }
 
+    public BeanResolver getDelegateInjectionPointResolver() {
+        return delegateInjectionPointResolver;
+    }
+
     public AssignabilityCheck getAssignabilityCheck() {
         return assignabilityCheck;
     }
@@ -580,10 +586,6 @@ public class BeanDeployment {
                 return Collections.emptyList();
             }
         }
-    }
-
-    BeanResolverImpl beanResolver() {
-        return beanResolver;
     }
 
     ClassInfo getInterceptorBinding(DotName name) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -454,7 +454,7 @@ public class BeanInfo implements InjectionTargetInfo {
             qualifiers = new HashSet<>();
             Collections.addAll(qualifiers, requiredQualifiers);
         }
-        return Beans.matches(this, requiredType, qualifiers);
+        return beanDeployment.getBeanResolver().matches(this, requiredType, qualifiers);
     }
 
     Consumer<MethodCreator> getCreatorConsumer() {
@@ -590,7 +590,9 @@ public class BeanInfo implements InjectionTargetInfo {
         // A decorator is bound to a bean if the bean is assignable to the delegate injection point
         List<DecoratorInfo> bound = new ArrayList<>();
         for (DecoratorInfo decorator : decorators) {
-            if (Beans.matches(this, decorator.getDelegateInjectionPoint().getTypeAndQualifiers())) {
+            // make sure we use delegate injection point assignability rules in this case
+            if (beanDeployment.delegateInjectionPointResolver.matches(this,
+                    decorator.getDelegateInjectionPoint().getTypeAndQualifiers())) {
                 bound.add(decorator);
             }
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanResolver.java
@@ -35,4 +35,43 @@ public interface BeanResolver {
      */
     BeanInfo resolveAmbiguity(Set<BeanInfo> beans);
 
+    /**
+     * Checks if given {@link BeanInfo} has type and qualifiers matching those in provided
+     * {@link InjectionPointInfo.TypeAndQualifiers}.
+     *
+     * @param bean Candidate bean
+     * @param typeAndQualifiers Required type and qualifiers
+     * @return True if provided {@link BeanInfo} matches given required type and qualifiers, false otherwise
+     */
+    boolean matches(BeanInfo bean, InjectionPointInfo.TypeAndQualifiers typeAndQualifiers);
+
+    /**
+     * Checks if given {@link BeanInfo} has type and qualifiers matching those in provided
+     * {@link InjectionPointInfo.TypeAndQualifiers}.
+     *
+     * @param bean Candidate bean
+     * @param requiredType Required bean type
+     * @param requiredQualifiers Required qualifiers
+     * @return True if provided {@link BeanInfo} matches given required type and qualifiers, false otherwise
+     */
+    boolean matches(BeanInfo bean, Type requiredType, Set<AnnotationInstance> requiredQualifiers);
+
+    /**
+     * Returns true if required and candidate bean type match, false otherwise.
+     *
+     * @param requiredType Required bean type
+     * @param beanType Candidate bean type
+     * @return True if required type and bean type match, false otherwise
+     */
+    boolean matches(Type requiredType, Type beanType);
+
+    /**
+     * Returns true if provided bean matches required type, false otherwise
+     *
+     * @param bean Candidate bean
+     * @param requiredType Required bean type
+     * @return Returns true if given bean matches required type, false otherwise
+     */
+    boolean matchesType(BeanInfo bean, Type requiredType);
+
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -363,23 +363,20 @@ public final class Beans {
         return null;
     }
 
+    /**
+     * Checks if given {@link BeanInfo} has type and qualifiers matching those in provided {@link TypeAndQualifiers}.
+     * Uses standard bean assignability rules; see {@link BeanResolverImpl}.
+     */
     public static boolean matches(BeanInfo bean, TypeAndQualifiers typeAndQualifiers) {
-        return matches(bean, typeAndQualifiers.type, typeAndQualifiers.qualifiers);
+        return bean.getDeployment().getBeanResolver().matches(bean, typeAndQualifiers);
     }
 
+    /**
+     * Checks if given {@link BeanInfo} has all the required qualifiers and a bean type that matches required type.
+     * Uses standard bean assignability rules; see {@link BeanResolverImpl}.
+     */
     static boolean matches(BeanInfo bean, Type requiredType, Set<AnnotationInstance> requiredQualifiers) {
-        // Bean has all the required qualifiers and a bean type that matches the required type
-        return matchesType(bean, requiredType) && hasQualifiers(bean, requiredQualifiers);
-    }
-
-    static boolean matchesType(BeanInfo bean, Type requiredType) {
-        BeanResolverImpl beanResolver = bean.getDeployment().beanResolver;
-        for (Type beanType : bean.getTypes()) {
-            if (beanResolver.matches(requiredType, beanType)) {
-                return true;
-            }
-        }
-        return false;
+        return bean.getDeployment().getBeanResolver().matches(bean, requiredType, requiredQualifiers);
     }
 
     static void resolveInjectionPoint(BeanDeployment deployment, InjectionTargetInfo target, InjectionPointInfo injectionPoint,

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DelegateInjectionPointResolverImpl.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DelegateInjectionPointResolverImpl.java
@@ -1,0 +1,101 @@
+package io.quarkus.arc.processor;
+
+import static org.jboss.jandex.Type.Kind.TYPE_VARIABLE;
+import static org.jboss.jandex.Type.Kind.WILDCARD_TYPE;
+
+import java.util.Collections;
+import java.util.List;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.WildcardType;
+
+/**
+ * Logic is mostly equal to that of bean type resolution.
+ * However, there are some nuances in parameter matching when it comes to generics.
+ */
+class DelegateInjectionPointResolverImpl extends BeanResolverImpl {
+
+    DelegateInjectionPointResolverImpl(BeanDeployment deployment) {
+        super(deployment);
+    }
+
+    @Override
+    boolean parametersMatch(Type delegateType, Type beanParameter) {
+        // this is the same as for bean types
+        if (isActualType(delegateType) && isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter and the bean type parameter are actual types with identical raw
+             * type, and, if the type is parameterized, the bean type parameter is assignable to the delegate
+             * type parameter according to these rules, or
+             */
+            return matches(delegateType, beanParameter);
+        }
+        // this is the same as for bean types
+        if (WILDCARD_TYPE.equals(delegateType.kind()) && isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter is a wildcard, the bean type parameter is an actual type and the
+             * actual type is assignable to the upper bound, if any, of the wildcard and assignable from the
+             * lower bound, if any, of the wildcard, or
+             */
+            return parametersMatch(delegateType.asWildcardType(), beanParameter);
+        }
+        // this is different from bean type rules
+        if (WILDCARD_TYPE.equals(delegateType.kind()) && TYPE_VARIABLE.equals(beanParameter.kind())) {
+            /*
+             * the delegate type parameter is a wildcard, the bean type parameter is a type variable and the
+             * upper bound of the type variable is assignable to the upper bound, if any, of the wildcard and
+             * assignable from the lower bound, if any, of the wildcard, or
+             */
+            return parametersMatch(delegateType.asWildcardType(), beanParameter.asTypeVariable());
+        }
+        // this is different from bean type rules
+        if (TYPE_VARIABLE.equals(delegateType.kind()) && TYPE_VARIABLE.equals(beanParameter.kind())) {
+            /*
+             * the required type parameter and the bean type parameter are both type variables and the upper bound of the
+             * required type parameter is assignable
+             * to the upper bound, if any, of the bean type parameter
+             */
+            return parametersMatch(delegateType.asTypeVariable(), beanParameter.asTypeVariable());
+        }
+        // this is different to bean type rules
+        if (TYPE_VARIABLE.equals(delegateType.kind()) && isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter is a type variable, the bean type parameter is an actual type, and
+             * the actual type is assignable to the upper bound, if any, of the type variable
+             */
+            return parametersMatch(delegateType.asTypeVariable(), beanParameter);
+        }
+        return false;
+    }
+
+    @Override
+    boolean parametersMatch(WildcardType requiredParameter, TypeVariable beanParameter) {
+        List<Type> beanParameterBounds = getUppermostTypeVariableBounds(beanParameter);
+        if (!lowerBoundsOfWildcardMatch(beanParameterBounds, requiredParameter)) {
+            return false;
+        }
+
+        List<Type> requiredUpperBounds = Collections.singletonList(requiredParameter.extendsBound());
+        // upper bound of the type variable is assignable to the upper bound of the wildcard
+        return (boundsMatch(requiredUpperBounds, beanParameterBounds));
+    }
+
+    @Override
+    boolean parametersMatch(TypeVariable requiredParameter, TypeVariable beanParameter) {
+        return boundsMatch(getUppermostTypeVariableBounds(requiredParameter), getUppermostTypeVariableBounds(beanParameter));
+    }
+
+    protected boolean parametersMatch(TypeVariable delegateParameter, Type beanParameter) {
+        for (Type type : getUppermostTypeVariableBounds(delegateParameter)) {
+            if (!beanDeployment.getAssignabilityCheck().isAssignableFrom(type, beanParameter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected BeanResolver getBeanResolver(BeanInfo bean) {
+        return bean.getDeployment().delegateInjectionPointResolver;
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/UnusedBeans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/UnusedBeans.java
@@ -60,8 +60,10 @@ final class UnusedBeans {
             }
             // Instance<Foo>
             for (InjectionPointInfo injectionPoint : instanceInjectionPoints) {
-                if (Beans.hasQualifiers(bean, injectionPoint.getRequiredQualifiers()) && Beans.matchesType(bean,
-                        injectionPoint.getType().asParameterizedType().arguments().get(0))) {
+                if (Beans.hasQualifiers(bean, injectionPoint.getRequiredQualifiers())
+                        && bean.getDeployment().getBeanResolver().matchesType(bean,
+                                injectionPoint.getType().asParameterizedType().arguments().get(0))) {
+
                     continue test;
                 }
             }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/DelegateInjectionPointAssignabilityRules.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/DelegateInjectionPointAssignabilityRules.java
@@ -1,0 +1,107 @@
+package io.quarkus.arc.impl;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+
+/**
+ * Code is mostly taken from Weld codebase.
+ * The logic is very much the same as with assignability rules for bean types but takes into consideration some
+ * special cases for parameter matching when it comes to generics.
+ */
+final class DelegateInjectionPointAssignabilityRules extends BeanTypeAssignabilityRules {
+
+    private DelegateInjectionPointAssignabilityRules() {
+    }
+
+    private static final DelegateInjectionPointAssignabilityRules INSTANCE = new DelegateInjectionPointAssignabilityRules();
+
+    public static DelegateInjectionPointAssignabilityRules instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected boolean parametersMatch(Type delegateParameter, Type beanParameter) {
+        // this is the same as for bean types
+        if (Types.isActualType(delegateParameter) && Types.isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter and the bean type parameter are actual types with identical raw
+             * type, and, if the type is parameterized, the bean type parameter is assignable to the delegate
+             * type parameter according to these rules, or
+             */
+            return matches(delegateParameter, beanParameter);
+        }
+        // this is the same as for bean types
+        if (delegateParameter instanceof WildcardType && Types.isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter is a wildcard, the bean type parameter is an actual type and the
+             * actual type is assignable to the upper bound, if any, of the wildcard and assignable from the
+             * lower bound, if any, of the wildcard, or
+             */
+            return parametersMatch((WildcardType) delegateParameter, beanParameter);
+        }
+        // this is different to bean type rules
+        if (delegateParameter instanceof WildcardType && beanParameter instanceof TypeVariable<?>) {
+            /*
+             * the delegate type parameter is a wildcard, the bean type parameter is a type variable and the
+             * upper bound of the type variable is assignable to the upper bound, if any, of the wildcard and
+             * assignable from the lower bound, if any, of the wildcard, or
+             */
+            return parametersMatch((WildcardType) delegateParameter, (TypeVariable<?>) beanParameter);
+        }
+        // this is different to bean type rules
+        if (delegateParameter instanceof TypeVariable<?> && beanParameter instanceof TypeVariable<?>) {
+            /*
+             * the delegate type parameter and the bean type parameter are both type variables and the upper
+             * bound of the bean type parameter is assignable to the upper bound, if any, of the delegate type
+             * parameter, or
+             */
+            return parametersMatch((TypeVariable<?>) delegateParameter, (TypeVariable<?>) beanParameter);
+        }
+        // this is different to bean type rules
+        if (delegateParameter instanceof TypeVariable<?> && Types.isActualType(beanParameter)) {
+            /*
+             * the delegate type parameter is a type variable, the bean type parameter is an actual type, and
+             * the actual type is assignable to the upper bound, if any, of the type variable
+             */
+            return parametersMatch((TypeVariable<?>) delegateParameter, beanParameter);
+        }
+        /*
+         * this is not defined by the specification but is here to retain backward compatibility with previous
+         * versions of Weld
+         * see CDITCK-430
+         */
+        if (Object.class.equals(delegateParameter) && beanParameter instanceof TypeVariable<?>) {
+            TypeVariable<?> beanParameterVariable = (TypeVariable<?>) beanParameter;
+            return Object.class.equals(beanParameterVariable.getBounds()[0]);
+        }
+
+        return false;
+    }
+
+    @Override
+    protected boolean parametersMatch(WildcardType delegateParameter, TypeVariable<?> beanParameter) {
+        Type[] beanParameterBounds = getUppermostTypeVariableBounds(beanParameter);
+        if (!lowerBoundsOfWildcardMatch(beanParameterBounds, delegateParameter)) {
+            return false;
+        }
+
+        Type[] requiredUpperBounds = delegateParameter.getUpperBounds();
+        // upper bound of the type variable is assignable to the upper bound of the wildcard
+        return boundsMatch(requiredUpperBounds, beanParameterBounds);
+    }
+
+    @Override
+    protected boolean parametersMatch(TypeVariable<?> delegateParameter, TypeVariable<?> beanParameter) {
+        return boundsMatch(getUppermostTypeVariableBounds(delegateParameter), getUppermostTypeVariableBounds(beanParameter));
+    }
+
+    protected boolean parametersMatch(TypeVariable<?> delegateParameter, Type beanParameter) {
+        for (Type type : getUppermostTypeVariableBounds(delegateParameter)) {
+            if (!CovariantTypes.isAssignableFrom(type, beanParameter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventTypeAssignabilityRules.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventTypeAssignabilityRules.java
@@ -16,10 +16,16 @@ import java.util.Set;
  */
 final class EventTypeAssignabilityRules {
 
+    private static final EventTypeAssignabilityRules INSTANCE = new EventTypeAssignabilityRules();
+
+    public static EventTypeAssignabilityRules instance() {
+        return INSTANCE;
+    }
+
     private EventTypeAssignabilityRules() {
     }
 
-    static boolean matches(Type observedType, Set<? extends Type> eventTypes) {
+    public boolean matches(Type observedType, Set<? extends Type> eventTypes) {
         for (Type eventType : eventTypes) {
             if (matches(observedType, eventType)) {
                 return true;
@@ -28,11 +34,11 @@ final class EventTypeAssignabilityRules {
         return false;
     }
 
-    static boolean matches(Type observedType, Type eventType) {
+    public boolean matches(Type observedType, Type eventType) {
         return matchesNoBoxing(Types.boxedType(observedType), Types.boxedType(eventType));
     }
 
-    static boolean matchesNoBoxing(Type observedType, Type eventType) {
+    boolean matchesNoBoxing(Type observedType, Type eventType) {
         if (observedType instanceof TypeVariable<?>) {
             /*
              * An event type is considered assignable to a type variable if the event type is assignable to the upper bound, if
@@ -63,8 +69,8 @@ final class EventTypeAssignabilityRules {
         return false;
     }
 
-    private static boolean matches(TypeVariable<?> observedType, Type eventType) {
-        for (Type bound : BeanTypeAssignabilityRules.getUppermostTypeVariableBounds(observedType)) {
+    private boolean matches(TypeVariable<?> observedType, Type eventType) {
+        for (Type bound : BeanTypeAssignabilityRules.instance().getUppermostTypeVariableBounds(observedType)) {
             if (!CovariantTypes.isAssignableFrom(bound, eventType)) {
                 return false;
             }
@@ -72,7 +78,7 @@ final class EventTypeAssignabilityRules {
         return true;
     }
 
-    private static boolean matches(ParameterizedType observedType, ParameterizedType eventType) {
+    private boolean matches(ParameterizedType observedType, ParameterizedType eventType) {
         if (!observedType.getRawType().equals(eventType.getRawType())) {
             return false;
         }
@@ -91,7 +97,7 @@ final class EventTypeAssignabilityRules {
      * A parameterized event type is considered assignable to a parameterized observed event type if they have identical raw
      * type and for each parameter:
      */
-    private static boolean parametersMatch(Type observedParameter, Type eventParameter) {
+    private boolean parametersMatch(Type observedParameter, Type eventParameter) {
         if (Types.isActualType(observedParameter) && Types.isActualType(eventParameter)) {
             /*
              * the observed event type parameter is an actual type with identical raw type to the event type parameter, and, if
@@ -126,8 +132,8 @@ final class EventTypeAssignabilityRules {
         return false;
     }
 
-    private static boolean parametersMatch(TypeVariable<?> observedParameter, Type eventParameter) {
-        for (Type bound : BeanTypeAssignabilityRules.getUppermostTypeVariableBounds(observedParameter)) {
+    private boolean parametersMatch(TypeVariable<?> observedParameter, Type eventParameter) {
+        for (Type bound : BeanTypeAssignabilityRules.instance().getUppermostTypeVariableBounds(observedParameter)) {
             if (!CovariantTypes.isAssignableFrom(bound, eventParameter)) {
                 return false;
             }
@@ -135,9 +141,9 @@ final class EventTypeAssignabilityRules {
         return true;
     }
 
-    private static boolean parametersMatch(WildcardType observedParameter, Type eventParameter) {
-        return (BeanTypeAssignabilityRules.lowerBoundsOfWildcardMatch(eventParameter, observedParameter)
-                && BeanTypeAssignabilityRules.upperBoundsOfWildcardMatch(observedParameter, eventParameter));
+    private boolean parametersMatch(WildcardType observedParameter, Type eventParameter) {
+        return (BeanTypeAssignabilityRules.instance().lowerBoundsOfWildcardMatch(eventParameter, observedParameter)
+                && BeanTypeAssignabilityRules.instance().upperBoundsOfWildcardMatch(observedParameter, eventParameter));
 
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/generics/DecoratorWithTypeVariableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/decorators/generics/DecoratorWithTypeVariableTest.java
@@ -1,0 +1,95 @@
+package io.quarkus.arc.test.decorators.generics;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.Priority;
+import io.quarkus.arc.Unremovable;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.util.List;
+import java.util.Set;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class DecoratorWithTypeVariableTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyParameterizedType.class, MyInterface.class, MyDecorator.class,
+            MyDelegateBean.class, Contract.class);
+
+    @Test
+    public void testDecoration() {
+        // Firstly verify that decorator was invoked and works, i.e. that build time resolution worked
+        MyDelegateBean bean = Arc.container().instance(MyDelegateBean.class).get();
+        Assertions.assertEquals(MyDecorator.class.getSimpleName(),
+                bean.doSomething(new MyParameterizedType<>("test", new Contract())));
+
+        // Secondly, assert that this decorator can be resolved at runtime via BM
+        List<javax.enterprise.inject.spi.Decorator<?>> decoratorsFound = Arc.container().beanManager()
+                .resolveDecorators(Set.of(new TypeLiteral<MyInterface<String, Contract>>() {
+                }.getType()), Any.Literal.INSTANCE);
+        Assertions.assertTrue(decoratorsFound.size() == 1);
+    }
+
+    public static class MyParameterizedType<K, V> {
+
+        final K key;
+
+        final V value;
+
+        public MyParameterizedType(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "key=" + key.toString() + ", value=" + value.toString();
+        }
+
+    }
+
+    public interface MyInterface<K, V> {
+
+        String doSomething(MyParameterizedType<K, V> myParameterizedType);
+
+    }
+
+    @Decorator
+    @Priority(1)
+    public static class MyDecorator<K, V> implements MyInterface<K, V> {
+
+        @Inject
+        @Delegate
+        @Any
+        MyInterface<K, V> delegate;
+
+        @Override
+        public String doSomething(MyParameterizedType<K, V> myParameterizedType) {
+            delegate.doSomething(myParameterizedType);
+            // return something else to verify decoration
+            return MyDecorator.class.getSimpleName();
+        }
+
+    }
+
+    @ApplicationScoped
+    @Unremovable
+    public static class MyDelegateBean implements MyInterface<String, Contract> {
+
+        @Override
+        public String doSomething(MyParameterizedType<String, Contract> myConcreteType) {
+            return MyDelegateBean.class.getSimpleName();
+        }
+
+    }
+
+    public static class Contract {
+
+    }
+}


### PR DESCRIPTION
Fixes #18982 

Heavily inspired by code logic present in Weld. The attached test cover user defined problem as well as runtime resolution of the decorator (since both scenarios use different rules for resolution).
That being said, there are many other cases of generic setups that are left untested but should be covered.