### PR TITLE
Guard `BasicLoggingEnabler` for concurrent test execution via `synchronized`

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/BasicLoggingEnabler.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/BasicLoggingEnabler.java
@@ -48,7 +48,7 @@ public class BasicLoggingEnabler implements BeforeAllCallback {
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public synchronized void beforeAll(ExtensionContext context) {
         if (enabled == null) {
             enabled = context.getConfigurationParameter(CFGKEY_ENABLED).map(Boolean::valueOf).orElse(Boolean.TRUE);
         }


### PR DESCRIPTION
Fixes #24524

Explanation of why I didn't do it more fine-grained can be found here: https://github.com/quarkusio/quarkus/issues/24524#issuecomment-1078519116