### PR TITLE
CLI info and update commands and basic tests

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/Info.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Info.java
@@ -1,0 +1,24 @@
+package io.quarkus.cli;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BaseBuildCommand;
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "info", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Quarkus project information.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+public class Info extends BaseBuildCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = { "--per-module" }, description = "Display information per project module.")
+    public boolean perModule = false;
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            final BuildSystemRunner runner = getRunner();
+            return runner.info(perModule);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to collect Quarkus project information: " + e.getMessage());
+        }
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/QuarkusCli.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.ScopeType;
 import picocli.CommandLine.UnmatchedArgumentException;
 
 @CommandLine.Command(name = "quarkus", subcommands = {
-        Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Version.class,
+        Create.class, Build.class, Dev.class, ProjectExtensions.class, Registry.class, Info.class, Update.class, Version.class,
         Completion.class }, scope = ScopeType.INHERIT, sortOptions = false, showDefaultValues = true, versionProvider = Version.class, subcommandsRepeatable = false, mixinStandardHelpOptions = false, commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", optionListHeading = "Options:%n", headerHeading = "%n", parameterListHeading = "%n")
 public class QuarkusCli implements QuarkusApplication, Callable<Integer> {
     static {

--- a/devtools/cli/src/main/java/io/quarkus/cli/Update.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/Update.java
@@ -1,0 +1,32 @@
+package io.quarkus.cli;
+
+import java.util.concurrent.Callable;
+
+import io.quarkus.cli.build.BaseBuildCommand;
+import io.quarkus.cli.build.BuildSystemRunner;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "update", sortOptions = false, showDefaultValues = true, mixinStandardHelpOptions = false, header = "Display recommended Quarkus updates.", headerHeading = "%n", commandListHeading = "%nCommands:%n", synopsisHeading = "%nUsage: ", parameterListHeading = "%n", optionListHeading = "%nOptions:%n")
+public class Update extends BaseBuildCommand implements Callable<Integer> {
+
+    @CommandLine.Option(names = {
+            "--rectify" }, description = "Display platform and/or extension version alignment recommendations.")
+    public boolean rectify = false;
+
+    @CommandLine.Option(names = {
+            "--recommended-state" }, description = "Display the state of the project as if the recommended updates were applied.")
+    public boolean recommendedState = false;
+
+    @CommandLine.Option(names = { "--per-module" }, description = "Display information per project module.")
+    public boolean perModule = false;
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            final BuildSystemRunner runner = getRunner();
+            return runner.update(rectify, recommendedState, perModule);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to collect Quarkus project information: " + e.getMessage());
+        }
+    }
+}

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BuildSystemRunner.java
@@ -100,6 +100,10 @@ public interface BuildSystemRunner {
 
     Integer removeExtension(RunModeOption runMode, Set<String> extensions) throws Exception;
 
+    Integer info(boolean perModule) throws Exception;
+
+    Integer update(boolean rectify, boolean recommendedState, boolean perModule) throws Exception;
+
     BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params);
 
     List<Supplier<BuildCommandArgs>> prepareDevMode(DevOptions devOptions, DebugOptions debugOptions,

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/GradleRunner.java
@@ -126,6 +126,32 @@ public class GradleRunner implements BuildSystemRunner {
     }
 
     @Override
+    public Integer info(boolean perModule) {
+        ArrayDeque<String> args = new ArrayDeque<>();
+        args.add("quarkusInfo");
+        if (perModule) {
+            args.add("--per-module");
+        }
+        return run(prependExecutable(args));
+    }
+
+    @Override
+    public Integer update(boolean rectify, boolean recommendedState, boolean perModule) throws Exception {
+        ArrayDeque<String> args = new ArrayDeque<>();
+        args.add("quarkusUpdate");
+        if (rectify) {
+            args.add("--rectify");
+        }
+        if (recommendedState) {
+            args.add("--recommended-state");
+        }
+        if (perModule) {
+            args.add("--per-module");
+        }
+        return run(prependExecutable(args));
+    }
+
+    @Override
     public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
         setGradleProperties(args, runMode.isBatchMode());

--- a/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/JBangRunner.java
@@ -70,6 +70,16 @@ public class JBangRunner implements BuildSystemRunner {
     }
 
     @Override
+    public Integer info(boolean perModule) {
+        throw new UnsupportedOperationException("Not there yet. ;)");
+    }
+
+    @Override
+    public Integer update(boolean rectify, boolean recommendedState, boolean perModule) {
+        throw new UnsupportedOperationException("Not there yet. ;)");
+    }
+
+    @Override
     public BuildCommandArgs prepareBuild(BuildOptions buildOptions, RunModeOption runMode, List<String> params) {
         ArrayDeque<String> args = new ArrayDeque<>();
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectInfoAndUpdateTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectInfoAndUpdateTest.java
@@ -1,0 +1,310 @@
+package io.quarkus.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Repository;
+import org.apache.maven.settings.RepositoryPolicy;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.io.DefaultSettingsReader;
+import org.apache.maven.settings.io.DefaultSettingsWriter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.registry.config.RegistriesConfigLocator;
+import picocli.CommandLine;
+
+public class MavenProjectInfoAndUpdateTest {
+
+    private static Path workDir;
+    private static Path settingsXml;
+    private static Path testRepo;
+    private static String prevConfigPath;
+    private static String prevRegistryClient;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        workDir = Path.of(System.getProperty("user.dir")).resolve("target").resolve("test-work-dir");
+        final Path registryConfigDir = workDir.resolve("registry");
+
+        final BootstrapMavenContext mavenContext = new BootstrapMavenContext(
+                BootstrapMavenContext.config().setWorkspaceDiscovery(false));
+
+        TestRegistryClientBuilder.newInstance()
+                .baseDir(registryConfigDir)
+                .newRegistry("registry.acme.org")
+                .newPlatform("org.acme.quarkus.platform")
+                .newStream("2.0")
+                .newRelease("2.0.0")
+                .quarkusVersion(getCurrentQuarkusVersion())
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .addDefaultCodestartExtensions()
+                .release()
+                .newMember("acme-bom").addExtension("acme-quarkus-supersonic").addExtension("acme-quarkus-subatomic")
+                .release().stream().platform()
+                .newStream("1.0")
+                .newRelease("1.0.0")
+                .quarkusVersion(getCurrentQuarkusVersion())
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .addDefaultCodestartExtensions()
+                .release()
+                .newMember("acme-bom").addExtension("acme-quarkus-supersonic").addExtension("acme-quarkus-subatomic")
+                .registry()
+                .newNonPlatformCatalog(getCurrentQuarkusVersion())
+                .addExtension("org.acme", "acme-quarkiverse-extension", "1.0")
+                .registry()
+                .clientBuilder()
+                .build();
+
+        prevConfigPath = System.setProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY,
+                registryConfigDir.resolve("config.yaml").toString());
+        prevRegistryClient = System.setProperty("quarkusRegistryClient", "true");
+        QuarkusProjectHelper.reset();
+
+        final Settings settings = getBaseMavenSettings(mavenContext.getUserSettings().toPath());
+
+        Profile profile = new Profile();
+        settings.addActiveProfile("qs-test-registry");
+        profile.setId("qs-test-registry");
+
+        Repository repo = configureRepo("original-local",
+                Path.of(mavenContext.getLocalRepo()).toUri().toURL().toExternalForm());
+        profile.addRepository(repo);
+        profile.addPluginRepository(repo);
+
+        settings.addProfile(profile);
+        repo = configureRepo("qs-test-registry",
+                TestRegistryClientBuilder.getMavenRepoDir(registryConfigDir).toUri().toURL().toExternalForm());
+        profile.addRepository(repo);
+        profile.addPluginRepository(repo);
+
+        settingsXml = workDir.resolve("settings.xml");
+        try (BufferedWriter writer = Files.newBufferedWriter(settingsXml)) {
+            new DefaultSettingsWriter().write(writer, Collections.emptyMap(), settings);
+        }
+        testRepo = registryConfigDir.resolve("test-repo");
+    }
+
+    private static Repository configureRepo(String id, String url)
+            throws MalformedURLException, BootstrapMavenException {
+        final Repository repo = new Repository();
+        repo.setId(id);
+        repo.setLayout("default");
+        repo.setUrl(url);
+        RepositoryPolicy policy = new RepositoryPolicy();
+        policy.setEnabled(true);
+        policy.setChecksumPolicy("ignore");
+        policy.setUpdatePolicy("never");
+        repo.setReleases(policy);
+        repo.setSnapshots(policy);
+        return repo;
+    }
+
+    private static String getCurrentQuarkusVersion() {
+        String v = System.getProperty("project.version");
+        if (v == null) {
+            throw new IllegalStateException("project.version property isn't available");
+        }
+        return v;
+    }
+
+    private static Settings getBaseMavenSettings(Path mavenSettings) throws IOException {
+        if (Files.exists(mavenSettings)) {
+            try (BufferedReader reader = Files.newBufferedReader(mavenSettings)) {
+                return new DefaultSettingsReader().read(reader, Collections.emptyMap());
+            }
+        }
+        return new Settings();
+    }
+
+    private static void resetProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    @AfterAll
+    static void cleanup() throws Exception {
+        //CliDriver.deleteDir(workDir);
+        resetProperty(RegistriesConfigLocator.CONFIG_FILE_PATH_PROPERTY, prevConfigPath);
+        resetProperty("quarkusRegistryClient", prevRegistryClient);
+    }
+
+    @Test
+    void testClean() throws Exception {
+
+        final CliDriver.Result createResult = execute(workDir, "create", "acme-clean",
+                "-x supersonic,acme-quarkiverse-extension");
+        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+                .as(() -> "Expected OK return code." + createResult);
+        assertThat(createResult.stdout).contains("SUCCESS")
+                .as(() -> "Expected confirmation that the project has been created." + createResult);
+
+        final Path projectDir = workDir.resolve("acme-clean");
+        final CliDriver.Result infoResult = execute(projectDir, "info");
+
+        assertQuarkusPlatformBoms(infoResult.stdout,
+                GACTV.pom("org.acme.quarkus.platform", "quarkus-bom", "2.0.0"),
+                GACTV.pom("org.acme.quarkus.platform", "acme-bom", "2.0.0"));
+        assertPlatformBomExtensions(infoResult.stdout, GACTV.pom("org.acme.quarkus.platform", "quarkus-bom", "2.0.0"),
+                GACTV.jar("io.quarkus", "quarkus-arc", null));
+        assertPlatformBomExtensions(infoResult.stdout, GACTV.pom("org.acme.quarkus.platform", "acme-bom", "2.0.0"),
+                GACTV.jar("org.acme.quarkus.platform", "acme-quarkus-supersonic", null));
+        assertRegistryExtensions(infoResult.stdout, "registry.acme.org",
+                GACTV.jar("org.acme", "acme-quarkiverse-extension", "1.0"));
+
+        final CliDriver.Result updateResult = execute(projectDir, "update");
+        assertThat(updateResult.stdout).contains("[INFO] The project is up-to-date");
+    }
+
+    @Test
+    void testMissalignedPlatformExtensionVersion() throws Exception {
+
+        final CliDriver.Result createResult = execute(workDir, "create", "acme-misaligned-ext-version",
+                "-x supersonic,acme-quarkiverse-extension,org.acme.quarkus.platform:acme-quarkus-subatomic:1.0.0");
+        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+                .as(() -> "Expected OK return code." + createResult);
+        assertThat(createResult.stdout).contains("SUCCESS")
+                .as(() -> "Expected confirmation that the project has been created." + createResult);
+
+        Path projectDir = workDir.resolve("acme-misaligned-ext-version");
+        final CliDriver.Result infoResult = execute(projectDir, "info");
+
+        assertQuarkusPlatformBoms(infoResult.stdout,
+                GACTV.pom("org.acme.quarkus.platform", "quarkus-bom", "2.0.0"),
+                GACTV.pom("org.acme.quarkus.platform", "acme-bom", "2.0.0"));
+        assertPlatformBomExtensions(infoResult.stdout, GACTV.pom("org.acme.quarkus.platform", "quarkus-bom", "2.0.0"),
+                GACTV.jar("io.quarkus", "quarkus-arc", null));
+        assertPlatformBomExtensions(infoResult.stdout, GACTV.pom("org.acme.quarkus.platform", "acme-bom", "2.0.0"),
+                GACTV.jar("org.acme.quarkus.platform", "acme-quarkus-supersonic", null),
+                GACTV.jar("org.acme.quarkus.platform", "acme-quarkus-subatomic", "1.0.0 | misaligned"));
+        assertRegistryExtensions(infoResult.stdout, "registry.acme.org",
+                GACTV.jar("org.acme", "acme-quarkiverse-extension", "1.0"));
+
+        final CliDriver.Result rectifyResult = execute(projectDir, "update", "--rectify");
+        assertThat(rectifyResult.stdout)
+                .contains("[INFO] Update: org.acme.quarkus.platform:acme-quarkus-subatomic:1.0.0 -> remove version (managed)");
+
+        final CliDriver.Result updateResult = execute(projectDir, "update", "-Dquarkus.platform.version=1.0.0");
+        assertQuarkusPlatformBomUpdates(updateResult.stdout,
+                GACTV.pom("org.acme.quarkus.platform", "quarkus-bom", "1.0.0 -> 2.0.0"),
+                GACTV.pom("org.acme.quarkus.platform", "acme-bom", "1.0.0 -> 2.0.0"));
+    }
+
+    private static void assertPlatformBomExtensions(String output, ArtifactCoords bom, ArtifactCoords... extensions) {
+        final StringWriter buf = new StringWriter();
+        try (BufferedWriter writer = new BufferedWriter(buf)) {
+            writer.write("[INFO] Extensions from ");
+            writer.write(bom.getGroupId());
+            writer.write(":");
+            writer.write(bom.getArtifactId());
+            writer.write(":");
+            writer.newLine();
+            for (ArtifactCoords c : extensions) {
+                writer.write("[INFO]   ");
+                writer.write(c.getGroupId());
+                writer.write(":");
+                writer.write(c.getArtifactId());
+                if (c.getVersion() != null) {
+                    writer.write(":");
+                    writer.write(c.getVersion());
+                }
+                writer.newLine();
+            }
+            writer.write("[INFO] ");
+            writer.newLine();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to compose output fragment", e);
+        }
+        assertThat(output).contains(buf.getBuffer().toString());
+    }
+
+    private static void assertRegistryExtensions(String output, String id, ArtifactCoords... extensions) {
+        final StringWriter buf = new StringWriter();
+        try (BufferedWriter writer = new BufferedWriter(buf)) {
+            writer.write("[INFO] Extensions from ");
+            writer.write(id);
+            writer.write(":");
+            writer.newLine();
+            for (ArtifactCoords c : extensions) {
+                writer.write("[INFO]   ");
+                writer.write(c.getGroupId());
+                writer.write(":");
+                writer.write(c.getArtifactId());
+                writer.write(":");
+                writer.write(c.getVersion());
+                writer.newLine();
+            }
+            writer.write("[INFO] ");
+            writer.newLine();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to compose output fragment", e);
+        }
+        assertThat(output).contains(buf.getBuffer().toString());
+    }
+
+    private static void assertQuarkusPlatformBoms(String output, ArtifactCoords... coords) {
+        final StringWriter buf = new StringWriter();
+        try (BufferedWriter writer = new BufferedWriter(buf)) {
+            writer.write("[INFO] Quarkus platform BOMs:");
+            writer.newLine();
+            for (ArtifactCoords c : coords) {
+                writer.write("[INFO]   ");
+                writer.write(c.toCompactCoords());
+                writer.newLine();
+            }
+            writer.write("[INFO] ");
+            writer.newLine();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to compose output fragment", e);
+        }
+        assertThat(output).contains(buf.getBuffer().toString());
+    }
+
+    private static void assertQuarkusPlatformBomUpdates(String output, ArtifactCoords... coords) {
+        final StringWriter buf = new StringWriter();
+        try (BufferedWriter writer = new BufferedWriter(buf)) {
+            writer.write("[INFO] Recommended Quarkus platform BOM updates:");
+            writer.newLine();
+            for (ArtifactCoords c : coords) {
+                writer.write("[INFO] Update: ");
+                writer.write(c.toCompactCoords());
+                writer.newLine();
+            }
+            writer.write("[INFO] ");
+            writer.newLine();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to compose output fragment", e);
+        }
+        assertThat(output).contains(buf.getBuffer().toString());
+    }
+
+    private CliDriver.Result execute(Path dir, String... args) throws Exception {
+        return CliDriver.builder()
+                .setStartingDir(dir)
+                .setMavenRepoLocal(testRepo.toString())
+                .setMavenSettings(settingsXml.toString())
+                .addArgs(args)
+                .execute();
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
@@ -15,6 +15,10 @@ public class GACTV implements ArtifactCoords, Serializable {
         return new GACTV(groupId, artifactId, null, TYPE_POM, version);
     }
 
+    public static ArtifactCoords jar(String groupId, String artifactId, String version) {
+        return new GACTV(groupId, artifactId, null, TYPE_JAR, version);
+    }
+
     protected static String[] split(String str, String[] parts) {
         final int versionSep = str.lastIndexOf(':');
         if (versionSep <= 0 || versionSep == str.length() - 1) {

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionCatalogFromProvidedPlatformsTest.java
@@ -37,7 +37,7 @@ public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformB
                 .newRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("acme-foo").release()
                 .stream().platform()
@@ -46,7 +46,7 @@ public class ExtensionCatalogFromProvidedPlatformsTest extends MultiplePlatformB
                 // 1.0.1 release
                 .newRelease("1.0.1")
                 .quarkusVersion("1.1.2")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("acme-foo").release()
                 .newMember("acme-baz-bom").addExtension("acme-baz").release()
                 .registry()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest.java
@@ -43,7 +43,7 @@ public class ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest extends Mul
                 .newRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("acme-foo").addExtension("org.other", "other-extension", "6.0")
                 .release()
@@ -53,7 +53,7 @@ public class ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest extends Mul
                 // 1.0.1 release
                 .newRelease("1.0.1")
                 .quarkusVersion("1.1.2")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("acme-foo").addExtension("org.other", "other-extension", "5.1")
                 .release()
                 .newMember("acme-baz-bom").addExtension("acme-baz").release()
@@ -61,7 +61,7 @@ public class ExtensionsAppearingInPlatformAndNonPlatformCatalogsTest extends Mul
                 // 1.0.0 release
                 .newRelease("1.0.0")
                 .quarkusVersion("1.1.1")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("acme-foo").addExtension("org.other", "other-extension", "5.0")
                 .release()
                 .newMember("acme-bar-bom").addExtension("acme-bar").release()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromMultiplePlatformsTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromMultiplePlatformsTest.java
@@ -27,7 +27,7 @@ public class MavenProjectImportingMultipleBomsFromMultiplePlatformsTest extends 
                 .newRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4").addExtension("ext-b").release()
                 .stream().platform().registry()
@@ -37,7 +37,7 @@ public class MavenProjectImportingMultipleBomsFromMultiplePlatformsTest extends 
                 // 1.0.1 release
                 .newRelease("1.0.1")
                 .quarkusVersion("1.1.2")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.1").release()
                 .newMember("acme-baz-bom").addExtension("io.acme", "ext-b", "1.0.1").release()
                 .stream().platform().registry()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromSinglePlatformTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/MavenProjectImportingMultipleBomsFromSinglePlatformTest.java
@@ -38,7 +38,7 @@ public class MavenProjectImportingMultipleBomsFromSinglePlatformTest extends Mul
                 .newRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("acme-foo").release()
                 .stream().platform()
@@ -47,14 +47,14 @@ public class MavenProjectImportingMultipleBomsFromSinglePlatformTest extends Mul
                 // 1.0.1 release
                 .newRelease("1.0.1")
                 .quarkusVersion("1.1.2")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("acme-foo").release()
                 .newMember("acme-baz-bom").addExtension("acme-baz").release()
                 .stream()
                 // 1.0.0 release
                 .newRelease("1.0.0")
                 .quarkusVersion("1.1.1")
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("acme-foo").release()
                 .newMember("acme-bar-bom").addExtension("acme-bar").release()
                 .newMember("acme-baz-bom").addExtension("acme-baz").release()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingArchivedUpstreamVersionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingArchivedUpstreamVersionTest.java
@@ -30,7 +30,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .quarkusVersion("2.2.2-downstream")
                 .upstreamQuarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4-downstream").release().stream().platform()
                 .newStream("1.0")
@@ -39,7 +39,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .quarkusVersion("1.1.1-downstream")
                 .upstreamQuarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4-downstream").release()
                 .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "1.0.4-downstream").release()
@@ -55,7 +55,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .newRelease("2.0.5")
                 .quarkusVersion("2.2.5")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.5").release()
                 .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "2.0.5").release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "2.0.5").release().stream()
@@ -63,7 +63,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .newArchivedRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4").release()
                 .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "2.0.4").release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "2.0.4").release().stream().platform()
