### PR TITLE
Fix NPE when setting the logger level to null

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogController.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/logstream/LogController.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.logging.Level;
 
-import org.jboss.logmanager.Level;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
 
@@ -78,11 +78,18 @@ public class LogController {
     public static void updateLogLevel(String loggerName, String levelValue) {
         LogContext logContext = LogContext.getLogContext();
         Logger logger = logContext.getLogger(loggerName);
-        if (logger != null) {
-            java.util.logging.Level level = Level.parse(levelValue);
-            logger.setLevel(level);
-            LOG.info("Log level updated [" + loggerName + "] changed to [" + levelValue + "]");
+        java.util.logging.Level level;
+        if (levelValue == null || levelValue.isBlank()) {
+            if (logger.getParent() != null) {
+                level = logger.getParent().getLevel();
+            } else {
+                throw new IllegalArgumentException("The level of the root logger cannot be set to null");
+            }
+        } else {
+            level = Level.parse(levelValue);
         }
+        logger.setLevel(level);
+        LOG.info("Log level updated [" + loggerName + "] changed to [" + levelValue + "]");
     }
 
     private static String getConfiguredLogLevel(Logger logger) {
@@ -100,22 +107,19 @@ public class LogController {
         return getEffectiveLogLevel(logger.getParent());
     }
 
-    public static final List<String> LEVELS = new ArrayList<>();
-
-    static {
-        LEVELS.add(OFF.getName());
-        LEVELS.add(SEVERE.getName());
-        LEVELS.add(ERROR.getName());
-        LEVELS.add(FATAL.getName());
-        LEVELS.add(WARNING.getName());
-        LEVELS.add(WARN.getName());
-        LEVELS.add(INFO.getName());
-        LEVELS.add(DEBUG.getName());
-        LEVELS.add(TRACE.getName());
-        LEVELS.add(CONFIG.getName());
-        LEVELS.add(FINE.getName());
-        LEVELS.add(FINER.getName());
-        LEVELS.add(FINEST.getName());
-        LEVELS.add(ALL.getName());
-    }
+    public static final List<String> LEVELS = List.of(
+            OFF.getName(),
+            SEVERE.getName(),
+            ERROR.getName(),
+            FATAL.getName(),
+            WARNING.getName(),
+            WARN.getName(),
+            INFO.getName(),
+            DEBUG.getName(),
+            TRACE.getName(),
+            CONFIG.getName(),
+            FINE.getName(),
+            FINER.getName(),
+            FINEST.getName(),
+            ALL.getName());
 }

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/logstream/LogControllerTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/logstream/LogControllerTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.vertx.http.runtime.logstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+
+class LogControllerTest {
+
+    @Test
+    void updateLogLevelShouldUseParentWhenLevelIsNull() {
+        Logger logger = Logger.getLogger("foo.bar");
+        logger.setLevel(Level.CONFIG);
+        Logger parent = Logger.getLogger("foo");
+        LogController.updateLogLevel("foo.bar", null);
+        assertThat(logger.getLevel()).isEqualTo(parent.getLevel());
+    }
+
+    @Test
+    void updateLogLevelShouldThrowIAEinRootLoggerWhenLevelIsNull() {
+        assertThatIllegalArgumentException().isThrownBy(() -> LogController.updateLogLevel("", null))
+                .withMessage("The level of the root logger cannot be set to null");
+    }
+
+}


### PR DESCRIPTION
The logger level is set to the parent level if null.

- Fixes #24358