### PR TITLE
Jakarta rewrite infrastructure

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5743,6 +5743,40 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.managed</recipe>
+                        <recipe>io.quarkus.maven.javax.versions</recipe>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                        <recipe>io.quarkus.jakarta-jaxrs-jaxb</recipe>
+                        <recipe>io.quarkus.jakarta-security</recipe>
+                        <recipe>io.quarkus.smallrye</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>rewrite-cleanup</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <configuration>
+                            <activeRecipes>
+                                <recipe>io.quarkus.jakarta-jaxrs-jaxb-cleanup</recipe>
+                                <recipe>io.quarkus.jakarta-security-cleanup</recipe>
+                            </activeRecipes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/core/launcher/pom.xml
+++ b/core/launcher/pom.xml
@@ -35,7 +35,7 @@
                 <executions>
                     <execution>
                         <id>unpack-dependencies</id>
-                        <phase>process-classes</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>

--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -64,6 +64,15 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.extensions.arc</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/reactive-routes/deployment/pom.xml
+++ b/extensions/reactive-routes/deployment/pom.xml
@@ -36,6 +36,11 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security-deployment</artifactId>
             <scope>test</scope>
         </dependency>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -306,13 +306,22 @@
                     <version>4.21.0-SNAPSHOT</version>
                     <configuration>
                         <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
-                        <activeRecipes>
-                            <recipe>io.quarkus.jakarta-versions</recipe>
-                        </activeRecipes>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <inherited>false</inherited>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -300,6 +300,17 @@
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeRecipes>
+                            <recipe>io.quarkus.jakarta-versions</recipe>
+                        </activeRecipes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -353,4 +353,18 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.allow</recipe>
+                        <recipe>io.quarkus.maven.javax.managed</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -220,8 +220,31 @@
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                        <recipe>io.quarkus.maven.javax.versions</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -235,6 +235,7 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <inherited>false</inherited>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
                 <configuration>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -72,6 +72,21 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>

--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -64,6 +64,17 @@
                         <argLine>${jacoco.agent.argLine}</argLine>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -234,6 +234,17 @@
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -496,6 +496,7 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <inherited>false</inherited>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
                 <configuration>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -481,8 +481,31 @@
                         <skip>${format.skip}</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                        <recipe>io.quarkus.jakarta-jaxrs-jaxb</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>

--- a/independent-projects/revapi/pom.xml
+++ b/independent-projects/revapi/pom.xml
@@ -35,6 +35,21 @@
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!-- 
             This is not deployed into a Maven repository. It is merely installed into the local Maven repository

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -23,6 +23,17 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.allow</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -384,6 +384,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <inherited>false</inherited>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
                 <configuration>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -240,6 +240,21 @@
     </distributionManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -366,6 +381,17 @@
                     <cachedir>.cache/impsort-maven-plugin-${impsort-maven-plugin.version}</cachedir>
                     <removeUnused>true</removeUnused>
                     <skip>${format.skip}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.managed</recipe>
