### PR TITLE
Allow reflective access to Jaeger DTO classes' fields

### DIFF
--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -62,6 +62,8 @@ public class JaegerProcessor {
                         "io.jaegertracing.internal.samplers.http.ProbabilisticSamplingStrategy",
                         "io.jaegertracing.internal.samplers.http.RateLimitingSamplingStrategy",
                         "io.jaegertracing.internal.samplers.http.SamplingStrategyResponse")
-                .finalFieldsWritable(true).build();
+                .fields(true)
+                .finalFieldsWritable(true)
+                .build();
     }
 }


### PR DESCRIPTION
The Jaeger client uses GSON to unmarshall JSON messages containing
sampling configuration to Java objects. GSON uses reflection on the DTO
object to determine fields that match the properties in the JSON object.

By default, the ReflectiveClassBuildItem does not allow access to a
class' fields via reflection so the error described in #10402 still occurs.
This PR explicitly enables it and should thus (finally) fix #10402.