### PR TITLE
Avoid random SmallRye Reactive Messaging Kafka Avro autodetection

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1459,6 +1459,7 @@ The full set of types supported by the serializer/deserializer autodetection is:
 * `io.vertx.core.json.JsonObject`
 * `io.vertx.core.json.JsonArray`
 * classes generated from Avro schemas, as well as Avro `GenericRecord`, if Confluent or Apicurio Registry _serde_ is present
+** in case multiple Avro serdes are present, serializer/deserializer must be configured manually for Avro-generated classes, because autodetection is impossible
 ** see xref:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio Registry libraries
 * classes for which a subclass of `ObjectMapperSerializer` / `ObjectMapperDeserializer` is present, as described in <<jackson-serialization>>
 ** it is technically not needed to subclass `ObjectMapperSerializer`, but in such case, autodetection isn't possible

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/Result.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/Result.java
@@ -4,14 +4,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 final class Result {
+    // false when a result is known to not exist (unlike unknown, which is represented as null Result)
+    final boolean exists;
     final String value; // serializer/deserializer type
     final Map<String, String> additionalProperties;
 
     static Result of(String result) {
-        return new Result(result, new HashMap<>());
+        return new Result(true, result, new HashMap<>());
     }
 
-    private Result(String value, Map<String, String> additionalProperties) {
+    static Result nonexistent() {
+        return new Result(false, null, new HashMap<>());
+    }
+
+    private Result(boolean exists, String value, Map<String, String> additionalProperties) {
+        this.exists = exists;
         this.value = value;
         this.additionalProperties = additionalProperties;
     }
@@ -27,6 +34,6 @@ final class Result {
 
         Map<String, String> additionalProperties = new HashMap<>(this.additionalProperties);
         additionalProperties.put(key, value);
-        return new Result(this.value, additionalProperties);
+        return new Result(this.exists, this.value, additionalProperties);
     }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -38,7 +38,7 @@ import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 
 public class SmallRyeReactiveMessagingKafkaProcessor {
 
-    private static final Logger LOGGER = Logger.getLogger(SmallRyeReactiveMessagingKafkaProcessor.class);
+    private static final Logger LOGGER = Logger.getLogger("io.quarkus.smallrye-reactive-messaging-kafka.deployment.processor");
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -611,6 +611,10 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflection,
             Map<String, String> alreadyGeneratedSerializers) {
         Result result = serializerDeserializerFor(discovery, type, false);
+        if (result != null && !result.exists) {
+            // avoid returning Result.nonexistent() to callers, they expect a non-null Result to always be known
+            return null;
+        }
         // if result is null, generate a jackson serializer, generatedClass is null if the generation is disabled.
         // also, only generate the serializer/deserializer for classes and only generate once
         if (result == null && type != null && generatedClass != null && type.kind() == Type.Kind.CLASS) {
@@ -633,6 +637,10 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflection,
             Map<String, String> alreadyGeneratedSerializers) {
         Result result = serializerDeserializerFor(discovery, type, true);
+        if (result != null && !result.exists) {
+            // avoid returning Result.nonexistent() to callers, they expect a non-null Result to always be known
+            return null;
+        }
         // if result is null, generate a jackson deserializer, generatedClass is null if the generation is disabled.
         // also, only generate the serializer/deserializer for classes and only generate once
         if (result == null && type != null && generatedClass != null && type.kind() == Type.Kind.CLASS) {
@@ -666,6 +674,16 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
         // Avro generated class or GenericRecord (serializer/deserializer provided by Confluent or Apicurio)
         boolean isAvroGenerated = discovery.isAvroGenerated(typeName);
         if (isAvroGenerated || DotNames.AVRO_GENERIC_RECORD.equals(typeName)) {
+            int avroLibraries = 0;
+            avroLibraries += discovery.hasConfluent() ? 1 : 0;
+            avroLibraries += discovery.hasApicurio1() ? 1 : 0;
+            avroLibraries += discovery.hasApicurio2() ? 1 : 0;
+            if (avroLibraries > 1) {
+                LOGGER.debugf("Skipping Avro serde autodetection for %s, because multiple Avro serde libraries are present",
+                        typeName);
+                return Result.nonexistent();
+            }
+
             if (discovery.hasConfluent()) {
                 return serializer
                         ? Result.of("io.confluent.kafka.serializers.KafkaAvroSerializer")
@@ -681,6 +699,9 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
                         ? Result.of("io.apicurio.registry.serde.avro.AvroKafkaSerializer")
                         : Result.of("io.apicurio.registry.serde.avro.AvroKafkaDeserializer")
                                 .with(isAvroGenerated, "apicurio.registry.use-specific-avro-reader", "true");
+            } else {
+                // we know it is an Avro type, no point in serializing it as JSON
+                return Result.nonexistent();
             }
         }
 


### PR DESCRIPTION
In case multiple Avro serde libraries are present on the classpath,
the autodetection code used to select one pretty much randomly
for Avro generated classes. The right thing to do in such situation,
however, is to autodetect nothing and require manual configuration.
That's what this commit does.

This change doesn't affect autodetecting serde for JSON and other
types, it only concerns Avro generated classes.

Fixes #21782