### PR TITLE
Restore RESTEasy codestart by default for Quarkus < 2.8

### DIFF
--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-version</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>maven-model-helper</artifactId>
         </dependency>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -43,6 +43,7 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
     public static final String INPUT_PROVIDED_CODE_KEY = "provided-code";
     private static final String IO_QUARKUS_GROUP_ID = "io.quarkus";
     private static final String IO_QUARKUS_PLATFORM_GROUP_ID = "io.quarkus.platform";
+    private static final String COM_REDHAT_QUARKUS_PLATFORM_GROUP_ID = "com.redhat.quarkus.platform";
     private static final String QUARKUS_BOM = "quarkus-bom";
     private static final String QUARKUS_UNIVERSE_BOM = "quarkus-universe-bom";
     private static final Set<String> LANGUAGE_EXTENSIONS = Set.of("quarkus-kotlin", "quarkus-scala");
@@ -211,7 +212,8 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
     }
 
     private boolean isPlatformBom(ArtifactCoords artifactCoords) {
-        return IO_QUARKUS_PLATFORM_GROUP_ID.equals(artifactCoords.getGroupId())
+        return (IO_QUARKUS_PLATFORM_GROUP_ID.equals(artifactCoords.getGroupId()) ||
+                COM_REDHAT_QUARKUS_PLATFORM_GROUP_ID.equals(artifactCoords.getGroupId()))
                 && QUARKUS_BOM.equals(artifactCoords.getArtifactId());
     }
 

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/codestarts/quarkus/QuarkusCodestartCatalog.java
@@ -14,10 +14,12 @@ import io.quarkus.devtools.codestarts.CodestartType;
 import io.quarkus.devtools.codestarts.DataKey;
 import io.quarkus.devtools.codestarts.core.GenericCodestartCatalog;
 import io.quarkus.devtools.project.extensions.Extensions;
+import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.platform.catalog.processor.ExtensionProcessor;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.smallrye.common.version.VersionScheme;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -38,6 +41,11 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
     public static final String INPUT_SELECTED_EXTENSIONS_KEY = "selected-extensions";
     public static final String INPUT_SELECTED_EXTENSIONS_GA_KEY = "selected-extensions-ga";
     public static final String INPUT_PROVIDED_CODE_KEY = "provided-code";
+    private static final String IO_QUARKUS_GROUP_ID = "io.quarkus";
+    private static final String IO_QUARKUS_PLATFORM_GROUP_ID = "io.quarkus.platform";
+    private static final String QUARKUS_BOM = "quarkus-bom";
+    private static final String QUARKUS_UNIVERSE_BOM = "quarkus-universe-bom";
+    private static final Set<String> LANGUAGE_EXTENSIONS = Set.of("quarkus-kotlin", "quarkus-scala");
     private final Map<String, Extension> extensionsMapping;
 
     public enum AppContent implements DataKey {
@@ -127,15 +135,17 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
                 .filter(c -> !isExample(c) || projectInput.getExample() == null || c.matches(projectInput.getExample()))
                 .collect(Collectors.toCollection(ArrayList::new));
 
-        // include default codestarts if no code selected and no extensions have been selected
+        // include default codestarts depending on the versions and the extensions being chosen or not
+        Optional<ExtensionCodestart> selectedDefaultCodeStart = getSelectedDefaultCodeStart(projectInput);
+
         if (projectInput.getAppContent().contains(CODE)
-                && projectInput.getExtensions().isEmpty()
+                && selectedDefaultCodeStart.isPresent()
                 && projectCodestarts.stream()
                         .noneMatch(c -> c.getType() == CodestartType.CODE && !c.getSpec().isPreselected())) {
             final Codestart defaultCodestart = codestarts.stream()
-                    .filter(c -> c.matches(ExtensionCodestart.RESTEASY_REACTIVE.key()))
+                    .filter(c -> c.matches(selectedDefaultCodeStart.get().key()))
                     .findFirst().orElseThrow(() -> new CodestartStructureException(
-                            ExtensionCodestart.RESTEASY_REACTIVE.key() + " codestart not found"));
+                            selectedDefaultCodeStart.get().key() + " codestart not found"));
             final String languageName = findLanguageName(projectCodestarts);
             if (defaultCodestart.implementsLanguage(languageName)) {
                 projectCodestarts.add(defaultCodestart);
@@ -163,6 +173,51 @@ public final class QuarkusCodestartCatalog extends GenericCodestartCatalog<Quark
         projectInput.getData().putAll(generateSelectionData(projectInput, projectCodestarts));
 
         return projectCodestarts;
+    }
+
+    private Optional<ExtensionCodestart> getSelectedDefaultCodeStart(QuarkusCodestartProjectInput projectInput) {
+        // This is very hackyish, we need a better data structure to do better
+        Optional<ArtifactCoords> quarkusBom = projectInput.getBoms().stream()
+                .map(ArtifactCoords::fromString)
+                .filter(b -> isCoreBom(b) || isPlatformBom(b) || isUniverseBom(b))
+                .findFirst();
+
+        String bomVersion = null;
+
+        if (quarkusBom.isPresent()) {
+            bomVersion = quarkusBom.get().getVersion();
+        }
+
+        if (bomVersion == null || VersionScheme.MAVEN.compare(bomVersion, "2.8") >= 0) {
+            if (projectInput.getExtensions().isEmpty() ||
+                    (projectInput.getExtensions().size() == 1
+                            && isLanguageExtension(projectInput.getExtensions().iterator().next()))) {
+                return Optional.of(ExtensionCodestart.RESTEASY_REACTIVE);
+            }
+
+            return Optional.empty();
+        }
+
+        return Optional.of(ExtensionCodestart.RESTEASY);
+    }
+
+    private boolean isCoreBom(ArtifactCoords artifactCoords) {
+        return IO_QUARKUS_GROUP_ID.equals(artifactCoords.getGroupId()) && QUARKUS_BOM.equals(artifactCoords.getArtifactId());
+    }
+
+    private boolean isUniverseBom(ArtifactCoords artifactCoords) {
+        return IO_QUARKUS_GROUP_ID.equals(artifactCoords.getGroupId())
+                && QUARKUS_UNIVERSE_BOM.equals(artifactCoords.getArtifactId());
+    }
+
+    private boolean isPlatformBom(ArtifactCoords artifactCoords) {
+        return IO_QUARKUS_PLATFORM_GROUP_ID.equals(artifactCoords.getGroupId())
+                && QUARKUS_BOM.equals(artifactCoords.getArtifactId());
+    }
+
+    private boolean isLanguageExtension(ArtifactCoords artifactCoords) {
+        return IO_QUARKUS_GROUP_ID.equals(artifactCoords.getGroupId())
+                && LANGUAGE_EXTENSIONS.contains(artifactCoords.getArtifactId());
     }
 
     private Set<String> getExtensionCodestarts(QuarkusCodestartProjectInput projectInput) {


### PR DESCRIPTION
This is very hackyish and we need to do better but that should do it
until we find a better solution.

@quarkusio/devtools that's what I could come up with as a band aid for now until we resolve this thing properly.
@aloubyansky I'm especially interested in your feedback for the BOM test. I know it's not pretty and we will need to do better but do you think it's good enough to cover most cases for now?