### PR TITLE
Migrate the guides to RESTEasy Reactive

### DIFF
--- a/docs/src/main/asciidoc/amazon-lambda-http.adoc
+++ b/docs/src/main/asciidoc/amazon-lambda-http.adoc
@@ -3,14 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Amazon Lambda with RESTEasy, Undertow, or Reactive Routes
+= Amazon Lambda with RESTEasy Reactive, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 :devtools-no-gradle:
 
 With Quarkus you can deploy your favorite Java HTTP frameworks as Amazon Lambda's using either the https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html[AWS Gateway HTTP API]
-or https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html[AWS Gateway REST API].  This means that you can deploy your microservices written with RESTEasy (JAX-RS),
+or https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html[AWS Gateway REST API].  This means that you can deploy your microservices written with RESTEasy Reactive (JAX-RS),
 Undertow (servlet), Reactive Routes, xref:funqy-http.adoc[Funqy HTTP] or any other Quarkus HTTP framework as an AWS Lambda.
 
 You can deploy your Lambda as a pure Java jar, or you can compile your project to a native image and deploy that for a smaller
@@ -237,7 +237,7 @@ There is nothing special about the POM other than the inclusion of the `quarkus-
 (if you are deploying an AWS Gateway HTTP API) or the `quarkus-amazon-lambda-rest` extension (if you are deploy an AWS Gateway REST API).
 These extensions automatically generate everything you might need for your lambda deployment.
 
-Also, at least in the generated Maven archetype `pom.xml`, the `quarkus-resteasy`, `quarkus-reactive-routes`, and `quarkus-undertow`
+Also, at least in the generated Maven archetype `pom.xml`, the `quarkus-resteasy-reactive`, `quarkus-reactive-routes`, and `quarkus-undertow`
 dependencies are all optional.  Pick which HTTP framework(s) you want to use (JAX-RS, Reactive Routes, and/or Servlet) and
 remove the other dependencies to shrink your deployment.
 
@@ -286,7 +286,7 @@ HTTP response messages and the `sam.yaml` file must configure the API Gateway to
 
 == Injectable AWS Context Variables
 
-If you are using RESTEasy and JAX-RS, you can inject various AWS Context variables into your JAX-RS resource classes
+If you are using RESTEasy Reactive and JAX-RS, you can inject various AWS Context variables into your JAX-RS resource classes
 using the JAX-RS `@Context` annotation or anywhere else with the CDI `@Inject` annotation.
 
 For the AWS HTTP API you can inject the AWS variables `com.amazonaws.services.lambda.runtime.Context` and

--- a/docs/src/main/asciidoc/azure-functions-http.adoc
+++ b/docs/src/main/asciidoc/azure-functions-http.adoc
@@ -3,12 +3,12 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Azure Functions (Serverless) with RESTEasy, Undertow, or Reactive Routes
+= Azure Functions (Serverless) with RESTEasy Reactive, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
-The `quarkus-azure-functions-http` extension allows you to write microservices with RESTEasy (JAX-RS),
+The `quarkus-azure-functions-http` extension allows you to write microservices with RESTEasy Reactive (JAX-RS),
 Undertow (servlet), Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] and make these microservices deployable to the Azure Functions runtime.
 
 One azure function deployment can represent any number of JAX-RS, servlet, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
@@ -95,8 +95,8 @@ https://{appName}.azurewebsites.net/api/funqyHello
 
 == Extension maven dependencies
 
-The sample project includes the RESTEasy, Undertow, Reactive Routes, xref:funqy-http.adoc[Funqy HTTP] extensions.  If you are only using one of those
-APIs (i.e. jax-rs only), respectively remove the maven dependency `quarkus-resteasy`, `quarkus-undertow`, `quarkus-funqy-http`, and/or
+The sample project includes the RESTEasy Reactive, Undertow, Reactive Routes, xref:funqy-http.adoc[Funqy HTTP] extensions.  If you are only using one of those
+APIs (i.e. jax-rs only), respectively remove the maven dependency `quarkus-resteasy-reactive`, `quarkus-undertow`, `quarkus-funqy-http`, and/or
 `quarkus-reactive-routes`.
 
 You must include the `quarkus-azure-functions-http` extension as this is a generic bridge between the Azure Functions

--- a/docs/src/main/asciidoc/blaze-persistence.adoc
+++ b/docs/src/main/asciidoc/blaze-persistence.adoc
@@ -205,7 +205,7 @@ public class GiftResource {
     @GET
     @Path("{id"})
     @Produces(MediaType.APPLICATION_JSON)
-    public GiftView getGift(@PathParam("id") Long id) {
+    public GiftView getGift(Long id) {
         return return entityViewManager.find(entityManager, GiftView.class, view.getId());
     }
 }

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -301,7 +301,7 @@ $ ./mvnw verify -Pnative
 [INFO] Running org.acme.quickstart.GreetingResourceIT
 Executing [/data/home/gsmet/git/quarkus-quickstarts/getting-started/target/getting-started-1.0.0-SNAPSHOT-runner, -Dquarkus.http.port=8081, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=build/quarkus.log]
 2019-04-15 11:33:20,348 INFO  [io.quarkus] (main) Quarkus 999-SNAPSHOT started in 0.002s. Listening on: http://[::]:8081
-2019-04-15 11:33:20,348 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2019-04-15 11:33:20,348 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.387 s - in org.acme.quickstart.GreetingResourceIT
 ...
 ----

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -38,10 +38,10 @@ The solution is located in the `cache-quickstart` {quickstarts-tree-url}/cache-q
 First, we need to create a new Quarkus project with the following command:
 
 :create-app-artifact-id: cache-quickstart
-:create-app-extensions: resteasy,cache,resteasy-jackson
+:create-app-extensions: cache,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
-This command generates the project and imports the `cache` and `resteasy-jackson` extensions.
+This command generates the project and imports the `cache` and `resteasy-reactive-jackson` extensions.
 
 If you already have your Quarkus project configured, you can add the `cache` extension
 to your project by running the following command in your project base directory:
@@ -155,7 +155,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.reactive.RestQuery;
 
 @Path("/weather")
 public class WeatherForecastResource {
@@ -164,13 +164,12 @@ public class WeatherForecastResource {
     WeatherForecastService service;
 
     @GET
-    public WeatherForecast getForecast(@QueryParam String city, @QueryParam long daysInFuture) { <1>
+    public WeatherForecast getForecast(@RestQuery String city, @RestQuery long daysInFuture) { <1>
         long executionStart = System.currentTimeMillis();
         List<String> dailyForecasts = Arrays.asList(
                 service.getDailyForecast(LocalDate.now().plusDays(daysInFuture), city),
                 service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 1L), city),
-                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 2L), city)
-        );
+                service.getDailyForecast(LocalDate.now().plusDays(daysInFuture + 2L), city));
         long executionEnd = System.currentTimeMillis();
         return new WeatherForecast(dailyForecasts, executionEnd - executionStart);
     }

--- a/docs/src/main/asciidoc/cassandra.adoc
+++ b/docs/src/main/asciidoc/cassandra.adoc
@@ -229,7 +229,7 @@ public class FruitDto {
 }
 ----
 
-The translation to and from JSON is done automatically by the Quarkus RestEasy extension, which is
+The translation to and from JSON is done automatically by the Quarkus RESTEasy Reactive extension, which is
 included in this guide's pom.xml file. If you want to add it manually to your application, add the
 below snippet to your application's ppm.xml file:
 
@@ -237,11 +237,11 @@ below snippet to your application's ppm.xml file:
 ----
 <dependency>
   <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-resteasy</artifactId>
+  <artifactId>quarkus-resteasy-reactive</artifactId>
 </dependency>
 <dependency>
   <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-resteasy-jsonb</artifactId>
+  <artifactId>quarkus-resteasy-jackson</artifactId>
 </dependency>
 ----
 
@@ -514,16 +514,7 @@ NOTE: The `getAll()` method above returns `Multi`, and the `add()` method return
 are the same Mutiny types that we met before; they are automatically recognized by the Quarkus
 reactive REST API, so we don't need to convert them into JSON ourselves.
 
-To effectively integrate the reactive logic with the REST API, your application needs to declare a
-dependency to the Quarkus RestEasy Mutiny extension:
-
-[source,xml]
-----
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-resteasy-mutiny</artifactId>
-</dependency>
-----
+RESTEasy Reactive natively supports the Mutiny reactive types e.g. `Uni` and `Multi`.
 
 This dependency is already included in this guide's pom.xml, but if you are starting a new project
 from scratch, make sure to include it.

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -29,7 +29,7 @@ The following examples will all be based on the same example application that yo
 Create an application with the `quarkus-logging-gelf` extension. You can use the following command to create it:
 
 :create-app-artifact-id: gelf-logging
-:create-app-extensions: resteasy,logging-gelf
+:create-app-extensions: resteasy-reactive,logging-gelf
 include::includes/devtools/create-app.adoc[]
 
 If you already have your Quarkus project configured, you can add the `logging-gelf` extension

--- a/docs/src/main/asciidoc/cli-tooling.adoc
+++ b/docs/src/main/asciidoc/cli-tooling.adoc
@@ -489,7 +489,7 @@ __  ____  __  _____   ___  __ ____  ______
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/
 2021-05-27 10:15:56,032 INFO  [io.quarkus] (Quarkus Main Thread) code-with-quarkus 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 1.387s. Listening on: http://localhost:8080
 2021-05-27 10:15:56,035 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2021-05-27 10:15:56,035 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy, smallrye-context-propagation]
+2021-05-27 10:15:56,035 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation]
 
 --
 Tests paused, press [r] to resume

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -33,7 +33,7 @@ The solution is located in the `config-quickstart` {quickstarts-tree-url}/config
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: config-quickstart
-:create-app-extensions: resteasy
+:create-app-extensions: resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 It generates:

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -10,7 +10,7 @@ include::./attributes.adoc[]
 Traditional blocking code uses link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ThreadLocal.html[`ThreadLocal`]
  variables to store contextual objects in order to avoid
 passing them as parameters everywhere. Many Quarkus extensions require those contextual objects to operate
-properly: xref:rest-json.adoc[RESTEasy], xref:cdi-reference.adoc[ArC] and xref:transaction.adoc[Transaction]
+properly: xref:rest-json.adoc[RESTEasy Reactive], xref:cdi-reference.adoc[ArC] and xref:transaction.adoc[Transaction]
 for example.
 
 If you write reactive/async code, you have to cut your work into a pipeline of code blocks that get executed
@@ -37,15 +37,15 @@ The solution is located in the `context-propagation-quickstart` {quickstarts-tre
 If you are using link:http://smallrye.io/smallrye-mutiny[Mutiny] (the `quarkus-mutiny` extension), you just need to add the
 the `quarkus-smallrye-context-propagation` extension to enable context propagation.
 
-In other words, add the following dependencies to your `pom.xml`:
+In other words, add the following dependencies to your build file:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
 ----
-<!-- RESTEasy support extensions if not already included -->
+<!-- RESTEasy Reactive extension if not already included -->
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-mutiny</artifactId>
+    <artifactId>quarkus-resteasy-reactive</artifactId>
 </dependency>
 <!-- Context Propagation extension -->
 <dependency>
@@ -57,13 +57,13 @@ In other words, add the following dependencies to your `pom.xml`:
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-// RESTEasy support extensions if not already included
-implementation("io.quarkus:quarkus-resteasy-mutiny")
+// RESTEasy Reactive extension if not already included
+implementation("io.quarkus:quarkus-resteasy-reactive")
 // Context Propagation extension
 implementation("io.quarkus:quarkus-smallrye-context-propagation")
 ----
 
-With this, you will get context propagation for ArC, RESTEasy and transactions, if you are using them.
+With this, you will get context propagation for ArC, RESTEasy Reactive and transactions, if you are using them.
 
 == Usage example with Mutiny
 
@@ -88,11 +88,14 @@ them to the client, you can do it like this:
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Publisher<Double> prices() {
         // get the next three prices from the price stream
         return Multi.createFrom().publisher(prices)
                 .select().first(3)
+                // The items are received from the event loop, so cannot use Hibernate ORM (classic)
+                // Switch to a worker thread, the transaction will be propagated
+                .emitOn(Infrastructure.getDefaultExecutor())
                 .map(price -> {
                     // store each price before we send them
                     Price priceEntity = new Price();
@@ -236,7 +239,7 @@ annotation:
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     // Get rid of all context propagation, since we don't need it here
     @CurrentThreadContext(unchanged = ThreadContext.ALL_REMAINING)
     public Publisher<Double> prices() {
@@ -263,7 +266,7 @@ You can also inject a custom-built `ThreadContext` using the https://javadoc.io/
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.TEXT_PLAIN)
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Publisher<Double> prices() {
         // Get rid of all context propagation, since we don't need it here
         try(CleanAutoCloseable ac = SmallRyeThreadContext.withThreadContext(threadContext)){

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -24,7 +24,8 @@ include::includes/devtools/prerequisites.adoc[]
 Let's create a new project that contains both the Kubernetes and Jib extensions:
 
 :create-app-artifact-id: kubernetes-quickstart
-:create-app-extensions: resteasy,kubernetes,jib
+:create-app-extensions: resteasy-reactive,kubernetes,jib
+:create-app-code:
 include::includes/devtools/create-app.adoc[]
 
 This added the following dependencies to the build file:
@@ -34,7 +35,7 @@ This added the following dependencies to the build file:
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy</artifactId>
+    <artifactId>quarkus-resteasy-reactive</artifactId>
 </dependency>
 <dependency>
     <groupId>io.quarkus</groupId>
@@ -49,7 +50,7 @@ This added the following dependencies to the build file:
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-resteasy")
+implementation("io.quarkus:quarkus-resteasy-reactive")
 implementation("io.quarkus:quarkus-kubernetes")
 implementation("io.quarkus:quarkus-container-image-jib")
 ----

--- a/docs/src/main/asciidoc/deploying-to-openshift.adoc
+++ b/docs/src/main/asciidoc/deploying-to-openshift.adoc
@@ -22,7 +22,7 @@ include::includes/devtools/prerequisites.adoc[]
 First, we need a new project that contains the OpenShift extension. This can be done using the following command:
 
 :create-app-artifact-id: openshift-quickstart
-:create-app-extensions: resteasy,openshift
+:create-app-extensions: resteasy-reactive,openshift
 :create-app-code:
 include::includes/devtools/create-app.adoc[]
 

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -31,17 +31,17 @@ The elements are stored in Elasticsearch.
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: elasticsearch-quickstart
-:create-app-extensions: resteasy,resteasy-jackson,elasticsearch-rest-client
+:create-app-extensions: resteasy-reactive-jackson,elasticsearch-rest-client
 include::includes/devtools/create-app.adoc[]
 
-This command generates a Maven structure importing the RESTEasy/JAX-RS, Jackson, and the Elasticsearch low level client extensions.
+This command generates a Maven structure importing the RESTEasy Reactive/JAX-RS, Jackson, and the Elasticsearch low level client extensions.
 After this, the `quarkus-elasticsearch-rest-client` extension has been added to your build file.
 
 If you want to use the high level client instead, replace the `elasticsearch-rest-client` extension by the `elasticsearch-rest-high-level-client` extension.
 
 [NOTE]
 ====
-We use the `resteasy-jackson` extension here and not the JSON-B variant because we will use the Vert.x `JsonObject` helper
+We use the `resteasy-reactive-jackson` extension here and not the JSON-B variant because we will use the Vert.x `JsonObject` helper
 to serialize/deserialize our objects to/from Elasticsearch and it uses Jackson under the hood.
 ====
 
@@ -196,12 +196,12 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
+
+import org.jboss.resteasy.reactive.RestQuery;
 
 @Path("/fruits")
 public class FruitResource {
@@ -220,13 +220,13 @@ public class FruitResource {
 
     @GET
     @Path("/{id}")
-    public Fruit get(@PathParam("id") String id) throws IOException {
+    public Fruit get(String id) throws IOException {
         return fruitService.get(id);
     }
 
     @GET
     @Path("/search")
-    public List<Fruit> search(@QueryParam("name") String name, @QueryParam("color") String color) throws IOException {
+    public List<Fruit> search(@RestQuery String name, @RestQuery String color) throws IOException {
         if (name != null) {
             return fruitService.searchByName(name);
         } else if (color != null) {

--- a/docs/src/main/asciidoc/extension-codestart.adoc
+++ b/docs/src/main/asciidoc/extension-codestart.adoc
@@ -59,7 +59,7 @@ Each codestart consists of:
 
 - In Quarkus core repo, the extension codestarts are all in the same https://github.com/quarkusio/quarkus/tree/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[module, window="_blank"].
 
-- RESTEasy, RESTEasy Reactive and Spring Web extension codestarts are part of https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[the base codestarts, window="_blank"].
+- RESTEasy Reactive, RESTEasy and Spring Web extension codestarts are part of https://github.com/quarkusio/quarkus/tree/main/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts[the base codestarts, window="_blank"].
 
 - For other extensions, the codestart will typically be located in the runtime module (with special instruction in the `pom.xml` to generate a separate codestart artifact).
 

--- a/docs/src/main/asciidoc/gcp-functions-http.adoc
+++ b/docs/src/main/asciidoc/gcp-functions-http.adoc
@@ -3,12 +3,12 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Google Cloud Functions (Serverless) with RESTEasy, Undertow, or Reactive Routes
+= Google Cloud Functions (Serverless) with RESTEasy Reactive, Undertow, or Reactive Routes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
-The `quarkus-google-cloud-functions-http` extension allows you to write microservices with RESTEasy (JAX-RS),
+The `quarkus-google-cloud-functions-http` extension allows you to write microservices with RESTEasy Reactive (JAX-RS),
 Undertow (Servlet), Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP], and make these microservices deployable to the Google Cloud Functions runtime.
 
 One Google Cloud Functions deployment can represent any number of JAX-RS, Servlet, Reactive Routes, or xref:funqy-http.adoc[Funqy HTTP] endpoints.
@@ -40,7 +40,7 @@ Create an application with the `quarkus-google-cloud-functions-http` extension.
 You can use the following Maven command to create it:
 
 :create-app-artifact-id: google-cloud-functions-http
-:create-app-extensions: resteasy,google-cloud-functions-http,resteasy-jackson,undertow,reactive-routes,funqy-http
+:create-app-extensions: google-cloud-functions-http,resteasy-reactive-jackson,undertow,reactive-routes,funqy-http
 include::includes/devtools/create-app.adoc[]
 
 == Login to Google Cloud
@@ -82,7 +82,7 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "hello";
+        return "Hello from RESTEasy Reactive";
     }
 }
 ----

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -72,7 +72,7 @@ The easiest way to create a new Quarkus project is to open a terminal and run th
 For Linux & MacOS users
 
 :create-app-artifact-id: getting-started
-:create-app-extensions: resteasy
+:create-app-extensions: resteasy-reactive
 :create-app-code:
 include::includes/devtools/create-app.adoc[]
 
@@ -141,14 +141,14 @@ If we focus on the dependencies section, you can see the extension allowing the 
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy</artifactId>
+    <artifactId>quarkus-resteasy-reactive</artifactId>
 </dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-resteasy")
+implementation("io.quarkus:quarkus-resteasy-reactive")
 ----
 
 === The JAX-RS resources
@@ -170,12 +170,12 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Hello RESTEasy";
+        return "Hello from RESTEasy Reactive";
     }
 }
 ----
 
-It's a very simple REST endpoint, returning "Hello RESTEasy" to requests on "/hello".
+It's a very simple REST endpoint, returning "Hello from RESTEasy Reactive" to requests on "/hello".
 
 [TIP]
 .Differences with vanilla JAX-RS
@@ -209,7 +209,7 @@ Listening for transport dt_socket at address: 5005
 2019-02-28 17:05:22,347 INFO  [io.qua.dep.QuarkusAugmentor] (main) Beginning quarkus augmentation
 2019-02-28 17:05:22,635 INFO  [io.qua.dep.QuarkusAugmentor] (main) Quarkus augmentation completed in 288ms
 2019-02-28 17:05:22,770 INFO  [io.quarkus] (main) Quarkus started in 0.668s. Listening on: http://localhost:8080
-2019-02-28 17:05:22,771 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2019-02-28 17:05:22,771 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 ----
 
 Once started, you can request the provided endpoint:
@@ -235,7 +235,7 @@ If you're new to CDI then we recommend you to read the xref:cdi.adoc[Introductio
 
 Quarkus only implements a subset of the CDI features and comes with non-standard features and specific APIS, you can learn more about it in the xref:cdi-reference.adoc[Contexts and Dependency Injection guide].
 
-ArC comes as a dependency of `quarkus-resteasy` so you already have it handy.
+ArC comes as a dependency of `quarkus-resteasy-reactive` so you already have it handy.
 
 Let's modify the application and add a companion bean.
 Create the `src/main/java/org/acme/GreetingService.java` file with the following content:
@@ -268,8 +268,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 @Path("/hello")
 public class GreetingResource {
 
@@ -279,7 +277,7 @@ public class GreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(@PathParam String name) {
+    public String greeting(String name) {
         return service.greeting(name);
     }
 

--- a/docs/src/main/asciidoc/gradle-tooling.adoc
+++ b/docs/src/main/asciidoc/gradle-tooling.adoc
@@ -19,7 +19,7 @@ To scaffold a Gradle project you can either use the xref:cli-tooling.adoc[Quarku
 [source, bash]
 ----
 quarkus create app my-groupId:my-artifactId \
-    --extension=resteasy,resteasy-jackson \
+    --extension=resteasy-reactive,resteasy-reactive-jackson \
     --gradle
 ----
 
@@ -34,7 +34,7 @@ _For more information about how to install the Quarkus CLI and use it, please re
 mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectGroupId=my-groupId \
     -DprojectArtifactId=my-artifactId \
-    -Dextensions="resteasy,resteasy-jackson" \
+    -Dextensions="resteasy-reactive,resteasy-reactive-jackson" \
     -DbuildTool=gradle
 ----
 

--- a/docs/src/main/asciidoc/grpc-getting-started.adoc
+++ b/docs/src/main/asciidoc/grpc-getting-started.adoc
@@ -34,8 +34,9 @@ Edit the `pom.xml` file to add the Quarkus gRPC extension dependency (just under
 </dependency>
 ----
 
-By default the `quarkus-grpc` extension relies on reactive programming model, in this guide we will follow reactive approach.
-Under the dependencies section of your `pom.xml` file replace the `quarkus-resteasy` dependency with:
+By default the `quarkus-grpc` extension relies on the reactive programming model.
+In this guide we will follow a reactive approach.
+Under the dependencies section of your `pom.xml` file, make sure you have the RESTEasy Reactive dependency:
 
 [source,xml]
 ----
@@ -277,7 +278,6 @@ import io.smallrye.mutiny.Uni;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -295,7 +295,7 @@ public class ExampleResource {
 
     @GET
     @Path("/{name}")
-    public Uni<String> hello(@PathParam("name") String name) {
+    public Uni<String> hello(String name) {
         return hello.sayHello(HelloRequest.newBuilder().setName(name).build())
                 .onItem().transform(helloReply -> helloReply.getMessage());  // <3>
     }

--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -79,7 +79,6 @@ import hello.Greeter;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -91,7 +90,7 @@ public class ExampleResource {
 
    @GET
    @Path("/mutiny/{name}")
-   public Uni<String> helloMutiny(@PathParam("name") String name) {
+   public Uni<String> helloMutiny(String name) {
       return hello.sayHello(HelloRequest.newBuilder().setName(name).build())
             .onItem().transform(HelloReply::getMessage);
    }
@@ -109,7 +108,6 @@ import hello.GreeterGrpc.GreeterBlockingStub;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -121,7 +119,7 @@ public class ExampleResource {
 
    @GET
    @Path("/blocking/{name}")
-   public String helloBlocking(@PathParam("name") String name) {
+   public String helloBlocking(String name) {
       return blockingHelloService.sayHello(HelloRequest.newBuilder().setName(name).build()).getMessage();
    }
 }
@@ -158,7 +156,6 @@ import io.smallrye.mutiny.Uni;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -178,7 +175,7 @@ public class StreamingEndpoint {
 
     @GET
     @Path("sink/{max}")
-    public Uni<Void> invokeSink(@PathParam("max") int max) {
+    public Uni<Void> invokeSink(int max) {
         // Send a stream and wait for completion
         Multi<Item> inputs = Multi.createFrom().range(0, max)
                 .map(i -> Integer.toString(i))
@@ -188,7 +185,7 @@ public class StreamingEndpoint {
 
     @GET
     @Path("/{max}")
-    public Multi<String> invokePipe(@PathParam("max") int max) {
+    public Multi<String> invokePipe(int max) {
         // Send a stream and retrieve a stream
         Multi<Item> inputs = Multi.createFrom().range(0, max)
                 .map(i -> Integer.toString(i))

--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -423,7 +423,7 @@ The repository pattern examples have been omitted for brevity.
 
 == Writing a JAX-RS resource
 
-First, include one of the RESTEasy extensions to enable JAX-RS endpoints, for example, add the `io.quarkus:quarkus-resteasy-jackson` dependency for JAX-RS and JSON support.
+First, include one of the RESTEasy Reactive extensions to enable JAX-RS endpoints, for example, add the `io.quarkus:quarkus-resteasy-reactive-jackson` dependency for JAX-RS and JSON support.
 
 Then, you can create the following resource to create/read/update/delete your Person entity:
 
@@ -441,7 +441,7 @@ public class PersonResource {
 
     @GET
     @Path("/{id}")
-    public Person get(@PathParam("id") Long id) {
+    public Person get(Long id) {
         return Person.findById(id);
     }
 
@@ -455,7 +455,7 @@ public class PersonResource {
     @PUT
     @Path("/{id}")
     @Transactional
-    public Person update(@PathParam("id") Long id, Person person) {
+    public Person update(Long id, Person person) {
         Person entity = Person.findById(id);
         if(entity == null) {
             throw new NotFoundException();
@@ -470,7 +470,7 @@ public class PersonResource {
     @DELETE
     @Path("/{id}")
     @Transactional
-    public void delete(@PathParam("id") Long id) {
+    public void delete(Long id) {
         Person entity = Person.findById(id);
         if(entity == null) {
             throw new NotFoundException();
@@ -480,7 +480,7 @@ public class PersonResource {
 
     @GET
     @Path("/search/{name}")
-    public Person search(@PathParam("name") String name) {
+    public Person search(String name) {
         return Person.findByName(name);
     }
 

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -43,7 +43,7 @@ The provided solution contains a few additional elements such as tests and testi
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: hibernate-search-orm-elasticsearch-quickstart
-:create-app-extensions: hibernate-orm-panache,jdbc-postgresql,hibernate-search-orm-elasticsearch,resteasy-jackson
+:create-app-extensions: hibernate-orm-panache,jdbc-postgresql,hibernate-search-orm-elasticsearch,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven structure importing the following extensions:
@@ -51,7 +51,7 @@ This command generates a Maven structure importing the following extensions:
  * Hibernate ORM with Panache,
  * the PostgreSQL JDBC driver,
  * Hibernate Search + Elasticsearch,
- * RESTEasy and Jackson.
+ * RESTEasy Reactive and Jackson.
 
 If you already have your Quarkus project configured, you can add the `hibernate-search-orm-elasticsearch` extension
 to your project by running the following command in your project base directory:
@@ -182,19 +182,26 @@ Create the `org.acme.hibernate.search.elasticsearch.LibraryResource` class:
 ----
 package org.acme.hibernate.search.elasticsearch;
 
+import java.util.List;
+import java.util.Optional;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 import javax.transaction.Transactional;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.acme.hibernate.search.elasticsearch.model.Author;
 import org.acme.hibernate.search.elasticsearch.model.Book;
-import org.jboss.resteasy.annotations.jaxrs.FormParam;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkus.runtime.StartupEvent;
 
 @Path("/library")
 public class LibraryResource {
@@ -203,7 +210,7 @@ public class LibraryResource {
     @Path("book")
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public void addBook(@FormParam String title, @FormParam Long authorId) {
+    public void addBook(@RestForm String title, @RestForm Long authorId) {
         Author author = Author.findById(authorId);
         if (author == null) {
             return;
@@ -221,7 +228,7 @@ public class LibraryResource {
     @DELETE
     @Path("book/{id}")
     @Transactional
-    public void deleteBook(@PathParam Long id) {
+    public void deleteBook(Long id) {
         Book book = Book.findById(id);
         if (book != null) {
             book.author.books.remove(book);
@@ -233,7 +240,7 @@ public class LibraryResource {
     @Path("author")
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public void addAuthor(@FormParam String firstName, @FormParam String lastName) {
+    public void addAuthor(@RestForm String firstName, @RestForm String lastName) {
         Author author = new Author();
         author.firstName = firstName;
         author.lastName = lastName;
@@ -244,7 +251,7 @@ public class LibraryResource {
     @Path("author/{id}")
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public void updateAuthor(@PathParam Long id, @FormParam String firstName, @FormParam String lastName) {
+    public void updateAuthor(Long id, @RestForm String firstName, @RestForm String lastName) {
         Author author = Author.findById(id);
         if (author == null) {
             return;
@@ -257,7 +264,7 @@ public class LibraryResource {
     @DELETE
     @Path("author/{id}")
     @Transactional
-    public void deleteAuthor(@PathParam Long id) {
+    public void deleteAuthor(Long id) {
         Author author = Author.findById(id);
         if (author != null) {
             author.delete();
@@ -266,7 +273,7 @@ public class LibraryResource {
 }
 ----
 
-Nothing out of the ordinary here: it is just good old Hibernate ORM with Panache operations in a standard JAX-RS service.
+Nothing out of the ordinary here: it is just good old Hibernate ORM with Panache operations in a REST service.
 
 In fact, the interesting part is that we will need to add very few elements to make our full text search application working.
 
@@ -489,13 +496,13 @@ And then we can add the following methods (and a few ``import``s):
     @GET
     @Path("author/search") // <3>
     @Transactional
-    public List<Author> searchAuthors(@QueryParam String pattern, // <4>
-            @QueryParam Optional<Integer> size) {
+    public List<Author> searchAuthors(@RestQuery String pattern, // <4>
+            @RestQuery Optional<Integer> size) {
         return searchSession.search(Author.class) // <5>
                 .where(f ->
                     pattern == null || pattern.trim().isEmpty() ?
-                            f.matchAll() : // <6>
-                            f.simpleQueryString()
+                        f.matchAll() : // <6>
+                        f.simpleQueryString()
                                 .fields("firstName", "lastName", "books.title").matching(pattern) // <7>
                 )
                 .sort(f -> f.field("lastName_sort").then().field("firstName_sort")) // <8>
@@ -509,7 +516,7 @@ All the upcoming updates coming through Hibernate ORM operations will be synchro
 If you don't import data manually in the database, you don't need that:
 the mass indexer should then only be used when you change your indexing configuration (adding a new field, changing an analyzer's configuration...) and you want the new configuration to be applied to your existing entities.
 <3> This is where the magic begins: just adding the annotations to our entities makes them available for full text search: we can now query the index using the Hibernate Search DSL.
-<4> Use the `org.jboss.resteasy.annotations.jaxrs.QueryParam` annotation type to avoid repeating the parameter name.
+<4> Use the `org.jboss.resteasy.reactive.RestQuery` annotation type to avoid repeating the parameter name.
 <5> We indicate that we are searching for ``Author``s.
 <6> We create a predicate: if the pattern is empty, we use a `matchAll()` predicate.
 <7> If we have a valid pattern, we create a https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html[`simpleQueryString()`] predicate on the `firstName`, `lastName` and `books.title` fields matching our pattern.

--- a/docs/src/main/asciidoc/jms.adoc
+++ b/docs/src/main/asciidoc/jms.adoc
@@ -52,7 +52,7 @@ or download an https://github.com/amqphub/quarkus-qpid-jms-quickstart/archive/ma
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: jms-quickstart
-:create-app-extensions: resteasy,qpid-jms
+:create-app-extensions: resteasy-reactive,qpid-jms
 include::includes/devtools/create-app.adoc[]
 
 This command generates a new project importing the quarkus-qpid-jms extension:
@@ -346,7 +346,7 @@ The Artemis JMS solution is located in the `jms-quickstart` {quickstarts-tree-ur
 Create a new project with the following command:
 
 :create-app-artifact-id: jms-quickstart
-:create-app-extensions: resteasy,artemis-jms
+:create-app-extensions: resteasy-reactive,artemis-jms
 include::includes/devtools/create-app.adoc[]
 
 This creates a new project importing the quarkus-artemis-jms extension:

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -230,11 +230,11 @@ which will run the Kafka Streams pipeline.
 Create another project like so:
 
 :create-app-artifact-id: kafka-streams-quickstart-aggregator
-:create-app-extensions: kafka-streams,resteasy-jackson
+:create-app-extensions: kafka-streams,resteasy-reactive-jackson
 :create-app-post-command: mv kafka-streams-quickstart-aggregator aggregator
 include::includes/devtools/create-app.adoc[]
 
-This creates the `aggregator` project with the Quarkus extension for Kafka Streams and with RESTEasy support for Jackson.
+This creates the `aggregator` project with the Quarkus extension for Kafka Streams and with the Jackson support for RESTEasy Reactive.
 
 If you already have your Quarkus project configured, you can add the `kafka-streams` extension
 to your project by running the following command in your project base directory:
@@ -726,7 +726,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -743,7 +742,7 @@ public class WeatherStationEndpoint {
 
     @GET
     @Path("/data/{id}")
-    public Response getWeatherStationData(@PathParam("id") int id) {
+    public Response getWeatherStationData(int id) {
         GetWeatherStationDataResult result = interactiveQueries.getWeatherStationData(id);
 
         if (result.getResult().isPresent()) {  // <1>
@@ -947,7 +946,6 @@ import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -968,7 +966,7 @@ public class WeatherStationEndpoint {
     @Path("/data/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getWeatherStationData(@PathParam("id") int id) {
+    public Response getWeatherStationData(int id) {
         GetWeatherStationDataResult result = interactiveQueries.getWeatherStationData(id);
 
         if (result.getResult().isPresent()) {                     // <1>

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -185,7 +185,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.jboss.resteasy.annotations.SseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 @Path("/prices")
 public class PriceResource {
@@ -197,7 +197,7 @@ public class PriceResource {
     @GET
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType("text/plain")
+    @RestStreamElementType(MediaType.TEXT_PLAIN)
     public Multi<Double> stream() {
         return prices;
     }
@@ -211,7 +211,7 @@ in this example exposing it as a Server-Sent Events endpoint.
 [NOTE]
 ====
 When consuming messages with `@Channel`, the application code is responsible for the subscription.
-In the example above, RESTEasy endpoint handles that for you.
+In the example above, the RESTEasy Reactive endpoint handles that for you.
 ====
 
 Following types can be injected as channels:

--- a/docs/src/main/asciidoc/kogito-dmn.adoc
+++ b/docs/src/main/asciidoc/kogito-dmn.adoc
@@ -67,13 +67,13 @@ The solution is located in the `kogito-dmn-quickstart` {quickstarts-tree-url}/ko
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: kogito-dmn-quickstart
-:create-app-extensions: dmn,resteasy-jackson
+:create-app-extensions: dmn,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven project, importing the `kogito-quarkus-decisions` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
-It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
+It also imports the `resteasy-reactive-jackson` extension that is needed for Kogito to expose REST services.
 
 The `kogito-quarkus-decisions` is a specialized extension of the Kogito project focusing only on DMN support; if you want to 
 make use of the full capabilities offered by the Kogito platform, you can reference the generic Kogito extension of Quarkus.

--- a/docs/src/main/asciidoc/kogito-drl.adoc
+++ b/docs/src/main/asciidoc/kogito-drl.adoc
@@ -50,13 +50,13 @@ The solution is located in the `kogito-drl-quickstart` {quickstarts-tree-url}/ko
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: kogito-drl-quickstart
-:create-app-extensions: kogito-quarkus-rules,resteasy-jackson
+:create-app-extensions: kogito-quarkus-rules,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven project, importing the `kogito-quarkus-rules` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
-It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
+It also imports the `resteasy-reactive-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito-quarkus-rules` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/kogito-pmml.adoc
+++ b/docs/src/main/asciidoc/kogito-pmml.adoc
@@ -53,13 +53,13 @@ The solution is located in the `kogito-pmml-quickstart` {quickstarts-tree-url}/k
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: kogito-pmml-quickstart
-:create-app-extensions: kogito,resteasy-jackson
+:create-app-extensions: kogito,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven project, importing the `kogito` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
-It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
+It also imports the `resteasy-reactive-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/kogito.adoc
+++ b/docs/src/main/asciidoc/kogito.adoc
@@ -80,13 +80,13 @@ The solution is located in the `kogito-quickstart` {quickstarts-tree-url}/kogito
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: kogito-quickstart
-:create-app-extensions: kogito,resteasy-jackson
+:create-app-extensions: kogito,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven project, importing the `kogito` extension
 that comes with all needed dependencies and configuration to equip your application
 with business automation.
