### PR TITLE
Oracle recorder ignores shared attribute in the reactive data source configuration

### DIFF
--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OraclePoolRecorder.java
@@ -83,6 +83,13 @@ public class OraclePoolRecorder {
             poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
         }
 
+        if (dataSourceReactiveRuntimeConfig.shared) {
+            poolOptions.setShared(true);
+            if (dataSourceReactiveRuntimeConfig.name.isPresent()) {
+                poolOptions.setName(dataSourceReactiveRuntimeConfig.name.get());
+            }
+        }
+
         if (dataSourceReactiveRuntimeConfig.eventLoopSize.isPresent()) {
             poolOptions.setEventLoopSize(Math.max(0, dataSourceReactiveRuntimeConfig.eventLoopSize.getAsInt()));
         } else if (eventLoopCount != null) {


### PR DESCRIPTION
…configuration

Follows-up on #22292

The attribute is used by every other Reactive SQL Client recorder.