### PR TITLE
Make sure correct runtime configuration is resolved before running quarkusGenerateCode

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -198,9 +198,25 @@ public class QuarkusPlugin implements Plugin<Project> {
                     TaskProvider<Task> testClassesTask = tasks.named(JavaPlugin.TEST_CLASSES_TASK_NAME);
                     TaskProvider<Task> testResourcesTask = tasks.named(JavaPlugin.PROCESS_TEST_RESOURCES_TASK_NAME);
 
-                    quarkusGenerateCode.configure(task -> task.dependsOn(resourcesTask));
-                    quarkusGenerateCodeDev.configure(task -> task.dependsOn(resourcesTask));
-                    quarkusGenerateCodeTests.configure(task -> task.dependsOn(resourcesTask));
+                    quarkusGenerateCode.configure(task -> {
+                        task.dependsOn(resourcesTask);
+                        task.setCompileClasspath(
+                                project.getConfigurations().getByName(
+                                        ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(LaunchMode.NORMAL)));
+                    });
+                    quarkusGenerateCodeDev.configure(task -> {
+                        task.dependsOn(resourcesTask);
+                        task.setCompileClasspath(
+                                project.getConfigurations().getByName(
+                                        ApplicationDeploymentClasspathBuilder
+                                                .getBaseRuntimeConfigName(LaunchMode.DEVELOPMENT)));
+                    });
+                    quarkusGenerateCodeTests.configure(task -> {
+                        task.dependsOn(resourcesTask);
+                        task.setCompileClasspath(
+                                project.getConfigurations().getByName(
+                                        ApplicationDeploymentClasspathBuilder.getBaseRuntimeConfigName(LaunchMode.TEST)));
+                    });
 
                     quarkusDev.configure(task -> {
                         task.dependsOn(classesTask, resourcesTask, testClassesTask, testResourcesTask,

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.InputFiles;
@@ -42,6 +42,7 @@ public class QuarkusGenerateCode extends QuarkusTask {
 
     public static final String INIT_AND_RUN = "initAndRun";
     private Set<Path> sourcesDirectories;
+    private Configuration compileClasspath;
     private Consumer<Path> sourceRegistrar = (p) -> {
     };
     private boolean test = false;
@@ -57,8 +58,12 @@ public class QuarkusGenerateCode extends QuarkusTask {
      * @return resolved compile classpath
      */
     @CompileClasspath
-    public FileCollection getClasspath() {
-        return QuarkusGradleUtils.getSourceSet(getProject(), SourceSet.MAIN_SOURCE_SET_NAME).getCompileClasspath();
+    public Configuration getClasspath() {
+        return compileClasspath;
+    }
+
+    public void setCompileClasspath(Configuration compileClasspath) {
+        this.compileClasspath = compileClasspath;
     }
 
     @InputFiles


### PR DESCRIPTION
This makes sure the correct runtime configuration is resolved before the task is run. 

close #24260 