### PR TITLE
Apply some small optimizations to the generated Reactive REST Client

### DIFF
--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
@@ -19,6 +19,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.jaxrs.client.reactive.runtime.ParameterAnnotationsSupplier;
+import io.quarkus.jaxrs.client.reactive.runtime.ParameterGenericTypesSupplier;
 
 class ClassRestClientContext implements AutoCloseable {
 
@@ -110,11 +111,11 @@ class ClassRestClientContext implements AutoCloseable {
                 return methodGenericTypeField;
             }
 
-            ResultHandle javaMethodGenericParametersHandle = clinit.invokeVirtualMethod(
-                    MethodDescriptor.ofMethod(Method.class, "getGenericParameterTypes", java.lang.reflect.Type[].class),
+            ResultHandle javaMethodGenericParametersHandle = clinit.newInstance(MethodDescriptor.ofConstructor(
+                    ParameterGenericTypesSupplier.class, Method.class),
                     clinit.readStaticField(methodStaticFields.get(methodIndex)));
             FieldDescriptor javaMethodGenericParametersField = FieldDescriptor.of(classCreator.getClassName(),
-                    "javaMethodGenericParameters" + methodIndex, java.lang.reflect.Type[].class);
+                    "javaMethodGenericParameters" + methodIndex, Supplier.class);
             classCreator.getFieldCreator(javaMethodGenericParametersField)
                     .setModifiers(Modifier.PUBLIC | Modifier.FINAL | Modifier.STATIC);
             clinit.writeStaticField(javaMethodGenericParametersField, javaMethodGenericParametersHandle);

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/ClassRestClientContext.java
@@ -1,6 +1,5 @@
 package io.quarkus.jaxrs.client.reactive.deployment;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -19,6 +18,7 @@ import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.jaxrs.client.reactive.runtime.ParameterAnnotationsSupplier;
 
 class ClassRestClientContext implements AutoCloseable {
 
@@ -84,11 +84,11 @@ class ClassRestClientContext implements AutoCloseable {
                 return methodParamAnnotationsField;
             }
 
-            ResultHandle javaMethodParamAnnotationsHandle = clinit.invokeVirtualMethod(
-                    MethodDescriptor.ofMethod(Method.class, "getParameterAnnotations", Annotation[][].class),
+            ResultHandle javaMethodParamAnnotationsHandle = clinit.newInstance(MethodDescriptor.ofConstructor(
+                    ParameterAnnotationsSupplier.class, Method.class),
                     clinit.readStaticField(methodStaticFields.get(methodIndex)));
             FieldDescriptor javaMethodParamAnnotationsField = FieldDescriptor.of(classCreator.getClassName(),
-                    "javaMethodParameterAnnotations" + methodIndex, Annotation[][].class);
+                    "javaMethodParameterAnnotations" + methodIndex, Supplier.class);
             classCreator.getFieldCreator(javaMethodParamAnnotationsField)
                     .setModifiers(Modifier.PUBLIC | Modifier.FINAL | Modifier.STATIC);
             clinit.writeStaticField(javaMethodParamAnnotationsField, javaMethodParamAnnotationsHandle);

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -16,7 +16,6 @@ import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNa
 
 import java.io.Closeable;
 import java.io.File;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -837,8 +836,8 @@ public class JaxrsClientReactiveProcessor {
                                     jandexMethod.parameters().get(paramIdx), index, methodCreator.getThis(),
                                     methodCreator.readArrayValue(
                                             methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodParamAnnotationsField.get()), paramIdx)));
+                                    methodCreator.readStaticField(methodParamAnnotationsField.get()),
+                                    paramIdx));
                         } else if (param.parameterType == ParameterType.BEAN) {
                             // bean params require both, web-target and Invocation.Builder, modifications
                             // The web target changes have to be done on the method level.
@@ -872,8 +871,8 @@ public class JaxrsClientReactiveProcessor {
                                     param.type, methodCreator.getThis(),
                                     methodCreator.readArrayValue(
                                             methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodParamAnnotationsField.get()), paramIdx));
