### PR TITLE
Register Protobuf enums in the native executable

### DIFF
--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcCommonProcessor.java
@@ -25,6 +25,14 @@ public class GrpcCommonProcessor {
         for (ClassInfo message : messages) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, message.name().toString()));
         }
+
+        // We also need to include enums.
+        Collection<ClassInfo> enums = combinedIndex.getIndex()
+                .getAllKnownSubclasses(GrpcDotNames.PROTOCOL_MESSAGE_ENUM);
+        for (ClassInfo en : enums) {
+            reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, en.name().toString()));
+        }
+
         Collection<ClassInfo> builders = combinedIndex.getIndex().getAllKnownSubclasses(GrpcDotNames.MESSAGE_BUILDER);
         for (ClassInfo builder : builders) {
             reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, true, builder.name().toString()));

--- a/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
+++ b/extensions/grpc-common/deployment/src/main/java/io/quarkus/grpc/common/deployment/GrpcDotNames.java
@@ -3,6 +3,7 @@ package io.quarkus.grpc.common.deployment;
 import org.jboss.jandex.DotName;
 
 import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.ProtocolMessageEnum;
 
 import io.grpc.LoadBalancerProvider;
 import io.grpc.NameResolverProvider;
@@ -10,6 +11,7 @@ import io.grpc.NameResolverProvider;
 public class GrpcDotNames {
     static final DotName MESSAGE_BUILDER = DotName.createSimple(GeneratedMessageV3.Builder.class.getName());
     static final DotName GENERATED_MESSAGE_V3 = DotName.createSimple(GeneratedMessageV3.class.getName());
+    static final DotName PROTOCOL_MESSAGE_ENUM = DotName.createSimple(ProtocolMessageEnum.class.getName());
     static final DotName NAME_RESOLVER_PROVIDER = DotName.createSimple(NameResolverProvider.class.getName());
     static final DotName LOAD_BALANCER_PROVIDER = DotName.createSimple(LoadBalancerProvider.class.getName());
 }

--- a/integration-tests/grpc-plain-text-mutiny/pom.xml
+++ b/integration-tests/grpc-plain-text-mutiny/pom.xml
@@ -16,11 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-mutiny</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -67,20 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
       <version>${project.version}</version>
       <type>pom</type>
       <scope>test</scope>

--- a/integration-tests/grpc-plain-text-mutiny/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
+++ b/integration-tests/grpc-plain-text-mutiny/src/main/java/io/quarkus/grpc/examples/hello/HelloWorldService.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import examples.HelloReply;
 import examples.HelloRequest;
+import examples.LanguageSpec;
 import examples.MutinyGreeterGrpc;
 import io.quarkus.grpc.GrpcService;
 import io.quarkus.grpc.RegisterInterceptor;
@@ -21,5 +22,28 @@ public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
         String name = request.getName();
         return Uni.createFrom().item("Hello " + name)
                 .map(res -> HelloReply.newBuilder().setMessage(res).setCount(count).build());
+    }
+
+    @Override
+    public Uni<HelloReply> greeting(LanguageSpec request) {
+        return Uni.createFrom().item(() -> {
+            String res = null;
+            switch (request.getSelectedLanguage()) {
+                case FRENCH:
+                    res = "Bonjour!";
+                    break;
+                case SPANISH:
+                    res = "Hola!";
+                    break;
+                case ENGLISH:
+                    res = "Hello!";
+                    break;
+                case UNRECOGNIZED:
+                    res = "Blurp!";
+                    break;
+            }
+            return res;
+        })
+                .map(res -> HelloReply.newBuilder().setMessage(res).build());
     }
 }

--- a/integration-tests/grpc-plain-text-mutiny/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-plain-text-mutiny/src/main/proto/helloworld.proto
@@ -40,6 +40,9 @@ package helloworld;
 service Greeter {
     // Sends a greeting
     rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+    rpc Greeting (LanguageSpec) returns (HelloReply) {}
+
 }
 
 // The request message containing the user's name.
@@ -51,4 +54,13 @@ message HelloRequest {
 message HelloReply {
     string message = 1;
     int32 count = 2;
+}
+
+message LanguageSpec {
+    enum Language {
+        ENGLISH = 0;
+        FRENCH = 1;
+        SPANISH = 2;
+    };
+    Language selected_language = 1;
 }

--- a/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
+++ b/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/HelloWorldServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import examples.GreeterGrpc;
 import examples.HelloReply;
 import examples.HelloRequest;
+import examples.LanguageSpec;
 import examples.MutinyGreeterGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -47,6 +48,20 @@ class HelloWorldServiceTest {
                 .sayHello(HelloRequest.newBuilder().setName("neo-mutiny").build())
                 .await().atMost(Duration.ofSeconds(5));
         assertThat(reply.getMessage()).isEqualTo("Hello neo-mutiny");
+    }
+
+    @Test
+    public void testEnumSupport() {
+        GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
+        HelloReply reply = client
+                .greeting(LanguageSpec.newBuilder().setSelectedLanguage(LanguageSpec.Language.FRENCH).build());
+        assertThat(reply.getMessage()).isEqualTo("Bonjour!");
+        reply = client
+                .greeting(LanguageSpec.newBuilder().setSelectedLanguage(LanguageSpec.Language.SPANISH).build());
+        assertThat(reply.getMessage()).isEqualTo("Hola!");
+        reply = client
+                .greeting(LanguageSpec.newBuilder().setSelectedLanguage(LanguageSpec.Language.ENGLISH).build());
+        assertThat(reply.getMessage()).isEqualTo("Hello!");
     }
 
 }


### PR DESCRIPTION
Protobuf enums generate enum classes.
Fortunately, we can locate them with Jandex using the ProtocolMessageEnum interface, as the generated enums implement this interface.

Fix https://github.com/quarkusio/quarkus/issues/24510.
