### PR TITLE
Unlist links modules

### DIFF
--- a/extensions/resteasy-classic/resteasy-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-classic/resteasy-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,6 +11,7 @@ metadata:
   - "web"
   - "serialization"
   status: "stable"
+  unlisted: true
   codestart:
     name: "resteasy"
     languages:

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,7 @@ metadata:
     - "web"
     - "reactive"
   status: "stable"
+  unlisted: true
   codestart:
     name: "resteasy-reactive"
     kind: "core"


### PR DESCRIPTION
We don't have any guide or quickstart for using links,
we only use these extensions as the REST Data modules