### PR TITLE
Update SmallRye Config to 2.9.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -39,7 +39,7 @@
         <microprofile-jwt.version>1.2</microprofile-jwt.version>
         <microprofile-lra.version>1.0</microprofile-lra.version>
         <smallrye-common.version>1.10.0</smallrye-common.version>
-        <smallrye-config.version>2.9.1</smallrye-config.version>
+        <smallrye-config.version>2.9.2</smallrye-config.version>
         <smallrye-health.version>3.2.0</smallrye-health.version>
         <smallrye-metrics.version>3.0.4</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.21</smallrye-open-api.version>

--- a/integration-tests/smallrye-config/src/main/resources/application.properties
+++ b/integration-tests/smallrye-config/src/main/resources/application.properties
@@ -6,7 +6,9 @@ smallrye.config.locations=config.properties
 smallrye.config.source.file.locations=src/main/smallrye-config-source-file-system
 
 # parent profile
-quarkus.config.profile.parent=common
+%prod.quarkus.config.profile.parent=common
+%test.quarkus.config.profile.parent=common
+%dev.quarkus.config.profile.parent=common
 
 %common.profile.property.shared=common
 %test.profile.property.shared=main


### PR DESCRIPTION
https://github.com/smallrye/smallrye-config/releases/tag/2.9.2

- Updated the Quarkus config properties Relocator to add the properties in the active profile to support reading the profile parent property from the active profile (this requires SmallRye Config 2.9.2).