### PR TITLE
Set content-length to 0 when the Reactive REST Client sends empty POST or PUT

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/EmptyPostTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/EmptyPostTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class EmptyPostTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest();
+
+    @Test
+    void shouldWork() {
+        Client client = clientWithUri(
+                "http://localhost:" + ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class));
+
+        assertThat(client.post()).isEqualTo("0");
+    }
+
+    private Client clientWithUri(String uri) {
+        return RestClientBuilder.newBuilder().baseUri(URI.create(uri)).build(Client.class);
+    }
+
+    @Path("/foo")
+    public interface Client {
+        @POST
+        String post();
+    }
+
+    @Path("/foo")
+    public static class Resource {
+        @POST
+        public String post(@HeaderParam("Content-Length") String contentLength) {
+            return contentLength;
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/handlers/ClientSendRequestHandler.java
@@ -407,6 +407,11 @@ public class ClientSendRequestHandler implements ClientRestHandler {
 
             actualEntity = state.writeEntity(entity, headerMap,
                     state.getConfiguration().getWriterInterceptors().toArray(Serialisers.NO_WRITER_INTERCEPTOR));
+        } else {
+            // some servers don't like the fact that a POST or PUT does not have a method body if there is no content-length header associated
+            if (state.getHttpMethod().equals("POST") || state.getHttpMethod().equals("PUT")) {
+                headerMap.putSingle(HttpHeaders.CONTENT_LENGTH, "0");
+            }
         }
         // set the Vertx headers after we've run the interceptors because they can modify them
         setVertxHeaders(httpClientRequest, headerMap);


### PR DESCRIPTION
Fixes #24349