### PR TITLE
Break dependency cycle between independent-projects/tools/ and core/

### DIFF
--- a/independent-projects/tools/devtools-testing/pom.xml
+++ b/independent-projects/tools/devtools-testing/pom.xml
@@ -24,9 +24,12 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-bootstrap-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -203,6 +203,11 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bootstrap-core</artifactId>
+                <version>${quarkus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-core</artifactId>
                 <type>test-jar</type>
                 <scope>test</scope>
                 <version>${quarkus.version}</version>


### PR DESCRIPTION
Doesn't look like it but this is part of the Jakarta effort :).

`independent-projects/tools/` was depending on `quarkus-junit5-internal` which in turn depends on `quarkus-core`. This shouldn't be the case and is a bit annoying for the migration.