### PR TITLE
AWT, Native: Removes a workaround for loading iio-plugin.properties

### DIFF
--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/JDKSubstitutions.java
@@ -1,33 +1,10 @@
 package io.quarkus.awt.runtime;
 
 import java.awt.FontFormatException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.PropertyResourceBundle;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-
-/**
- * TODO: This is just a workaround,
- * see AwtProcessor#yankI18NPropertiesFromHostJDK
- */
-@TargetClass(className = "com.sun.imageio.plugins.common.I18NImpl")
-final class Target_com_sun_imageio_plugins_common_I18NImpl {
-
-    @Substitute
-    private static String getString(String className, String resource_name, String key) {
-        PropertyResourceBundle bundle = null;
-        try {
-            // className ignored, there is only one such file in the imageio anyway
-            InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource_name);
-            bundle = new PropertyResourceBundle(stream);
-        } catch (Throwable e) {
-            throw new RuntimeException(e);
-        }
-        return (String) bundle.handleGetObject(key);
-    }
-}
 
 /**
  * Getting .pfb/.pfa files to work would require additional runtime re-init adjustments.

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersTest.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersTest.java
@@ -130,8 +130,8 @@ public class ImageDecodersTest {
     "weird_488-1.tif        █OK", // Affects sun.awt.image.*Raster
     "test_hyperstack.tiff   █OK", // Affects tiff plugin
     "test_lut_3c_fiji.tiff  █OK", // Life sciences imagery, Fiji used to edit colour Lookup Table (LUT)
-    "test_jpeg.tiff         █NOK█.*test_jpeg.tiff.*Unsupported Image Type.*", // JPEG compression TIFF by GIMP*/
-    "weird_230.bmp          █NOK█.*weird_230.bmp.*New BMP version not implemented yet.*" // Currently, fails, no iio-plugin.properties.
+    "test_jpeg.tiff         █NOK█.*test_jpeg.tiff.*Unsupported Image Type.*", // JPEG compression TIFF by GIMP
+    "weird_230.bmp          █NOK█.*weird_230.bmp.*New BMP version not implemented yet.*" // Tested with a custom iio-plugin.properties too
     })
     // @formatter:on
     public void testComplexImages(String testData) throws IOException {


### PR DESCRIPTION
The `iio-plugin.properties` is correctly loaded from the JDK that is bundling the native-image toolchain, not from the one running the Maven build. Most importantly, if one runs the build using a builder image container, the properties file is loaded from the JDK bundled in the builder image.

I tested that with a custom JDK build and a custom Mandrel build to have a garbled `iio-plugin.properties` to compare.

Why removing the workaround now: There likely hasn't been any reason for it to be there in the first place, I just didn't know any better :) 
