### PR TITLE
Rename the RESTEasy extensions consistently to RESTEasy Classic

### DIFF
--- a/extensions/resteasy-classic/rest-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client Jackson"
+name: "REST Client Classic Jackson"
 metadata:
   keywords:
   - "rest-client-jackson"

--- a/extensions/resteasy-classic/rest-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client JAXB"
+name: "REST Client Classic JAXB"
 metadata:
   keywords:
   - "rest-client-jaxb"

--- a/extensions/resteasy-classic/rest-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client JSON-B"
+name: "REST Client Classic JSON-B"
 metadata:
   keywords:
   - "rest-client-jsonb"

--- a/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,4 +11,4 @@ metadata:
   categories:
   - "web"
   - "reactive"
-  status: "preview"
+  status: "deprecated"

--- a/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "Mutiny support for REST Client"
+name: "REST Client Classic Mutiny support"
 metadata:
   keywords:
   - "rest-client-mutiny"

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "REST Client"
+name: "REST Client Classic"
 metadata:
   keywords:
   - "rest-client"

--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy JAX-RS Common"
+name: "RESTEasy Classic Common"
 metadata:
   keywords:
   - "resteasy"

--- a/extensions/resteasy-classic/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-jackson/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: "RESTEasy Jackson"
+name: "RESTEasy Classic Jackson"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:

--- a/extensions/resteasy-classic/resteasy-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-jaxb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy JAXB"
+name: "RESTEasy Classic JAXB"
 metadata:
   keywords:
   - "resteasy-jaxb"

--- a/extensions/resteasy-classic/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-jsonb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy JSON-B"
+name: "RESTEasy Classic JSON-B"
 metadata:
   keywords:
   - "resteasy-jsonb"

--- a/extensions/resteasy-classic/resteasy-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Links"
+name: "RESTEasy Classic Links"
 metadata:
   keywords:
   - "resteasy-links"

--- a/extensions/resteasy-classic/resteasy-multipart/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-multipart/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Multipart"
+name: "RESTEasy Classic Multipart"
 metadata:
   keywords:
   - "resteasy-multipart"

--- a/extensions/resteasy-classic/resteasy-mutiny-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-mutiny-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,5 +1,5 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Mutiny Common"
+name: "RESTEasy Classic Mutiny Common"
 metadata:
   unlisted: true

--- a/extensions/resteasy-classic/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Mutiny"
+name: "RESTEasy Classic Mutiny"
 metadata:
   keywords:
     - "resteasy-mutiny"

--- a/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-qute/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,6 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Qute"
+name: "RESTEasy Classic Qute"
 metadata:
   keywords:
   - "templating"

--- a/extensions/resteasy-classic/resteasy-server-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-server-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,13 +1,13 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "RESTEasy Server Common"
+name: "RESTEasy Classic Server Common"
 metadata:
   keywords:
   - "resteasy"
   - "jaxrs"
   - "web"
   - "rest"
-  guide: "https://quarkus.io/guides/rest-json"
+  guide: "https://quarkus.io/guides/resteasy"
   categories:
   - "web"
   status: "stable"

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,4 +1,4 @@
-name: "RESTEasy JAX-RS"
+name: "RESTEasy Classic"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   short-name: "jax-rs"
@@ -7,7 +7,7 @@ metadata:
   - "jaxrs"
   - "web"
   - "rest"
-  guide: "https://quarkus.io/guides/rest-json"
+  guide: "https://quarkus.io/guides/resteasy"
   categories:
   - "web"
   status: "stable"

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/commands/ListExtensionsTest.java
@@ -104,7 +104,7 @@ public class ListExtensionsTest extends PlatformAwareTestBase {
                     resteasy = true;
                     assertTrue(
                             line.endsWith(
-                                    String.format("%s", "https://quarkus.io/guides/rest-json")),
+                                    String.format("%s", "https://quarkus.io/guides/resteasy")),
                             "RESTEasy should list as having an guide: " + line);
                 } else if (line.contains("quarkus-hibernate-orm-panache ")) {
                     assertTrue(line.startsWith("✬"), "Panache is a platform extension: " + line);

--- a/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/platform/catalog/ExtensionProcessorTest.java
@@ -35,7 +35,7 @@ public class ExtensionProcessorTest extends PlatformAwareTestBase {
         assertThat(extensionProcessor.getCodestartLanguages()).contains("java", "kotlin", "scala");
         assertThat(extensionProcessor.getKeywords()).contains("resteasy", "jaxrs", "web", "rest");
         assertThat(extensionProcessor.getExtendedKeywords()).contains("resteasy", "jaxrs", "web", "rest");
-        assertThat(extensionProcessor.getGuide()).isEqualTo("https://quarkus.io/guides/rest-json");
+        assertThat(extensionProcessor.getGuide()).isEqualTo("https://quarkus.io/guides/resteasy");
     }
 
     @Test


### PR DESCRIPTION
We need some sort of brand to avoid confusion.