### PR TITLE
Qute standalone - list element can be accessed directly via an index

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1613,7 +1613,7 @@ TIP: A map value can be also accessed directly: `{map.myKey}`. Use the bracket n
 * `takeLast`: Returns the last `n` elements from the given list; throws an `IndexOutOfBoundsException` if `n` is out of range
 ** `{#for r in recordsList.takeLast(3)}`
 
-TIP: A list element can be accessed directly: `{list.10}` or `{list[10]}`.
+TIP: A list element can be accessed directly via an index: `{list.10}` or even `{list[10]}`.
 
 ===== Numbers
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ListResolverTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ListResolverTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.qute;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ListResolverTest {
+
+    @Test
+    public void tesResolver() {
+        List<String> list = List.of("jedna", "dva", "tri");
+        Engine engine = Engine.builder().addDefaults().build();
+        assertEquals("3::jedna::jedna::dva::tri",
+                engine.parse("{list.size}::{list.get(0)}::{list.take(1).0}::{list.takeLast(2).get(0)}::{list.2}")
+                        .data("list", list).render());
+        assertThatExceptionOfType(TemplateException.class)
+                .isThrownBy(() -> engine.parse("{list.abc}").data("list", List.of()).render())
+                .withMessageContaining(
+                        "Property \"abc\" not found on the base object")
+                .withMessageContaining("in expression {list.abc}");
+    }
+
+}


### PR DESCRIPTION
- such as {list.10}
- this is already supported in quarkus