### PR TITLE
Bump Keycloak version to 17.0.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -177,7 +177,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>17.0.0</keycloak.version>
+        <keycloak.version>17.0.1</keycloak.version>
         <logstash-gelf.version>1.15.0</logstash-gelf.version>
         <checker-qual.version>3.21.3</checker-qual.version>
         <error-prone-annotations.version>2.11.0</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -96,7 +96,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>17.0.0</keycloak.version>
+        <keycloak.version>17.0.1</keycloak.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.version}-legacy</keycloak.docker.legacy.image>
         

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -28,7 +28,7 @@ public class DevServicesConfig {
      *
      * Image with a Quarkus based distribution is used by default.
      * Image with a WildFly based distribution can be selected instead, for example:
-     * 'quay.io/keycloak/keycloak:17.0.0-legacy'.
+     * 'quay.io/keycloak/keycloak:17.0.1-legacy'.
      * <p>
      * Note Keycloak Quarkus and Keycloak WildFly images are initialized differently.
      * By default, Dev Services for Keycloak will assume it is a Keycloak Quarkus image if the image version does not end with a
@@ -36,7 +36,7 @@ public class DevServicesConfig {
      * string.
      * Set 'quarkus.keycloak.devservices.keycloak-x-image' to override this check.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:17.0.0")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:17.0.1")
     public String imageName;
 
     /**


### PR DESCRIPTION
This is a try number 2 at bumping the Keycloak version to 17.0.1. `integration-tests/container-image` tests were failing in Native, in the end adding `--hostname-port` in the shared network case resolved the `issuer` mismatch issue - it is a test issue only, `17.0.1` might've done some extra changes related to it.
I've also added a check that the realm is available after it has been created - it is not what makes the tests pass - but it would not harm I guess 