### PR TITLE
ArC - injection point validation

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -958,6 +958,8 @@ public class Processor {
 }
 ----
 
+NOTE: Neither a type variable nor a wildcard is a legal type parameter for an `@All List<>` injection point, i.e. `@Inject @All List<?> all` is not supported and results in a deployment error.
+
 === Ignoring Class-Level Interceptor Bindings for Methods and Constructors
 
 If a managed bean declares interceptor binding annotations on the class level, the corresponding `@AroundInvoke` interceptors will apply to all business methods.

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInvalidTypeParamTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInvalidTypeParamTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.arc.test.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.spi.DeploymentException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.All;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ListInvalidTypeParamTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(Foo.class)).assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                assertTrue(rootCause instanceof DeploymentException);
+                String suppressedMessage = Arrays.stream(rootCause.getSuppressed()).map(Throwable::getMessage)
+                        .collect(Collectors.joining("::"));
+                assertTrue(suppressedMessage.contains("Type variable is not a legal type argument"), rootCause.toString());
+                assertTrue(suppressedMessage.contains("Wildcard is not a legal type argument"), rootCause.toString());
+            });
+
+    @Test
+    public void testFailure() {
+        fail();
+    }
+
+    @Singleton
+    static class Foo<T> {
+
+        @Inject
+        @All
+        List<T> services;
+
+        @All
+        List<?> counters;
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectionFailedTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/InjectionFailedTest.java
@@ -37,7 +37,7 @@ public class InjectionFailedTest {
                     assertTrue(s.getMessage().contains(
                             "No template found for path [foo] defined at io.quarkus.qute.deployment.inject.InjectionFailedTest#foo")
                             || s.getMessage().contains(
-                                    "No template found for path [alpha] defined at io.quarkus.qute.deployment.inject.InjectionFailedTest$Client().alpha"),
+                                    "No template found for path [alpha] defined at io.quarkus.qute.deployment.inject.InjectionFailedTest$Client()"),
                             s.getMessage());
                 }
             });

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -520,8 +520,12 @@ public class BeanInfo implements InjectionTargetInfo {
                 if (injectionPoint.isDelegate() && !isDecorator()) {
                     errors.add(new DeploymentException(String.format(
                             "Only decorators can declare a delegate injection point: %s", this)));
+                } else if (injectionPoint.getType().kind() == org.jboss.jandex.Type.Kind.TYPE_VARIABLE) {
+                    errors.add(new DefinitionException(String.format("Type variable is not a legal injection point type: %s",
+                            injectionPoint.getTargetInfo())));
+                } else {
+                    Beans.resolveInjectionPoint(beanDeployment, this, injectionPoint, errors);
                 }
-                Beans.resolveInjectionPoint(beanDeployment, this, injectionPoint, errors);
             }
         }
         if (disposer != null) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -3,7 +3,6 @@ package io.quarkus.arc.processor;
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 
 import io.quarkus.arc.processor.InjectionPointInfo.TypeAndQualifiers;
