### PR TITLE
Creates Redis RunningDevService with proper connection url

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
@@ -184,8 +184,11 @@ public class DevServicesRedisProcessor {
         };
 
         return redisContainerLocator.locateContainer(devServicesConfig.serviceName, devServicesConfig.shared, launchMode)
-                .map(containerAddress -> new RunningDevService(Feature.REDIS_CLIENT.getName(), containerAddress.getId(),
-                        null, configPrefix + RedisConfig.HOSTS_CONFIG_NAME, containerAddress.getUrl()))
+                .map(containerAddress -> {
+                    String redisUrl = REDIS_SCHEME + containerAddress.getUrl();
+                    return new RunningDevService(Feature.REDIS_CLIENT.getName(), containerAddress.getId(),
+                            null, configPrefix + RedisConfig.HOSTS_CONFIG_NAME, redisUrl);
+                })
                 .orElseGet(defaultRedisServerSupplier);
     }
 


### PR DESCRIPTION
Fixes an issue where the RunningDevService for Redis would be created with
an incorrect connection url if the Service was already running.

fixes #24473