@@ -72,7 +72,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .newRelease("1.0.5")
                 .quarkusVersion("1.1.5")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.5").addExtension("io.acme", "ext-e", "1.0.5")
                 .release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "1.0.5").release()
@@ -80,7 +80,7 @@ public class QuarkusPlatformReferencingArchivedUpstreamVersionTest extends Multi
                 .newArchivedRelease("1.0.4")
                 .quarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4").addExtension("io.acme", "ext-e", "1.0.4")
                 .release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "1.0.4").release()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingUpstreamVersionTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/QuarkusPlatformReferencingUpstreamVersionTest.java
@@ -29,7 +29,7 @@ public class QuarkusPlatformReferencingUpstreamVersionTest extends MultiplePlatf
                 .quarkusVersion("2.2.2-downstream")
                 .upstreamQuarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4-downstream").release().stream().platform()
                 .newStream("1.0")
@@ -38,7 +38,7 @@ public class QuarkusPlatformReferencingUpstreamVersionTest extends MultiplePlatf
                 .quarkusVersion("1.1.1-downstream")
                 .upstreamQuarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4-downstream").release()
                 .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "1.0.4-downstream").release()
@@ -54,7 +54,7 @@ public class QuarkusPlatformReferencingUpstreamVersionTest extends MultiplePlatf
                 .newRelease("2.0.4")
                 .quarkusVersion("2.2.2")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "2.0.4").release()
                 .newMember("acme-e-bom").addExtension("io.acme", "ext-e", "2.0.4").release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "2.0.4").release().stream().platform()
