### PR TITLE
Ease restriction on native-sources type and container image extension

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -1,6 +1,8 @@
 
 package io.quarkus.container.image.docker.deployment;
 
+import static io.quarkus.container.image.deployment.util.EnablementUtil.buildContainerImageNeeded;
+import static io.quarkus.container.image.deployment.util.EnablementUtil.pushContainerImageNeeded;
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 
 import java.io.BufferedReader;
@@ -73,12 +75,9 @@ public class DockerProcessor {
             @SuppressWarnings("unused") // used to ensure that the jar has been built
             JarBuildItem jar) {
 
-        if (containerImageConfig.isBuildExplicitlyDisabled() && !containerImageConfig.isPushExplicitlyEnabled()) {
-            return;
-        }
-
-        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
-                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        boolean buildContainerImage = buildContainerImageNeeded(containerImageConfig, buildRequest);
+        boolean pushContainerImage = pushContainerImageNeeded(containerImageConfig, pushRequest);
+        if (!buildContainerImage && !pushContainerImage) {
             return;
         }
 
@@ -104,7 +103,7 @@ public class DockerProcessor {
         ImageIdReader reader = new ImageIdReader();
         String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImageInfo, out, reader,
                 false,
-                pushRequest.isPresent(), packageConfig);
+                pushContainerImage, packageConfig);
 
         // a pull is not required when using this image locally because the docker strategy always builds the container image
         // locally before pushing it to the registry
