### PR TITLE
Make sure quarkus-undertow is built before RESTEasy Classic

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/pom.xml
+++ b/extensions/resteasy-classic/resteasy/deployment/pom.xml
@@ -79,6 +79,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
quarkus-undertow is not in the dependencies but AsyncIOUndertowTest
relies on quarkus-undertow so we need to make sure this module is built before
RESTEasy Classic.

Fixes regular build issues in snapshot deployment and early access
build (these builds do not rely on a previous full build before running
the tests).