-It also imports the `resteasy-jackson` extension that is needed for Kogito to expose REST services.
+It also imports the `resteasy-reactive-jackson` extension that is needed for Kogito to expose REST services.
 
 If you already have your Quarkus project configured, you can add the `kogito` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -49,7 +49,7 @@ class ReactiveGreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    fun hello() = "Hello RESTEasy Reactive"
+    fun hello() = "Hello from RESTEasy Reactive"
 }
 ----
 
@@ -430,7 +430,6 @@ import javax.enterprise.context.ApplicationScoped
 
 import javax.ws.rs.GET
 import javax.ws.rs.Path
-import javax.ws.rs.PathParam
 import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
@@ -455,7 +454,7 @@ class ReactiveGreetingResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/hello/{name}")
-    fun greeting(@PathParam("name") name: String): String {
+    fun greeting(name: String): String {
         return service.greeting(name)
     }
 
@@ -471,7 +470,6 @@ import javax.enterprise.context.ApplicationScoped
 
 import javax.ws.rs.GET
 import javax.ws.rs.Path
-import javax.ws.rs.PathParam
 import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
@@ -490,7 +488,7 @@ class ReactiveGreetingResource(
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/hello/{name}")
-    fun greeting(@PathParam("name") name: String): String {
+    fun greeting(name: String): String {
         return service.greeting(name)
     }
 

--- a/docs/src/main/asciidoc/kubernetes-client.adoc
+++ b/docs/src/main/asciidoc/kubernetes-client.adoc
@@ -95,7 +95,7 @@ public class Pods {
 
     @GET
     @Path("/{namespace}")
-    public List<Pod> pods(@PathParam("namespace") String namespace) {
+    public List<Pod> pods(String namespace) {
         return kubernetesClient.pods().inNamespace(namespace).list().getItems();
     }
 }

--- a/docs/src/main/asciidoc/maven-tooling.adoc
+++ b/docs/src/main/asciidoc/maven-tooling.adoc
@@ -405,7 +405,7 @@ $ ./mvnw verify -Pnative
 [INFO] Running org.acme.quickstart.GreetingResourceIT
 Executing [/Users/starksm/Dev/JBoss/Quarkus/starksm64-quarkus-quickstarts/getting-started-native/target/quarkus-quickstart-runner, -Dquarkus.http.port=8081, -Dtest.url=http://localhost:8081, -Dquarkus.log.file.path=target/quarkus.log]
 2019-02-28 16:52:42,020 INFO  [io.quarkus] (main) Quarkus started in 0.007s. Listening on: http://localhost:8080
-2019-02-28 16:52:42,021 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2019-02-28 16:52:42,021 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.081 s - in org.acme.quickstart.GreetingResourceIT
 [INFO]
 [INFO] Results:

--- a/docs/src/main/asciidoc/micrometer.adoc
+++ b/docs/src/main/asciidoc/micrometer.adoc
@@ -56,7 +56,7 @@ For this example, we'll use the Prometheus registry.
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: micrometer-quickstart
-:create-app-extensions: resteasy,micrometer-registry-prometheus
+:create-app-extensions: resteasy-reactive,micrometer-registry-prometheus
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Maven project, that imports the `micrometer-registry-prometheus` extension as a dependency.
@@ -103,7 +103,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
 @Path("/example")
@@ -140,7 +139,7 @@ observes the size of a list:
 
     @GET
     @Path("gauge/{number}")
-    public Long checkListSize(@PathParam("number") long number) {
+    public Long checkListSize(long number) {
         if (number == 2 || number % 2 == 0) {
             // add even numbers to the list
             list.add(number);
@@ -197,7 +196,7 @@ test a number to see if it is prime:
 ----
     @GET
     @Path("prime/{number}")
-    public String checkIfPrime(@PathParam("number") long number) {
+    public String checkIfPrime(long number) {
         if (number < 1) {
             return "Only natural numbers can be prime numbers.";
         }
@@ -244,7 +243,7 @@ the counter to add some tags to convey additional information.
 ----
     @GET
     @Path("prime/{number}")
-    public String checkIfPrime(@PathParam("number") long number) {
+    public String checkIfPrime(long number) {
         if (number < 1) {
             registry.counter("example.prime.number", "type", "not-natural").increment();
             return "Only natural numbers can be prime numbers.";

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -434,7 +434,7 @@ public class PersonResource {
 
     @GET
     @Path("/{id}")
-    public Person get(@PathParam("id") String id) {
+    public Person get(String id) {
         return Person.findById(new ObjectId(id));
     }
 
@@ -446,13 +446,13 @@ public class PersonResource {
 
     @PUT
     @Path("/{id}")
-    public void update(@PathParam("id") String id, Person person) {
+    public void update(String id, Person person) {
         person.update();
     }
 
     @DELETE
     @Path("/{id}")
-    public void delete(@PathParam("id") String id) {
+    public void delete(String id) {
         Person person = Person.findById(new ObjectId(id));
         if(person == null) {
             throw new NotFoundException();
@@ -462,7 +462,7 @@ public class PersonResource {
 
     @GET
     @Path("/search/{name}")
-    public Person search(@PathParam("name") String name) {
+    public Person search(String name) {
         return Person.findByName(name);
     }
 
@@ -776,7 +776,7 @@ you need to provide the value by yourself.
 ====
 
 `ObjectId` can be difficult to use if you want to expose its value in your REST service.
-So we created Jackson and JSON-B providers to serialize/deserialize them as a `String` which are automatically registered if your project depends on either the RESTEasy Jackson extension or the RESTEasy JSON-B extension.
+So we created Jackson and JSON-B providers to serialize/deserialize them as a `String` which are automatically registered if your project depends on either the RESTEasy Reactive Jackson extension or the RESTEasy Reactive JSON-B extension.
 
 [IMPORTANT]
 ====
@@ -786,7 +786,7 @@ If you use the standard `ObjectId` ID type, don't forget to retrieve your entity
 ----
 @GET
 @Path("/{id}")
-public Person findById(@PathParam("id") String id) {
+public Person findById(String id) {
     return Person.findById(new ObjectId(id));
 }
 ----
@@ -945,15 +945,15 @@ Uni<Boolean> deleted = ReactivePerson.deleteById(personId);
 Uni<Long> updated = ReactivePerson.update("name", "Mortal").where("status", Status.Alive);
 ----
 
-TIP: If you use MongoDB with Panache in conjunction with RESTEasy, you can directly return a reactive type inside your JAX-RS resource endpoint as long as you include the `quarkus-resteasy-mutiny` extension.
+TIP: If you use MongoDB with Panache in conjunction with RESTEasy Reactive, you can directly return a reactive type inside your JAX-RS resource endpoint.
 
 The same query facility exists for the reactive types, but the `stream()` methods act differently: they return a `Multi` (which implement  a reactive stream `Publisher`) instead of a `Stream`.
 
-It allows more advanced reactive use cases, for example, you can use it to send server-sent events (SSE) via RESTEasy:
+It allows more advanced reactive use cases, for example, you can use it to send server-sent events (SSE) via RESTEasy Reactive:
 
 [source,java]
 ----
-import org.jboss.resteasy.annotations.SseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 import org.reactivestreams.Publisher;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -962,13 +962,13 @@ import javax.ws.rs.Produces;
 @GET
 @Path("/stream")
 @Produces(MediaType.SERVER_SENT_EVENTS)
-@SseElementType(MediaType.APPLICATION_JSON)
+@RestStreamElementType(MediaType.APPLICATION_JSON)
 public Multi<ReactivePerson> streamPersons() {
     return ReactivePerson.streamAll();
 }
 ----
 
-TIP: `@SseElementType(MediaType.APPLICATION_JSON)` tells RESTEasy to serialize the object in JSON.
+TIP: `@RestStreamElementType(MediaType.APPLICATION_JSON)` tells RESTEasy Reactive to serialize the object in JSON.
 
 WARNING: Transactions are not supported for Reactive Entities and Repositories.
 

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -48,7 +48,7 @@ Open a terminal and run the following command:
 For Linux & MacOS users
 
 :create-app-artifact-id: debugging-native
-:create-app-extensions: resteasy,container-image-docker
+:create-app-extensions: resteasy-reactive,container-image-docker
 :create-app-code:
 include::includes/devtools/create-app.adoc[]
 
@@ -78,7 +78,7 @@ As a first step, change to the project directory and build the native executable
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative
+./mvnw package -DskipTests -Dnative
 ----
 
 Run the application to verify it works as expected. In one terminal:
@@ -101,7 +101,7 @@ We can obtain this information while building the native executable by adding ad
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args=--native-image-info
 ----
 
@@ -156,7 +156,7 @@ or whether some third party jar has some native-image configuration embedded in 
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args=--verbose
 ----
 
@@ -172,7 +172,7 @@ One may also combine multiple native build options by separating with a comma, e
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args=--native-image-info,--verbose
 ----
 
@@ -258,7 +258,7 @@ Optionally, the native build process can generate reports that show what goes in
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.enable-reports
 ----
 
@@ -276,7 +276,7 @@ The CSV output can be enabled by adding `-H:PrintAnalysisCallTreeType=CSV` to th
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.enable-reports \
     -Dquarkus.native.additional-build-args=-H:PrintAnalysisCallTreeType=CSV
 ----
@@ -524,7 +524,7 @@ Rebuild the binary using:
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative
+./mvnw package -DskipTests -Dnative
 ----
 
 Run the application in one terminal
@@ -554,8 +554,6 @@ To see this in action, add this REST resource:
 ----
 package org.acme;
 
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.ws.rs.GET;
@@ -584,7 +582,7 @@ public class EncryptDecryptResource {
 
     @GET
     @Path("/{message}")
-    public String encryptDecrypt(@PathParam String message) throws Exception {
+    public String encryptDecrypt(String message) throws Exception {
         KeyPair keyPair = KEY_PAIR_GEN.generateKeyPair();
 
         byte[] text = message.getBytes(StandardCharsets.UTF_8);
@@ -606,7 +604,7 @@ When trying to rebuild the application, you’ll encounter an error:
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative
+./mvnw package -DskipTests -Dnative
 ...
 Error: Unsupported features in 2 methods
 Detailed message:
@@ -635,7 +633,7 @@ As suggested by the message, let's start by adding an option to track object ins
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args="--trace-object-instantiation=java.security.SecureRandom"
 ...
 Error: Unsupported features in 2 methods
@@ -719,7 +717,7 @@ Recompile the application, rebuild the binary and run it. Attempting a simple cu
 
 [source,bash,subs=attributes+]
 ----
-$ ./mvnw package -DskipTests -Pnative
+$ ./mvnw package -DskipTests -Dnative
 ...
 $ docker run -i --rm -p 8080:8080 test/debugging-native:1.0.0-SNAPSHOT
 ...
@@ -822,7 +820,7 @@ From outside the tools container, execute:
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.debug.enabled \
     -Dquarkus.native.additional-build-args=-H:-DeleteLocalSymbols
 ----
@@ -938,7 +936,7 @@ Build the native executable with debug info:
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.debug.enabled \
     -Dquarkus.native.additional-build-args=-H:-DeleteLocalSymbols
 ----
@@ -1044,7 +1042,7 @@ To verify this compile and run the example application:
 
 [source,bash,subs=attributes+]
 ----
-$ ./mvnw package -DskipTests -Pnative
+$ ./mvnw package -DskipTests -Dnative
 ...
 $ docker run -i --rm -p 8080:8080 test/debugging-native:1.0.0-SNAPSHOT
 ...
@@ -1121,7 +1119,7 @@ On top of that, add `-H:-OmitInlinedMethodDebugLineInfo` option to avoid inlined
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.debug.enabled \
     -Dquarkus.native.additional-build-args=-H:-OmitInlinedMethodDebugLineInfo
 ...
@@ -1465,7 +1463,7 @@ To generate the native executable using these flags, do the following:
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative
+./mvnw package -DskipTests -Dnative
     -Dquarkus.native.additional-build-args=-H:+PreserveFramePointer,-H:-DeleteLocalSymbols
 ----
 
@@ -1518,7 +1516,7 @@ To debug this process, simply add `--debug-attach=*:8000` as an additional build
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative \
+./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args=--debug-attach=*:8000
 ----
 
@@ -1529,7 +1527,7 @@ so you can remote debug this process by adding the `--vm.agentlib:jdwp=transport
 
 [source,bash,subs=attributes+]
 ----
-$ ./mvnw package -DskipTests -Pnative \
+$ ./mvnw package -DskipTests -Dnative \
     -Dquarkus.native.additional-build-args=--vm.agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=y\\,address=*:8000
 ----
 
@@ -1552,7 +1550,7 @@ E.g.
 
 [source,bash,subs=attributes+]
 ----
-./mvnw package -DskipTests -Pnative -Dquarkus.native.container-build=true \
+./mvnw package -DskipTests -Dnative -Dquarkus.native.container-build=true \
     -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:{mandrel-flavor} \
     -Dquarkus.native.enable-vm-inspection=true
 ----

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -33,7 +33,7 @@ The solution is located in the `openapi-swaggerui-quickstart` {quickstarts-tree-
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: openapi-swaggerui-quickstart
-:create-app-extensions: resteasy,resteasy-jackson
+:create-app-extensions: resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 == Expose a REST Resource
@@ -169,7 +169,7 @@ You just need to add the `openapi` extension to your Quarkus application:
 :add-extension-extensions: quarkus-smallrye-openapi
 include::includes/devtools/extension-add.adoc[]
 
-This will add the following to your `pom.xml`:
+This will add the following to your build file:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -33,7 +33,7 @@ The solution is located in the `opentelemetry-quickstart` {quickstarts-tree-url}
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: opentelemetry-quickstart
-:create-app-extensions: resteasy,quarkus-opentelemetry-exporter-otlp
+:create-app-extensions: resteasy-reactive,quarkus-opentelemetry-exporter-otlp
 include::includes/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `quarkus-opentelemetry-exporter-otlp` extension,

--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -33,7 +33,7 @@ The solution is located in the `opentracing-quickstart` {quickstarts-tree-url}/o
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: opentracing-quickstart
-:create-app-extensions: resteasy,quarkus-smallrye-opentracing
+:create-app-extensions: resteasy-reactive,quarkus-smallrye-opentracing
 include::includes/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `smallrye-opentracing` extension, which

--- a/docs/src/main/asciidoc/optaplanner.adoc
+++ b/docs/src/main/asciidoc/optaplanner.adoc
@@ -55,15 +55,15 @@ include::includes/devtools/prerequisites.adoc[]
 Use https://code.quarkus.io/[code.quarkus.io] to generate an application
 with the following extensions, for Maven or Gradle:
 
-* RESTEasy JAX-RS (`quarkus-resteasy`)
-* RESTEasy Jackson (`quarkus-resteasy-jackson`)
+* RESTEasy Reactive (`quarkus-resteasy-reactive`)
+* RESTEasy Reactive Jackson (`quarkus-resteasy-reactive-jackson`)
 * OptaPlanner (`optaplanner-quarkus`)
 * OptaPlanner Jackson (`optaplanner-quarkus-jackson`)
 
 Alternatively, generate it from the command line:
 
 :create-app-artifact-id: optaplanner-quickstart
-:create-app-extensions: resteasy,resteasy-jackson,optaplanner-quarkus,optaplanner-quarkus-jackson
+:create-app-extensions: resteasy-reactive,resteasy-reactive-jackson,optaplanner-quarkus,optaplanner-quarkus-jackson
 include::includes/devtools/create-app.adoc[]
 
 This will include the following dependencies in your build file:
@@ -92,11 +92,11 @@ This will include the following dependencies in your build file:
 <dependencies>
     <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-resteasy</artifactId>
+        <artifactId>quarkus-resteasy-reactive</artifactId>
     </dependency>
     <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-resteasy-jackson</artifactId>
+        <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
     <dependency>
         <groupId>org.optaplanner</groupId>
@@ -121,8 +121,8 @@ This will include the following dependencies in your build file:
 dependencies {
     implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:{quarkus-version}")
     implementation enforcedPlatform("io.quarkus.platform:quarkus-optaplanner-bom:{quarkus-version}")
-    implementation 'io.quarkus:quarkus-resteasy'
-    implementation 'io.quarkus:quarkus-resteasy-jackson'
+    implementation 'io.quarkus:quarkus-resteasy-reactive'
+    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
     implementation 'org.optaplanner:optaplanner-quarkus'
     implementation 'org.optaplanner:optaplanner-quarkus-jackson'
 

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -188,7 +188,7 @@ $ date +"%T.%3N" &&  ./target/quarkus-timing-runner
 10:57:32.508
 10:57:32.512
 2019-04-05 10:57:32,512 INFO  [io.quarkus] (main) Quarkus 0.11.0 started in 0.002s. Listening on: http://127.0.0.1:8080
-2019-04-05 10:57:32,512 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jackson]
+2019-04-05 10:57:32,512 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, resteasy-reactive-jackson]
 10:57:32.537
 ----
 

--- a/docs/src/main/asciidoc/quarkus-intro.adoc
+++ b/docs/src/main/asciidoc/quarkus-intro.adoc
@@ -25,7 +25,7 @@ Embraces 12 factor architecture in environments like Kubernetes
 Unify imperative and reactive::
 Brings under one programming model non blocking and imperative styles of development
 Standards-based::
-Based on the standards and the libraries you love and use (RESTEasy, Hibernate, Netty, Eclipse Vert.x, Apache Camel...)
+Based on the standards and the libraries you love and use (RESTEasy Reactive, Hibernate, Netty, Eclipse Vert.x, Apache Camel...)
 Microservice First::
 Brings lightning fast startup time to Java applications
 Extreme productivity::
@@ -47,7 +47,7 @@ It unifies imperative and reactive.
 It is a Microservice first toolkit.
 
 Standards based
-Quarkus brings all the standards and frameworks you love and use: RESTEasy, Hibernate, Netty, vert.x, Camel...)
+Quarkus brings all the standards and frameworks you love and use: RESTEasy Reactive, Hibernate, Netty, vert.x, Camel...)
 
 Imperative and Reactive
 

--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -38,7 +38,7 @@ The solution is located in the `quartz-quickstart` {quickstarts-tree-url}/quartz
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: quartz-quickstart
-:create-app-extensions: resteasy,quartz,hibernate-orm-panache,flyway,resteasy-jackson,jdbc-postgresql
+:create-app-extensions: resteasy-reactive-jackson,quartz,hibernate-orm-panache,flyway,jdbc-postgresql
 include::includes/devtools/create-app.adoc[]
 
 It generates:

--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1384,7 +1384,6 @@ package org.acme.quarkus.sample;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -1403,7 +1402,7 @@ public class ItemResource {
     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
-    public TemplateInstance get(@PathParam("id") Integer id) {
+    public TemplateInstance get(Integer id) {
         return Templates.item(service.findItem(id)); <3>
     }
 }

--- a/docs/src/main/asciidoc/qute.adoc
+++ b/docs/src/main/asciidoc/qute.adoc
@@ -27,24 +27,7 @@ The solution is located in the `qute-quickstart` {quickstarts-tree-url}/qute-qui
 
 If you want to use Qute in your JAX-RS application, you need to add an extension first:
 
-* either `quarkus-resteasy-qute` if you are using RESTEasy Classic:
-+
-[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
-.pom.xml
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-qute</artifactId>
-</dependency>
-----
-+
-[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
-.build.gradle
-----
-implementation("io.quarkus:quarkus-resteasy-qute")
-----
-
-* or `quarkus-resteasy-reactive-qute` if you are using RESTEasy Reactive:
+* either `quarkus-resteasy-reactive-qute` if you are using RESTEasy Reactive:
 +
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -59,6 +42,23 @@ implementation("io.quarkus:quarkus-resteasy-qute")
 .build.gradle
 ----
 implementation("io.quarkus:quarkus-resteasy-reactive-qute")
+----
+
+* or `quarkus-resteasy-qute` if you are using RESTEasy Classic:
++
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-qute</artifactId>
+</dependency>
+----
++
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-resteasy-qute")
 ----
 
 We'll start with a very simple template:
@@ -263,7 +263,6 @@ package org.acme.quarkus.sample;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -282,7 +281,7 @@ public class ItemResource {
     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
-    public TemplateInstance get(@PathParam("id") Integer id) {
+    public TemplateInstance get(Integer id) {
         return Templates.item(service.findItem(id)); <2>
     }
 }
@@ -325,7 +324,6 @@ package org.acme.quarkus.sample;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
@@ -344,7 +342,7 @@ public class ItemResource {
     @GET
     @Path("{id}")
     @Produces(MediaType.TEXT_HTML)
-    public TemplateInstance get(@PathParam("id") Integer id) {
+    public TemplateInstance get(Integer id) {
         return item.data("item", service.findItem(id)); <2>
     }
 }

--- a/docs/src/main/asciidoc/reactive-event-bus.adoc
+++ b/docs/src/main/asciidoc/reactive-event-bus.adoc
@@ -26,7 +26,7 @@ This mechanism uses the Vert.x EventBus, so you need to enable the `vertx` exten
 If you are creating a new project, set the `extensions` parameter are follows:
 
 :create-app-artifact-id: vertx-quickstart
-:create-app-extensions: vertx,resteasy-mutiny
+:create-app-extensions: vertx,resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 If you have an already created project, the `vertx` extension can be added to an existing Quarkus project with
@@ -238,7 +238,6 @@ package org.acme.vertx;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.eventbus.Message;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -255,7 +254,7 @@ public class EventResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
-    public Uni<String> greeting(@PathParam String name) {
+    public Uni<String> greeting(String name) {
         return bus.<String>request("greeting", name)        // <2>
                 .onItem().transform(Message::body);
     }
@@ -291,7 +290,7 @@ This message is consumed by another bean and the response is sent using the _rep
 First create a new project using:
 
 :create-app-artifact-id: vertx-http-quickstart
-:create-app-extensions: vertx,resteasy-mutiny
+:create-app-extensions: vertx,resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 You can already start the application in _dev mode_ using:
@@ -308,7 +307,6 @@ package org.acme.vertx;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.eventbus.Message;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -325,7 +323,7 @@ public class EventResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
-    public Uni<String> greeting(@PathParam String name) {
+    public Uni<String> greeting(String name) {
         return bus.<String>request("greeting", name)            // <1>
                 .onItem().transform(Message::body);            // <2>
     }
@@ -393,7 +391,7 @@ So you can exchange objects as follows:
 @GET
 @Produces(MediaType.TEXT_PLAIN)
 @Path("{name}")
-public Uni<String> greeting(@PathParam String name) {
+public Uni<String> greeting(String name) {
     return bus.<String>request("greeting", new MyName(name))
         .onItem().transform(Message::body);
 }
@@ -411,7 +409,7 @@ If you want to use a specific codec, you need to explicitly set it on both ends:
 @GET
 @Produces(MediaType.TEXT_PLAIN)
 @Path("{name}")
-public Uni<String> greeting(@PathParam String name) {
+public Uni<String> greeting(String name) {
     return bus.<String>request("greeting", name,
         new DeliveryOptions().setCodecName(MyNameCodec.class.getName())) // <1>
         .onItem().transform(Message::body);

--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -644,7 +644,7 @@ Check the https://vertx.io/docs/vertx-web/java/#_basic_vert_x_web_concepts[Vert.
 [NOTE]
 ====
 `Router` access is provided by the `quarkus-vertx-http` extension.
-If you use `quarkus-resteasy` or `quarkus-reactive-routes`, the extension will be added automatically.
+If you use `quarkus-resteasy-reactive` or `quarkus-reactive-routes`, the extension will be added automatically.
 ====
 
 You can also receive the Mutiny variant of the Router (`io.vertx.mutiny.ext.web.Router`):

--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -74,7 +74,7 @@ First, make sure your project has the `quarkus-reactive-pg-client` extension ena
 If you are creating a new project, use the following command:
 
 :create-app-artifact-id: reactive-pg-client-quickstart
-:create-app-extensions: resteasy,reactive-pg-client,resteasy-mutiny
+:create-app-extensions: resteasy-reactive,reactive-pg-client
 include::includes/devtools/create-app.adoc[]
 
 If you have an already created project, the `reactive-pg-client` extension can be added to an existing Quarkus project with the `add-extension` command:
@@ -101,10 +101,7 @@ implementation("io.quarkus:quarkus-reactive-pg-client")
 
 === Mutiny
 
-Reactive REST endpoints in your application that return Uni or Multi need `Mutiny support for RESTEasy` extension (`io.quarkus:quarkus-resteasy-mutiny`) to work properly:
-
-:add-extension-extensions: resteasy-mutiny
-include::includes/devtools/extension-add.adoc[]
+RESTEasy Reactive includes supports for Mutiny types (e.g. `Uni` and `Multi`) out of the box.
 
 [TIP]
 ====
@@ -115,7 +112,7 @@ If you are not familiar with Mutiny, check xref:mutiny-primer.adoc[Mutiny - an i
 === JSON Binding
 
 We will expose `Fruit` instances over HTTP in the JSON format.
-Consequently, you also need to add the `quarkus-resteasy-jackson` extension:
+Consequently, you also need to add the `quarkus-resteasy-reactive-jackson` extension:
 
 :add-extension-extensions: resteasy-jackson
 include::includes/devtools/extension-add.adoc[]
@@ -127,14 +124,14 @@ If you prefer not to use the command line, manually add the dependency to your b
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
+    <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
 </dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-resteasy-jackson")
+implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 ----
 
 Of course, this is only a requirement for this guide, not any application using the Reactive PostgreSQL Client.
@@ -318,7 +315,7 @@ And in the JAX-RS resource:
 ----
 @GET
 @Path("{id}")
-public Uni<Response> getSingle(@PathParam Long id) {
+public Uni<Response> getSingle(Long id) {
     return Fruit.findById(client, id)
             .onItem().transform(fruit -> fruit != null ? Response.ok(fruit) : Response.status(Status.NOT_FOUND)) // <1>
             .onItem().transform(ResponseBuilder::build); // <2>
@@ -377,7 +374,7 @@ And to handle the HTTP `DELETE` method in the web resource:
 ----
 @DELETE
 @Path("{id}")
-public Uni<Response> delete(@PathParam Long id) {
+public Uni<Response> delete(Long id) {
     return Fruit.delete(client, id)
             .onItem().transform(deleted -> deleted ? Status.NO_CONTENT : Status.NOT_FOUND)
             .onItem().transform(status -> Response.status(status).build());

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -38,7 +38,7 @@ The solution is located in the `redis-quickstart` {quickstarts-tree-url}/redis-q
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: redis-quickstart
-:create-app-extensions: redis-client,resteasy-jackson,resteasy-mutiny
+:create-app-extensions: redis-client,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a new project, importing the Redis extension.
@@ -201,7 +201,6 @@ package org.acme.redis;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.POST;
@@ -229,19 +228,19 @@ public class IncrementResource {
 
     @GET
     @Path("/{key}")
-    public Increment get(@PathParam("key") String key) {
+    public Increment get(String key) {
         return new Increment(key, Integer.valueOf(service.get(key)));
     }
 
     @PUT
     @Path("/{key}")
-    public void increment(@PathParam("key") String key, Integer value) {
+    public void increment(String key, Integer value) {
         service.increment(key, value);
     }
 
     @DELETE
     @Path("/{key}")
-    public Uni<Void> delete(@PathParam("key") String key) {
+    public Uni<Void> delete(String key) {
         return service.del(key);
     }
 }

--- a/docs/src/main/asciidoc/rest-client-multipart.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart.adoc
@@ -7,6 +7,15 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
+[WARNING]
+====
+This guide is about the multipart support of the REST Client compatible with https://resteasy.dev[RESTEasy Classic] which used to be the default JAX-RS implementation until Quarkus 2.8.
+
+It is now recommended to use RESTEasy Reactive, which supports equally well traditional blocking workloads and reactive workloads.
+For more information about RESTEasy Reactive,
+please see the xref:rest-client-reactive.adoc[REST Client Reactive guide] and, for the server side, the xref:rest-json.adoc[introductory REST JSON guide] or the more detailed xref:resteasy-reactive.adoc[RESTEasy Reactive guide].
+====
+
 RESTEasy has rich support for the `multipart/*` and `multipart/form-data` mime types. The multipart mime format is used to pass lists of content bodies. Multiple content bodies are embedded in one message. `multipart/form-data` is often found in web application HTML Form documents and is generally used to upload files. The form-data format is the same as other multipart formats, except that each inlined piece of content has a name associated with it.
 
 

--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -8,7 +8,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::./attributes.adoc[]
 
 This guide explains how to use the REST Client Reactive in order to interact with REST APIs.
-REST Client Reactive is a non-blocking counterpart of the RESTEasy REST Client.
+REST Client Reactive is the REST Client implementation compatible with RESTEasy Reactive.
 
 If your application uses a client and exposes REST endpoints, please use xref:resteasy-reactive.adoc[RESTEasy Reactive]
 for the server part.
@@ -703,6 +703,7 @@ public interface ExtensionsService {
 
 Naturally this handling is per REST Client. `@ClientExceptionMapper` uses the default priority if the `priority` attribute is not set and the normal rules of invoking all handlers in turn apply.
 
+[[multipart]]
 == Multipart Form support
 
 REST Client Reactive support multipart messages.

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -7,6 +7,15 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
+[WARNING]
+====
+This guide is about the REST Client compatible with https://resteasy.dev[RESTEasy Classic] which used to be the default JAX-RS implementation until Quarkus 2.8.
+
+It is now recommended to use RESTEasy Reactive, which supports equally well traditional blocking workloads and reactive workloads.
+For more information about RESTEasy Reactive,
+please see the xref:rest-client-reactive.adoc[REST Client Reactive guide] and, for the server side, the xref:rest-json.adoc[introductory REST JSON guide] or the more detailed xref:resteasy-reactive.adoc[RESTEasy Reactive guide].
+====
+
 This guide explains how to use the RESTEasy REST Client in order to interact with REST APIs
 with very little effort.
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -12,11 +12,17 @@ include::./attributes.adoc[]
 :mutinyapi: https://smallrye.io/smallrye-mutiny/apidocs
 :httpspec: https://tools.ietf.org/html/rfc7231
 :jsonpapi: https://javadoc.io/doc/javax.json/javax.json-api/1.1.4
-:vertxapi: https://javadoc.io/static/io.vertx/vertx-core/4.1.0
-:resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/2.0.0.Final
-:resteasy-reactive-common-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive-common/2.0.0.Final
+:vertxapi: https://javadoc.io/doc/io.vertx/vertx-core/latest/index.html
+:resteasy-reactive-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive/{quarkus-version}
+:resteasy-reactive-common-api: https://javadoc.io/doc/io.quarkus.resteasy.reactive/resteasy-reactive-common/{quarkus-version}
 
 This guide explains how to write REST Services with RESTEasy Reactive in Quarkus.
+
+[TIP]
+====
+This is the reference guide for RESTEasy Reactive.
+For a more lightweight introduction, please refer to the xref:rest-json.adoc[Writing JSON REST services guides].
+====
 
 == What is RESTEasy Reactive?
 
@@ -1131,6 +1137,16 @@ Importing this module will allow HTTP message bodies to be read from XML
 and serialised to XML, for <<resource-types,all the types not already registered with a more specific
 serialisation>>.
 
+== CORS filter
+
+link:https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-origin resource sharing] (CORS) is a mechanism that
+allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource
+was served.
+
+Quarkus comes with a CORS filter at the HTTP layer level.
+Read the xref:http-reference.adoc#cors-filter[HTTP Reference Documentation] to learn
+how to use it.
+
 == More advanced usage
 
 Here are some more advanced topics that you may not need to know about initially, but
@@ -1386,6 +1402,8 @@ It may declare any of the following return types:
 
 === Request or response filters
 
+==== Via annotations
+
 You can declare functions which are invoked in the following phases of the request processing:
 
 - Before the endpoint method is identified: pre-routing request filter
@@ -1456,8 +1474,6 @@ class Filters {
 }
 ----
 
-You can also link:{jaxrsspec}#filters[declare request and response filters in the JAX-RS way].
-
 Your filters may declare any of the following parameter types:
 
 .Table Filter parameters
@@ -1496,6 +1512,64 @@ It may declare any of the following return types:
 |===
 
 NOTE: You can restrict the Resource methods for which a filter runs, by using link:{jaxrsapi}/javax/ws/rs/NameBinding.html[`@NameBinding`] meta-annotations.
+
+==== The JAX-RS way
+
+You can also link:{jaxrsspec}#filters[declare request and response filters in the JAX-RS way].
+
+Both HTTP request and response can be intercepted by providing `ContainerRequestFilter` or `ContainerResponseFilter`
+implementations respectively. These filters are suitable for processing the metadata associated with a message: HTTP
+headers, query parameters, media type, and other metadata. They also have the capability to abort the request
+processing, for instance when the user does not have the permissions to access the endpoint.
+
+Let's use `ContainerRequestFilter` to add logging capability to our service. We can do that by implementing
+`ContainerRequestFilter` and annotating it with the `@Provider` annotation:
+
+[source,java]
+----
+package org.acme.rest.json;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class LoggingFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(LoggingFilter.class);
+
+    @Context
+    UriInfo info;
+
+    @Context
+    HttpServerRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext context) {
+
+        final String method = context.getMethod();
+        final String path = info.getPath();
+        final String address = request.remoteAddress().toString();
+
+        LOG.infof("Request %s %s from IP %s", method, path, address);
+    }
+}
+----
+
+Now, whenever a REST method is invoked, the request will be logged into the console:
+
+[source,text]
+----
+2019-06-05 12:44:26,526 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /legumes from IP 127.0.0.1
+2019-06-05 12:49:19,623 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /fruits from IP 0:0:0:0:0:0:0:1
+2019-06-05 12:50:44,019 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request POST /fruits from IP 0:0:0:0:0:0:0:1
+2019-06-05 12:51:04,485 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /fruits from IP 127.0.0.1
+----
 
 === Readers and Writers: mapping entities and HTTP bodies
 
@@ -1727,6 +1801,19 @@ public class FroMageIOInterceptor implements ReaderInterceptor, WriterIntercepto
     }
 }
 ----
+
+==== RESTEasy Reactive and REST Client Reactive interactions
+
+In Quarkus, the RESTEasy Reactive extension and xref:rest-client-reactive.adoc[the REST Client Reactive extension] share the same infrastructure.
+One important consequence of this consideration is that they share the same list of providers (in the JAX-RS meaning of the word).
+
+For instance, if you declare a `WriterInterceptor`, it will by default intercept both the servers calls and the client calls,
+which might not be the desired behavior.
+
+However, you can change this default behavior and constrain a provider to:
+
+* only consider *server* calls by adding the `@ConstrainedTo(RuntimeType.SERVER)` annotation to your provider;
+* only consider *client* calls by adding the `@ConstrainedTo(RuntimeType.CLIENT)` annotation to your provider.
 
 === Parameter mapping
 
@@ -2113,7 +2200,7 @@ Please note that if a JAX-RS Application has been detected and the method `getCl
 
 == RESTEasy Reactive client
 
-In addition to the Server side, RESTEasy Reactive comes with a new MicroProfile Rest Client implementation that is non-blocking at its core.
+In addition to the Server side, RESTEasy Reactive comes with a new MicroProfile REST Client implementation that is non-blocking at its core.
 
 Please note that the `quarkus-rest-client` extension may not be used with RESTEasy Reactive, use `quarkus-rest-client-reactive` instead.
 

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -3,25 +3,20 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Writing JSON REST Services
+= RESTEasy Classic
 
 include::./attributes.adoc[]
 
-JSON is now the _lingua franca_ between microservices.
-
-In this guide, we see how you can get your REST services to consume and produce JSON payloads.
-
-TIP: there is another guide if you need a xref:rest-client-reactive.adoc[REST client] (including support for JSON).
-
-[TIP]
+[WARNING]
 ====
-This is an introduction to writing JSON REST services with Quarkus.
-A more detailed guide about RESTEasy Reactive is available xref:resteasy-reactive.adoc[here].
+This guide is about https://resteasy.dev[RESTEasy Classic] which used to be the default JAX-RS implementation until Quarkus 2.8.
+
+It is now recommended to use RESTEasy Reactive, which supports equally well traditional blocking workloads and reactive workloads.
+For more information about RESTEasy Reactive,
+please see the xref:rest-json.adoc[introductory REST JSON guide] or the more detailed xref:resteasy-reactive.adoc[RESTEasy Reactive guide].
 ====
 
-== Prerequisites
-
-include::includes/devtools/prerequisites.adoc[]
+TIP: there is another guide if you need a xref:rest-client.adoc[REST client based on RESTEasy Classic] (including support for JSON).
 
 == Architecture
 
@@ -29,24 +24,15 @@ The application built in this guide is quite simple: the user can add elements i
 
 All the information between the browser and the server are formatted as JSON.
 
-== Solution
-
-We recommend that you follow the instructions in the next sections and create the application step by step.
-However, you can go right to the completed example.
-
-Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
-
-The solution is located in the `rest-json-quickstart` {quickstarts-tree-url}/rest-json-quickstart[directory].
-
 == Creating the Maven project
 
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: rest-json-quickstart
-:create-app-extensions: resteasy-reactive-jackson
+:create-app-extensions: resteasy-jackson
 include::includes/devtools/create-app.adoc[]
 
-This command generates a new project importing the RESTEasy Reactive/JAX-RS and https://github.com/FasterXML/jackson[Jackson] extensions,
+This command generates a new project importing the RESTEasy/JAX-RS and https://github.com/FasterXML/jackson[Jackson] extensions,
 and in particular adds the following dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -54,14 +40,14 @@ and in particular adds the following dependency:
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+    <artifactId>quarkus-resteasy-jackson</artifactId>
 </dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
+implementation("io.quarkus:quarkus-resteasy-jackson")
 ----
 
 [NOTE]
@@ -69,13 +55,13 @@ implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 To improve user experience, Quarkus registers the three Jackson https://github.com/FasterXML/jackson-modules-java8[Java 8 modules] so you don't need to do it manually.
 ====
 
-Quarkus also supports https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] so, if you prefer JSON-B over Jackson, you can create a project relying on the RESTEasy Reactive JSON-B extension instead:
+Quarkus also supports https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] so, if you prefer JSON-B over Jackson, you can create a project relying on the RESTEasy JSON-B extension instead:
 
 :create-app-artifact-id: rest-json-quickstart
-:create-app-extensions: resteasy-reactive-jsonb
+:create-app-extensions: resteasy-jsonb
 include::includes/devtools/create-app.adoc[]
 
-This command generates a new project importing the RESTEasy Reactive/JAX-RS and https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] extensions,
+This command generates a new project importing the RESTEasy/JAX-RS and https://eclipse-ee4j.github.io/jsonb-api/[JSON-B] extensions,
 and in particular adds the following dependency:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -83,22 +69,15 @@ and in particular adds the following dependency:
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
+    <artifactId>quarkus-resteasy-jsonb</artifactId>
 </dependency>
 ----
 
 [source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
 .build.gradle
 ----
-implementation("io.quarkus:quarkus-resteasy-reactive-jsonb")
+implementation("io.quarkus:quarkus-resteasy-jsonb")
 ----
-
-[NOTE]
-====
-While named "reactive", RESTEasy Reactive supports equally well both traditional blocking patterns and reactive patterns.
-
-For more information about RESTEasy Reactive, please refer to the xref:resteasy-reactive.adoc[dedicated guide].
-====
 
 == Creating your first JSON REST service
 
@@ -506,19 +485,39 @@ This time, you can see our list of legumes.
 [[reactive]]
 == Being reactive
 
+[WARNING]
+====
+For reactive workloads, please always use xref:resteasy-reactive.adoc[RESTEasy Reactive].
+====
+
 You can return _reactive types_ to handle asynchronous processing.
 Quarkus recommends the usage of https://smallrye.io/smallrye-mutiny[Mutiny] to write reactive and asynchronous code.
 
-RESTEasy Reactive is naturally integrated with Mutiny.
+To integrate Mutiny and RESTEasy, you need to add the `quarkus-resteasy-mutiny` dependency to your project:
 
-Your endpoints can return `Uni` or `Multi` instances:
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-mutiny</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-resteasy-mutiny")
+----
+
+Then, your endpoint can return `Uni` or `Multi` instances:
 
 [source,java]
 ----
 
 @GET
 @Path("/{name}")
-public Uni<Fruit> getOne(String name) {
+public Uni<Fruit> getOne(@PathParam String name) {
     return findByName(name);
 }
 
@@ -534,6 +533,178 @@ Use `Multi` when you have multiple items that may be emitted asynchronously.
 You can use `Uni` and `Response` to return asynchronous HTTP responses: `Uni<Response>`.
 
 More details about Mutiny can be found in xref:mutiny-primer.adoc[Mutiny - an intuitive reactive programming library].
+
+== HTTP filters and interceptors
+
+Both HTTP request and response can be intercepted by providing `ContainerRequestFilter` or `ContainerResponseFilter`
+implementations respectively. These filters are suitable for processing the metadata associated with a message: HTTP
+headers, query parameters, media type, and other metadata. They also have the capability to abort the request
+processing, for instance when the user does not have the permissions to access the endpoint.
+
+Let's use `ContainerRequestFilter` to add logging capability to our service. We can do that by implementing
+`ContainerRequestFilter` and annotating it with the `@Provider` annotation:
+
+[source,java]
+----
+package org.acme.rest.json;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class LoggingFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(LoggingFilter.class);
+
+    @Context
+    UriInfo info;
+
+    @Context
+    HttpServerRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext context) {
+
+        final String method = context.getMethod();
+        final String path = info.getPath();
+        final String address = request.remoteAddress().toString();
+
+        LOG.infof("Request %s %s from IP %s", method, path, address);
+    }
+}
+----
+
+Now, whenever a REST method is invoked, the request will be logged into the console:
+
+[source,text]
+----
+2019-06-05 12:44:26,526 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /legumes from IP 127.0.0.1
+2019-06-05 12:49:19,623 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /fruits from IP 0:0:0:0:0:0:0:1
+2019-06-05 12:50:44,019 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request POST /fruits from IP 0:0:0:0:0:0:0:1
+2019-06-05 12:51:04,485 INFO  [org.acm.res.jso.LoggingFilter] (executor-thread-1) Request GET /fruits from IP 127.0.0.1
+----
+
+== CORS filter
+
+link:https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[Cross-origin resource sharing] (CORS) is a mechanism that
+allows restricted resources on a web page to be requested from another domain outside the domain from which the first resource
+was served.
+
+Quarkus comes with a CORS filter. Read the xref:http-reference.adoc#cors-filter[HTTP Reference Documentation] to learn
+how to use it.
+
+== GZip Support
+
+Quarkus comes with GZip support (even though it is not enabled by default). The following configuration knobs allow to configure GZip support.
+
+[source, properties]
+----
+quarkus.resteasy.gzip.enabled=true // <1>
+quarkus.resteasy.gzip.max-input=10M // <2>
+----
+
+<1> Enable Gzip support.
+<2> Configure the upper limit on deflated request body. This is useful to mitigate potential attacks by limiting their reach. The default value is `10M`.
+This configuration option would recognize strings in this format (shown as a regular expression): `[0-9]+[KkMmGgTtPpEeZzYy]?`. If no suffix is given, assume bytes.
+
+Once GZip support has been enabled you can use it on an endpoint by adding the `@org.jboss.resteasy.annotations.GZIP` annotation to your endpoint method.
+
+If you want to compress everything then we recommended that you use the `quarkus.http.enable-compression=true` setting instead to globally enable
+compression support.
+
+== Multipart Support
+
+RESTEasy supports multipart via the https://docs.jboss.org/resteasy/docs/4.5.6.Final/userguide/html/Multipart.html[RESTEasy Multipart Provider].
+
+Quarkus provides an extension called `quarkus-resteasy-multipart` to make things easier for you.
+
+This extension slightly differs from the RESTEasy default behavior as the default charset (if none is specified in your request) is UTF-8 rather than US-ASCII.
+
+You can configure this behavior with the following configuration properties:
+
+include::{generated-dir}/config/quarkus-resteasy-multipart.adoc[leveloffset=+1, opts=optional]
+
+== Servlet compatibility
+
+In Quarkus, RESTEasy can either run directly on top of the Vert.x HTTP server, or on top of Undertow if you have any servlet dependency.
+
+As a result, certain classes, such as `HttpServletRequest` are not always available for injection. Most use-cases for this particular
+class are covered by JAX-RS equivalents, except for getting the remote client's IP. RESTEasy comes with a replacement API which you can inject:
+https://docs.jboss.org/resteasy/docs/4.5.6.Final/javadocs/org/jboss/resteasy/spi/HttpRequest.html[`HttpRequest`], which has the methods
+https://docs.jboss.org/resteasy/docs/4.5.6.Final/javadocs/org/jboss/resteasy/spi/HttpRequest.html#getRemoteAddress--[`getRemoteAddress()`]
+and https://docs.jboss.org/resteasy/docs/4.5.6.Final/javadocs/org/jboss/resteasy/spi/HttpRequest.html#getRemoteHost--[`getRemoteHost()`]
+to solve this problem.
+
+== RESTEasy and REST Client interactions
+
+In Quarkus, the RESTEasy extension and xref:rest-client.adoc[the REST Client extension] share the same infrastructure.
+One important consequence of this consideration is that they share the same list of providers (in the JAX-RS meaning of the word).
+
+For instance, if you declare a `WriterInterceptor`, it will by default intercept both the servers calls and the client calls,
+which might not be the desired behavior.
+
+However, you can change this default behavior and constrain a provider to:
+
+* only consider *server* calls by adding the `@ConstrainedTo(RuntimeType.SERVER)` annotation to your provider;
+* only consider *client* calls by adding the `@ConstrainedTo(RuntimeType.CLIENT)` annotation to your provider.
+
+== What's Different from Jakarta EE Development
+
+=== No Need for `Application` Class
+
+Configuration via an application-supplied subclass of `Application` is supported, but not required.
+
+=== Only a single JAX-RS application
+
+In contrast to JAX-RS (and RESTeasy) running in a standard servlet-container, Quarkus only supports the deployment of a single JAX-RS application.
+If multiple JAX-RS `Application` classes are defined, the build will fail with the message `Multiple classes have been annotated with @ApplicationPath which is currently not supported`.
+
+If multiple JAX-RS applications are defined, the property `quarkus.resteasy.ignore-application-classes=true` can be used to ignore all explicit `Application` classes. This makes all resource-classes available via the application-path as defined by `quarkus.resteasy.path` (default: `/`).
+
+=== Support limitations of JAX-RS application
+
+The RESTEasy extension doesn't support the method `getProperties()` of the class `javax.ws.rs.core.Application`. Moreover, it only relies on the methods `getClasses()` and `getSingletons()` to filter out the annotated resource, provider and feature classes.
+It doesn't filter out the built-in resource, provider and feature classes and also the resource, provider and feature classes registered by the other extensions.
+Finally the objects returned by the method `getSingletons()` are ignored, only the classes are took into account to filter out the resource, provider and feature classes, in other words the method `getSingletons()` is actually managed the same way as `getClasses()`.
+
+=== Lifecycle of Resources
+
+In Quarkus all JAX-RS resources are treated as CDI beans.
+It's possible to inject other beans via `@Inject`, bind interceptors using bindings such as `@Transactional`, define `@PostConstruct` callbacks, etc.
+
+If there is no scope annotation declared on the resource class then the scope is defaulted.
+The default scope can be controlled through the `quarkus.resteasy.singleton-resources` property.
+If set to `true` (default) then a *single instance* of a resource class is created to service all requests (as defined by `@javax.inject.Singleton`).
+If set to `false` then a *new instance* of the resource class is created per each request.
+An explicit CDI scope annotation (`@RequestScoped`, `@ApplicationScoped`, etc.) always overrides the default behavior and specifies the lifecycle of resource instances.
+
+== Include/Exclude JAX-RS classes with build time conditions
+
+Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.
+Thus, the various JAX-RS classes can be annotated with profile conditions (`@io.quarkus.arc.profile.IfBuildProfile` or `@io.quarkus.arc.profile.UnlessBuildProfile`) and/or with property conditions (`io.quarkus.arc.properties.IfBuildProperty` or `io.quarkus.arc.properties.UnlessBuildProperty`) to indicate to Quarkus at build time under which conditions these JAX-RS classes should be included.
+
+In the following example, Quarkus includes the endpoint `sayHello` if and only if the build profile `app1` has been enabled.
+
+[source,java]
+----
+@IfBuildProfile("app1")
+public class ResourceForApp1Only {
+
+    @GET
+    @Path("sayHello")
+    public String sayHello() {
+        return "hello";
+     }
+}
+----
+
+Please note that if a JAX-RS Application has been detected and the method `getClasses()` and/or `getSingletons()` has/have been overridden, Quarkus will ignore the build time conditions and consider only what has been defined in the JAX-RS Application.
 
 == Conclusion
 

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -37,7 +37,7 @@ The solution is located in the `scheduler-quickstart` {quickstarts-tree-url}/sch
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: scheduler-quickstart
-:create-app-extensions: resteasy,scheduler
+:create-app-extensions: resteasy-reactive,scheduler
 include::includes/devtools/create-app.adoc[]
 
 It generates a new project including:
@@ -46,7 +46,7 @@ It generates a new project including:
 * example `Dockerfile` files for both `native` and `jvm` modes
 * the application configuration file
 
-The project also imports the RESTEasy and scheduler extensions.
+The project also imports the RESTEasy Reactive and scheduler extensions.
 
 If you already have your Quarkus project configured, you can add the `scheduler` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/scripting.adoc
+++ b/docs/src/main/asciidoc/scripting.adoc
@@ -28,7 +28,7 @@ Normally we would link to a Git repository to clone but in this case there is no
 [source,java,subs=attributes+]
 ----
 //usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.quarkus:quarkus-resteasy:{quarkus-version}
+//DEPS io.quarkus:quarkus-resteasy-reactive:{quarkus-version}
 //JAVAC_OPTIONS -parameters
 //JAVA_OPTIONS -Djava.util.logging.manager=org.jboss.logmanager.LogManager
 
@@ -39,7 +39,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.jboss.logging.Logger;
 
 @Path("/hello")
@@ -61,7 +60,7 @@ public class quarkusapp {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(@PathParam String name) {
+    public String greeting(String name) {
         return service.greeting(name);
     }
 
@@ -115,11 +114,11 @@ The next line
 
 Is illustrating how you add dependencies to this script. This is a feature of JBang.
 
-Go ahead and update this line to include the `quarkus-resteasy` dependency like so:
+Go ahead and update this line to include the `quarkus-resteasy-reactive` dependency like so:
 
 [source,java,subs=attributes+]
 ----
-//DEPS io.quarkus:quarkus-resteasy:{quarkus-version}
+//DEPS io.quarkus:quarkus-resteasy-reactive:{quarkus-version}
 ----
 
 Now, run `jbang quarkusapp.java` and you will see JBang resolving this dependency and building the jar with help from Quarkus' JBang integration.
@@ -211,7 +210,7 @@ __  ____  __  _____   ___  __ ____  ______
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/
 2020-08-30 05:49:03,255 INFO  [io.quarkus] (main) Quarkus {quarkus-version} on JVM started in 0.638s. Listening on: http://0.0.0.0:8080
 2020-08-30 05:49:03,272 INFO  [io.quarkus] (main) Profile prod activated.
-2020-08-30 05:49:03,272 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2020-08-30 05:49:03,272 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 ----
 
 Once started, you can request the provided endpoint:
@@ -231,9 +230,9 @@ We are using `curl -w "\n"` in this example to avoid your terminal printing a '%
 ====
 
 [TIP]
-.Why is `quarkus-resteasy` not resolved?
+.Why is `quarkus-resteasy-reactive` not resolved?
 ====
-In this second run you should not see a line saying it is resolving `quarkus-resteasy` as JBang caches the dependency resolution between runs.
+In this second run you should not see a line saying it is resolving `quarkus-resteasy-reactive` as JBang caches the dependency resolution between runs.
 If you want to clear the caches to force resolution use `jbang cache clear`.
 ====
 
@@ -242,7 +241,7 @@ If you want to clear the caches to force resolution use `jbang cache clear`.
 Dependency injection in Quarkus is based on ArC which is a CDI-based dependency injection solution tailored for Quarkus' architecture.
 You can learn more about it in the xref:cdi-reference.adoc[Contexts and Dependency Injection guide].
 
-ArC comes as a dependency of `quarkus-resteasy` so you already have it handy.
+ArC comes as a dependency of `quarkus-resteasy-reactive` so you already have it handy.
 
 Let's modify the application and add a companion bean.
 
@@ -278,7 +277,7 @@ Edit the `quarksapp` class to inject the `GreetingService` and create a new endp
 [source,java,subs=attributes+]
 ----
 //usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.quarkus:quarkus-resteasy:{quarkus-version}
+//DEPS io.quarkus:quarkus-resteasy-reactive:{quarkus-version}
 
 import io.quarkus.runtime.Quarkus;
 import javax.enterprise.context.ApplicationScoped;
@@ -287,7 +286,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 @Path("/hello")
 @ApplicationScoped
@@ -308,7 +306,7 @@ public class quarkusapp {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/greeting/{name}")
-    public String greeting(@PathParam String name) {
+    public String greeting(String name) {
         return service.greeting(name);
     }
 
@@ -332,7 +330,7 @@ hello null
 
 Now that is unexpected, why is it returning `hello null` and not `hello quarkus`?
 
-The reason is that JAX-RS `@PathParam` relies on the `-parameters` compiler flag to be set to be able to map `{name}` to the `name` parameter.
+The reason is that RESTEasy Reactive relies on the `-parameters` compiler flag to be set to be able to map `{name}` to the `name` parameter.
 
 We fix that by adding the following comment instruction to the file:
 
@@ -418,7 +416,7 @@ __  ____  __  _____   ___  __ ____  ______
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/
 2020-08-30 06:22:32,012 INFO  [io.quarkus] (main) Quarkus {quarkus-version} native started in 0.017s. Listening on: http://0.0.0.0:8080
 2020-08-30 06:22:32,013 INFO  [io.quarkus] (main) Profile prod activated.
-2020-08-30 06:22:32,013 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2020-08-30 06:22:32,013 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 ----
 
 This native build will take some time on first run but any subsequent runs (without changing `quarkusapp.java`) will be close to instant thanks to JBang cache:
@@ -432,7 +430,7 @@ __  ____  __  _____   ___  __ ____  ______
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/
 2020-08-30 06:23:36,846 INFO  [io.quarkus] (main) Quarkus {quarkus-version} native started in 0.015s. Listening on: http://0.0.0.0:8080
 2020-08-30 06:23:36,846 INFO  [io.quarkus] (main) Profile prod activated.
-2020-08-30 06:23:36,846 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
+2020-08-30 06:23:36,846 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive]
 ----
 
 === Conclusion

--- a/docs/src/main/asciidoc/security-jdbc.adoc
+++ b/docs/src/main/asciidoc/security-jdbc.adoc
@@ -40,7 +40,7 @@ The solution is located in the `security-jdbc-quickstart` {quickstarts-tree-url}
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-jdbc-quickstart
-:create-app-extensions: elytron-security-jdbc,jdbc-postgresql,resteasy
+:create-app-extensions: elytron-security-jdbc,jdbc-postgresql,resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 [NOTE]

--- a/docs/src/main/asciidoc/security-jpa.adoc
+++ b/docs/src/main/asciidoc/security-jpa.adoc
@@ -41,7 +41,7 @@ The solution is located in the `security-jpa-quickstart` {quickstarts-tree-url}/
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-jpa-quickstart
-:create-app-extensions: security-jpa,jdbc-postgresql,resteasy,hibernate-orm-panache
+:create-app-extensions: security-jpa,jdbc-postgresql,resteasy-reactive,hibernate-orm-panache
 include::includes/devtools/create-app.adoc[]
 
 [NOTE]

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -36,7 +36,7 @@ The solution is located in the `security-jwt-quickstart` {quickstarts-tree-url}/
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-jwt-quickstart
-:create-app-extensions: resteasy,resteasy-jackson,smallrye-jwt,smallrye-jwt-build
+:create-app-extensions: resteasy-reactive-jackson,smallrye-jwt,smallrye-jwt-build
 include::includes/devtools/create-app.adoc[]
 
 This command generates the Maven project and imports the `smallrye-jwt` extension, which includes the {mp-jwt} support.
@@ -124,7 +124,7 @@ public class TokenSecuredResource {
     }
 
     private boolean hasJwt() {
-	return jwt.getClaimNames() != null;
+        return jwt.getClaimNames() != null;
     }
 }
 ----
@@ -156,7 +156,7 @@ and you should see output similar to:
 Listening for transport dt_socket at address: 5005
 2020-07-15 16:09:50,883 INFO  [io.quarkus] (Quarkus Main Thread) security-jwt-quickstart 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 1.073s. Listening on: http://0.0.0.0:8080
 2020-07-15 16:09:50,885 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2020-07-15 16:09:50,885 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, mutiny, resteasy, resteasy-jackson, security, smallrye-context-propagation, smallrye-jwt, vertx, vertx-web]
+2020-07-15 16:09:50,885 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, mutiny, resteasy-reactive, resteasy-reactive-jackson, security, smallrye-context-propagation, smallrye-jwt, vertx, vertx-web]
 ----
 
 Now that the REST endpoint is running, we can access it using a command line tool like curl:
@@ -571,7 +571,7 @@ And executed using `java -jar target/quarkus-app/quarkus-run.jar`:
 ----
 $ java -jar target/quarkus-app/quarkus-run.jar
 2019-03-28 14:27:48,839 INFO  [io.quarkus] (main) Quarkus {quarkus-version} started in 0.796s. Listening on: http://[::]:8080
-2019-03-28 14:27:48,841 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jackson, security, smallrye-jwt]
+2019-03-28 14:27:48,841 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, resteasy-reactive-jackson, security, smallrye-jwt]
 ----
 
 You can also generate the native executable with:
@@ -600,7 +600,7 @@ include::includes/devtools/build-native.adoc[]
 
 $ ./target/security-jwt-quickstart-runner
 2019-03-28 14:31:37,315 INFO  [io.quarkus] (main) Quarkus 0.12.0 started in 0.006s. Listening on: http://[::]:8080
-2019-03-28 14:31:37,316 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jackson, security, smallrye-jwt]
+2019-03-28 14:31:37,316 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, resteasy-reactive-jackson, security, smallrye-jwt]
 ----
 
 === Explore the Solution

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -64,7 +64,7 @@ First, we need a new project.
 Create a new project with the following command:
 
 :create-app-artifact-id: security-keycloak-authorization-quickstart
-:create-app-extensions: oidc,keycloak-authorization,resteasy-jackson
+:create-app-extensions: oidc,keycloak-authorization,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project, importing the `keycloak-authorization` extension which is an implementation of a Keycloak Adapter for Quarkus applications and provides all the necessary capabilities to integrate with a Keycloak Server and perform bearer token authorization.

--- a/docs/src/main/asciidoc/security-ldap.adoc
+++ b/docs/src/main/asciidoc/security-ldap.adoc
@@ -43,7 +43,7 @@ The solution is located in the `security-ldap-quickstart` {quickstarts-tree-url}
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-ldap-quickstart
-:create-app-extensions: elytron-security-ldap,resteasy
+:create-app-extensions: elytron-security-ldap,resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project, importing the `elytron-security-ldap` extension

--- a/docs/src/main/asciidoc/security-oauth2.adoc
+++ b/docs/src/main/asciidoc/security-oauth2.adoc
@@ -36,7 +36,7 @@ It contains a very simple UI to use the JAX-RS resources created here, too.
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-oauth2-quickstart
-:create-app-extensions: resteasy,resteasy-jackson,security-oauth2
+:create-app-extensions: resteasy-reactive-jackson,security-oauth2
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project and imports the `elytron-security-oauth2` extension, which includes the OAuth2 opaque token support.
@@ -289,7 +289,7 @@ And executed using `java -jar target/quarkus-app/quarkus-run.jar`:
 ...
 $ java -jar target/quarkus-app/quarkus-run.jar
 2019-03-28 14:27:48,839 INFO  [io.quarkus] (main) Quarkus {quarkus-version} started in 0.796s. Listening on: http://[::]:8080
-2019-03-28 14:27:48,841 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jackson, security, security-oauth2]
+2019-03-28 14:27:48,841 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, resteasy-reactive-jackson, security, security-oauth2]
 ----
 
 You can also generate the native executable with:
@@ -317,7 +317,7 @@ include::includes/devtools/build-native.adoc[]
 
 $ ./target/security-oauth2-quickstart-runner
 2019-03-28 14:31:37,315 INFO  [io.quarkus] (main) Quarkus 0.20.0 started in 0.006s. Listening on: http://[::]:8080
-2019-03-28 14:31:37,316 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy, resteasy-jackson, security, security-oauth2]
+2019-03-28 14:31:37,316 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, resteasy-reactive-jackson, security, security-oauth2]
 ----
 
 [[integration-testing]]

--- a/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-multitenancy.adoc
@@ -44,7 +44,7 @@ The solution is located in the `security-openid-connect-multi-tenancy-quickstart
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-openid-connect-multi-tenancy-quickstart
-:create-app-extensions: oidc,resteasy-jackson
+:create-app-extensions: oidc,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 If you already have your Quarkus project configured, you can add the `oidc` extension
@@ -81,6 +81,7 @@ package org.acme.quickstart.oidc;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -103,6 +104,7 @@ public class HomeResource {
      * @return the landing page HTML
      */
     @GET
+    @Produces("text/html")
     public String getHome() {
         StringBuilder response = new StringBuilder().append("<html>").append("<body>");
         

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -45,7 +45,7 @@ The solution is located in the `security-openid-connect-web-authentication-quick
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-openid-connect-web-authentication-quickstart
-:create-app-extensions: resteasy,oidc
+:create-app-extensions: resteasy-reactive,oidc
 include::includes/devtools/create-app.adoc[]
 
 If you already have your Quarkus project configured, you can add the `oidc` extension
@@ -82,6 +82,7 @@ package org.acme.security.openid.connect.web.authentication;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
@@ -114,9 +115,10 @@ public class TokenResource {
      * Returns the tokens available to the application. This endpoint exists only for demonstration purposes, you should not
      * expose these tokens in a real application.
      *
-     * @return a map containing the tokens available to the application
+     * @return a HTML page containing the tokens available to the application
      */
     @GET
+    @Produces("text/html")
     public String getTokens() {
         StringBuilder response = new StringBuilder().append("<html>")
                 .append("<body>")

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -55,11 +55,11 @@ The solution is located in the `security-openid-connect-quickstart` {quickstarts
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: security-openid-connect-quickstart
-:create-app-extensions: resteasy,oidc,resteasy-jackson
+:create-app-extensions: oidc,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
-This command generates a Maven project, importing the `keycloak` extension
-which is an implementation of a Keycloak Adapter for Quarkus applications and provides all the necessary capabilities to integrate with a Keycloak Server and perform bearer token authorization.
+This command generates a Maven project, importing the `oidc` extension
+which is an implementation of OIDC for Quarkus.
 
 If you already have your Quarkus project configured, you can add the `oidc` extension
 to your project by running the following command in your project base directory:
@@ -97,7 +97,7 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.annotations.cache.NoCache;
+import org.jboss.resteasy.reactive.NoCache;
 import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/api/users")

--- a/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
+++ b/docs/src/main/asciidoc/smallrye-fault-tolerance.adoc
@@ -42,10 +42,10 @@ The solution is located in the `microprofile-fault-tolerance-quickstart` {quicks
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: microprofile-fault-tolerance-quickstart
-:create-app-extensions: resteasy,smallrye-fault-tolerance,resteasy-jackson
+:create-app-extensions: smallrye-fault-tolerance,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
-This command generates a project, importing the extensions for RESTEasy/JAX-RS and SmallRye Fault Tolerance.
+This command generates a project, importing the extensions for RESTEasy Reactive/JAX-RS and SmallRye Fault Tolerance.
 
 If you already have your Quarkus project configured, you can add the `smallrye-fault-tolerance` extension
 to your project by running the following command in your project base directory:
@@ -256,7 +256,6 @@ and save the file.
 
 [source,java]
 ----
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 ...
 public class CoffeeResource {
@@ -264,7 +263,7 @@ public class CoffeeResource {
     @GET
     @Path("/{id}/recommendations")
     @Timeout(250)
-    public List<Coffee> recommendations(@PathParam int id) {
+    public List<Coffee> recommendations(int id) {
         long started = System.currentTimeMillis();
         final long invocationNumber = counter.getAndIncrement();
 
@@ -309,14 +308,13 @@ as follows:
 [source,java]
 ----
 import java.util.Collections;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
 ...
 public class CoffeeResource {
     ...
     @Fallback(fallbackMethod = "fallbackRecommendations")
-    public List<Coffee> recommendations(@PathParam int id) {
+    public List<Coffee> recommendations(int id) {
         ...
     }
 
@@ -389,7 +387,7 @@ public class CoffeeResource {
     ...
     @Path("/{id}/availability")
     @GET
-    public Response availability(@PathParam int id) {
+    public Response availability(int id) {
         final Long invocationNumber = counter.getAndIncrement();
 
         Coffee coffee = coffeeRepository.getCoffeeById(id);

--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -61,7 +61,7 @@ The solution is located in the `microprofile-graphql-quickstart` {quickstarts-tr
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: microprofile-graphql-quickstart
-:create-app-extensions: resteasy,graphql
+:create-app-extensions: graphql
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project, importing the `smallrye-graphql` extension.

--- a/docs/src/main/asciidoc/smallrye-metrics.adoc
+++ b/docs/src/main/asciidoc/smallrye-metrics.adoc
@@ -44,7 +44,7 @@ git clone {quickstarts-clone-url}
 To create a new project:
 
 :create-app-artifact-id: microprofile-metrics-quickstart
-:create-app-extensions: resteasy,smallrye-metrics
+:create-app-extensions: resteasy-reactive,smallrye-metrics
 include::includes/devtools/create-app.adoc[]
 
 This command generates a Quarkus project that uses the `smallrye-metrics` extension.
@@ -91,7 +91,6 @@ import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -108,7 +107,7 @@ public class PrimeNumberChecker {
     @Produces(MediaType.TEXT_PLAIN)
     @Counted(name = "performedChecks", description = "How many primality checks have been performed.")
     @Timed(name = "checksTimer", description = "A measure of how long it takes to perform the primality test.", unit = MetricUnits.MILLISECONDS)
-    public String checkIfPrime(@PathParam long number) {
+    public String checkIfPrime(long number) {
         if (number < 1) {
             return "Only natural numbers can be prime numbers.";
         }

--- a/docs/src/main/asciidoc/spring-boot-properties.adoc
+++ b/docs/src/main/asciidoc/spring-boot-properties.adoc
@@ -31,7 +31,7 @@ The solution is located in the `spring-boot-properties-quickstart` {quickstarts-
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-boot-properties-quickstart
-:create-app-extensions: resteasy,spring-boot-properties
+:create-app-extensions: resteasy-reactive,spring-boot-properties
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project and imports the `spring-boot-properties` extension.

--- a/docs/src/main/asciidoc/spring-cache.adoc
+++ b/docs/src/main/asciidoc/spring-cache.adoc
@@ -21,7 +21,7 @@ include::includes/devtools/prerequisites.adoc[]
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-cache-quickstart
-:create-app-extensions: resteasy,spring-di,spring-cache
+:create-app-extensions: resteasy-reactive,spring-di,spring-cache
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project which imports the `spring-cache` and `spring-di` extensions.
@@ -136,7 +136,7 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.reactive.RestQuery;
 
 @Path("/weather")
 public class WeatherForecastResource {
@@ -145,7 +145,7 @@ public class WeatherForecastResource {
     WeatherForecastService service;
 
     @GET
-    public WeatherForecast getForecast(@QueryParam String city, @QueryParam long daysInFuture) { // <1>
+    public WeatherForecast getForecast(@RestQuery String city, @RestQuery long daysInFuture) { // <1>
         long executionStart = System.currentTimeMillis();
         List<String> dailyForecasts = Arrays.asList(
                 service.getDailyForecast(LocalDate.now().plusDays(daysInFuture), city),

--- a/docs/src/main/asciidoc/spring-cloud-config-client.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-config-client.adoc
@@ -27,7 +27,7 @@ The end result of that process is a running Config Server that will provide the 
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-cloud-config-quickstart
-:create-app-extensions: spring-cloud-config-client
+:create-app-extensions: resteasy-reactive,spring-cloud-config-client
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project which imports the `spring-cloud-config-client` extension.

--- a/docs/src/main/asciidoc/spring-data-jpa.adoc
+++ b/docs/src/main/asciidoc/spring-data-jpa.adoc
@@ -28,10 +28,10 @@ The solution is located in the `spring-data-jpa-quickstart` {quickstarts-tree-ur
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-data-jpa-quickstart
-:create-app-extensions: resteasy,spring-data-jpa,resteasy-jackson,quarkus-jdbc-postgresql
+:create-app-extensions: resteasy-reactive-jackson,spring-data-jpa,quarkus-jdbc-postgresql
 include::includes/devtools/create-app.adoc[]
 
-This command generates a Maven project with a REST endpoint and imports the `spring-data-jpa` extension.
+This command generates a Maven project and imports the `spring-data-jpa` extension.
 
 If you already have your Quarkus project configured, you can add the `spring-data-jpa` extension
 to your project by running the following command in your project base directory:
@@ -197,8 +197,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -219,19 +217,19 @@ public class FruitResource {
 
     @DELETE
     @Path("{id}")
-    public void delete(@PathParam long id) {
+    public void delete(long id) {
         fruitRepository.deleteById(id);
     }
 
     @POST
     @Path("/name/{name}/color/{color}")
-    public Fruit create(@PathParam String name, @PathParam String color) {
+    public Fruit create(String name, String color) {
         return fruitRepository.save(new Fruit(name, color));
     }
 
     @PUT
     @Path("/id/{id}/color/{color}")
-    public Fruit changeColor(@PathParam Long id, @PathParam String color) {
+    public Fruit changeColor(Long id, String color) {
         Optional<Fruit> optional = fruitRepository.findById(id);
         if (optional.isPresent()) {
             Fruit fruit = optional.get();
@@ -244,7 +242,7 @@ public class FruitResource {
 
     @GET
     @Path("/color/{color}")
-    public List<Fruit> findByColor(@PathParam String color) {
+    public List<Fruit> findByColor(String color) {
         return fruitRepository.findByColor(color);
     }
 }

--- a/docs/src/main/asciidoc/spring-data-rest.adoc
+++ b/docs/src/main/asciidoc/spring-data-rest.adoc
@@ -32,7 +32,7 @@ The solution is located in the `spring-data-rest-quickstart` {quickstarts-tree-u
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-data-rest-quickstart
-:create-app-extensions: spring-data-rest,resteasy-jackson,quarkus-jdbc-postgresql
+:create-app-extensions: spring-data-rest,resteasy-reactive-jackson,quarkus-jdbc-postgresql
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project with the `spring-data-rest` extension.

--- a/docs/src/main/asciidoc/spring-di.adoc
+++ b/docs/src/main/asciidoc/spring-di.adoc
@@ -29,7 +29,7 @@ The solution is located in the `spring-di-quickstart` {quickstarts-tree-url}/spr
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-di-quickstart
-:create-app-extensions: resteasy,spring-di
+:create-app-extensions: resteasy-reactive,spring-di
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project which imports the `spring-di` extension.

--- a/docs/src/main/asciidoc/spring-scheduled.adoc
+++ b/docs/src/main/asciidoc/spring-scheduled.adoc
@@ -30,10 +30,10 @@ The solution is located in the `spring-scheduled-quickstart` {quickstarts-tree-u
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-scheduler-quickstart
-:create-app-extensions: resteasy,spring-scheduled
+:create-app-extensions: resteasy-reactive,spring-scheduled
 include::includes/devtools/create-app.adoc[]
 
-This command generates a Maven project with a REST endpoint and adds the `spring-scheduled` extension.
+This command generates a Maven project with the `spring-scheduled` extension.
 
 If you already have your Quarkus project configured, you can add the `spring-scheduled` extension
 to your project by running the following command in your project base directory:

--- a/docs/src/main/asciidoc/spring-security.adoc
+++ b/docs/src/main/asciidoc/spring-security.adoc
@@ -30,7 +30,7 @@ The solution is located in the `spring-security-quickstart` {quickstarts-tree-ur
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-security-quickstart
-:create-app-extensions: spring-web,spring-security,quarkus-elytron-security-properties-file,resteasy-jackson
+:create-app-extensions: spring-web,spring-security,quarkus-elytron-security-properties-file,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project which imports the `spring-web`, `spring-security` and `security-properties-file` extensions.
@@ -38,7 +38,7 @@ This command generates a project which imports the `spring-web`, `spring-securit
 If you already have your Quarkus project configured, you can add the `spring-web`, `spring-security` and `security-properties-file` extensions
 to your project by running the following command in your project base directory:
 
-:add-extension-extensions: spring-web,spring-security,quarkus-elytron-security-properties-file,resteasy-jackson
+:add-extension-extensions: spring-web,spring-security,quarkus-elytron-security-properties-file,resteasy-reactive-jackson
 include::includes/devtools/extension-add.adoc[]
 
 This will add the following to your build file:
@@ -60,7 +60,7 @@ This will add the following to your build file:
 </dependency>
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
+    <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
 </dependency>
 ----
 
@@ -70,7 +70,7 @@ This will add the following to your build file:
 implementation("io.quarkus:quarkus-spring-web")
 implementation("io.quarkus:quarkus-spring-security")
 implementation("io.quarkus:quarkus-elytron-security-properties-file")
-implementation("io.quarkus:quarkus-resteasy-jackson")
+implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 ----
 
 For more information about `security-properties-file`, you can check out the guide of the xref:security-properties.adoc[quarkus-elytron-security-properties-file] extension.

--- a/docs/src/main/asciidoc/spring-web.adoc
+++ b/docs/src/main/asciidoc/spring-web.adoc
@@ -31,7 +31,7 @@ The solution is located in the `spring-web-quickstart` {quickstarts-tree-url}/sp
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: spring-web-quickstart
-:create-app-extensions: spring-web,resteasy-jackson
+:create-app-extensions: spring-web,resteasy-reactive-jackson
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project which imports the `spring-web` extension.
@@ -39,7 +39,7 @@ This command generates a project which imports the `spring-web` extension.
 If you already have your Quarkus project configured, you can add the `spring-web` extension
 to your project by running the following command in your project base directory:
 
-:add-extension-extensions: spring-web,resteasy-jackson
+:add-extension-extensions: spring-web,resteasy-reactive-jackson
 include::includes/devtools/extension-add.adoc[]
 
 This will add the following to your build file:
@@ -53,7 +53,7 @@ This will add the following to your build file:
 </dependency>
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-resteasy-jackson</artifactId>
+    <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
 </dependency>
 ----
 
@@ -61,12 +61,12 @@ This will add the following to your build file:
 .build.gradle
 ----
 implementation("io.quarkus:quarkus-spring-web")
-implementation("io.quarkus:quarkus-resteasy-jackson")
+implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
 ----
 
 [IMPORTANT]
 ====
-`quarkus-spring-web` needs to be complemented with either `quarkus-resteasy-jackson` or `quarkus-resteasy-reactive-jackson` in order to work.
+`quarkus-spring-web` needs to be complemented with either `quarkus-resteasy-reactive-jackson` or `quarkus-resteasy-jackson` in order to work.
 ====
 
 == GreetingController

--- a/docs/src/main/asciidoc/tests-with-coverage.adoc
+++ b/docs/src/main/asciidoc/tests-with-coverage.adoc
@@ -50,7 +50,7 @@ The solution is located in the `tests-with-coverage-quickstart` {quickstarts-tre
 Let's start from an empty application created with the Quarkus Maven plugin:
 
 :create-app-artifact-id: tests-with-coverage-quickstart
-:create-app-extensions: resteasy
+:create-app-extensions: resteasy-reactive
 include::includes/devtools/create-app.adoc[]
 
 Now we'll be adding all the elements necessary to have an application that is properly covered with tests.
@@ -349,7 +349,7 @@ In order to run the integration tests as a jar with the Jacoco agent, add the fo
 
 ----
 
-WARNING: Sharing the same value for `quarkus.test.arg-line` might break integration test runs that test different types of Quarkus artifacts. In such cases, the use of maven profiles is advised.
+WARNING: Sharing the same value for `quarkus.test.arg-line` might break integration test runs that test different types of Quarkus artifacts. In such cases, the use of Maven profiles is advised.
 
 == Setting coverage thresholds
 

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -38,10 +38,10 @@ The solution is located in the `validation-quickstart` {quickstarts-tree-url}/va
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: validation-quickstart
-:create-app-extensions: resteasy,resteasy-jackson,hibernate-validator
+:create-app-extensions: resteasy-reactive-jackson,hibernate-validator
 include::includes/devtools/create-app.adoc[]
 
-This command generates a Maven structure importing the RESTEasy/JAX-RS, Jackson and Hibernate Validator/Bean Validation extensions.
+This command generates a Maven structure importing the RESTEasy Reactive/JAX-RS, Jackson and Hibernate Validator/Bean Validation extensions.
 
 If you already have your Quarkus project configured, you can add the `hibernate-validator` extension
 to your project by running the following command in your project base directory:
@@ -354,7 +354,7 @@ You can configure this behavior by adding the following configuration in your `a
 quarkus.default-locale=fr-FR
 ----
 
-If you are using RESTEasy, in the context of a JAX-RS endpoint, Hibernate Validator will automatically resolve the optimal locale to use from the `Accept-Language` HTTP header,
+If you are using RESTEasy Reactive, in the context of a JAX-RS endpoint, Hibernate Validator will automatically resolve the optimal locale to use from the `Accept-Language` HTTP header,
 provided the supported locales have been properly specified in the `application.properties`:
 
 [source, properties]

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -141,7 +141,7 @@ To learn more about the usage of the Vert.x Mutiny API, refer to https://smallry
 
 === Example of usage
 
-This section gives an example using the Vert.x `WebClient`.
+This section gives an example using the Vert.x `WebClient` in the context of a RESTEasy Reactive application.
 As indicated in the table above, add the following dependency to your project:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
@@ -174,7 +174,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import io.smallrye.mutiny.Uni;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.WebClient;
@@ -194,7 +193,7 @@ public class ResourceUsingWebClient {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{name}")
-    public Uni<JsonObject> getFruitData(@PathParam("name") String name) {
+    public Uni<JsonObject> getFruitData(String name) {
         return client.getAbs("https://.../api/fruit/" + name)
                 .send()
                 .onItem().transform(resp -> {
@@ -268,21 +267,19 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
-
 @Path("/hello")
 @Produces(MediaType.APPLICATION_JSON)
 public class VertxJsonResource {
 
     @GET
     @Path("{name}/object")
-    public JsonObject jsonObject(@PathParam String name) {
+    public JsonObject jsonObject(String name) {
         return new JsonObject().put("Hello", name);
     }
 
     @GET
     @Path("{name}/array")
-    public JsonArray jsonArray(@PathParam String name) {
+    public JsonArray jsonArray(String name) {
         return new JsonArray().add("Hello").add(name);
     }
 }
@@ -660,7 +657,6 @@ package org.acme.vertx;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.eventbus.Message;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -677,7 +673,7 @@ public class EventResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
-    public Uni<String> greeting(@PathParam String name) {
+    public Uni<String> greeting(String name) {
         return bus.<String>request("greeting", name)        // <2>
                 .onItem().transform(Message::body);
     }
@@ -714,7 +710,7 @@ So you can exchange objects as follows:
 @GET
 @Produces(MediaType.TEXT_PLAIN)
 @Path("{name}")
-public Uni<String> greeting(@PathParam String name) {
+public Uni<String> greeting(String name) {
     return bus.<String>request("greeting", new MyName(name))
         .onItem().transform(Message::body);
 }
@@ -732,7 +728,7 @@ If you want to use a specific codec, you need to set it on both ends explicitly:
 @GET
 @Produces(MediaType.TEXT_PLAIN)
 @Path("{name}")
-public Uni<String> greeting(@PathParam String name) {
+public Uni<String> greeting(String name) {
     return bus.<String>request("greeting", name,
         new DeliveryOptions().setCodecName(MyNameCodec.class.getName())) // <1>
         .onItem().transform(Message::body);
@@ -762,7 +758,6 @@ package org.acme.vertx;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.eventbus.EventBus;
 import io.vertx.mutiny.core.eventbus.Message;
-import org.jboss.resteasy.annotations.jaxrs.PathParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -779,7 +774,7 @@ public class EventResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{name}")
-    public Uni<String> greeting(@PathParam String name) {
+    public Uni<String> greeting(String name) {
         return bus.<String>request("greeting", name)            // <1>
                 .onItem().transform(Message::body);            // <2>
     }

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2249,7 +2249,7 @@ If multiple extensions register a feature of the same name the build fails.
 
 The feature name should also map to a label in the extension's `devtools/common/src/main/filtered/extensions.json` entry so that
 the feature name displayed by the startup line matches a label that one can used to select the extension when creating a project
-using the Quarkus maven plugin as shown in this example taken from the xref:rest-json.adoc[Writing JSON REST Services] guide where the `resteasy-jackson` feature is referenced:
+using the Quarkus maven plugin as shown in this example taken from the xref:rest-json.adoc[Writing JSON REST Services] guide where the `resteasy-reactive-jackson` feature is referenced:
 
 [source,bash,subs=attributes+]
 ----
@@ -2258,7 +2258,7 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create \
     -DprojectArtifactId=rest-json \
     -DclassName="org.acme.rest.json.FruitResource" \
     -Dpath="/fruits" \
-    -Dextensions="resteasy,resteasy-jackson"
+    -Dextensions="resteasy-reactive,resteasy-reactive-jackson"
 cd rest-json
 ----
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
@@ -10,9 +10,9 @@ language:
   base:
     data:
       resource:
-        class-name: ReactiveGreetingResource
+        class-name: GreetingResource
         path: "/hello"
-        response: "Hello RESTEasy Reactive"
+        response: "Hello from RESTEasy Reactive"
     dependencies:
       - io.quarkus:quarkus-resteasy-reactive
     test-dependencies:

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveCodestartTest.java
@@ -22,9 +22,9 @@ class RESTEasyReactiveCodestartTest {
 
     @Test
     void testContent() throws Throwable {
-        codestartTest.checkGeneratedSource("org.acme.ReactiveGreetingResource");
-        codestartTest.checkGeneratedTestSource("org.acme.ReactiveGreetingResourceTest");
-        codestartTest.checkGeneratedTestSource("org.acme.ReactiveGreetingResourceIT");
+        codestartTest.checkGeneratedSource("org.acme.GreetingResource");
+        codestartTest.checkGeneratedTestSource("org.acme.GreetingResourceTest");
+        codestartTest.checkGeneratedTestSource("org.acme.GreetingResourceIT");
     }
 
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
@@ -6,11 +6,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/hello")
-public class ReactiveGreetingResource {
+public class GreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Hello RESTEasy Reactive";
+        return "Hello from RESTEasy Reactive";
     }
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_kotlin_ilove_quark_us_GreetingResource.kt
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_kotlin_ilove_quark_us_GreetingResource.kt
@@ -6,9 +6,9 @@ import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
 @Path("/hello")
-class ReactiveGreetingResource {
+class GreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    fun hello() = "Hello RESTEasy Reactive"
+    fun hello() = "Hello from RESTEasy Reactive"
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_scala_ilove_quark_us_GreetingResource.scala
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_main_scala_ilove_quark_us_GreetingResource.scala
@@ -4,9 +4,9 @@ import javax.ws.rs.{GET, Path, Produces}
 import javax.ws.rs.core.MediaType
 
 @Path("/hello")
-class ReactiveGreetingResource {
+class GreetingResource {
 
     @GET
     @Produces(Array[String](MediaType.TEXT_PLAIN))
-    def hello() = "Hello RESTEasy Reactive"
+    def hello() = "Hello from RESTEasy Reactive"
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingResourceIT.java
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingResourceIT.java
@@ -3,7 +3,7 @@ package ilove.quark.us;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-public class ReactiveGreetingResourceIT extends ReactiveGreetingResourceTest {
+public class GreetingResourceIT extends GreetingResourceTest {
 
     // Execute the same tests but in native mode.
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingResourceTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_java_ilove_quark_us_GreetingResourceTest.java
@@ -7,7 +7,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-public class ReactiveGreetingResourceTest {
+public class GreetingResourceTest {
 
     @Test
     public void testHelloEndpoint() {
@@ -15,7 +15,7 @@ public class ReactiveGreetingResourceTest {
           .when().get("/hello")
           .then()
              .statusCode(200)
-             .body(is("Hello RESTEasy Reactive"));
+             .body(is("Hello from RESTEasy Reactive"));
     }
 
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingResourceIT.kt
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingResourceIT.kt
@@ -3,4 +3,4 @@ package ilove.quark.us
 import io.quarkus.test.junit.QuarkusIntegrationTest
 
 @QuarkusIntegrationTest
-class ReactiveGreetingResourceIT : ReactiveGreetingResourceTest()
+class GreetingResourceIT : GreetingResourceTest()

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingResourceTest.kt
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_kotlin_ilove_quark_us_GreetingResourceTest.kt
@@ -6,7 +6,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-class ReactiveGreetingResourceTest {
+class GreetingResourceTest {
 
     @Test
     fun testHelloEndpoint() {
@@ -14,7 +14,7 @@ class ReactiveGreetingResourceTest {
           .`when`().get("/hello")
           .then()
              .statusCode(200)
-             .body(`is`("Hello RESTEasy Reactive"))
+             .body(`is`("Hello from RESTEasy Reactive"))
     }
 
 }

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_scala_ilove_quark_us_GreetingResourceIT.scala
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_scala_ilove_quark_us_GreetingResourceIT.scala
@@ -3,4 +3,4 @@ package ilove.quark.us
 import io.quarkus.test.junit.QuarkusIntegrationTest
 
 @QuarkusIntegrationTest
-class ReactiveGreetingResourceIT extends ReactiveGreetingResourceTest
+class GreetingResourceIT extends GreetingResourceTest

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_scala_ilove_quark_us_GreetingResourceTest.scala
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/RESTEasyReactiveCodestartTest/testContent/src_test_scala_ilove_quark_us_GreetingResourceTest.scala
@@ -6,7 +6,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
-class ReactiveGreetingResourceTest {
+class GreetingResourceTest {
 
     @Test
     def testHelloEndpoint() = {
@@ -14,7 +14,7 @@ class ReactiveGreetingResourceTest {
           .`when`().get("/hello")
           .then()
              .statusCode(200)
-             .body(`is`("Hello RESTEasy Reactive"))
+             .body(`is`("Hello from RESTEasy Reactive"))
     }
 
 }

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveCodestartsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/RESTEasyReactiveCodestartsTest.java
@@ -19,7 +19,7 @@ public class RESTEasyReactiveCodestartsTest {
     @Test
     void testContent() throws Throwable {
         codestartTest.checkGeneratedSource("org.acme.SomePage");
-        codestartTest.checkGeneratedSource("org.acme.ReactiveGreetingResource");
+        codestartTest.checkGeneratedSource("org.acme.GreetingResource");
         codestartTest.assertThatGeneratedFileMatchSnapshot(JAVA, "src/main/resources/templates/page.qute.html");
     }
 

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_java_ilove_quark_us_GreetingResource.java
@@ -6,11 +6,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/hello")
-public class ReactiveGreetingResource {
+public class GreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
-        return "Hello RESTEasy Reactive";
+        return "Hello from RESTEasy Reactive";
     }
 }

--- a/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_kotlin_ilove_quark_us_GreetingResource.kt
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/RESTEasyReactiveCodestartsTest/testContent/src_main_kotlin_ilove_quark_us_GreetingResource.kt
@@ -6,9 +6,9 @@ import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType
 
 @Path("/hello")
-class ReactiveGreetingResource {
+class GreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    fun hello() = "Hello RESTEasy Reactive"
+    fun hello() = "Hello from RESTEasy Reactive"
 }


### PR DESCRIPTION
@geoand this is the first step I had in mind.

I think, after this is in, we need:
- to have a closer look to the RESTEasy Reactive guide. I remember things being a bit weird there especially in the class names of the examples and I would prefer we make things more mainstream
- the REST JSON guide needs a check by you, especially to make sure everything I left there is valid for RESTEasy Reactive. Frankly I think the filter/interceptor part should rather be in the RESTEasy Reactive guide. I haven't found any information about the filters there.

Hopefully I haven't done too many mistakes, I'll do a review of the changes tomorrow but my eyes are too tired tonight.

Fixes #24174