### PR TITLE
Provide a new `ApplicationNotRunning` predicate for `@Scheduled`

### DIFF
--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -103,7 +103,7 @@ public class SchedulerProcessor {
     @BuildStep
     void beans(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         if (capabilities.isMissing(Capability.QUARTZ)) {
-            additionalBeans.produce(new AdditionalBeanBuildItem(SimpleScheduler.class));
+            additionalBeans.produce(new AdditionalBeanBuildItem(SimpleScheduler.class, Scheduled.ApplicationNotRunning.class));
         }
     }
 

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ApplicationNotRunningPredicateTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/ApplicationNotRunningPredicateTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.scheduler.test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.event.Observes;
+import javax.interceptor.Interceptor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Priority;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.FailedExecution;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.SuccessfulExecution;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ApplicationNotRunningPredicateTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().withApplicationRoot((jar) -> jar.addClasses(Jobs.class));
+
+    static final CountDownLatch SUCCESS_LATCH = new CountDownLatch(1);
+    static volatile FailedExecution failedExecution;
+
+    @Test
+    public void testTriggerErrorStatus() throws InterruptedException {
+        assertTrue(SUCCESS_LATCH.await(5, TimeUnit.SECONDS));
+        assertNull(failedExecution);
+    }
+
+    void observeSuccessfulExecution(@Observes SuccessfulExecution successfulExecution) {
+        SUCCESS_LATCH.countDown();
+    }
+
+    void observeFailedExecution(@Observes FailedExecution failedExecution) {
+        ApplicationNotRunningPredicateTest.failedExecution = failedExecution;
+    }
+
+    static class Jobs {
+
+        volatile boolean preStart;
+
+        void started(@Observes @Priority(Interceptor.Priority.PLATFORM_BEFORE) StartupEvent event) {
+            preStart = true;
+        }
+
+        @Scheduled(every = "0.2s", skipExecutionIf = Scheduled.ApplicationNotRunning.class)
+        void scheduleAfterStarted() {
+            if (!preStart) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `@Scheduled` annotation's `skipExecutionIf` attribute can be used to skip individual executions in a schedule. Currently, Quarkus only provides the `Never` implementation, which is also the default (never skips an execution).

Since the scheduler is initialized very early (priority `PLATFORM_BEFORE`) it can happen that executions get scheduled before the application has been fully started. An application can solve this by itself waiting to get notified with the `StartupEvent` or it can now use this new predicate: `@Scheduled(..., skipExecutionIf = ApplicationNotRunning.class)`.