@@ -125,12 +124,9 @@ public class DockerProcessor {
             // used to ensure that the native binary has been built
             NativeImageBuildItem nativeImage) {
 
-        if (containerImageConfig.isBuildExplicitlyDisabled() && !containerImageConfig.isPushExplicitlyEnabled()) {
-            return;
-        }
-
-        if (!containerImageConfig.isBuildExplicitlyEnabled() && !containerImageConfig.isPushExplicitlyEnabled()
-                && !buildRequest.isPresent() && !pushRequest.isPresent()) {
+        boolean buildContainerImage = buildContainerImageNeeded(containerImageConfig, buildRequest);
+        boolean pushContainerImage = pushContainerImageNeeded(containerImageConfig, pushRequest);
+        if (!buildContainerImage && !pushContainerImage) {
             return;
         }
 
@@ -147,7 +143,7 @@ public class DockerProcessor {
 
         ImageIdReader reader = new ImageIdReader();
         String builtContainerImage = createContainerImage(containerImageConfig, dockerConfig, containerImage, out, reader, true,
-                pushRequest.isPresent(), packageConfig);
+                pushContainerImage, packageConfig);
 
         // a pull is not required when using this image locally because the docker strategy always builds the container image
         // locally before pushing it to the registry

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.container.image.jib.deployment;
 
+import static io.quarkus.container.image.deployment.util.EnablementUtil.buildContainerImageNeeded;
+import static io.quarkus.container.image.deployment.util.EnablementUtil.pushContainerImageNeeded;
 import static io.quarkus.container.util.PathsUtil.findMainSourcesRoot;
 
 import java.io.IOException;
@@ -134,10 +136,8 @@ public class JibProcessor {
             Optional<AppCDSResultBuildItem> appCDSResult,
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
 
-        Boolean buildContainerImage = containerImageConfig.isBuildExplicitlyEnabled()
-                || (buildRequest.isPresent() && !containerImageConfig.isBuildExplicitlyDisabled());
-        Boolean pushContainerImage = containerImageConfig.isPushExplicitlyEnabled()
-                || (pushRequest.isPresent() && !containerImageConfig.isPushExplicitlyDisabled());
+        boolean buildContainerImage = buildContainerImageNeeded(containerImageConfig, buildRequest);
+        boolean pushContainerImage = pushContainerImageNeeded(containerImageConfig, pushRequest);
         if (!buildContainerImage && !pushContainerImage) {
             return;
         }
@@ -167,7 +167,7 @@ public class JibProcessor {
 
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "jar-container",
                 Map.of("container-image", container.getTargetImage().toString(), "pull-required",
-                        pushContainerImage.toString())));
+                        Boolean.toString(pushContainerImage))));
     }
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, JibBuild.class, NativeBuild.class })
@@ -181,10 +181,8 @@ public class JibProcessor {
             Optional<UpxCompressedBuildItem> upxCompressed, // used to ensure that we work with the compressed native binary if compression was enabled
             BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
 
-        Boolean buildContainerImage = containerImageConfig.isBuildExplicitlyEnabled()
-                || (buildRequest.isPresent() && !containerImageConfig.isBuildExplicitlyDisabled());
-        Boolean pushContainerImage = containerImageConfig.isPushExplicitlyEnabled()
-                || (pushRequest.isPresent() && !containerImageConfig.isPushExplicitlyDisabled());
+        boolean buildContainerImage = buildContainerImageNeeded(containerImageConfig, buildRequest);
+        boolean pushContainerImage = pushContainerImageNeeded(containerImageConfig, pushRequest);
         if (!buildContainerImage && !pushContainerImage) {
             return;
         }
@@ -207,7 +205,7 @@ public class JibProcessor {
 
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container",
                 Map.of("container-image", container.getTargetImage().toString(), "pull-required",
-                        pushContainerImage.toString())));
+                        "" + pushContainerImage)));
     }
 
     private JibContainer containerize(ContainerImageConfig containerImageConfig,

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageProcessor.java
@@ -1,11 +1,15 @@
 package io.quarkus.container.image.deployment;
 
+import static io.quarkus.container.image.deployment.util.EnablementUtil.*;
+
 import java.util.Collections;
 import java.util.Optional;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
+import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
 import io.quarkus.container.spi.FallbackContainerImageRegistryBuildItem;
 import io.quarkus.container.spi.ImageReference;
 import io.quarkus.deployment.Capabilities;
@@ -22,9 +26,14 @@ public class ContainerImageProcessor {
     private static final Logger log = Logger.getLogger(ContainerImageProcessor.class);
 
     @BuildStep(onlyIf = NativeSourcesBuild.class)
-    void failForNativeSources(BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
-        throw new IllegalArgumentException(
-                "The Container Image extensions are incompatible with the 'native-sources' package type.");
+    void failForNativeSources(ContainerImageConfig containerImageConfig,
+            Optional<ContainerImageBuildRequestBuildItem> buildRequest,
+            Optional<ContainerImagePushRequestBuildItem> pushRequest,
+            BuildProducer<ArtifactResultBuildItem> artifactResultProducer) {
+        if (buildOrPushContainerImageNeeded(containerImageConfig, buildRequest, pushRequest)) {
+            throw new IllegalArgumentException(
+                    "The Container Image extensions are incompatible with the 'native-sources' package type.");
+        }
     }
 
     @BuildStep

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/EnablementUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/util/EnablementUtil.java
@@ -1,0 +1,29 @@
+package io.quarkus.container.image.deployment.util;
+
+import java.util.Optional;
+
+import io.quarkus.container.image.deployment.ContainerImageConfig;
+import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
+import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
+
+public class EnablementUtil {
+
+    public static boolean buildContainerImageNeeded(ContainerImageConfig containerImageConfig,
+            Optional<ContainerImageBuildRequestBuildItem> buildRequest) {
+        return containerImageConfig.isBuildExplicitlyEnabled()
+                || (buildRequest.isPresent() && !containerImageConfig.isBuildExplicitlyDisabled());
+    }
+
+    public static boolean pushContainerImageNeeded(ContainerImageConfig containerImageConfig,
+            Optional<ContainerImagePushRequestBuildItem> pushRequest) {
+        return containerImageConfig.isPushExplicitlyEnabled()
+                || (pushRequest.isPresent() && !containerImageConfig.isPushExplicitlyDisabled());
+    }
+
+    public static boolean buildOrPushContainerImageNeeded(ContainerImageConfig containerImageConfig,
+            Optional<ContainerImageBuildRequestBuildItem> buildRequest,
+            Optional<ContainerImagePushRequestBuildItem> pushRequest) {
+        return buildContainerImageNeeded(containerImageConfig, buildRequest)
+                || pushContainerImageNeeded(containerImageConfig, pushRequest);
+    }
+}


### PR DESCRIPTION
The build now only fails when the package type is set to native-sources
and one of the container image extensions would actually perform a
container build.

Fixes: #24351