### PR TITLE
Use container runtime detection in @QuarkusIntegrationTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -5,13 +5,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.quarkus.runtime.annotations.ConvertWith;
 import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class NativeConfig {

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunner.java
@@ -14,8 +14,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.ProcessUtil;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public abstract class NativeImageBuildContainerRunner extends NativeImageBuildRunner {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -11,8 +11,8 @@ import java.util.List;
 import org.apache.commons.lang3.SystemUtils;
 
 import io.quarkus.deployment.pkg.NativeConfig;
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContainerRunner {
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -20,9 +20,9 @@ import io.quarkus.deployment.pkg.NativeConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.NativeImageBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.deployment.util.ProcessUtil;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class UpxCompressionBuildStep {
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/util/ContainerRuntimeUtil.java
@@ -1,4 +1,4 @@
-package io.quarkus.deployment.util;
+package io.quarkus.runtime.util;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -47,7 +47,7 @@ public final class ContainerRuntimeUtil {
                     .redirectErrorStream(true);
             versionProcess = pb.start();
             versionProcess.waitFor();
-            return new String(FileUtil.readFileContents(versionProcess.getInputStream()), StandardCharsets.UTF_8);
+            return new String(versionProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException | InterruptedException e) {
             // If an exception is thrown in the process, just return an empty String
             log.debugf(e, "Failure to read version output from %s", containerRuntime.getExecutableName());

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -72,9 +72,9 @@ import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.pkg.builditem.UpxCompressedBuildItem;
 import io.quarkus.deployment.pkg.steps.JarResultBuildStep;
 import io.quarkus.deployment.pkg.steps.NativeBuild;
-import io.quarkus.deployment.util.ContainerRuntimeUtil;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.dependency.ResolvedDependency;
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 
 public class JibProcessor {
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultDockerContainerLauncher.java
@@ -20,11 +20,10 @@ import java.util.function.Function;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
+import io.quarkus.runtime.util.ContainerRuntimeUtil;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 
 public class DefaultDockerContainerLauncher implements DockerContainerArtifactLauncher {
-
-    private static final String DOCKER_BINARY = "docker";
 
     private int httpPort;
     private int httpsPort;
@@ -41,6 +40,8 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     private boolean isSsl;
 
     private String containerName;
+
+    private String containerRuntimeBinaryName;
 
     @Override
     public void init(DockerContainerArtifactLauncher.DockerInitContext initContext) {
@@ -63,11 +64,13 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     @Override
     public void start() throws IOException {
 
+        containerRuntimeBinaryName = determineBinary();
+
         if (pullRequired) {
             System.out.println("Pulling container image '" + containerImage + "'");
             try {
                 int pullResult = new ProcessBuilder().redirectError(DISCARD).redirectOutput(DISCARD)
-                        .command(DOCKER_BINARY, "pull", containerImage).start().waitFor();
+                        .command(containerRuntimeBinaryName, "pull", containerImage).start().waitFor();
                 if (pullResult > 0) {
                     throw new RuntimeException("Pulling container image '" + containerImage + "' completed unsuccessfully");
                 }
@@ -86,7 +89,7 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         }
 
         List<String> args = new ArrayList<>();
-        args.add(DOCKER_BINARY); // TODO: determine this dynamically?
+        args.add(containerRuntimeBinaryName);
         args.add("run");
         if (!argLine.isEmpty()) {
             args.addAll(argLine);
@@ -149,6 +152,10 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
         }
     }
 
+    private String determineBinary() {
+        return ContainerRuntimeUtil.detectContainerRuntime().getExecutableName();
+    }
+
     private int getRandomPort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
@@ -180,7 +187,8 @@ public class DefaultDockerContainerLauncher implements DockerContainerArtifactLa
     @Override
     public void close() {
         try {
-            Process dockerStopProcess = new ProcessBuilder(DOCKER_BINARY, "stop", containerName).redirectError(DISCARD)
+            Process dockerStopProcess = new ProcessBuilder(containerRuntimeBinaryName, "stop", containerName)
+                    .redirectError(DISCARD)
                     .redirectOutput(DISCARD).start();
             dockerStopProcess.waitFor(10, TimeUnit.SECONDS);
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
This is done with the same code that is used during build time.
For this to work, the code that perform the detection was moved
from the build time module to the runtime module.