+                        <recipe>io.quarkus.maven.javax.versions</recipe>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                    </activeRecipes>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -40,6 +40,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -54,6 +59,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -40,6 +40,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -67,6 +72,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonp-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/test-extension/extension/runtime/pom.xml
+++ b/integration-tests/test-extension/extension/runtime/pom.xml
@@ -128,6 +128,15 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.jakarta-jaxb-switch</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jakarta/README.md
+++ b/jakarta/README.md
@@ -1,0 +1,103 @@
+# Jakarta migration
+
+This directory contains scripts and configuration files to automate the migration to Jakarta EE 9 (for now) and hopefully Jakarta EE 10 soon.
+
+## jakarta/transform.sh
+
+`jakarta/transform.sh` is the main script to run.
+It has to be run from the root of the Quarkus repository.
+
+It consists of several steps that leverage various tools:
+
+- [OpenRewrite](https://github.com/openrewrite/rewrite) - rewrites the POM files
+- [Eclipse Transformer](https://projects.eclipse.org/projects/technology.transformer) - rewrites the classes
+
+Note that this script also builds:
+
+- A patched version of OpenRewrite (while waiting for integration of our patches)
+- A patched version of the Rewrite Maven Plugin (to point to the patched OpenRewrite version)
+- A patched version of the Kotlin Maven Plugin (to allow skipping the `main` compilation, it's required for the OpenRewrite run)
+- SmallRye Config while waiting for a CR2
+
+## Approach
+
+### OpenRewrite
+
+The OpenRewrite transformation is done in one unique step to alleviate dependency issues we had before switching to this approach.
+You don't need to run OpenRewrite for the modules you add to `transform.sh`, you just need to adjust the configuration.
+
+OpenRewrite recipes are declared in the `jakarta/rewrite.yml` file.
+
+Documentation for writing recipes can be found:
+
+- In the [official documentation](https://docs.openrewrite.org/reference/recipes/maven)
+- In the [source for those not already released](https://github.com/gsmet/rewrite/tree/main/rewrite-maven/src/main/java/org/openrewrite/maven) (things are very simple there and well documented in the source)
+
+Recipes are not applied on all POM files, you need to declare the ones you want to apply to a given target POM when changes are necessary.
+Note that in most cases, you don't need to apply any changes.
+
+The active recipes have to be declared in the target POM with a `plugin` block in the `<build><plugins>` section similar to:
+
+```xml
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.managed</recipe>
+                        <recipe>io.quarkus.maven.javax.versions</recipe>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+```
+
+If you declare the `rewrite-maven-plugin` in a POM that is a parent POM, make sure the plugin is not inherited by adding `<inherited>false</inherited>` to the `<plugin>` block
+as it's highly probable you don't want to apply the same rule to the child POM files:
+
+```xml
+            <plugin>
+                <inherited>false</inherited>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>io.quarkus.maven.javax.managed</recipe>
+                        <recipe>io.quarkus.maven.javax.versions</recipe>
+                        <recipe>io.quarkus.jakarta-versions</recipe>
+                    </activeRecipes>
+                </configuration>
+            </plugin>
+```
+
+:warning: Not all recipes are equal and please be extremely careful when adjusting existing recipes.
+
+In particular, be extremely care with the `io.quarkus.jakarta-versions` recipe:
+
+- It is used for several POM files
+- It shouldn't add any content that is not common to all these POM files (for instance, adding some new dependencies is forbidden as there is a good chance you don't want to add them in all the POM adjusted by `io.quarkus.jakarta-versions`)
+- If you need to go further than just updating versions, create a specific recipe such as `io.quarkus.jakarta-jaxrs-jaxb`
+
+### Eclipse Transformer
+
+The transformer phase is done at a more granular level but, typically, for now we transform the whole `extensions` subdirectory at once.
+There's not much to say about this phase.
+AFAICS, it just works.
+
+## Experimenting
+
+It is recommended to do the experiments in a separate copy of the Quarkus repository and:
+
+- do the adjustments in a work branch of your original Quarkus repository, for instance `jakarta-work`
+- commit in this branch
+- then sync the branch and run the migration scripts in the separate `quarkus-jakarta` repository
+
+Note that the `transform.sh` script will remove all `999-SNAPSHOT` Quarkus artifacts that are in your local Maven repository.
+
+That way, you can easily reinitialize your `quarkus-jakarta` copy after having attempted a migration.
+
+You can for instance use the following approach:
+
+- create a `quarkus-jakarta` copy of your `quarkus` repository
+- add a `jakarta` remote to this `quarkus-jakarta` copy: `git remote add jakarta ../quarkus/`
+- then you can run the following command to perform a full migration: `rm -rf ~/.m2/repository/io/quarkus && git checkout -- . && git pull jakarta jakarta-work && ./jakarta/transform.sh ; paplay /usr/share/sounds/freedesktop/stereo/complete.oga` (the last part plays a sound on Linux when done, if you use macOS, remove it)

--- a/jakarta/README.md
+++ b/jakarta/README.md
@@ -25,7 +25,6 @@ Note that this script also builds:
 - A patched version of OpenRewrite (while waiting for integration of our patches)
 - A patched version of the Rewrite Maven Plugin (to point to the patched OpenRewrite version)
 - A patched version of the Kotlin Maven Plugin (to allow skipping the `main` compilation, it's required for the OpenRewrite run)
-- SmallRye Config while waiting for a CR2
 
 ## Approach
 

--- a/jakarta/README.md
+++ b/jakarta/README.md
@@ -7,6 +7,14 @@ This directory contains scripts and configuration files to automate the migratio
 `jakarta/transform.sh` is the main script to run.
 It has to be run from the root of the Quarkus repository.
 
+If you are offline and can't fetch the external projects, do:
+```
+export REWRITE_OFFLINE=true
+jakarta/transform.sh
+```
+Obviously, you need to have run a full build before.
+Also keep in mind you should run a full build from time to time to get the potential updates to OpenRewrite.
+
 It consists of several steps that leverage various tools:
 
 - [OpenRewrite](https://github.com/openrewrite/rewrite) - rewrites the POM files

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -192,7 +192,7 @@ recipeList:
       newValue: 3.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-config.version
-      newValue: 3.0.0-SNAPSHOT
+      newValue: 3.0.0-RC2
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-health.version
       newValue: 4.0.0-RC1

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -1,0 +1,297 @@
+---
+type: specs.openrewrite.org/v1beta/style
+name: io.quarkus.style.maven
+styleConfigs:
+  - org.openrewrite.xml.style.TabsAndIndentsStyle:
+      useTabCharacter: false
+      tabSize: 1
+      indentSize: 4
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-versions
+displayName: Adjust Jakarta versions
+recipeList:
+  # Activation
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.activation.version
+      newValue: 2.0.1
+  # Annotation
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: version.jakarta-annotation
+      newValue: 2.0.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.annotation-api.version
+      newValue: 2.0.0
+  # EL
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.el-impl.version
+      newValue: 4.0.1
+  # CDI
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: version.cdi
+      newValue: 3.0.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.enterprise.cdi-api.version
+      newValue: 3.0.0
+  # Inject
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.inject-api.version
+      newValue: 2.0.0
+  # Interceptor
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.interceptor-api.version
+      newValue: 2.0.0
+  # JAX-RS - See below
+  # JAXB - See below
+  # JSON
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.json.version
+      newValue: 2.0.0
+  # JSON Bind
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.json.bind-api.version
+      newValue: 2.0.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: yasson.version
+      newValue: 2.0.4
+  # JPA
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: version.jpa
+      newValue: 3.0.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.persistence-api.version
+      newValue: 3.0.0
+  # Security - See below
+  # Servlet
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.servlet-api.version
+      newValue: 5.0.0
+  # Transaction
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: version.jta
+      newValue: 2.0.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.transaction-api.version
+      newValue: 2.0.0
+  # Validation
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.validation-api.version
+      newValue: 3.0.1
+  # Websockets
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.websocket-api.version
+      newValue: 2.0.0
+  # XML Bind
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.xml.bind-api.version
+      newValue: 3.0.1
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jaxb-runtime.version
+      newValue: 3.0.2
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-jaxrs-jaxb
+displayName: Adjust JAX-RS/JAXB dependencies
+recipeList:
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
+      version: "${jakarta.xml.bind-api.version}"
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: org.jboss.spec.javax.ws.rs
+      artifactId: jboss-jaxrs-api_3.0_spec
+      version: "${jboss-jaxrs-api_3.0_spec.version}"
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.xml.bind-api.version
+      newValue: 3.0.1
+      addIfMissing: true
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jboss-jaxrs-api_3.0_spec.version
+      newValue: 1.0.1.Final
+      addIfMissing: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-jaxrs-jaxb-cleanup
+displayName: Adjust JAX-RS/JAXB dependencies
+recipeList:
+  - org.openrewrite.maven.RemoveManagedDependency:
+      groupId: org.jboss.spec.javax.xml.bind
+      artifactId: jboss-jaxb-api_2.3_spec
+  - org.openrewrite.maven.RemoveManagedDependency:
+      groupId: org.jboss.spec.javax.ws.rs
+      artifactId: jboss-jaxrs-api_2.1_spec
+  - org.openrewrite.maven.RemoveProperty:
+      propertyName: jboss-jaxrs-api_2.1_spec.version
+  - org.openrewrite.maven.RemoveProperty:
+      propertyName: jboss-jaxb-api_2.3_spec.version
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-jaxb-switch
+displayName: Switch JAXB version
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.jboss.spec.javax.xml.bind
+      oldArtifactId: jboss-jaxb-api_2.3_spec
+      newGroupId: jakarta.xml.bind
+      newArtifactId: jakarta.xml.bind-api
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-security
+displayName: Adjust Javax security dependencies
+recipeList:
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: jakarta.authorization
+      artifactId: jakarta.authorization-api
+      version: "${jakarta.authorization-api.version}" 
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: jakarta.authentication
+      artifactId: jakarta.authentication-api
+      version: "${jakarta.authentication-api}"
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.authorization-api.version
+      newValue: 2.0.0
+      addIfMissing: true
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jakarta.authentication-api
+      newValue: 2.0.0
+      addIfMissing: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.jakarta-security-cleanup
+displayName: Adjust Javax security dependencies
+recipeList:
+  - org.openrewrite.maven.RemoveManagedDependency:
+      groupId: jakarta.security.jacc
+      artifactId: jakarta.security.jacc-api
+  - org.openrewrite.maven.RemoveManagedDependency:
+      groupId: jakarta.security.auth.message
+      artifactId: jakarta.security.auth.message-api
+  - org.openrewrite.maven.RemoveProperty:
+      propertyName: jakarta.security.jacc-api.version
+  - org.openrewrite.maven.RemoveProperty:
+      propertyName: jakarta.security.auth.message-api.version
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.smallrye
+displayName: Adjust SmallRye dependencies
+recipeList:
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: smallrye-common.version
+      newValue: 2.0.0-RC2
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: microprofile-context-propagation.version
+      newValue: 1.3
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: smallrye-context-propagation.version
+      newValue: 2.0.0-RC1
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: microprofile-config-api.version
+      newValue: 3.0
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: smallrye-config.version
+      newValue: 3.0.0-SNAPSHOT
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: smallrye-health.version
+      newValue: 4.0.0-RC1
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: microprofile-metrics-api.version
+      newValue: 4.0.1
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: smallrye-metrics.version
+      newValue: 4.0.0-RC1
+# In progress, these ones need a change:
+#        <microprofile-opentracing-api.version>2.0</microprofile-opentracing-api.version>
+#        <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
+#        <microprofile-rest-client.version>2.0</microprofile-rest-client.version>
+#        <microprofile-jwt.version>1.2</microprofile-jwt.version>
+#        <microprofile-lra.version>1.0</microprofile-lra.version>
+#        <smallrye-open-api.version>2.1.22</smallrye-open-api.version>
+#        <smallrye-graphql.version>1.4.3</smallrye-graphql.version>
+#        <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
+#        <smallrye-fault-tolerance.version>5.3.1</smallrye-fault-tolerance.version>
+#        <smallrye-jwt.version>3.3.3</smallrye-jwt.version>
+#        <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
+#        <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
+#        <smallrye-mutiny-vertx-binding.version>2.19.0</smallrye-mutiny-vertx-binding.version>
+#        <smallrye-reactive-messaging.version>3.15.0</smallrye-reactive-messaging.version>
+#        <smallrye-stork.version>1.1.0</smallrye-stork.version>
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.maven.javax.managed
+displayName: Adjust inject dependencies for Maven
+recipeList:
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: javax.inject
+      artifactId: javax.inject
+      version: "${javax.inject.version}"
+  - org.openrewrite.maven.AddManagedDependency:
+      groupId: javax.annotation
+      artifactId: javax.annotation-api
+      version: "${javax.annotation-api.version}"
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.maven.javax.allow
+displayName: Adjust inject dependencies for Maven
+recipeList:
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-plugin-api
+      exclusionGroupId: javax.inject
+      exclusionArtifactId: javax.inject
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-plugin-api
+      exclusionGroupId: javax.annotation
+      exclusionArtifactId: javax.annotation-api
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-core
+      exclusionGroupId: javax.inject
+      exclusionArtifactId: javax.inject
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-embedder
+      exclusionGroupId: javax.inject
+      exclusionArtifactId: javax.inject
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-embedder
+      exclusionGroupId: javax.annotation
+      exclusionArtifactId: javax.annotation-api
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-resolver-provider
+      exclusionGroupId: javax.inject
+      exclusionArtifactId: javax.inject
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.apache.maven
+      artifactId: maven-settings-builder
+      exclusionGroupId: javax.inject
+      exclusionArtifactId: javax.inject
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.maven.javax.versions
+displayName: Adjust bootstrap
+recipeList:
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: javax.inject.version
+      newValue: 1
+      addIfMissing: true
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: javax.annotation-api.version
+      newValue: 1.3.2
+      addIfMissing: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.extensions.arc
+displayName: Adjust ArC extension
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.jboss.spec.javax.ejb
+      oldArtifactId: jboss-ejb-api_3.1_spec
+      newGroupId: jakarta.ejb
+      newArtifactId: jakarta.ejb-api
+      newVersion: 4.0.0

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -30,12 +30,12 @@ if [ "${REWRITE_OFFLINE-false}" != "true" ]; then
   popd
 
   # Build SmallRye Config (temporary)
-  rm -rf target/smallrye-config
-  git clone git@github.com:smallrye/smallrye-config.git target/smallrye-config
-  pushd target/smallrye-config
-  git checkout jakarta
-  mvn clean install -DskipTests -DskipITs
-  popd
+  #rm -rf target/smallrye-config
+  #git clone git@github.com:smallrye/smallrye-config.git target/smallrye-config
+  #pushd target/smallrye-config
+  #git checkout jakarta
+  #mvn clean install -DskipTests -DskipITs
+  #popd
 
   # Build Kotlin Maven Plugin to allow skipping main compilation
   # (skipping test compilation is supported but not main)

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e -u -o pipefail
+shopt -s failglob
+
 # This script is used to gradually transform Quarkus bits from javax to jakarta namespaces and update dependencies
 
 # Each transformed module/project is expected to:
@@ -7,37 +10,107 @@
 # b) update dependencies to their respective EE 9 versions
 # c) add a build and test command that will verify the functionality
 
-quarkusPath="$(pwd)"
-echo "Path to quarkus repo is: $quarkusPath"
+if [ ! -f dco.txt ]; then
+    echo "ERROR: This script has to be run from the root of the Quarkus project"
+    exit 1
+fi
 
-BOM="$quarkusPath/bom/application/pom.xml"
+# Prepare OpenRewrite - we temporarily build a local version as we need a patch
+rm -rf target/rewrite
+git clone git@github.com:gsmet/rewrite.git target/rewrite
+pushd target/rewrite
+git checkout jakarta
+./gradlew -x test -x javadoc publishToMavenLocal
+popd
+
+rm -rf target/rewrite-maven-plugin
+git clone git@github.com:gsmet/rewrite-maven-plugin.git target/rewrite-maven-plugin
+pushd target/rewrite-maven-plugin
+git checkout jakarta
+./mvnw clean install -DskipTests -DskipITs
+popd
+
+# Build SmallRye Config (temporary)
+rm -rf target/smallrye-config
+git clone git@github.com:smallrye/smallrye-config.git target/smallrye-config
+pushd target/smallrye-config
+git checkout jakarta
+mvn clean install -DskipTests -DskipITs
+popd
 
 # Set up jbang alias, we are using latest released transformer version
 jbang alias add --name transform org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0
 
+start_module () {
+  echo "# $1"
+}
+
 # Function to help transform a particular Maven module using Eclipse Transformer
 transform_module () {
-  local modulePath="$quarkusPath/$1"
-  local transformationTemp="$quarkusPath/JAKARTA_TEMP"
+  local modulePath="$1"
+  local transformationTemp="JAKARTA_TEMP"
   rm -Rf $transformationTemp
   mkdir $transformationTemp
-  echo "Transforming $modulePath"
+  echo "  - Transforming $modulePath"
   jbang transform -o $modulePath $transformationTemp
   rm -Rf "$modulePath"
   mv "$transformationTemp" "$modulePath"
-  echo "Transformation done"
+  echo "    > Transformation done"
+}
+
+# Rewrite a module with OpenRewrite
+rewrite_module () {
+  local modulePath="$1"
+  echo "  - Rewriting $modulePath"
+  ./mvnw -B rewrite:run -f "${modulePath}/pom.xml" -N
+  echo "    > Rewriting done"
+}
+
+# Rewrite a module with OpenRewrite but with the rewrite-cleanup profile
+rewrite_module_cleanup () {
+  local modulePath="$1"
+  echo "  - Rewriting $modulePath"
+  ./mvnw -B rewrite:run -f "${modulePath}/pom.xml" -N -Prewrite-cleanup
+  echo "    > Rewriting done"
+}
+
+# Remove a banned dependency
+remove_banned_dependency () {
+  sed -i "s@<exclude>$2</exclude>@<!-- $3 -->@g" $1/pom.xml
+}
+
+# Update a banned dependency
+update_banned_dependency () {
+  sed -i "s@<exclude>$2</exclude>@<exclude>$3</exclude>@g" $1/pom.xml
+}
+
+update_banned_dependency_advanced () {
+  sed -i "s@$2@$3@g" $1/pom.xml
 }
 
 # Build, test and install a particular maven module (chosen by relative path)
 build_module () {
-  local pomPath="$quarkusPath/$1/pom.xml"
+  local pomPath="$1/pom.xml"
   ./mvnw -B clean install -f "$pomPath"
-  echo "Installed newly built $pomPath"
+  echo "  - Installed newly built $pomPath"
+}
+
+# Build module without testing it
+build_module_no_tests () {
+  local pomPath="$1/pom.xml"
+  ./mvnw -B clean install -f "$pomPath" -DskipTests -DskipITs
+  echo "  - Installed newly built $pomPath"
+}
+
+build_module_only_no_tests () {
+  local pomPath="$1/pom.xml"
+  ./mvnw -B clean install -f "$pomPath" -DskipTests -DskipITs -N
+  echo "  - Installed newly built $pomPath"
 }
 
 # Sets the EDITING variable to the file being edited by set_property
 edit_begin () {
-  EDITING="$quarkusPath/$1"
+  EDITING="$1"
 }
 
 # Finds a particular property and replaces its value
@@ -50,30 +123,111 @@ set_property () {
   sed -i "s/<$propName>.*<\/$propName>/<$propName>$propValue<\/$propName>/g" "$EDITING"
 }
 
-# Arc project transformation
+# Install root parent
+./mvnw clean install -N
+
+# Install utility projects
+build_module_no_tests "independent-projects/ide-config"
+build_module_no_tests "independent-projects/enforcer-rules"
+build_module_no_tests "independent-projects/revapi"
+
+# ArC
+start_module "ArC"
 transform_module "independent-projects/arc"
-
-# Now we need to update CDI, JTA, JPA and common annotations artifacts
-edit_begin "independent-projects/arc/pom.xml"
-set_property "version.cdi" "3.0.0"
-set_property "version.jta" "2.0.0"
-set_property "version.jakarta-annotation" "2.0.0"
-set_property "version.jpa" "3.0.0"
-
-# Test & install modified Arc
+rewrite_module "independent-projects/arc"
 build_module "independent-projects/arc"
 
-# Switch parent BOM to Jakarta artifacts
-edit_begin "bom/application/pom.xml"
-set_property "jakarta.inject-api.version" "2.0.0"
-set_property "jakarta.interceptor-api.version" "2.0.0"
-set_property "jakarta.transaction-api.version" "2.0.0"
-set_property "jakarta.enterprise.cdi-api.version" "3.0.0"
-set_property "jakarta.annotation-api.version" "2.0.0"
-set_property "jakarta.persistence-api.version" "3.0.0"
+# Bootstrap
+start_module "Bootstrap"
+rewrite_module "independent-projects/bootstrap/bom"
+rewrite_module "independent-projects/bootstrap"
+remove_banned_dependency "independent-projects/bootstrap" 'javax.inject:javax.inject' 'we allow javax.inject for Maven'
+remove_banned_dependency "independent-projects/bootstrap" 'javax.annotation:javax.annotation-api' 'we allow javax.annotation-api for Maven'
+build_module "independent-projects/bootstrap"
 
-# Install the modified BOM:
+# Qute
+build_module_no_tests "independent-projects/qute"
+
+# Tools
+remove_banned_dependency "independent-projects/tools" 'javax.inject:javax.inject' 'we allow javax.inject for Maven'
+remove_banned_dependency "independent-projects/tools" 'javax.annotation:javax.annotation-api' 'we allow javax.annotation-api for Maven'
+build_module_no_tests "independent-projects/tools"
+rewrite_module "independent-projects/tools/devtools-common"
+rewrite_module "independent-projects/tools"
+build_module "independent-projects/tools"
+
+## Starting here, we don't run the tests until post cleanup phase, use build_module_no_tests
+## and then add another build of your module after the Clean up phase
+
+# BOM
+start_module "BOM"
+rewrite_module "bom/application"
+build_module_no_tests "bom/application"
+build_module_only_no_tests "bom/test"
+
+# Build parent
+start_module "Build parent"
+remove_banned_dependency "build-parent" 'javax.inject:javax.inject' 'we allow javax.inject for Maven'
+remove_banned_dependency "build-parent" 'javax.annotation:javax.annotation-api' 'we allow javax.annotation-api for Maven'
+update_banned_dependency "build-parent" 'jakarta.xml.bind:jakarta.xml.bind-api' 'org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec'
+update_banned_dependency_advanced "build-parent" '<exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>' "<exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>\n                                            <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>"
+build_module_no_tests "build-parent"
+
+# Needed for core
+build_module_only_no_tests devtools
+build_module_no_tests "devtools/platform-descriptor-json-plugin"
+build_module_no_tests "devtools/platform-properties"
+
+# Core
+transform_module "core"
+build_module_no_tests "core"
+build_module_no_tests "core"
+
+# Test framework
+transform_module "test-framework"
+
+## Clean up phase
+## This removes the dependencies that shouldn't be there anymore - we need to do that once everything has been rewritten
+rewrite_module_cleanup "bom/application"
+
+# Build
 build_module "bom/application"
+build_module "bom/test"
+build_module "build-parent"
+build_module "core"
+build_module_only_no_tests "test-framework"
+build_module "test-framework/common"
+build_module "test-framework/devmode-test-utils"
+build_module "test-framework/junit5-properties"
+build_module "test-framework/junit5"
+build_module "test-framework/junit5-internal"
+build_module "test-framework/maven"
+
+# Extensions
+transform_module "extensions"
+build_module_only_no_tests "extensions"
+build_module_only_no_tests "extensions/vertx-http"
+build_module "extensions/vertx-http/dev-console-runtime-spi"
+build_module "extensions/vertx-http/dev-console-spi"
+# couldn't find a way to apply a rewrite here because we can't build the runtime module without the deployment module around :/
+# I'm working on a different approach but let's live with it for now as I'm not sure my approach will fly and I want to unblock other people
+sed -i 's@<groupId>org.jboss.spec.javax.ejb</groupId>@<groupId>jakarta.ejb</groupId>@' extensions/arc/deployment/pom.xml
+sed -i 's@<artifactId>jboss-ejb-api_3.1_spec</artifactId>@<artifactId>jakarta.ejb-api</artifactId>@' extensions/arc/deployment/pom.xml
+sed -i 's@<version>1.0.2.Final</version>@<version>4.0.0</version>@' extensions/arc/deployment/pom.xml
+build_module "extensions/arc"
+
+exit 1
+
+# These ones require ArC and Munity extensions
+#build_module "test-framework/junit5-mockito-config"
+#build_module "test-framework/junit5-mockito"
+
+# Dev Tools - needs to be done after all the extensions have been built and before we run the ITs
+#transform_module "devtools"
+#build_module_no_tests "devtools"
+
+# For later, now that I moved it out of core
+#rewrite_module "core/test-extension/runtime"
 
 ## Arc Extension [Incomplete: other modules need to go first]
 

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -13,36 +13,38 @@ if [ ! -f dco.txt ]; then
     exit 1
 fi
 
-# Prepare OpenRewrite - we temporarily build a local version as we need a patch
-rm -rf target/rewrite
-git clone git@github.com:gsmet/rewrite.git target/rewrite
-pushd target/rewrite
-git checkout jakarta
-./gradlew -x test -x javadoc publishToMavenLocal
-popd
+if [ "${REWRITE_OFFLINE-false}" != "true" ]; then
+  # Prepare OpenRewrite - we temporarily build a local version as we need a patch
+  rm -rf target/rewrite
+  git clone git@github.com:gsmet/rewrite.git target/rewrite
+  pushd target/rewrite
+  git checkout jakarta
+  ./gradlew -x test -x javadoc publishToMavenLocal
+  popd
 
-rm -rf target/rewrite-maven-plugin
-git clone git@github.com:gsmet/rewrite-maven-plugin.git target/rewrite-maven-plugin
-pushd target/rewrite-maven-plugin
-git checkout jakarta
-./mvnw clean install -DskipTests -DskipITs
-popd
+  rm -rf target/rewrite-maven-plugin
+  git clone git@github.com:gsmet/rewrite-maven-plugin.git target/rewrite-maven-plugin
+  pushd target/rewrite-maven-plugin
+  git checkout jakarta
+  ./mvnw clean install -DskipTests -DskipITs
+  popd
 
-# Build SmallRye Config (temporary)
-rm -rf target/smallrye-config
-git clone git@github.com:smallrye/smallrye-config.git target/smallrye-config
-pushd target/smallrye-config
-git checkout jakarta
-mvn clean install -DskipTests -DskipITs
-popd
+  # Build SmallRye Config (temporary)
+  rm -rf target/smallrye-config
+  git clone git@github.com:smallrye/smallrye-config.git target/smallrye-config
+  pushd target/smallrye-config
+  git checkout jakarta
+  mvn clean install -DskipTests -DskipITs
+  popd
 
-# Build Kotlin Maven Plugin to allow skipping main compilation
-# (skipping test compilation is supported but not main)
-rm -rf target/kotlin
-git clone -b v1.6.10-jakarta --depth 1 git@github.com:gsmet/kotlin.git target/kotlin
-pushd target/kotlin/libraries/tools/kotlin-maven-plugin
-mvn clean install -DskipTests -DskipITs
-popd
+  # Build Kotlin Maven Plugin to allow skipping main compilation
+  # (skipping test compilation is supported but not main)
+  rm -rf target/kotlin
+  git clone -b v1.6.10-jakarta --depth 1 git@github.com:gsmet/kotlin.git target/kotlin
+  pushd target/kotlin/libraries/tools/kotlin-maven-plugin
+  mvn clean install -DskipTests -DskipITs
+  popd
+fi
 
 # Set up jbang alias, we are using latest released transformer version
 jbang alias add --name transform org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,17 @@
                     <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
                     <version>${quarkus-platform-bom-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                    <configuration>
+                        <configLocation>${maven.multiModuleProjectDirectory}/jakarta/rewrite.yml</configLocation>
+                        <activeStyles>
+                            <style>io.quarkus.style.maven</style>
+                        </activeStyles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <extensions>

--- a/test-framework/common/pom.xml
+++ b/test-framework/common/pom.xml
@@ -19,10 +19,6 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonp-deployment</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
         </dependency>


### PR DESCRIPTION
Hey @manovotn @Sanne @maxandersen @n1hility @radcortez ,

Here is the promised PR with the Jakarta rewrite infrastructure. It required quite a lot of experiments but I'm quite happy with the result (it looks far more simple in the end than all the experiments I had to do to get to this result). The hardest part was to find a way to apply the changes without ending up with something you can't build anymore as OpenRewrite needs the Maven build to work.

I went until the ArC extension in this first PR. My next step is to be able to build the Hibernate Validator one as it shouldn't be too hard on the HV side but will unblock quite a lot of dependencies as a lot of them are built on the same model and will require the same dependencies for them to work.
It should be far faster now that I figured out a way to orchestrate this thing.

I added a `jakarta/README.md` explaining the general approach and I would be happy to present the approach to you anytime.

Note that this requires (but good news, everything is taken care of in the `jakarta/transform.sh` script so you don't have to do anything related to this):
- a patched version of OpenRewrite (I'm contributing my patches back there so that's until they merged them)
- a patched version of the Rewrite Maven Plugin
- a patched version of the Kotlin Maven Plugin (yes, I know... but I need to be able to skip the main compilation which the Kotlin plugin does not support, it only supports `maven.test.skip` for the test compilation)
- the script also builds SmallRye Config while waiting for the CR2 promised by Roberto

Please see the `jakarta/README.md` before experimenting with this as it has a few advices on how to experiment.

Let's wait for CI on this one as I had to do some more build fixes in addition to the ones that I already merged. These build fixes are in separate commits.

Questions welcome. Happy to present this work in a call.