### PR TITLE
Make some additional address resolver options configurable

### DIFF
--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -467,6 +467,8 @@ public class VertxCoreRecorder {
         opts.setCacheMaxTimeToLive(ar.cacheMaxTimeToLive);
         opts.setCacheMinTimeToLive(ar.cacheMinTimeToLive);
         opts.setCacheNegativeTimeToLive(ar.cacheNegativeTimeToLive);
+        opts.setMaxQueries(ar.maxQueries);
+        opts.setQueryTimeout(ar.queryTimeout.toMillis());
 
         options.setAddressResolverOptions(opts);
     }

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/AddressResolverConfiguration.java
@@ -1,5 +1,7 @@
 package io.quarkus.vertx.core.runtime.config;
 
+import java.time.Duration;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -26,4 +28,15 @@ public class AddressResolverConfiguration {
     @ConfigItem(defaultValue = "0")
     public int cacheNegativeTimeToLive;
 
+    /**
+     * The maximum number of queries to be sent during a resolution.
+     */
+    @ConfigItem(defaultValue = "4")
+    public int maxQueries;
+
+    /**
+     * The duration after which a DNS query is considered to be failed.
+     */
+    @ConfigItem(defaultValue = "5S")
+    public Duration queryTimeout;
 }

--- a/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
+++ b/extensions/vertx/runtime/src/test/java/io/quarkus/vertx/core/runtime/VertxCoreProducerTest.java
@@ -70,6 +70,8 @@ public class VertxCoreProducerTest {
         AddressResolverConfiguration ar = configuration.resolver;
         ar.cacheMaxTimeToLive = 3;
         ar.cacheNegativeTimeToLive = 1;
+        ar.maxQueries = 2;
+        ar.queryTimeout = Duration.ofMillis(200L);
 
         VertxOptionsCustomizer customizers = new VertxOptionsCustomizer(Arrays.asList(
                 new Consumer<VertxOptions>() {
@@ -80,6 +82,8 @@ public class VertxCoreProducerTest {
                                 AddressResolverOptions.DEFAULT_CACHE_MIN_TIME_TO_LIVE,
                                 vertxOptions.getAddressResolverOptions().getCacheMinTimeToLive());
                         Assertions.assertEquals(1, vertxOptions.getAddressResolverOptions().getCacheNegativeTimeToLive());
+                        Assertions.assertEquals(2, vertxOptions.getAddressResolverOptions().getMaxQueries());
+                        Assertions.assertEquals(200L, vertxOptions.getAddressResolverOptions().getQueryTimeout());
                     }
                 }));
 
@@ -160,6 +164,8 @@ public class VertxCoreProducerTest {
         vc.resolver.cacheMaxTimeToLive = Integer.MAX_VALUE;
         vc.resolver.cacheMinTimeToLive = 0;
         vc.resolver.cacheNegativeTimeToLive = 0;
+        vc.resolver.maxQueries = 4;
+        vc.resolver.queryTimeout = Duration.ofSeconds(5);
         return vc;
     }
 }


### PR DESCRIPTION
This is a follow-up to #13214, adding support for configuring the
managed vert.x instance's DNS resolver's query timeout and max number of
DNS query attempts per resolution.

It would be nice if this could be adopted in the 2.7 branch as well.