### PR TITLE
Support compression for reactive routes and resteasy reactive

### DIFF
--- a/docs/src/main/asciidoc/reactive-routes.adoc
+++ b/docs/src/main/asciidoc/reactive-routes.adoc
@@ -682,6 +682,26 @@ public class MyFilters {
 <1> The `RouteFilter#value()` defines the priority used to sort the filters - filters with higher priority are called first.
 <2> The filter is likely required to call the `next()` method to continue the chain.
 
+== HTTP Compression
+
+The body of an HTTP response is not compressed by default.
+You can enable the HTTP compression support by means of `quarkus.http.enable-compression=true`.
+
+If compression support is enabled then the response body is compressed if:
+
+- the route method is annotated with `@io.quarkus.vertx.http.Compressed`, or
+- the `Content-Type` header is set and the value is a compressed media type as configured via `quarkus.http.compress-media-types`.
+
+The response body is never compressed if:
+
+- the route method is annotated with `@io.quarkus.vertx.http.Uncompressed`, or
+- the `Content-Type` header is not set.
+
+TIP: By default, the following list of media types is compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript` and `application/javascript`.
+
+NOTE: If the client does not support HTTP compression then the response body is not compressed.
+
+
 == Adding OpenAPI and Swagger UI
 
 You can add support for link:https://www.openapis.org/[OpenAPI] and link:https://swagger.io/tools/swagger-ui/[Swagger UI] by using the `quarkus-smallrye-openapi` extension.

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -2177,6 +2177,26 @@ Or plain text:
 < {"name":"roquefort"} 
 ----
 
+=== HTTP Compression
+
+The body of an HTTP response is not compressed by default.
+You can enable the HTTP compression support by means of `quarkus.http.enable-compression=true`.
+
+If compression support is enabled then the response body is compressed if:
+
+- the resource method is annotated with `@io.quarkus.vertx.http.Compressed`, or
+- the `Content-Type` header is set and the value is a compressed media type as configured via `quarkus.http.compress-media-types`.
+
+The response body is never compressed if:
+
+- the resource method is annotated with `@io.quarkus.vertx.http.Uncompressed`, or
+- the `Content-Type` header is not set.
+
+TIP: By default, the following list of media types is compressed: `text/html`, `text/plain`, `text/xml`, `text/css`, `text/javascript` and `application/javascript`.
+
+NOTE: If the client does not support HTTP compression then the response body is not compressed.
+
+
 == Include/Exclude JAX-RS classes with build time conditions
 
 Quarkus enables the inclusion or exclusion of JAX-RS Resources, Providers and Features directly thanks to build time conditions in the same that it does for CDI beans.

--- a/docs/src/main/asciidoc/resteasy.adoc
+++ b/docs/src/main/asciidoc/resteasy.adoc
@@ -615,8 +615,7 @@ This configuration option would recognize strings in this format (shown as a reg
 
 Once GZip support has been enabled you can use it on an endpoint by adding the `@org.jboss.resteasy.annotations.GZIP` annotation to your endpoint method.
 
-If you want to compress everything then we recommended that you use the `quarkus.http.enable-compression=true` setting instead to globally enable
-compression support.
+NOTE: The configuration property `quarkus.http.enable-compression` has no effect on compression support of RESTEasy Classic endpoints.
 
 == Multipart Support
 

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/AnnotatedRouteHandlerBuildItem.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/AnnotatedRouteHandlerBuildItem.java
@@ -7,6 +7,7 @@ import org.jboss.jandex.MethodInfo;
 
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.vertx.http.runtime.HttpCompression;
 
 public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
 
@@ -14,13 +15,23 @@ public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
     private final List<AnnotationInstance> routes;
     private final AnnotationInstance routeBase;
     private final MethodInfo method;
+    private final boolean blocking;
+    private final HttpCompression compression;
 
     public AnnotatedRouteHandlerBuildItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> routes,
             AnnotationInstance routeBase) {
+        this(bean, method, routes, routeBase, false, HttpCompression.UNDEFINED);
+    }
+
+    public AnnotatedRouteHandlerBuildItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> routes,
+            AnnotationInstance routeBase, boolean blocking, HttpCompression compression) {
+        super();
         this.bean = bean;
-        this.method = method;
         this.routes = routes;
         this.routeBase = routeBase;
+        this.method = method;
+        this.blocking = blocking;
+        this.compression = compression;
     }
 
     public BeanInfo getBean() {
@@ -37,6 +48,14 @@ public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
 
     public AnnotationInstance getRouteBase() {
         return routeBase;
+    }
+
+    public boolean isBlocking() {
+        return blocking;
+    }
+
+    public HttpCompression getCompression() {
+        return compression;
     }
 
 }

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/DotNames.java
@@ -5,6 +5,8 @@ import java.util.concurrent.CompletionStage;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
 import io.quarkus.vertx.web.Body;
 import io.quarkus.vertx.web.Header;
 import io.quarkus.vertx.web.Param;
@@ -50,5 +52,7 @@ final class DotNames {
     static final DotName THROWABLE = DotName.createSimple(Throwable.class.getName());
     static final DotName BLOCKING = DotName.createSimple(Blocking.class.getName());
     static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
+    static final DotName COMPRESSED = DotName.createSimple(Compressed.class.getName());
+    static final DotName UNCOMPRESSED = DotName.createSimple(Uncompressed.class.getName());
 
 }

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -9,6 +9,7 @@ import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,6 +102,7 @@ import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.NotFoundPageDisplayableEndpointBuildItem;
 import io.quarkus.vertx.http.deployment.devmode.RouteDescriptionBuildItem;
 import io.quarkus.vertx.http.runtime.HandlerType;
+import io.quarkus.vertx.http.runtime.HttpCompression;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.Route.HttpMethod;
@@ -145,12 +147,12 @@ class ReactiveRoutesProcessor {
     @BuildStep
     void unremovableBeans(BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
         unremovableBeans
-                .produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE));
+                .produce(UnremovableBeanBuildItem.beanClassAnnotation(DotNames.ROUTE));
         unremovableBeans
-                .produce(UnremovableBeanBuildItem.beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTES));
+                .produce(UnremovableBeanBuildItem.beanClassAnnotation(DotNames.ROUTES));
         unremovableBeans
                 .produce(UnremovableBeanBuildItem
-                        .beanClassAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE_FILTER));
+                        .beanClassAnnotation(DotNames.ROUTE_FILTER));
     }
 
     @BuildStep
@@ -168,18 +170,22 @@ class ReactiveRoutesProcessor {
             // NOTE: inherited business methods are not taken into account
             ClassInfo beanClass = bean.getTarget().get().asClass();
             AnnotationInstance routeBaseAnnotation = beanClass
-                    .classAnnotation(io.quarkus.vertx.web.deployment.DotNames.ROUTE_BASE);
+                    .classAnnotation(DotNames.ROUTE_BASE);
             for (MethodInfo method : beanClass.methods()) {
+                if (method.isSynthetic() || Modifier.isStatic(method.flags()) || method.name().equals("<init>")) {
+                    continue;
+                }
+
                 List<AnnotationInstance> routes = new LinkedList<>();
                 AnnotationInstance routeAnnotation = annotationStore.getAnnotation(method,
-                        io.quarkus.vertx.web.deployment.DotNames.ROUTE);
+                        DotNames.ROUTE);
                 if (routeAnnotation != null) {
                     validateRouteMethod(bean, method, transformedAnnotations, beanArchive.getIndex(), routeAnnotation);
                     routes.add(routeAnnotation);
                 }
                 if (routes.isEmpty()) {
                     AnnotationInstance routesAnnotation = annotationStore.getAnnotation(method,
-                            io.quarkus.vertx.web.deployment.DotNames.ROUTES);
+                            DotNames.ROUTES);
                     if (routesAnnotation != null) {
                         for (AnnotationInstance annotation : routesAnnotation.value().asNestedArray()) {
                             validateRouteMethod(bean, method, transformedAnnotations, beanArchive.getIndex(), annotation);
@@ -187,14 +193,31 @@ class ReactiveRoutesProcessor {
                         }
                     }
                 }
+
                 if (!routes.isEmpty()) {
                     LOGGER.debugf("Found route handler business method %s declared on %s", method, bean);
+
+                    HttpCompression compression = HttpCompression.UNDEFINED;
+                    if (annotationStore.hasAnnotation(method, DotNames.COMPRESSED)) {
+                        compression = HttpCompression.ON;
+                    }
+                    if (annotationStore.hasAnnotation(method, DotNames.UNCOMPRESSED)) {
+                        if (compression == HttpCompression.ON) {
+                            errors.produce(new ValidationErrorBuildItem(new IllegalStateException(
+                                    String.format(
+                                            "@Compressed and @Uncompressed cannot be both declared on business method %s declared on %s",
+                                            method, bean))));
+                        } else {
+                            compression = HttpCompression.OFF;
+                        }
+                    }
                     routeHandlerBusinessMethods
-                            .produce(new AnnotatedRouteHandlerBuildItem(bean, method, routes, routeBaseAnnotation));
+                            .produce(new AnnotatedRouteHandlerBuildItem(bean, method, routes, routeBaseAnnotation,
+                                    annotationStore.hasAnnotation(method, DotNames.BLOCKING), compression));
                 }
                 //
                 AnnotationInstance filterAnnotation = annotationStore.getAnnotation(method,
-                        io.quarkus.vertx.web.deployment.DotNames.ROUTE_FILTER);
+                        DotNames.ROUTE_FILTER);
                 if (filterAnnotation != null) {
                     if (!routes.isEmpty()) {
                         errors.produce(new ValidationErrorBuildItem(new IllegalStateException(
@@ -367,7 +390,7 @@ class ReactiveRoutesProcessor {
                     }
                 }
 
-                if (businessMethod.getMethod().annotation(DotNames.BLOCKING) != null) {
+                if (businessMethod.isBlocking()) {
                     if (handlerType == HandlerType.NORMAL) {
                         handlerType = HandlerType.BLOCKING;
                     } else if (handlerType == HandlerType.FAILURE) {
@@ -388,6 +411,10 @@ class ReactiveRoutesProcessor {
                     routeHandler = recorder.createHandler(handlerClass);
                     routeHandlers.put(routeString, routeHandler);
                 }
+
+                // Wrap the route handler if necessary
+                // Note that route annotations with the same values share a single handler implementation
+                routeHandler = recorder.compressRouteHandler(routeHandler, businessMethod.getCompression());
 
                 RouteMatcher matcher = new RouteMatcher(path, regex, produces, consumes, methods, order);
                 matchers.put(matcher, businessMethod.getMethod());
@@ -453,9 +480,9 @@ class ReactiveRoutesProcessor {
     @BuildStep
     AutoAddScopeBuildItem autoAddScope() {
         return AutoAddScopeBuildItem.builder()
-                .containsAnnotations(io.quarkus.vertx.web.deployment.DotNames.ROUTE,
-                        io.quarkus.vertx.web.deployment.DotNames.ROUTES,
-                        io.quarkus.vertx.web.deployment.DotNames.ROUTE_FILTER)
+                .containsAnnotations(DotNames.ROUTE,
+                        DotNames.ROUTES,
+                        DotNames.ROUTE_FILTER)
                 .defaultScope(BuiltinScope.SINGLETON)
                 .reason("Found route handler business methods").build();
     }
@@ -467,10 +494,10 @@ class ReactiveRoutesProcessor {
         }
         List<Type> params = method.parameters();
         if (params.size() != 1 || !params.get(0).name()
-                .equals(io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT)) {
+                .equals(DotNames.ROUTING_CONTEXT)) {
             throw new IllegalStateException(String.format(
                     "Route filter method must accept exactly one parameter of type %s: %s [method: %s, bean: %s]",
-                    io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT, params, method, bean));
+                    DotNames.ROUTING_CONTEXT, params, method, bean));
         }
     }
 
@@ -1252,7 +1279,7 @@ class ReactiveRoutesProcessor {
         List<ParameterInjector> injectors = new ArrayList<>();
 
         injectors.add(
-                ParameterInjector.builder().canEndResponse().matchType(io.quarkus.vertx.web.deployment.DotNames.ROUTING_CONTEXT)
+                ParameterInjector.builder().canEndResponse().matchType(DotNames.ROUTING_CONTEXT)
                         .resultHandleProvider(new ResultHandleProvider() {
                             @Override
                             public ResultHandle get(MethodInfo method, Type paramType, Set<AnnotationInstance> annotations,

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/compress/CompressionTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/compress/CompressionTest.java
@@ -1,0 +1,109 @@
+package io.quarkus.vertx.web.compress;
+
+import static io.restassured.RestAssured.get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
+import io.quarkus.vertx.web.Route;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.vertx.ext.web.RoutingContext;
+
+public class CompressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(MyRoutes.class)
+                    .addAsManifestResource(new StringAsset(MyRoutes.MESSAGE), "resources/file.txt")
+                    .addAsManifestResource(new StringAsset(MyRoutes.MESSAGE), "resources/my.doc"))
+            .overrideConfigKey("quarkus.http.enable-compression", "true");
+
+    @Test
+    public void testRoutes() {
+        assertCompressed("/compressed");
+        assertUncompressed("/uncompressed");
+        assertCompressed("/compressed-content-type");
+        assertUncompressed("/uncompressed-content-type");
+        assertCompressed("/content-type-implicitly-compressed");
+        assertCompressed("/content-type-with-param-implicitly-compressed");
+        assertUncompressed("/content-type-implicitly-uncompressed");
+        assertCompressed("/compression-disabled-manually");
+        assertCompressed("/file.txt");
+        assertUncompressed("/my.doc");
+    }
+
+    private void assertCompressed(String path) {
+        String bodyStr = get(path).then().statusCode(200).header("Content-Encoding", "gzip").extract().asString();
+        assertEquals("Hello compression!", bodyStr);
+    }
+
+    private void assertUncompressed(String path) {
+        ExtractableResponse<Response> response = get(path)
+                .then().statusCode(200).extract();
+        assertTrue(response.header("Content-Encoding") == null, response.headers().toString());
+        assertEquals(MyRoutes.MESSAGE, response.asString());
+    }
+
+    @ApplicationScoped
+    public static class MyRoutes {
+
+        static String MESSAGE = "Hello compression!";
+
+        @Compressed
+        @Route
+        String compressed() {
+            return MESSAGE;
+        }
+
+        @Uncompressed
+        @Route
+        String uncompressed() {
+            return MESSAGE;
+        }
+
+        @Uncompressed
+        @Route
+        void uncompressedContentType(RoutingContext context) {
+            context.response().setStatusCode(200).putHeader("Content-type", "text/plain").end(MESSAGE);
+        }
+
+        @Compressed
+        @Route
+        void compressedContentType(RoutingContext context) {
+            context.response().setStatusCode(200).putHeader("Content-type", "foo/bar").end(MESSAGE);
+        }
+
+        @Route
+        void contentTypeImplicitlyCompressed(RoutingContext context) {
+            context.response().setStatusCode(200).putHeader("Content-type", "text/plain").end(MESSAGE);
+        }
+
+        @Route
+        void contentTypeWithParamImplicitlyCompressed(RoutingContext context) {
+            context.response().setStatusCode(200).putHeader("Content-type", "text/plain;charset=UTF-8").end(MESSAGE);
+        }
+
+        @Route
+        void contentTypeImplicitlyUncompressed(RoutingContext context) {
+            context.response().setStatusCode(200).putHeader("Content-type", "foo/bar").end(MESSAGE);
+        }
+
+        @Route
+        void compressionDisabledManually(RoutingContext context) {
+            context.response().headers().remove("Content-Encoding");
+            context.response().setStatusCode(200).putHeader("Content-type", "text/plain").end(MESSAGE);
+        }
+
+    }
+
+}

--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/HttpCompressionHandler.java
@@ -1,0 +1,60 @@
+package io.quarkus.vertx.web.runtime;
+
+import java.util.Set;
+
+import io.quarkus.vertx.http.runtime.HttpCompression;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+public class HttpCompressionHandler implements Handler<RoutingContext> {
+
+    private final Handler<RoutingContext> routeHandler;
+    private final HttpCompression compression;
+    private final Set<String> compressedMediaTypes;
+
+    public HttpCompressionHandler(Handler<RoutingContext> routeHandler, HttpCompression compression,
+            Set<String> compressedMediaTypes) {
+        this.routeHandler = routeHandler;
+        this.compression = compression;
+        this.compressedMediaTypes = compressedMediaTypes;
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        context.addEndHandler(new Handler<AsyncResult<Void>>() {
+            @Override
+            public void handle(AsyncResult<Void> result) {
+                if (result.succeeded()) {
+                    MultiMap headers = context.response().headers();
+                    String contentEncoding = headers.get(HttpHeaders.CONTENT_ENCODING);
+                    if (contentEncoding != null && HttpHeaders.IDENTITY.toString().equals(contentEncoding)) {
+                        switch (compression) {
+                            case ON:
+                                headers.remove(HttpHeaders.CONTENT_ENCODING);
+                                break;
+                            case UNDEFINED:
+                                String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
+                                int paramIndex = contentType.indexOf(';');
+                                if (paramIndex > -1) {
+                                    contentType = contentType.substring(0, paramIndex);
+                                }
+                                if (contentType != null
+                                        && compressedMediaTypes.contains(contentType)) {
+                                    headers.remove(HttpHeaders.CONTENT_ENCODING);
+                                }
+                                break;
+                            default:
+                                // OFF - no action is needed because the "Content-Encoding: identity" header is set
+                                break;
+                        }
+                    }
+                }
+            }
+        });
+        routeHandler.handle(context);
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -417,6 +417,12 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     }
 
     @Override
+    public void removeResponseHeader(String name) {
+        // Servlet API does not support this functionality
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean closed() {
         return context.response().closed();
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/CompressionScanner.java
@@ -1,0 +1,52 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.resteasy.reactive.common.processor.EndpointIndexer;
+import org.jboss.resteasy.reactive.common.processor.transformation.AnnotationStore;
+import org.jboss.resteasy.reactive.server.model.FixedHandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.model.HandlerChainCustomizer;
+import org.jboss.resteasy.reactive.server.processor.scanning.MethodScanner;
+
+import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveCompressionHandler;
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
+import io.quarkus.vertx.http.runtime.HttpCompression;
+
+public class CompressionScanner implements MethodScanner {
+
+    static final DotName COMPRESSED = DotName.createSimple(Compressed.class.getName());
+    static final DotName UNCOMPRESSED = DotName.createSimple(Uncompressed.class.getName());
+
+    @Override
+    public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
+            Map<String, Object> methodContext) {
+        AnnotationStore annotationStore = (AnnotationStore) methodContext.get(EndpointIndexer.METHOD_CONTEXT_ANNOTATION_STORE);
+        HttpCompression compression = HttpCompression.UNDEFINED;
+        if (annotationStore.hasAnnotation(method, COMPRESSED)) {
+            compression = HttpCompression.ON;
+        }
+        if (annotationStore.hasAnnotation(method, UNCOMPRESSED)) {
+            if (compression == HttpCompression.ON) {
+                throw new IllegalStateException(
+                        String.format(
+                                "@Compressed and @Uncompressed cannot be both declared on resource method %s declared on %s",
+                                method, actualEndpointClass));
+            } else {
+                compression = HttpCompression.OFF;
+            }
+        }
+        if (compression == HttpCompression.OFF) {
+            // No action is needed because the "Content-Encoding: identity" header is set for every request if compression is enabled
+            return List.of();
+        }
+        ResteasyReactiveCompressionHandler handler = new ResteasyReactiveCompressionHandler();
+        handler.setCompression(compression);
+        return List.of(new FixedHandlerChainCustomizer(handler, HandlerChainCustomizer.Phase.AFTER_RESPONSE_CREATED));
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -90,6 +90,11 @@ public class ResteasyReactiveScanningProcessor {
     }
 
     @BuildStep
+    public MethodScannerBuildItem compressionSupport() {
+        return new MethodScannerBuildItem(new CompressionScanner());
+    }
+
+    @BuildStep
     public ResourceInterceptorsContributorBuildItem scanForInterceptors(CombinedIndexBuildItem combinedIndexBuildItem,
             ApplicationResultBuildItem applicationResultBuildItem) {
         return new ResourceInterceptorsContributorBuildItem(new Consumer<ResourceInterceptors>() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/compress/CompressionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/compress/CompressionTest.java
@@ -1,0 +1,110 @@
+package io.quarkus.resteasy.reactive.server.test.compress;
+
+import static io.restassured.RestAssured.get;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class CompressionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(MyEndpoint.class)
+                    .addAsManifestResource(new StringAsset(MyEndpoint.MESSAGE), "resources/file.txt")
+                    .addAsManifestResource(new StringAsset(MyEndpoint.MESSAGE), "resources/my.doc"))
+            .overrideConfigKey("quarkus.http.enable-compression", "true");
+
+    @Test
+    public void testEndpoint() {
+        assertCompressed("/endpoint/compressed");
+        assertUncompressed("/endpoint/uncompressed");
+        assertCompressed("/endpoint/compressed-content-type");
+        assertUncompressed("/endpoint/uncompressed-content-type");
+        assertCompressed("/endpoint/content-type-implicitly-compressed");
+        assertCompressed("/endpoint/content-type-with-param-implicitly-compressed");
+        assertUncompressed("/endpoint/content-type-implicitly-uncompressed");
+
+        assertCompressed("/file.txt");
+        assertUncompressed("/my.doc");
+    }
+
+    private void assertCompressed(String path) {
+        String bodyStr = get(path).then().statusCode(200).header("Content-Encoding", "gzip").extract().asString();
+        assertEquals(MyEndpoint.MESSAGE, bodyStr);
+    }
+
+    private void assertUncompressed(String path) {
+        ExtractableResponse<Response> response = get(path)
+                .then().statusCode(200).extract();
+        assertTrue(response.header("Content-Encoding") == null, response.headers().toString());
+        assertEquals(MyEndpoint.MESSAGE, response.asString());
+    }
+
+    @Path("endpoint")
+    public static class MyEndpoint {
+
+        static String MESSAGE = "Hello compression!";
+
+        @Compressed
+        @GET
+        @Path("compressed")
+        public String compressed() {
+            return MESSAGE;
+        }
+
+        @Uncompressed
+        @GET
+        @Path("uncompressed")
+        public String uncompressed() {
+            return MESSAGE;
+        }
+
+        @Uncompressed
+        @GET
+        @Path("uncompressed-content-type")
+        public RestResponse<Object> uncompressedContentType() {
+            return RestResponse.ResponseBuilder.ok().entity(MESSAGE).header("Content-type", "text/plain").build();
+        }
+
+        @Compressed
+        @GET
+        @Path("compressed-content-type")
+        public RestResponse<Object> compressedContentType() {
+            return RestResponse.ResponseBuilder.ok().entity(MESSAGE).header("Content-type", "foo/bar").build();
+        }
+
+        @GET
+        @Path("content-type-implicitly-compressed")
+        public RestResponse<Object> contentTypeImplicitlyCompressed() {
+            return RestResponse.ResponseBuilder.ok().entity(MESSAGE).header("Content-type", "text/plain").build();
+        }
+
+        @GET
+        @Path("content-type-with-param-implicitly-compressed")
+        public RestResponse<Object> contentTypeWithParamImplicitlyCompressed() {
+            return RestResponse.ResponseBuilder.ok().entity(MESSAGE).header("Content-type", "text/plain;charset=UTF-8").build();
+        }
+
+        @GET
+        @Path("content-type-implicitly-uncompressed")
+        public RestResponse<Object> contentTypeImplicitlyUncompressed() {
+            return RestResponse.ResponseBuilder.ok().entity(MESSAGE).header("Content-type", "foo/bar").build();
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveCompressionHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveCompressionHandler.java
@@ -1,0 +1,63 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import java.util.Set;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfigurableServerRestHandler;
+import org.jboss.resteasy.reactive.server.spi.RuntimeConfiguration;
+import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+
+import io.quarkus.vertx.http.runtime.HttpCompression;
+
+public class ResteasyReactiveCompressionHandler implements ServerRestHandler, RuntimeConfigurableServerRestHandler {
+
+    private HttpCompression compression;
+    private volatile boolean enableCompression;
+    private volatile Set<String> compressMediaTypes;
+
+    public ResteasyReactiveCompressionHandler() {
+    }
+
+    public HttpCompression getCompression() {
+        return compression;
+    }
+
+    public void setCompression(HttpCompression compression) {
+        this.compression = compression;
+    }
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
+        if (enableCompression) {
+            ServerHttpResponse response = requestContext.serverResponse();
+            String contentEncoding = response.getResponseHeader(HttpHeaders.CONTENT_ENCODING);
+            if (contentEncoding != null && io.vertx.core.http.HttpHeaders.IDENTITY.toString().equals(contentEncoding)) {
+                switch (compression) {
+                    case ON:
+                        response.removeResponseHeader(HttpHeaders.CONTENT_ENCODING);
+                        break;
+                    case UNDEFINED:
+                        MediaType contentType = requestContext.getResponseContentType().getMediaType();
+                        if (contentType != null
+                                && compressMediaTypes.contains(contentType.getType() + '/' + contentType.getSubtype())) {
+                            response.removeResponseHeader(HttpHeaders.CONTENT_ENCODING);
+                        }
+                        break;
+                    default:
+                        // OFF - no action is needed because the "Content-Encoding: identity" header is set
+                        break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void configure(RuntimeConfiguration configuration) {
+        enableCompression = configuration.enableCompression();
+        compressMediaTypes = configuration.compressMediaTypes();
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRuntimeRecorder.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.reactive.server.runtime;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.spi.DefaultRuntimeConfiguration;
@@ -33,7 +34,8 @@ public class ResteasyReactiveRuntimeRecorder {
         RuntimeConfiguration runtimeConfiguration = new DefaultRuntimeConfiguration(httpConf.readTimeout,
                 httpConf.body.deleteUploadedFilesOnEnd, httpConf.body.uploadsDirectory,
                 runtimeConf.multipart.inputPart.defaultCharset, maxBodySize,
-                httpConf.limits.maxFormAttributeSize.asLongValue());
+                httpConf.limits.maxFormAttributeSize.asLongValue(), httpConf.enableCompression,
+                Set.copyOf(httpConf.compressMediaTypes.orElse(List.of())));
 
         List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers = deployment.getValue()
                 .getRuntimeConfigurableServerRestHandlers();

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/StaticResourcesProcessor.java
@@ -30,6 +30,7 @@ import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
+import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.StaticResourcesRecorder;
 
 /**
@@ -123,9 +124,8 @@ public class StaticResourcesProcessor {
     @BuildStep
     @Record(RUNTIME_INIT)
     public void runtimeInit(Optional<io.quarkus.vertx.http.deployment.spi.StaticResourcesBuildItem> staticResources,
-            StaticResourcesRecorder recorder,
-            CoreVertxBuildItem vertx, BeanContainerBuildItem beanContainer,
-            BuildProducer<DefaultRouteBuildItem> defaultRoutes) {
+            StaticResourcesRecorder recorder, CoreVertxBuildItem vertx, BeanContainerBuildItem beanContainer,
+            BuildProducer<DefaultRouteBuildItem> defaultRoutes, HttpConfiguration config) {
         if (staticResources.isPresent()) {
             defaultRoutes.produce(new DefaultRouteBuildItem(recorder.start(staticResources.get().getPaths())));
         }

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/CompressionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Router;
 
 public class CompressionTest {
@@ -57,10 +58,13 @@ public class CompressionTest {
         public void register(@Observes Router router) {
 
             router.route("/compress").handler(rc -> {
+                // The content-encoding header must be removed
+                rc.response().headers().remove(HttpHeaders.CONTENT_ENCODING);
                 rc.response().end(longString);
             });
             router.route("/nocompress").handler(rc -> {
-                rc.response().headers().set("content-encoding", "identity");
+                // This header is set by default
+                // rc.response().headers().set("content-encoding", "identity");
                 rc.response().end(longString);
             });
         }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/Compressed.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/Compressed.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to enable the compression of an HTTP response for a particular method.
+ *
+ * @see Uncompressed
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Compressed {
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/Uncompressed.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/Uncompressed.java
@@ -1,0 +1,18 @@
+package io.quarkus.vertx.http;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to disable the compression of an HTTP response for a particular method.
+ *
+ * @see Compressed
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Uncompressed {
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpCompression.java
@@ -1,0 +1,24 @@
+package io.quarkus.vertx.http.runtime;
+
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
+
+public enum HttpCompression {
+    /**
+     * Compression is explicitly enabled.
+     *
+     * @see Compressed
+     */
+    ON,
+    /**
+     * Compression is explicitly disabled.
+     *
+     * @see Uncompressed
+     */
+    OFF,
+    /**
+     * Compression will be enabled if the response has the {@code Content-Type} header set and the value is listed in
+     * {@link HttpConfiguration#compressMediaTypes}.
+     */
+    UNDEFINED
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -9,6 +10,8 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.vertx.http.Compressed;
+import io.quarkus.vertx.http.Uncompressed;
 import io.quarkus.vertx.http.runtime.cors.CORSConfig;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -236,6 +239,19 @@ public class HttpConfiguration {
      */
     @ConfigItem
     public boolean enableDecompression;
+
+    /**
+     * List of media types for which the compression should be enabled automatically, unless declared explicitly via
+     * {@link Compressed} or {@link Uncompressed}.
+     */
+    @ConfigItem(defaultValue = "text/html,text/plain,text/xml,text/css,text/javascript,application/javascript")
+    public Optional<List<String>> compressMediaTypes;
+
+    /**
+     * The compression level used when compression support is enabled.
+     */
+    @ConfigItem
+    public OptionalInt compressionLevel;
 
     /**
      * Provides a hint (optional) for the default content type of responses generated for

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/DefaultRuntimeConfiguration.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/DefaultRuntimeConfiguration.java
@@ -3,14 +3,24 @@ package org.jboss.resteasy.reactive.server.spi;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
 public class DefaultRuntimeConfiguration implements RuntimeConfiguration {
     final Duration readTimeout;
     private final Body body;
     private final Limits limits;
+    private final boolean enableCompression;
+    private final Set<String> compressMediaTypes;
 
     public DefaultRuntimeConfiguration(Duration readTimeout, boolean deleteUploadedFilesOnEnd, String uploadsDirectory,
             Charset defaultCharset, Optional<Long> maxBodySize, long maxFormAttributeSize) {
+        this(readTimeout, deleteUploadedFilesOnEnd, uploadsDirectory, defaultCharset, maxBodySize, maxFormAttributeSize, false,
+                Set.of());
+    }
+
+    public DefaultRuntimeConfiguration(Duration readTimeout, boolean deleteUploadedFilesOnEnd, String uploadsDirectory,
+            Charset defaultCharset, Optional<Long> maxBodySize, long maxFormAttributeSize, boolean enableCompression,
+            Set<String> compressMediaTypes) {
         this.readTimeout = readTimeout;
         body = new Body() {
             @Override
@@ -39,6 +49,8 @@ public class DefaultRuntimeConfiguration implements RuntimeConfiguration {
                 return maxFormAttributeSize;
             }
         };
+        this.enableCompression = enableCompression;
+        this.compressMediaTypes = compressMediaTypes;
     }
 
     @Override
@@ -54,5 +66,15 @@ public class DefaultRuntimeConfiguration implements RuntimeConfiguration {
     @Override
     public Limits limits() {
         return limits;
+    }
+
+    @Override
+    public boolean enableCompression() {
+        return enableCompression;
+    }
+
+    @Override
+    public Set<String> compressMediaTypes() {
+        return compressMediaTypes;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/RuntimeConfiguration.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.server.spi;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
 public interface RuntimeConfiguration {
 
@@ -11,6 +12,10 @@ public interface RuntimeConfiguration {
     Body body();
 
     Limits limits();
+
+    boolean enableCompression();
+
+    Set<String> compressMediaTypes();
 
     interface Body {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ServerHttpResponse.java
@@ -28,6 +28,8 @@ public interface ServerHttpResponse extends StreamingResponse<ServerHttpResponse
 
     String getResponseHeader(String name);
 
+    void removeResponseHeader(String name);
+
     boolean closed();
 
     ServerHttpResponse setChunked(boolean chunked);

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -379,6 +379,11 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     }
 
     @Override
+    public void removeResponseHeader(String name) {
+        response.headers().remove(name);
+    }
+
+    @Override
     public boolean closed() {
         return response.closed();
     }


### PR DESCRIPTION
Functionality:

- nothing is compressed by default
- if `quarkus.http.enable-compression=true` then an HTTP response body of a static resource, reactive route and resteasy-reactive resource method is compressed if:
    -  the method is annotated with `@io.quarkus.vertx.http.Compressed`, OR 
    -  the content-type header is set and the value is listed in `quarkus.http.compress-media-types` (`text/html,text/plain,text/xml,text/css,text/javascript,application/javascript` by default).
- a reactive route or resource method is never compressed if annotated with `@io.quarkus.vertx.http.Uncompressed`

Impl. notes:

- if `quarkus.http.enable-compression=true` then every response has the `Content-Encoding: identity` header set by default; this effectively disables the compression
- static resources, reactive routes and resteasy-reactive remove this header to enable the compression (rules described above)
- resteasy-reactive removes the header in a special `ServerRestHandler` that is added to the chain for any resource method unless `@Uncompressed` is used
- reactive routes use an end handler to remove the header if needed, unless `@Uncompressed` is used

Note that it's a breaking change in the sense that previously `quarkus.http.enable-compression=true` enabled compression for every HTTP response which is not the case anymore. The configuration property is effectively ignored for `reasteasy-classic` endpoints and [routes registered manually](https://quarkus.io/guides/reactive-routes#using-the-vert-x-web-router).