### PR TITLE
More cleanup for RESTEasy Reactive switch of rest-json.adoc

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -178,16 +178,10 @@ depending on the extension you chose when initializing the project.
 
 [NOTE]
 ====
-When a JSON extension is installed such as `quarkus-resteasy-jackson` or `quarkus-resteasy-jsonb`, Quarkus will use the `application/json` media type
+When a JSON extension is installed such as `quarkus-resteasy-reactive-jackson` or `quarkus-resteasy-reactive-jsonb`, Quarkus will use the `application/json` media type
 by default for most return values, unless the media type is explicitly set via
 `@Produces` or `@Consumes` annotations (there are some exceptions for well known types, such as `String` and `File`, which default to `text/plain` and `application/octet-stream`
 respectively).
-
-If you don't want JSON by default you can set `quarkus.resteasy-json.default-json=false` and the default will change back to being auto-negotiated. If you set this
-you will need to add `@Produces(MediaType.APPLICATION_JSON)` and `@Consumes(MediaType.APPLICATION_JSON)` to your endpoints in order to use JSON.
-
-If you don't rely on the JSON default, it is heavily recommended to annotate your endpoints with the `@Produces` and `@Consumes` annotations to define precisely the expected content-types.
-It will allow to narrow down the number of JAX-RS providers (which can be seen as converters) included in the native executable.
 ====
 
 [[json]]


### PR DESCRIPTION
AFAICS, the corresponding switch in RESTEasy Reactive is marked experimental and it says it might be
removed later so let's not advertise it.