+                                    methodCreator.readStaticField(methodParamAnnotationsField.get()),
+                                    paramIdx);
                         } else if (param.parameterType == ParameterType.BODY) {
                             // just store the index of parameter used to create the body, we'll use it later
                             bodyParameterIdx = paramIdx;
@@ -919,8 +918,8 @@ public class JaxrsClientReactiveProcessor {
                                     restClientInterface.getClassName(), methodCreator.getThis(), formParams,
                                     methodCreator.readArrayValue(
                                             methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodParamAnnotationsField.get()), paramIdx));
+                                    methodCreator.readStaticField(methodParamAnnotationsField.get()),
+                                    paramIdx);
                         } else if (param.parameterType == ParameterType.MULTI_PART_FORM) {
                             if (multipartForm != null) {
                                 throw new IllegalArgumentException("MultipartForm data set twice for method "
@@ -1152,9 +1151,8 @@ public class JaxrsClientReactiveProcessor {
                                         subMethodCreator.readArrayValue(
                                                 subMethodCreator.readStaticField(methodGenericParametersField.get()),
                                                 paramIdx),
-                                        subMethodCreator.readArrayValue(
-                                                subMethodCreator.readStaticField(methodParamAnnotationsField.get()),
-                                                paramIdx)));
+                                        subMethodCreator.readStaticField(methodParamAnnotationsField.get()),
+                                        paramIdx));
                     } else if (param.parameterType == ParameterType.BEAN) {
                         // bean params require both, web-target and Invocation.Builder, modifications
                         // The web target changes have to be done on the method level.
@@ -1190,8 +1188,8 @@ public class JaxrsClientReactiveProcessor {
                                 subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
                                 subMethodCreator.readArrayValue(
                                         subMethodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
-                                subMethodCreator.readArrayValue(
-                                        subMethodCreator.readStaticField(methodParamAnnotationsField.get()), paramIdx));
+                                subMethodCreator.readStaticField(methodParamAnnotationsField.get()),
+                                paramIdx);
                     } else if (param.parameterType == ParameterType.BODY) {
                         // just store the index of parameter used to create the body, we'll use it later
                         bodyParameterValue = paramValue;
@@ -1261,9 +1259,8 @@ public class JaxrsClientReactiveProcessor {
                                         subMethodCreator.readArrayValue(
                                                 subMethodCreator.readStaticField(subMethodGenericParametersField.get()),
                                                 paramIdx),
-                                        subMethodCreator.readArrayValue(
-                                                subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()),
-                                                paramIdx)));
+                                        subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()),
+                                        paramIdx));
                     } else if (param.parameterType == ParameterType.BEAN) {
                         // bean params require both, web-target and Invocation.Builder, modifications
                         // The web target changes have to be done on the method level.
@@ -1299,8 +1296,8 @@ public class JaxrsClientReactiveProcessor {
                                 subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
                                 subMethodCreator.readArrayValue(
                                         subMethodCreator.readStaticField(subMethodGenericParametersField.get()), paramIdx),
-                                subMethodCreator.readArrayValue(
-                                        subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()), paramIdx));
+                                subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()),
+                                paramIdx);
                     } else if (param.parameterType == ParameterType.BODY) {
                         // just store the index of parameter used to create the body, we'll use it later
                         bodyParameterValue = subMethodCreator.getMethodParam(paramIdx);
@@ -2178,9 +2175,11 @@ public class JaxrsClientReactiveProcessor {
             IndexView index,
             String restClientInterfaceClassName,
             ResultHandle client,
-            ResultHandle invocationEnricherClient, // this client or containing client if this is a sub-client
+            ResultHandle invocationEnricherClient,
+            // this client or containing client if this is a sub-client
             AssignableResultHandle formParams,
-            Supplier<FieldDescriptor> methodGenericTypeField, Supplier<FieldDescriptor> methodParamAnnotationsField,
+            Supplier<FieldDescriptor> methodGenericTypeField,
+            Supplier<FieldDescriptor> methodParamAnnotationsField,
             int paramIdx) {
         // Form params collector must be initialized at method root level before any inner blocks that may use it
         if (areFormParamsDefinedIn(beanParamItems)) {
@@ -2208,7 +2207,8 @@ public class JaxrsClientReactiveProcessor {
             // this client or containing client if this is a sub-client
             ResultHandle invocationEnricherClient,
             AssignableResultHandle formParams,
-            Supplier<FieldDescriptor> methodGenericTypeField, Supplier<FieldDescriptor> methodParamAnnotationsField,
+            Supplier<FieldDescriptor> methodGenericTypeField,
+            Supplier<FieldDescriptor> methodParamAnnotationsField,
             int paramIdx) {
         BytecodeCreator creator = methodCreator.ifNotNull(param).trueBranch();
         BytecodeCreator invoEnricher = invocationBuilderEnricher.ifNotNull(invocationBuilderEnricher.getMethodParam(1))
@@ -2233,8 +2233,8 @@ public class JaxrsClientReactiveProcessor {
                                     index, client,
                                     creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()),
                                             paramIdx),
-                                    creator.readArrayValue(creator.readStaticField(methodParamAnnotationsField.get()),
-                                            paramIdx)));
+                                    creator.readStaticField(methodParamAnnotationsField.get()),
+                                    paramIdx));
                     break;
                 case COOKIE:
                     CookieParamItem cookieParam = (CookieParamItem) item;
