### PR TITLE
Fix DevServices for Keycloak UI regression

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -31,20 +31,20 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
             BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> devConsoleRuntimeInfo,
             Optional<KeycloakDevServicesConfigBuildItem> configProps,
             Capabilities capabilities, CurateOutcomeBuildItem curateOutcomeBuildItem) {
-        if (configProps.isPresent() && configProps.get().getProperties().containsKey("keycloak.url")) {
-            String keycloakUrl = (String) configProps.get().getProperties().get("keycloak.url");
-            String realmUrl = keycloakUrl + "/realms/" + configProps.get().getProperties().get("keycloak.realm");
-
-            devConsoleInfo.produce(new DevConsoleTemplateInfoBuildItem("keycloakAdminUrl", keycloakUrl));
+        if (configProps.isPresent() && configProps.get().getConfig().containsKey("keycloak.url")) {
             devConsoleInfo.produce(
-                    new DevConsoleTemplateInfoBuildItem("keycloakUsers", configProps.get().getProperties().get("oidc.users")));
+                    new DevConsoleTemplateInfoBuildItem("keycloakAdminUrl", configProps.get().getConfig().get("keycloak.url")));
+            devConsoleInfo.produce(
+                    new DevConsoleTemplateInfoBuildItem("keycloakUsers",
+                            configProps.get().getProperties().get("oidc.users")));
 
+            String realmUrl = configProps.get().getConfig().get("quarkus.oidc.auth-server-url");
             produceDevConsoleTemplateItems(capabilities,
                     devConsoleInfo,
                     devConsoleRuntimeInfo,
                     curateOutcomeBuildItem,
                     "Keycloak",
-                    (String) configProps.get().getProperties().get("quarkus.oidc.application-type"),
+                    (String) configProps.get().getConfig().get("quarkus.oidc.application-type"),
                     oidcConfig.devui.grant.type.isPresent() ? oidcConfig.devui.grant.type.get().getGrantType()
                             : keycloakConfig.devservices.grant.type.getGrantType(),
                     realmUrl + "/protocol/openid-connect/auth",
@@ -57,7 +57,7 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     void invokeEndpoint(BuildProducer<DevConsoleRouteBuildItem> devConsoleRoute,
             Optional<KeycloakDevServicesConfigBuildItem> configProps) {
-        if (configProps.isPresent() && configProps.get().getProperties().containsKey("keycloak.url")) {
+        if (configProps.isPresent() && configProps.get().getConfig().containsKey("keycloak.url")) {
             @SuppressWarnings("unchecked")
             Map<String, String> users = (Map<String, String>) configProps.get().getProperties().get("oidc.users");
             Duration webClientTimeout = oidcConfig.devui.webClienTimeout.isPresent() ? oidcConfig.devui.webClienTimeout.get()

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesConfigBuildItem.java
@@ -6,13 +6,19 @@ import io.quarkus.builder.item.SimpleBuildItem;
 
 public final class KeycloakDevServicesConfigBuildItem extends SimpleBuildItem {
 
+    private final Map<String, String> config;
     private final Map<String, Object> properties;
 
-    public KeycloakDevServicesConfigBuildItem(Map<String, Object> configProperties) {
+    public KeycloakDevServicesConfigBuildItem(Map<String, String> config, Map<String, Object> configProperties) {
+        this.config = config;
         this.properties = configProperties;
     }
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
     }
 }


### PR DESCRIPTION
Fixes #24329

I had to use `KeycloakDevServicesConfigBuildItem` to pass a Map of users to the devconsole processor in addition to `config` Map of strings - I tried to pass them with `DevServicesResultBuildItem` but it did not work (having 2 optional build items) - so I just used `KeycloakDevServicesConfigBuildItem`.

Also did a minor cleanup related to recalculating `auth-server-url`, @ozangunalp your refactoring was good and helped to optimize it further.

I confirmed in the quickstart it works now as expected, so all is good; 

But unfortunately I was not able to test `/q/dev` returns a `Provider: Keycloak` neither in `extensions/oidc/deployment` nor in `integrations-tests/devmode/.../devconsole/DevModeOidcSmokeTest` - calling `q/dev` returns a default devconsole HTML representation with the empty OIDC card, looks like `embedded.html` is not loaded yet at the moment the test runs or a KC container has not started yet.
