### PR TITLE
Fixed extension name in smallrye-graphql examples

### DIFF
--- a/docs/src/main/asciidoc/smallrye-graphql.adoc
+++ b/docs/src/main/asciidoc/smallrye-graphql.adoc
@@ -61,7 +61,7 @@ The solution is located in the `microprofile-graphql-quickstart` {quickstarts-tr
 First, we need a new project. Create a new project with the following command:
 
 :create-app-artifact-id: microprofile-graphql-quickstart
-:create-app-extensions: graphql
+:create-app-extensions: quarkus-smallrye-graphql
 include::includes/devtools/create-app.adoc[]
 
 This command generates a project, importing the `smallrye-graphql` extension.
@@ -69,7 +69,7 @@ This command generates a project, importing the `smallrye-graphql` extension.
 If you already have your Quarkus project configured, you can add the `smallrye-graphql` extension
 to your project by running the following command in your project base directory:
 
-:add-extension-extensions: graphql
+:add-extension-extensions: quarkus-smallrye-graphql
 include::includes/devtools/extension-add.adoc[]
 
 This will add the following to your build file:


### PR DESCRIPTION
Trying one of the "add-extension" examples gave me an error. Here is a little boyscouting