@@ -2258,14 +2258,16 @@ public class JaxrsClientReactiveProcessor {
                             pathParam.getPathParamName(),
                             pathParam.extract(creator, param), pathParam.getParamType(), client,
                             creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()), paramIdx),
-                            creator.readArrayValue(creator.readStaticField(methodParamAnnotationsField.get()), paramIdx));
+                            creator.readStaticField(methodParamAnnotationsField.get()),
+                            paramIdx);
                     break;
                 case FORM_PARAM:
                     FormParamItem formParam = (FormParamItem) item;
                     addFormParam(creator, formParam.getFormParamName(), formParam.extract(creator, param),
                             formParam.getParamType(), restClientInterfaceClassName, client, formParams,
                             creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()), paramIdx),
-                            creator.readArrayValue(creator.readStaticField(methodParamAnnotationsField.get()), paramIdx));
+                            creator.readStaticField(methodParamAnnotationsField.get()),
+                            paramIdx);
                     break;
                 default:
                     throw new IllegalStateException("Unimplemented");
@@ -2299,7 +2301,7 @@ public class JaxrsClientReactiveProcessor {
             // this client or containing client if we're in a subresource
             ResultHandle client,
             ResultHandle genericType,
-            ResultHandle paramAnnotations) {
+            ResultHandle paramAnnotations, int paramIndex) {
         ResultHandle paramArray;
         String componentType = null;
 
@@ -2331,8 +2333,9 @@ public class JaxrsClientReactiveProcessor {
 
         paramArray = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
-                        Class.class, java.lang.reflect.Type.class, Annotation[].class),
-                client, paramArray, notNullValue.loadClassFromTCCL(componentType), genericType, paramAnnotations);
+                        Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                client, paramArray, notNullValue.loadClassFromTCCL(componentType), genericType, paramAnnotations,
+                methodCreator.load(paramIndex));
 
         notNullValue.assign(result, notNullValue.invokeInterfaceMethod(
                 MethodDescriptor.ofMethod(WebTarget.class, "queryParam", WebTarget.class,
@@ -2358,20 +2361,20 @@ public class JaxrsClientReactiveProcessor {
 
     private void addHeaderParam(BytecodeCreator invoBuilderEnricher, AssignableResultHandle invocationBuilder,
             String paramName, ResultHandle headerParamHandle, String paramType, ResultHandle client,
-            FieldDescriptor methodGenericTypeField, FieldDescriptor methodParamAnnotationsField, int paramIdx) {
+            FieldDescriptor methodGenericTypeField, FieldDescriptor methodParamAnnotationsField,
+            int paramIdx) {
 
         BytecodeCreator notNullValue = invoBuilderEnricher.ifNull(headerParamHandle).falseBranch();
         ResultHandle genericType = notNullValue.readArrayValue(
                 notNullValue.readStaticField(methodGenericTypeField), paramIdx);
 
-        ResultHandle parameterAnnotations = notNullValue.readArrayValue(
-                notNullValue.readStaticField(methodParamAnnotationsField), paramIdx);
+        ResultHandle parameterAnnotations = notNullValue.readStaticField(methodParamAnnotationsField);
 
         headerParamHandle = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
                 client, headerParamHandle,
-                notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations);
+                notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations, notNullValue.load(paramIdx));
 
         notNullValue.assign(invocationBuilder,
                 notNullValue.invokeInterfaceMethod(
@@ -2382,12 +2385,13 @@ public class JaxrsClientReactiveProcessor {
 
     private void addPathParam(BytecodeCreator methodCreator, AssignableResultHandle methodTarget,
             String paramName, ResultHandle pathParamHandle, String parameterType, ResultHandle client,
-            ResultHandle genericType, ResultHandle parameterAnnotations) {
+            ResultHandle genericType, ResultHandle parameterAnnotations, int paramIndex) {
         ResultHandle handle = methodCreator.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
                 client, pathParamHandle,
-                methodCreator.loadClassFromTCCL(parameterType), genericType, parameterAnnotations);
+                methodCreator.loadClassFromTCCL(parameterType), genericType, parameterAnnotations,
+                methodCreator.load(paramIndex));
         methodCreator.assign(methodTarget,
                 methodCreator.invokeInterfaceMethod(WEB_TARGET_RESOLVE_TEMPLATE_METHOD,
                         methodTarget,
@@ -2397,13 +2401,14 @@ public class JaxrsClientReactiveProcessor {
     private void addFormParam(BytecodeCreator methodCreator, String paramName, ResultHandle formParamHandle,
             String parameterType, String restClientInterfaceClassName,
             ResultHandle client, AssignableResultHandle formParams, ResultHandle genericType,
-            ResultHandle parameterAnnotations) {
+            ResultHandle parameterAnnotations, int methodIndex) {
         BytecodeCreator notNullValue = methodCreator.ifNull(formParamHandle).falseBranch();
         ResultHandle convertedFormParam = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
                 client, formParamHandle,
-                notNullValue.loadClassFromTCCL(parameterType), genericType, parameterAnnotations);
+                notNullValue.loadClassFromTCCL(parameterType), genericType, parameterAnnotations,
+                notNullValue.load(methodIndex));
         ResultHandle isString = notNullValue.instanceOf(convertedFormParam, String.class);
         BranchResult isStringBranch = notNullValue.ifTrue(isString);
         isStringBranch.falseBranch().throwException(IllegalStateException.class,
@@ -2426,14 +2431,13 @@ public class JaxrsClientReactiveProcessor {
         ResultHandle genericType = notNullValue.readArrayValue(
                 notNullValue.readStaticField(methodGenericTypeField), paramIdx);
 
-        ResultHandle parameterAnnotations = notNullValue.readArrayValue(
-                notNullValue.readStaticField(methodParamAnnotationsField), paramIdx);
+        ResultHandle parameterAnnotations = notNullValue.readStaticField(methodParamAnnotationsField);
 
         cookieParamHandle = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Annotation[].class),
+                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
                 client, cookieParamHandle,
-                notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations);
+                notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations, notNullValue.load(paramIdx));
         notNullValue.assign(invocationBuilder,
                 notNullValue.invokeInterfaceMethod(
                         MethodDescriptor.ofMethod(Invocation.Builder.class, "cookie", Invocation.Builder.class, String.class,

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/deployment/src/main/java/io/quarkus/jaxrs/client/reactive/deployment/JaxrsClientReactiveProcessor.java
@@ -834,8 +834,7 @@ public class JaxrsClientReactiveProcessor {
                             methodCreator.assign(methodTarget, addQueryParam(methodCreator, methodTarget, param.name,
                                     methodCreator.getMethodParam(paramIdx),
                                     jandexMethod.parameters().get(paramIdx), index, methodCreator.getThis(),
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
+                                    methodCreator.readStaticField(methodGenericParametersField.get()),
                                     methodCreator.readStaticField(methodParamAnnotationsField.get()),
                                     paramIdx));
                         } else if (param.parameterType == ParameterType.BEAN) {
@@ -869,8 +868,7 @@ public class JaxrsClientReactiveProcessor {
                             // methodTarget = methodTarget.resolveTemplate(paramname, paramvalue);
                             addPathParam(methodCreator, methodTarget, param.name, methodCreator.getMethodParam(paramIdx),
                                     param.type, methodCreator.getThis(),
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
+                                    methodCreator.readStaticField(methodGenericParametersField.get()),
                                     methodCreator.readStaticField(methodParamAnnotationsField.get()),
                                     paramIdx);
                         } else if (param.parameterType == ParameterType.BODY) {
@@ -916,8 +914,7 @@ public class JaxrsClientReactiveProcessor {
                             formParams = createIfAbsent(methodCreator, formParams);
                             addFormParam(methodCreator, param.name, methodCreator.getMethodParam(paramIdx), param.type,
                                     restClientInterface.getClassName(), methodCreator.getThis(), formParams,
-                                    methodCreator.readArrayValue(
-                                            methodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
+                                    methodCreator.readStaticField(methodGenericParametersField.get()),
                                     methodCreator.readStaticField(methodParamAnnotationsField.get()),
                                     paramIdx);
                         } else if (param.parameterType == ParameterType.MULTI_PART_FORM) {
@@ -1148,9 +1145,7 @@ public class JaxrsClientReactiveProcessor {
                                 addQueryParam(subMethodCreator, methodTarget, param.name,
                                         paramValue, jandexMethod.parameters().get(paramIdx), index,
                                         subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
-                                        subMethodCreator.readArrayValue(
-                                                subMethodCreator.readStaticField(methodGenericParametersField.get()),
-                                                paramIdx),
+                                        subMethodCreator.readStaticField(methodGenericParametersField.get()),
                                         subMethodCreator.readStaticField(methodParamAnnotationsField.get()),
                                         paramIdx));
                     } else if (param.parameterType == ParameterType.BEAN) {
@@ -1186,8 +1181,7 @@ public class JaxrsClientReactiveProcessor {
                         addPathParam(subMethodCreator, methodTarget, param.name, paramValue,
                                 param.type,
                                 subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
-                                subMethodCreator.readArrayValue(
-                                        subMethodCreator.readStaticField(methodGenericParametersField.get()), paramIdx),
+                                subMethodCreator.readStaticField(methodGenericParametersField.get()),
                                 subMethodCreator.readStaticField(methodParamAnnotationsField.get()),
                                 paramIdx);
                     } else if (param.parameterType == ParameterType.BODY) {
@@ -1256,9 +1250,7 @@ public class JaxrsClientReactiveProcessor {
                                         subMethodCreator.getMethodParam(paramIdx),
                                         jandexSubMethod.parameters().get(paramIdx), index,
                                         subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
-                                        subMethodCreator.readArrayValue(
-                                                subMethodCreator.readStaticField(subMethodGenericParametersField.get()),
-                                                paramIdx),
+                                        subMethodCreator.readStaticField(subMethodGenericParametersField.get()),
                                         subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()),
                                         paramIdx));
                     } else if (param.parameterType == ParameterType.BEAN) {
@@ -1294,8 +1286,7 @@ public class JaxrsClientReactiveProcessor {
                         addPathParam(subMethodCreator, methodTarget, param.name,
                                 subMethodCreator.getMethodParam(paramIdx), param.type,
                                 subMethodCreator.readInstanceField(clientField, subMethodCreator.getThis()),
-                                subMethodCreator.readArrayValue(
-                                        subMethodCreator.readStaticField(subMethodGenericParametersField.get()), paramIdx),
+                                subMethodCreator.readStaticField(subMethodGenericParametersField.get()),
                                 subMethodCreator.readStaticField(subMethodParamAnnotationsField.get()),
                                 paramIdx);
                     } else if (param.parameterType == ParameterType.BODY) {
@@ -2231,8 +2222,7 @@ public class JaxrsClientReactiveProcessor {
                                     queryParam.extract(creator, param),
                                     queryParam.getValueType(),
                                     index, client,
-                                    creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()),
-                                            paramIdx),
+                                    creator.readStaticField(methodGenericTypeField.get()),
                                     creator.readStaticField(methodParamAnnotationsField.get()),
                                     paramIdx));
                     break;
@@ -2257,7 +2247,7 @@ public class JaxrsClientReactiveProcessor {
                     addPathParam(creator, target,
                             pathParam.getPathParamName(),
                             pathParam.extract(creator, param), pathParam.getParamType(), client,
-                            creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()), paramIdx),
+                            creator.readStaticField(methodGenericTypeField.get()),
                             creator.readStaticField(methodParamAnnotationsField.get()),
                             paramIdx);
                     break;
@@ -2265,7 +2255,7 @@ public class JaxrsClientReactiveProcessor {
                     FormParamItem formParam = (FormParamItem) item;
                     addFormParam(creator, formParam.getFormParamName(), formParam.extract(creator, param),
                             formParam.getParamType(), restClientInterfaceClassName, client, formParams,
-                            creator.readArrayValue(creator.readStaticField(methodGenericTypeField.get()), paramIdx),
+                            creator.readStaticField(methodGenericTypeField.get()),
                             creator.readStaticField(methodParamAnnotationsField.get()),
                             paramIdx);
                     break;
@@ -2333,7 +2323,7 @@ public class JaxrsClientReactiveProcessor {
 
         paramArray = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParamArray", Object[].class, Object[].class,
-                        Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                        Class.class, Supplier.class, Supplier.class, int.class),
                 client, paramArray, notNullValue.loadClassFromTCCL(componentType), genericType, paramAnnotations,
                 methodCreator.load(paramIndex));
 
@@ -2365,14 +2355,13 @@ public class JaxrsClientReactiveProcessor {
             int paramIdx) {
 
         BytecodeCreator notNullValue = invoBuilderEnricher.ifNull(headerParamHandle).falseBranch();
-        ResultHandle genericType = notNullValue.readArrayValue(
-                notNullValue.readStaticField(methodGenericTypeField), paramIdx);
+        ResultHandle genericType = notNullValue.readStaticField(methodGenericTypeField);
 
         ResultHandle parameterAnnotations = notNullValue.readStaticField(methodParamAnnotationsField);
 
         headerParamHandle = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                        Object.class, Class.class, Supplier.class, Supplier.class, int.class),
                 client, headerParamHandle,
                 notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations, notNullValue.load(paramIdx));
 
@@ -2388,7 +2377,7 @@ public class JaxrsClientReactiveProcessor {
             ResultHandle genericType, ResultHandle parameterAnnotations, int paramIndex) {
         ResultHandle handle = methodCreator.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                        Object.class, Class.class, Supplier.class, Supplier.class, int.class),
                 client, pathParamHandle,
                 methodCreator.loadClassFromTCCL(parameterType), genericType, parameterAnnotations,
                 methodCreator.load(paramIndex));
@@ -2405,7 +2394,7 @@ public class JaxrsClientReactiveProcessor {
         BytecodeCreator notNullValue = methodCreator.ifNull(formParamHandle).falseBranch();
         ResultHandle convertedFormParam = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                        Object.class, Class.class, Supplier.class, Supplier.class, int.class),
                 client, formParamHandle,
                 notNullValue.loadClassFromTCCL(parameterType), genericType, parameterAnnotations,
                 notNullValue.load(methodIndex));
@@ -2428,14 +2417,13 @@ public class JaxrsClientReactiveProcessor {
 
         BytecodeCreator notNullValue = invoBuilderEnricher.ifNull(cookieParamHandle).falseBranch();
 
-        ResultHandle genericType = notNullValue.readArrayValue(
-                notNullValue.readStaticField(methodGenericTypeField), paramIdx);
+        ResultHandle genericType = notNullValue.readStaticField(methodGenericTypeField);
 
         ResultHandle parameterAnnotations = notNullValue.readStaticField(methodParamAnnotationsField);
 
         cookieParamHandle = notNullValue.invokeVirtualMethod(
                 MethodDescriptor.ofMethod(RestClientBase.class, "convertParam", Object.class,
-                        Object.class, Class.class, java.lang.reflect.Type.class, Supplier.class, int.class),
+                        Object.class, Class.class, Supplier.class, Supplier.class, int.class),
                 client, cookieParamHandle,
                 notNullValue.loadClassFromTCCL(paramType), genericType, parameterAnnotations, notNullValue.load(paramIdx));
         notNullValue.assign(invocationBuilder,

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterAnnotationsSupplier.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterAnnotationsSupplier.java
@@ -1,0 +1,23 @@
+package io.quarkus.jaxrs.client.reactive.runtime;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.function.Supplier;
+
+public class ParameterAnnotationsSupplier implements Supplier<Annotation[][]> {
+
+    private final Method method;
+    private volatile Annotation[][] value;
+
+    public ParameterAnnotationsSupplier(Method method) {
+        this.method = method;
+    }
+
+    @Override
+    public Annotation[][] get() {
+        if (value == null) {
+            value = method.getParameterAnnotations();
+        }
+        return value;
+    }
+}

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterGenericTypesSupplier.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/ParameterGenericTypesSupplier.java
@@ -1,0 +1,23 @@
+package io.quarkus.jaxrs.client.reactive.runtime;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.function.Supplier;
+
+public class ParameterGenericTypesSupplier implements Supplier<Type[]> {
+
+    private final Method method;
+    private volatile Type[] value;
+
+    public ParameterGenericTypesSupplier(Method method) {
+        this.method = method;
+    }
+
+    @Override
+    public Type[] get() {
+        if (value == null) {
+            value = method.getGenericParameterTypes();
+        }
+        return value;
+    }
+}

--- a/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
+++ b/extensions/resteasy-reactive/jaxrs-client-reactive/runtime/src/main/java/io/quarkus/jaxrs/client/reactive/runtime/RestClientBase.java
@@ -20,7 +20,7 @@ public abstract class RestClientBase implements Closeable {
     }
 
     @SuppressWarnings("unused") // used by generated code
-    public <T> Object[] convertParamArray(T[] value, Class<T> type, Type genericType,
+    public <T> Object[] convertParamArray(T[] value, Class<T> type, Supplier<Type[]> genericType,
             Supplier<Annotation[][]> methodAnnotations, int paramIndex) {
         ParamConverter<T> converter = getConverter(type, genericType, methodAnnotations, paramIndex);
 
@@ -37,7 +37,8 @@ public abstract class RestClientBase implements Closeable {
     }
 
     @SuppressWarnings("unused") // used by generated code
-    public <T> Object convertParam(T value, Class<T> type, Type genericType, Supplier<Annotation[][]> methodAnnotations,
+    public <T> Object convertParam(T value, Class<T> type, Supplier<Type[]> genericType,
+            Supplier<Annotation[][]> methodAnnotations,
             int paramIndex) {
         ParamConverter<T> converter = getConverter(type, genericType, methodAnnotations, paramIndex);
         if (converter != null) {
@@ -47,13 +48,15 @@ public abstract class RestClientBase implements Closeable {
         }
     }
 
-    private <T> ParamConverter<T> getConverter(Class<T> type, Type genericType, Supplier<Annotation[][]> methodAnnotations,
+    private <T> ParamConverter<T> getConverter(Class<T> type, Supplier<Type[]> genericType,
+            Supplier<Annotation[][]> methodAnnotations,
             int paramIndex) {
         ParamConverterProvider converterProvider = providerForClass.get(type);
 
         if (converterProvider == null) {
             for (ParamConverterProvider provider : paramConverterProviders) {
-                ParamConverter<T> converter = provider.getConverter(type, genericType, methodAnnotations.get()[paramIndex]);
+                ParamConverter<T> converter = provider.getConverter(type, genericType.get()[paramIndex],
+                        methodAnnotations.get()[paramIndex]);
                 if (converter != null) {
                     providerForClass.put(type, provider);
                     return converter;
@@ -61,7 +64,7 @@ public abstract class RestClientBase implements Closeable {
             }
             providerForClass.put(type, NO_PROVIDER);
         } else if (converterProvider != NO_PROVIDER) {
-            return converterProvider.getConverter(type, genericType, methodAnnotations.get()[paramIndex]);
+            return converterProvider.getConverter(type, genericType.get()[paramIndex], methodAnnotations.get()[paramIndex]);
         }
         return null;
     }


### PR DESCRIPTION
The goal of these is to avoid calling the various methods of `java.lang.reflect.Method` (which are slow) unless we absolutely have to (which in most cases we don't)