@@ -62,7 +62,7 @@ public class QuarkusPlatformReferencingUpstreamVersionTest extends MultiplePlatf
                 .newRelease("1.0.4")
                 .quarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-foo-bom").addExtension("io.acme", "ext-a", "1.0.4").addExtension("io.acme", "ext-e", "1.0.4")
                 .release()
                 .newMember("acme-bar-bom").addExtension("io.acme", "ext-b", "1.0.4").release()

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/UpstreamStreamCoordsWithNullPlatformKeyTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/UpstreamStreamCoordsWithNullPlatformKeyTest.java
@@ -29,7 +29,7 @@ public class UpstreamStreamCoordsWithNullPlatformKeyTest extends MultiplePlatfor
                 .quarkusVersion("1.1.1-downstream")
                 .upstreamQuarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 // foo platform member
                 .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1-downstream").release()
                 .stream().platform().registry()
@@ -43,14 +43,14 @@ public class UpstreamStreamCoordsWithNullPlatformKeyTest extends MultiplePlatfor
                 .newRelease("2.0.5")
                 .quarkusVersion("2.0.5")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "2.0.5").release().stream().platform()
                 // 1.0 STREAM
                 .newStream("1.0")
                 .newRelease("1.1.1")
                 .quarkusVersion("1.1.1")
                 // default bom including quarkus-core + essential metadata