-import io.quarkus.arc.processor.InjectionTargetInfo.TargetKind;
 import io.quarkus.gizmo.Gizmo;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -387,20 +386,7 @@ public final class Beans {
         }
         BuiltinBean builtinBean = BuiltinBean.resolve(injectionPoint);
         if (builtinBean != null) {
-            if (BuiltinBean.INJECTION_POINT == builtinBean
-                    && (target.kind() != TargetKind.BEAN || !BuiltinScope.DEPENDENT.is(target.asBean().getScope()))) {
-                errors.add(new DefinitionException("Only @Dependent beans can access metadata about an injection point: "
-                        + injectionPoint.getTargetInfo()));
-            } else if (BuiltinBean.EVENT_METADATA == builtinBean
-                    && target.kind() != TargetKind.OBSERVER) {
-                errors.add(new DefinitionException("EventMetadata can be only injected into an observer method: "
-                        + injectionPoint.getTargetInfo()));
-            } else if (BuiltinBean.INSTANCE == builtinBean
-                    && injectionPoint.getType().kind() != Kind.PARAMETERIZED_TYPE) {
-                errors.add(
-                        new DefinitionException("An injection point of raw type javax.enterprise.inject.Instance is defined: "
-                                + injectionPoint.getTargetInfo()));
-            }
+            builtinBean.validate(target, injectionPoint, errors::add);
             // Skip built-in beans
             return;
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -11,6 +11,7 @@ import io.quarkus.arc.impl.InstanceProvider;
 import io.quarkus.arc.impl.InterceptedBeanMetadataProvider;
 import io.quarkus.arc.impl.ResourceProvider;
 import io.quarkus.arc.processor.InjectionPointInfo.InjectionPointKind;
+import io.quarkus.arc.processor.InjectionTargetInfo.TargetKind;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -20,11 +21,15 @@ import io.quarkus.gizmo.ResultHandle;
 import java.lang.reflect.Member;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import javax.enterprise.inject.spi.DefinitionException;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type.Kind;
 
 /**
  *
@@ -32,183 +37,54 @@ import org.jboss.jandex.DotName;
  */
 enum BuiltinBean {
 
-    INSTANCE(ctx -> {
-        ResultHandle qualifiers = BeanGenerator.collectInjectionPointQualifiers(ctx.classOutput, ctx.clazzCreator,
-                ctx.beanDeployment,
-                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals);
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
-        ResultHandle annotationsHandle = BeanGenerator.collectInjectionPointAnnotations(ctx.classOutput, ctx.clazzCreator,
-                ctx.beanDeployment,
-                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals, ctx.injectionPointAnnotationsPredicate);
-        ResultHandle javaMemberHandle = BeanGenerator.getJavaMemberHandle(ctx.constructor, ctx.injectionPoint,
-                ctx.reflectionRegistration);
-        ResultHandle beanHandle;
-        switch (ctx.targetInfo.kind()) {
-            case OBSERVER:
-                // For observers the first argument is always the declaring bean
-                beanHandle = ctx.constructor.invokeInterfaceMethod(
-                        MethodDescriptors.SUPPLIER_GET, ctx.constructor.getMethodParam(0));
-                break;
-            case BEAN:
-                beanHandle = ctx.constructor.getThis();
-                break;
-            default:
-                throw new IllegalStateException("Unsupported target info: " + ctx.targetInfo);
-        }
-        ResultHandle instanceProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(InstanceProvider.class, java.lang.reflect.Type.class, Set.class,
-                        InjectableBean.class, Set.class, Member.class, int.class),
-                parameterizedType, qualifiers, beanHandle, annotationsHandle, javaMemberHandle,
-                ctx.constructor.load(ctx.injectionPoint.getPosition()));
-        ResultHandle instanceProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, instanceProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(), instanceProviderSupplier);
-    }, DotNames.INSTANCE, DotNames.PROVIDER, DotNames.INJECTABLE_INSTANCE),
-    INJECTION_POINT(ctx -> {
-        // this.injectionPointProvider1 = () -> new InjectionPointProvider();
-        ResultHandle injectionPointProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(InjectionPointProvider.class));
-        ResultHandle injectionPointProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, injectionPointProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(),
-                injectionPointProviderSupplier);
-    }, DotNames.INJECTION_POINT),
-    BEAN(ctx -> {
-        // this.beanProvider1 = () -> new BeanMetadataProvider<>();
-        if (ctx.targetInfo.kind() != InjectionTargetInfo.TargetKind.BEAN) {
-            throw new IllegalStateException("Invalid injection target info: " + ctx.targetInfo);
-        }
-        ResultHandle beanProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(BeanMetadataProvider.class, String.class),
-                ctx.constructor.load(ctx.targetInfo.asBean().getIdentifier()));
-        ResultHandle beanProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(),
-                beanProviderSupplier);
-    }, ip -> {
-        return isCdiAndRawTypeMatches(ip, DotNames.BEAN, DotNames.INJECTABLE_BEAN) && ip.hasDefaultedQualifier();
-    }, DotNames.BEAN),
-    INTERCEPTED_BEAN(ctx -> {
-        if (!(ctx.targetInfo instanceof InterceptorInfo)) {
-            throw new IllegalStateException("Invalid injection target info: " + ctx.targetInfo);
-        }
-        ResultHandle interceptedBeanMetadataProvider = ctx.constructor
-                .newInstance(MethodDescriptor.ofConstructor(InterceptedBeanMetadataProvider.class));
+    INSTANCE(BuiltinBean::generateInstanceBytecode, BuiltinBean::cdiAndRawTypeMatches,
+            BuiltinBean::validateInstance, DotNames.INSTANCE, DotNames.PROVIDER, DotNames.INJECTABLE_INSTANCE),
+    INJECTION_POINT(BuiltinBean::generateInjectionPointBytecode, BuiltinBean::cdiAndRawTypeMatches,
+            BuiltinBean::validateInjectionPoint, DotNames.INJECTION_POINT),
+    BEAN(BuiltinBean::generateBeanBytecode,
+            (ip, names) -> cdiAndRawTypeMatches(ip, DotNames.BEAN, DotNames.INJECTABLE_BEAN) && ip.hasDefaultedQualifier(),
+            DotNames.BEAN),
 
-        ResultHandle interceptedBeanMetadataProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, interceptedBeanMetadataProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(),
-                interceptedBeanMetadataProviderSupplier);
-    }, ip -> {
-        return isCdiAndRawTypeMatches(ip, DotNames.BEAN, DotNames.INJECTABLE_BEAN) && !ip.hasDefaultedQualifier()
-                && ip.getRequiredQualifiers().size() == 1
-                && ip.getRequiredQualifiers().iterator().next().name().equals(DotNames.INTERCEPTED);
-    }, DotNames.BEAN),
-    BEAN_MANAGER(ctx -> {
-        ResultHandle beanManagerProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(BeanManagerProvider.class));
-        ResultHandle injectionPointProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanManagerProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(),
-                injectionPointProviderSupplier);
-    }, DotNames.BEAN_MANAGER),
-    EVENT(ctx -> {
-
-        ResultHandle qualifiers = ctx.constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-        if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
-            // Set<Annotation> instanceProvider1Qualifiers = new HashSet<>()
-            // instanceProvider1Qualifiers.add(javax.enterprise.inject.Default.Literal.INSTANCE)
-
-            for (AnnotationInstance qualifierAnnotation : ctx.injectionPoint.getRequiredQualifiers()) {
-                BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
-                if (qualifier != null) {
-                    ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
-                            qualifier.getLiteralInstance(ctx.constructor));
-                } else {
-                    // Create annotation literal first
-                    ClassInfo qualifierClass = ctx.beanDeployment.getQualifier(qualifierAnnotation.name());
-                    ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
-                            ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
-                                    qualifierClass, qualifierAnnotation,
-                                    Types.getPackageName(ctx.clazzCreator.getClassName())));
-                }
-            }
-        }
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
-        ResultHandle eventProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(EventProvider.class, java.lang.reflect.Type.class,
-                        Set.class),
-                parameterizedType, qualifiers);
-        ResultHandle eventProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, eventProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(), eventProviderSupplier);
-    }, DotNames.EVENT),
-    RESOURCE(ctx -> {
-
-        ResultHandle annotations = ctx.constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
-        // For a resource field the required qualifiers contain all annotations declared on the field
-        if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
-            for (AnnotationInstance annotation : ctx.injectionPoint.getRequiredQualifiers()) {
-                // Create annotation literal first
-                ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getBeanArchiveIndex(), annotation.name());
-                ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotations,
-                        ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
-                                annotationClass, annotation,
-                                Types.getPackageName(ctx.clazzCreator.getClassName())));
-            }
-        }
-        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
-        ResultHandle resourceProvider = ctx.constructor.newInstance(
-                MethodDescriptor.ofConstructor(ResourceProvider.class, java.lang.reflect.Type.class,
-                        Set.class),
-                parameterizedType, annotations);
-        ResultHandle resourceProviderSupplier = ctx.constructor.newInstance(
-                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, resourceProvider);
-        ctx.constructor.writeInstanceField(
-                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
-                        Supplier.class.getName()),
-                ctx.constructor.getThis(), resourceProviderSupplier);
-    }, ip -> ip.getKind() == InjectionPointKind.RESOURCE, DotNames.OBJECT),
-    EVENT_METADATA(ctx -> {
-    }, DotNames.EVENT_METADATA),
-    ;
+    INTERCEPTED_BEAN(BuiltinBean::generateInterceptedBeanBytecode,
+            (ip, names) -> cdiAndRawTypeMatches(ip, DotNames.BEAN, DotNames.INJECTABLE_BEAN) && !ip.hasDefaultedQualifier()
+                    && ip.getRequiredQualifiers().size() == 1
+                    && ip.getRequiredQualifiers().iterator().next().name().equals(DotNames.INTERCEPTED),
+            DotNames.BEAN),
+    BEAN_MANAGER(BuiltinBean::generateBeanManagerBytecode, DotNames.BEAN_MANAGER),
+    EVENT(BuiltinBean::generateEventBytecode, DotNames.EVENT),
+    RESOURCE(BuiltinBean::generateResourceBytecode, (ip, names) -> ip.getKind() == InjectionPointKind.RESOURCE,
+            DotNames.OBJECT),
+    EVENT_METADATA(Generator.NOOP, BuiltinBean::cdiAndRawTypeMatches,
+            BuiltinBean::validateEventMetadata, DotNames.EVENT_METADATA),
+            ;
 
     private final DotName[] rawTypeDotNames;
