### PR TITLE
Initial commit adding shutdown hooks

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Application.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Application.java
@@ -11,6 +11,7 @@ import org.wildfly.common.lock.Locks;
 
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.dev.appstate.ApplicationStateNotification;
+import io.quarkus.runtime.shutdown.ShutdownHooks;
 import io.quarkus.runtime.shutdown.ShutdownRecorder;
 
 /**
@@ -199,6 +200,7 @@ public abstract class Application implements Closeable {
         }
         Timing.staticInitStopped(auxilaryApplication);
         try {
+            ShutdownHooks.runShutdown();
             ShutdownRecorder.runShutdown();
             doStop();
         } finally {

--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -2,11 +2,13 @@ package io.quarkus.runtime;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import org.jboss.logging.Logger;
 
 import io.quarkus.launcher.QuarkusLauncher;
+import io.quarkus.runtime.shutdown.ShutdownHooks;
 
 /**
  * The entry point for applications that use a main method. Quarkus will shut down when the main method returns.
@@ -183,4 +185,32 @@ public class Quarkus {
             app.awaitShutdown();
         }
     }
+
+    /**
+     * Registers a shutdown hook which runs on application shutdown and
+     * waits indefinitely on completion.
+     * <p>
+     * Registered hooks are run in reverse order of registration.
+     *
+     * @param runnable the shutdown hook to run on shutdown.
+     */
+    public static void addShutdownHook(Runnable runnable) {
+        ShutdownHooks.registerShutdownHook(runnable);
+    }
+
+    /**
+     * Registers a shutdown hook which runs on application shutdown and
+     * waits if necessary for at most the given time on completion.
+     * <p>
+     * Registered hooks are run in reverse order of registration.
+     *
+     * @param runnable the shutdown hook to run on shutdown.
+     * @param timeout the maximum time to wait.
+     * @param unit the time unit of the timeout argument.
+     * @throws IllegalArgumentException if the value of timeout is negative or unit is null.
+     */
+    public static void addShutdownHook(Runnable runnable, long timeout, TimeUnit unit) {
+        ShutdownHooks.registerShutdownHook(runnable, timeout, unit);
+    }
+
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownHooks.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownHooks.java
@@ -32,7 +32,7 @@ public class ShutdownHooks {
     private static class ShutdownHook implements Runnable {
 
         private final Runnable runnable;
-        private Long timeout = -1L;
+        private long timeout = -1L;
         private TimeUnit unit = TimeUnit.MILLISECONDS;
 
         public ShutdownHook(Runnable runnable) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownHooks.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownHooks.java
@@ -1,0 +1,69 @@
+package io.quarkus.runtime.shutdown;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.logging.Logger;
+
+public class ShutdownHooks {
+
+    private static final Logger LOG = Logger.getLogger(ShutdownHooks.class);
+
+    private static volatile List<Runnable> shutdownHooks = new ArrayList<>();
+
+    public static void registerShutdownHook(Runnable runnable) {
+        shutdownHooks.add(new ShutdownHook(runnable));
+    }
+
+    public static void registerShutdownHook(Runnable runnable, long timeout, TimeUnit unit) {
+        shutdownHooks.add(new ShutdownHook(runnable, timeout, unit));
+    }
+
+    public static void runShutdown() {
+        List<Runnable> toClose = new ArrayList<>(shutdownHooks);
+        Collections.reverse(toClose);
+        for (Runnable r : toClose) {
+            r.run();
+        }
+    }
+
+    private static class ShutdownHook implements Runnable {
+
+        private final Runnable runnable;
+        private Long timeout = -1L;
+        private TimeUnit unit = TimeUnit.MILLISECONDS;
+
+        public ShutdownHook(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        private ShutdownHook(Runnable runnable, long timeout, TimeUnit unit) {
+            if (timeout < 0) {
+                throw new IllegalArgumentException("timeout value is negative");
+            }
+            if (unit == null) {
+                throw new IllegalArgumentException("unit has no value");
+            }
+            this.runnable = runnable;
+            this.timeout = timeout;
+            this.unit = unit;
+        }
+
+        public void run() {
+            try {
+                Thread t = new Thread(runnable);
+                t.setDaemon(false);
+                t.start();
+                if (timeout >= 0) {
+                    t.join(unit.toMillis(timeout));
+                } else {
+                    t.join();
+                }
+            } catch (Throwable e) {
+                LOG.error("Running a shutdown task failed", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Preliminary PR which fixes #15742 to create a discussion on the specific implementation.

@geoand The current implementation hooks into the `Application#stop(Runnable r)` method. All other functionality is basically static. My gut tells me it should be part of `Application` or `ApplicationLifecyleManager` or ultimately `ShutdownContext`, but I need some pointers to make that happen.

Furthermore, I'd like to have some testcases for this functionality, but don't see where to put them. The runtime module seems to have none which test the shutdown procedure currently. Any hints on where to put some testcases.

Documentation is other than Javadoc has not been created yet.

