### PR TITLE
Add JDBC tracing info to the OpenTelemetry guide

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -204,6 +204,38 @@ Then visit the http://localhost:16686[Jaeger UI] to see the tracing information.
 
 Hit `CTRL+C` to stop the application.
 
+=== JDBC
+
+The https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jdbc/library[JDBC instrumentation] will add a span for each JDBC queries done by your application, to enable it, add the following dependency to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-jdbc</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.opentelemetry.instrumentation:opentelemetry-jdbc")
+----
+
+As it uses a dedicated JDBC driver, you must configure your datasource and Hibernate ORM to use it.
+
+[source, properties]
+----
+quarkus.datasource.db-kind=postgresql
+# add ':otel' to your database URL
+quarkus.datasource.jdbc.url=jdbc:otel:postgresql://localhost:5432/mydatabase
+# use the 'OpenTelemetryDriver' instead of the one for your database
+quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
+# configure Hibernate ORM dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+----
+
 == Additional configuration
 Some use cases will require custom configuration of OpenTelemetry.
 These sections will outline what is necessary to properly configure it.


### PR DESCRIPTION
OpenTelemetry version of the older OpenTracing JDBC setup steps