-
     private final Generator generator;
+    private final BiPredicate<InjectionPointInfo, DotName[]> matcher;
+    private final Validator validator;
 
-    private final Predicate<InjectionPointInfo> matcher;
-
-    BuiltinBean(Generator generator, DotName... rawTypeDotNames) {
-        this(generator, ip -> isCdiAndRawTypeMatches(ip, rawTypeDotNames), rawTypeDotNames);
+    private BuiltinBean(Generator generator, DotName... rawTypeDotNames) {
+        this(generator, BuiltinBean::cdiAndRawTypeMatches, rawTypeDotNames);
     }
 
-    BuiltinBean(Generator generator, Predicate<InjectionPointInfo> matcher, DotName... rawTypeDotNames) {
+    private BuiltinBean(Generator generator, BiPredicate<InjectionPointInfo, DotName[]> matcher, DotName... rawTypeDotNames) {
+        this(generator, matcher, Validator.NOOP, rawTypeDotNames);
+    }
+
+    private BuiltinBean(Generator generator, BiPredicate<InjectionPointInfo, DotName[]> matcher, Validator validator,
+            DotName... rawTypeDotNames) {
         this.rawTypeDotNames = rawTypeDotNames;
         this.generator = generator;
         this.matcher = matcher;
+        this.validator = validator;
     }
 
     boolean matches(InjectionPointInfo injectionPoint) {
-        return matcher.test(injectionPoint);
+        return matcher.test(injectionPoint, rawTypeDotNames);
+    }
+
+    void validate(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint, Consumer<Throwable> errors) {
+        validator.validate(injectionTarget, injectionPoint, errors);
     }
 
     DotName[] getRawTypeDotNames() {
@@ -274,11 +150,24 @@ enum BuiltinBean {
     @FunctionalInterface
     interface Generator {
 
+        Generator NOOP = ctx -> {
+        };
+
         void generate(GeneratorContext context);
 
     }
 
-    private static boolean isCdiAndRawTypeMatches(InjectionPointInfo injectionPoint, DotName... rawTypeDotNames) {
+    @FunctionalInterface
+    interface Validator {
+
+        Validator NOOP = (it, ip, e) -> {
+        };
+
+        void validate(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint, Consumer<Throwable> errors);
+
+    }
+
+    private static boolean cdiAndRawTypeMatches(InjectionPointInfo injectionPoint, DotName... rawTypeDotNames) {
         if (injectionPoint.getKind() != InjectionPointKind.CDI) {
             return false;
         }
@@ -288,6 +177,193 @@ enum BuiltinBean {
             }
         }
         return false;
+    }
+
+    private static void generateInstanceBytecode(GeneratorContext ctx) {
+        ResultHandle qualifiers = BeanGenerator.collectInjectionPointQualifiers(ctx.classOutput, ctx.clazzCreator,
+                ctx.beanDeployment,
+                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals);
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
+        ResultHandle annotationsHandle = BeanGenerator.collectInjectionPointAnnotations(ctx.classOutput, ctx.clazzCreator,
+                ctx.beanDeployment,
+                ctx.constructor, ctx.injectionPoint, ctx.annotationLiterals, ctx.injectionPointAnnotationsPredicate);
+        ResultHandle javaMemberHandle = BeanGenerator.getJavaMemberHandle(ctx.constructor, ctx.injectionPoint,
+                ctx.reflectionRegistration);
+        ResultHandle beanHandle;
+        switch (ctx.targetInfo.kind()) {
+            case OBSERVER:
+                // For observers the first argument is always the declaring bean
+                beanHandle = ctx.constructor.invokeInterfaceMethod(
+                        MethodDescriptors.SUPPLIER_GET, ctx.constructor.getMethodParam(0));
+                break;
+            case BEAN:
+                beanHandle = ctx.constructor.getThis();
+                break;
+            default:
+                throw new IllegalStateException("Unsupported target info: " + ctx.targetInfo);
+        }
+        ResultHandle instanceProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(InstanceProvider.class, java.lang.reflect.Type.class, Set.class,
+                        InjectableBean.class, Set.class, Member.class, int.class),
+                parameterizedType, qualifiers, beanHandle, annotationsHandle, javaMemberHandle,
+                ctx.constructor.load(ctx.injectionPoint.getPosition()));
+        ResultHandle instanceProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, instanceProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(), instanceProviderSupplier);
+    }
+
+    private static void generateEventBytecode(GeneratorContext ctx) {
+        ResultHandle qualifiers = ctx.constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+        if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
+            // Set<Annotation> instanceProvider1Qualifiers = new HashSet<>()
+            // instanceProvider1Qualifiers.add(javax.enterprise.inject.Default.Literal.INSTANCE)
+
+            for (AnnotationInstance qualifierAnnotation : ctx.injectionPoint.getRequiredQualifiers()) {
+                BuiltinQualifier qualifier = BuiltinQualifier.of(qualifierAnnotation);
+                if (qualifier != null) {
+                    ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
+                            qualifier.getLiteralInstance(ctx.constructor));
+                } else {
+                    // Create annotation literal first
+                    ClassInfo qualifierClass = ctx.beanDeployment.getQualifier(qualifierAnnotation.name());
+                    ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
+                            ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
+                                    qualifierClass, qualifierAnnotation,
+                                    Types.getPackageName(ctx.clazzCreator.getClassName())));
+                }
+            }
+        }
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
+        ResultHandle eventProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(EventProvider.class, java.lang.reflect.Type.class,
+                        Set.class),
+                parameterizedType, qualifiers);
+        ResultHandle eventProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, eventProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(), eventProviderSupplier);
+    }
+
+    private static void generateInjectionPointBytecode(GeneratorContext ctx) {
+        // this.injectionPointProvider1 = () -> new InjectionPointProvider();
+        ResultHandle injectionPointProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(InjectionPointProvider.class));
+        ResultHandle injectionPointProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, injectionPointProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(),
+                injectionPointProviderSupplier);
+    }
+
+    private static void generateBeanBytecode(GeneratorContext ctx) {
+        // this.beanProvider1 = () -> new BeanMetadataProvider<>();
+        if (ctx.targetInfo.kind() != InjectionTargetInfo.TargetKind.BEAN) {
+            throw new IllegalStateException("Invalid injection target info: " + ctx.targetInfo);
+        }
+        ResultHandle beanProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(BeanMetadataProvider.class, String.class),
+                ctx.constructor.load(ctx.targetInfo.asBean().getIdentifier()));
+        ResultHandle beanProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(),
+                beanProviderSupplier);
+    }
+
+    private static void generateInterceptedBeanBytecode(GeneratorContext ctx) {
+        if (!(ctx.targetInfo instanceof InterceptorInfo)) {
+            throw new IllegalStateException("Invalid injection target info: " + ctx.targetInfo);
+        }
+        ResultHandle interceptedBeanMetadataProvider = ctx.constructor
+                .newInstance(MethodDescriptor.ofConstructor(InterceptedBeanMetadataProvider.class));
+
+        ResultHandle interceptedBeanMetadataProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, interceptedBeanMetadataProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(),
+                interceptedBeanMetadataProviderSupplier);
+    }
+
+    private static void generateBeanManagerBytecode(GeneratorContext ctx) {
+        ResultHandle beanManagerProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(BeanManagerProvider.class));
+        ResultHandle injectionPointProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, beanManagerProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(),
+                injectionPointProviderSupplier);
+    }
+
+    private static void generateResourceBytecode(GeneratorContext ctx) {
+        ResultHandle annotations = ctx.constructor.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+        // For a resource field the required qualifiers contain all annotations declared on the field
+        if (!ctx.injectionPoint.getRequiredQualifiers().isEmpty()) {
+            for (AnnotationInstance annotation : ctx.injectionPoint.getRequiredQualifiers()) {
+                // Create annotation literal first
+                ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getBeanArchiveIndex(), annotation.name());
+                ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotations,
+                        ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
+                                annotationClass, annotation,
+                                Types.getPackageName(ctx.clazzCreator.getClassName())));
+            }
+        }
+        ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());
+        ResultHandle resourceProvider = ctx.constructor.newInstance(
+                MethodDescriptor.ofConstructor(ResourceProvider.class, java.lang.reflect.Type.class,
+                        Set.class),
+                parameterizedType, annotations);
+        ResultHandle resourceProviderSupplier = ctx.constructor.newInstance(
+                MethodDescriptors.FIXED_VALUE_SUPPLIER_CONSTRUCTOR, resourceProvider);
+        ctx.constructor.writeInstanceField(
+                FieldDescriptor.of(ctx.clazzCreator.getClassName(), ctx.providerName,
+                        Supplier.class.getName()),
+                ctx.constructor.getThis(), resourceProviderSupplier);
+    }
+
+    private static void validateInstance(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint,
+            Consumer<Throwable> errors) {
+        if (injectionPoint.getType().kind() != Kind.PARAMETERIZED_TYPE) {
+            errors.accept(
+                    new DefinitionException("An injection point of raw type javax.enterprise.inject.Instance is defined: "
+                            + injectionPoint.getTargetInfo()));
+        } else if (injectionPoint.getRequiredType().kind() == Kind.WILDCARD_TYPE) {
+            errors.accept(
+                    new DefinitionException("Wildcard is not a legal type argument for javax.enterprise.inject.Instance: " +
+                            injectionPoint.getTargetInfo()));
+        } else if (injectionPoint.getRequiredType().kind() == Kind.TYPE_VARIABLE) {
+            errors.accept(new DefinitionException(
+                    "Type variable is not a legal type argument for javax.enterprise.inject.Instance: " +
+                            injectionPoint.getTargetInfo()));
+        }
+    }
+
+    private static void validateInjectionPoint(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint,
+            Consumer<Throwable> errors) {
+        if (injectionTarget.kind() != TargetKind.BEAN || !BuiltinScope.DEPENDENT.is(injectionTarget.asBean().getScope())) {
+            errors.accept(new DefinitionException("Only @Dependent beans can access metadata about an injection point: "
+                    + injectionPoint.getTargetInfo()));
+        }
+    }
+
+    private static void validateEventMetadata(InjectionTargetInfo injectionTarget, InjectionPointInfo injectionPoint,
+            Consumer<Throwable> errors) {
+        if (injectionTarget.kind() != TargetKind.OBSERVER) {
+            errors.accept(new DefinitionException("EventMetadata can be only injected into an observer method: "
+                    + injectionPoint.getTargetInfo()));
+        }
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InjectionPointInfo.java
@@ -246,7 +246,7 @@ public class InjectionPointInfo {
                 } else {
                     method = "#" + method;
                 }
-                return target.asMethod().declaringClass().name() + method + "()" + "." + param;
+                return target.asMethod().declaringClass().name() + method + "()" + ":" + param;
             default:
                 return target.toString();
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableFieldInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableFieldInjectionPointTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.injection.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TypeVariableFieldInjectionPointTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();;
+
+    @Test
+    public void testError() {
+        Throwable failure = container.getFailure();
+        assertNotNull(failure);
+        assertTrue(failure instanceof DefinitionException);
+        assertEquals(
+                "Type variable is not a legal injection point type: io.quarkus.arc.test.injection.illegal.TypeVariableFieldInjectionPointTest$Head#it",
+                failure.getMessage());
+    }
+
+    @Dependent
+    static class Head<T> {
+
+        @Inject
+        T it;
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableInitializerInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/injection/illegal/TypeVariableInitializerInjectionPointTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.injection.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TypeVariableInitializerInjectionPointTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();;
+
+    @Test
+    public void testError() {
+        Throwable failure = container.getFailure();
+        assertNotNull(failure);
+        assertTrue(failure instanceof DefinitionException);
+        assertEquals(
+                "Type variable is not a legal injection point type: io.quarkus.arc.test.injection.illegal.TypeVariableInitializerInjectionPointTest$Head#setIt():it",
+                failure.getMessage());
+    }
+
+    @Dependent
+    static class Head<T> {
+
+        @Inject
+        void setIt(T it) {
+        }
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/illegal/TypeVariableInstanceInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/illegal/TypeVariableInstanceInjectionPointTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.instance.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TypeVariableInstanceInjectionPointTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();;
+
+    @Test
+    public void testError() {
+        Throwable failure = container.getFailure();
+        assertNotNull(failure);
+        assertTrue(failure instanceof DefinitionException);
+        assertEquals(
+                "Type variable is not a legal type argument for javax.enterprise.inject.Instance: io.quarkus.arc.test.instance.illegal.TypeVariableInstanceInjectionPointTest$Head#instance",
+                failure.getMessage());
+    }
+
+    @Dependent
+    static class Head<T> {
+
+        @Inject
+        Instance<T> instance;
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/illegal/WildcardInstanceInjectionPointTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/illegal/WildcardInstanceInjectionPointTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.arc.test.instance.illegal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class WildcardInstanceInjectionPointTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(Head.class).shouldFail().build();;
+
+    @Test
+    public void testError() {
+        Throwable failure = container.getFailure();
+        assertNotNull(failure);
+        assertTrue(failure instanceof DefinitionException);
+        assertEquals(
+                "Wildcard is not a legal type argument for javax.enterprise.inject.Instance: io.quarkus.arc.test.instance.illegal.WildcardInstanceInjectionPointTest$Head#instance",
+                failure.getMessage());
+    }
+
+    @Dependent
+    static class Head {
+
+        @Inject
+        Instance<? extends Number> instance;
+
+    }
+
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/unused/RemoveUnusedBeansTest.java
@@ -29,7 +29,7 @@ public class RemoveUnusedBeansTest extends RemoveUnusedComponentsTest {
     @RegisterExtension
     public ArcTestContainer container = ArcTestContainer.builder()
             .beanClasses(HasObserver.class, Foo.class, FooAlternative.class, HasName.class, UnusedProducers.class,
-                    InjectedViaInstance.class, InjectedViaInstanceWithWildcard.class, InjectedViaInstanceWithWildcard2.class,
+                    InjectedViaInstance.class, InjectedViaInstanceWithWildcard.class,
                     InjectedViaProvider.class, Excluded.class,
                     UsedProducers.class,
                     UnusedProducerButInjected.class, UsedViaInstanceWithUnusedProducer.class, UsesBeanViaInstance.class)
@@ -43,7 +43,6 @@ public class RemoveUnusedBeansTest extends RemoveUnusedComponentsTest {
         assertPresent(HasName.class);
         assertPresent(InjectedViaInstance.class);
         assertPresent(InjectedViaInstanceWithWildcard.class);
-        assertPresent(InjectedViaInstanceWithWildcard2.class);
         assertPresent(InjectedViaProvider.class);
         assertPresent(String.class);
         assertPresent(UsedProducers.class);
@@ -105,9 +104,6 @@ public class RemoveUnusedBeansTest extends RemoveUnusedComponentsTest {
         Instance<InjectedViaInstance> instance;
 
         @Inject
-        Instance<? extends InjectedViaInstanceWithWildcard> instanceWildcard;
-
-        @Inject
         Instance<Comparable<? extends Foo>> instanceWildcard2;
 
         @Inject
@@ -121,12 +117,7 @@ public class RemoveUnusedBeansTest extends RemoveUnusedComponentsTest {
     }
 
     @Singleton
-    static class InjectedViaInstanceWithWildcard {
-
-    }
-
-    @Singleton
-    static class InjectedViaInstanceWithWildcard2 implements Comparable<FooAlternative> {
+    static class InjectedViaInstanceWithWildcard implements Comparable<FooAlternative> {
 
         @Override
         public int compareTo(FooAlternative o) {


### PR DESCRIPTION
- type variable is not a legal injection point type
- also validate type params of types related to programmatic lookup,
i.e. Instance<> and List<> with All qualifier