-                .addCoreMember()
+                .addCoreMember().release()
                 .newMember("acme-a-bom").addExtension("io.acme", "ext-a", "1.1.1")
                 .registry()
                 .clientBuilder()

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/ExtensionCatalogResolver.java
@@ -420,8 +420,8 @@ public class ExtensionCatalogResolver {
         int platformIndex = 0;
         for (Platform platform : pc.getPlatforms()) {
             platformIndex++;
+            int releaseIndex = 0;
             for (PlatformStream stream : platform.getStreams()) {
-                int releaseIndex = 0;
                 for (PlatformRelease release : stream.getReleases()) {
                     releaseIndex++;
                     final String quarkusVersion = release.getQuarkusCoreVersion();
@@ -775,8 +775,8 @@ public class ExtensionCatalogResolver {
             RegistryExtensionResolver registry, int platformIndex,
             Platform p) throws RegistryResolutionException {
 
+        int releaseIndex = 0;
         for (PlatformStream s : p.getStreams()) {
-            int releaseIndex = 0;
             for (PlatformRelease r : s.getReleases()) {
                 ++releaseIndex;
                 int memberIndex = 0;


### PR DESCRIPTION
The first version of the `info` and `update` commands that delegate to the corresponding commands of the target Quarkus plugin.

The test class combines both `info` and `update` just to re-use the test setup that includes mocks of a registry, platforms and maven repo, that are relatively time consuming to setup. These basic info and update tests need ~28 sec to run on my laptop.

The tests are asserting certain content is present in the output of the commands. Which isn't optimal but pretty much the only way to test it for now. We'll need to come up with a better API to represent the info and update states that could be used in tests and other tools in the future.