### PR TITLE
Add support for OIDC BackChannel Logout

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -468,6 +468,25 @@ quarkus.oidc.logout.post-logout-uri-param=returnTo
 quarkus.oidc.logout.extra-params.client_id=${quarkus.oidc.client-id}
 ----
 
+[[back-channel-logout]]
+==== Back-Channel Logout
+
+link:https://openid.net/specs/openid-connect-backchannel-1_0.html[Back-Channel Logout] is used by OpenId Connect providers to logout the current user from all the applications this user is currently logged in, bypassing the user agent.
+
+You can configure Quarkus to support `Back-Channel Logout` as follows:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.client-id=frontend
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+
+quarkus.oidc.logout.backchannel.path=/back-channel-logout
+----
+
+Absolute `Back-Channel Logout` URL is calculated by adding `quarkus.oidc.back-channel-logout.path` to the current endpoint URL, for example, `http://localhost:8080/back-channel-logout`. You will need to configure this URL in the Admin Console of your OpenId Connect Provider.
+
 [[local-logout]]
 ==== Local Logout
 

--- a/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
+++ b/extensions/elytron-security-properties-file/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronPropertiesFileRecorder.java
@@ -155,7 +155,7 @@ public class ElytronPropertiesFileRecorder {
                     List<Credential> credentials = new ArrayList<>();
                     credentials.add(passwordCred);
                     String rawRoles = roleInfo.get(user);
-                    String[] roles = rawRoles.split(",");
+                    String[] roles = rawRoles != null ? rawRoles.split(",") : new String[0];
                     Attributes attributes = new MapAttributes();
                     for (String role : roles) {
                         attributes.addLast("groups", role);

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -58,4 +58,9 @@ public final class OidcConstants {
 
     public static final String PKCE_CODE_CHALLENGE_METHOD = "code_challenge_method";
     public static final String PKCE_CODE_CHALLENGE_S256 = "S256";
+
+    public static final String BACK_CHANNEL_LOGOUT_TOKEN = "logout_token";
+    public static final String BACK_CHANNEL_EVENTS_CLAIM = "events";
+    public static final String BACK_CHANNEL_EVENT_NAME = "http://schemas.openid.net/event/backchannel-logout";
+    public static final String BACK_CHANNEL_LOGOUT_SID_CLAIM = "sid";
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.SecurityEvent;
 import io.quarkus.oidc.TokenIntrospectionCache;
 import io.quarkus.oidc.UserInfoCache;
+import io.quarkus.oidc.runtime.BackChannelLogoutHandler;
 import io.quarkus.oidc.runtime.DefaultTenantConfigResolver;
 import io.quarkus.oidc.runtime.DefaultTokenIntrospectionUserInfoCache;
 import io.quarkus.oidc.runtime.DefaultTokenStateManager;
@@ -89,7 +90,8 @@ public class OidcBuildStep {
                 .addBeanClass(OidcIdentityProvider.class)
                 .addBeanClass(DefaultTenantConfigResolver.class)
                 .addBeanClass(DefaultTokenStateManager.class)
-                .addBeanClass(OidcSessionImpl.class);
+                .addBeanClass(OidcSessionImpl.class)
+                .addBeanClass(BackChannelLogoutHandler.class);
         additionalBeans.produce(builder.build());
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -98,7 +98,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Token token = new Token();
 
     /**
-     * Logout configuration
+     * RP Initiated and BackChannel Logout configuration
      */
     @ConfigItem
     public Logout logout = new Logout();
@@ -171,6 +171,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Map<String, String> extraParams;
 
+        /**
+         * Back-Channel Logout configuration
+         */
+        @ConfigItem
+        public Backchannel backchannel = new Backchannel();
+
         public void setPath(Optional<String> path) {
             this.path = path;
         }
@@ -201,6 +207,31 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setPostLogoutUriParam(String postLogoutUriParam) {
             this.postLogoutUriParam = postLogoutUriParam;
+        }
+
+        public Backchannel getBackchannel() {
+            return backchannel;
+        }
+
+        public void setBackchannel(Backchannel backchannel) {
+            this.backchannel = backchannel;
+        }
+    }
+
+    @ConfigGroup
+    public static class Backchannel {
+        /**
+         * The relative path of the Back-Channel Logout endpoint at the application.
+         */
+        @ConfigItem
+        public Optional<String> path = Optional.empty();
+
+        public void setPath(Optional<String> path) {
+            this.path = path;
+        }
+
+        public String getPath() {
+            return path.get();
         }
     }
 
@@ -893,6 +924,24 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public OptionalInt lifespanGrace = OptionalInt.empty();
 
         /**
+         * Token age.
+         *
+         * It allows for the number of seconds to be specified that must not elapse since the `iat` (issued at) time.
+         * A small leeway to account for clock skew which can be configured with 'quarkus.oidc.token.lifespan-grace' to verify
+         * the token expiry time
+         * can also be used to verify the token age property.
+         *
+         * Note that setting this property does not relax the requirement that Bearer and Code Flow JWT tokens
+         * must have a valid ('exp') expiry claim value. The only exception where setting this property relaxes the requirement
+         * is when a logout token is sent with a back-channel logout request since the current
+         * OpenId Connect Back-Channel specification does not explicitly require the logout tokens to contain an 'exp' claim.
+         * However even if the current logout token is allowed to have no 'exp' claim, the `exp` claim will be still verified
+         * if the logout token contains it.
+         */
+        @ConfigItem
+        public Optional<Duration> age = Optional.empty();
+
+        /**
          * Name of the claim which contains a principal name. By default, the 'upn', 'preferred_username' and `sub` claims are
          * checked.
          */
@@ -1044,6 +1093,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setAllowOpaqueTokenIntrospection(boolean allowOpaqueTokenIntrospection) {
             this.allowOpaqueTokenIntrospection = allowOpaqueTokenIntrospection;
+        }
+
+        public Optional<Duration> getAge() {
+            return age;
+        }
+
+        public void setAge(Duration age) {
+            this.age = Optional.of(age);
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -1,0 +1,145 @@
+package io.quarkus.oidc.runtime;
+
+import java.util.function.Consumer;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.jboss.logging.Logger;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class BackChannelLogoutHandler {
+    private static final Logger LOG = Logger.getLogger(BackChannelLogoutHandler.class);
+
+    @Inject
+    DefaultTenantConfigResolver resolver;
+
+    private final OidcConfig oidcConfig;
+
+    public BackChannelLogoutHandler(OidcConfig oidcConfig) {
+        this.oidcConfig = oidcConfig;
+    }
+
+    public void setup(@Observes Router router) {
+        addRoute(router, oidcConfig.defaultTenant);
+
+        for (OidcTenantConfig oidcTenantConfig : oidcConfig.namedTenants.values()) {
+            addRoute(router, oidcTenantConfig);
+        }
+    }
+
+    private void addRoute(Router router, OidcTenantConfig oidcTenantConfig) {
+        if (oidcTenantConfig.isTenantEnabled() && oidcTenantConfig.logout.backchannel.path.isPresent()) {
+            router.route(oidcTenantConfig.logout.backchannel.path.get()).handler(new RouteHandler(oidcTenantConfig));
+        }
+    }
+
+    class RouteHandler implements Handler<RoutingContext> {
+        private final OidcTenantConfig oidcTenantConfig;
+
+        RouteHandler(OidcTenantConfig oidcTenantConfig) {
+            this.oidcTenantConfig = oidcTenantConfig;
+        }
+
+        @Override
+        public void handle(RoutingContext context) {
+            LOG.debugf("Back channel logout request for the tenant %s received", oidcTenantConfig.getTenantId().get());
+            final TenantConfigContext tenantContext = getTenantConfigContext(context);
+            if (tenantContext == null) {
+                LOG.debugf(
+                        "Tenant configuration for the tenant %s is not available or does not match the backchannel logout path",
+                        oidcTenantConfig.getTenantId().get());
+            }
+
+            if (OidcUtils.isFormUrlEncodedRequest(context)) {
+                OidcUtils.getFormUrlEncodedData(context)
+                        .subscribe().with(new Consumer<MultiMap>() {
+                            @Override
+                            public void accept(MultiMap form) {
+
+                                String encodedLogoutToken = form.get(OidcConstants.BACK_CHANNEL_LOGOUT_TOKEN);
+                                if (encodedLogoutToken == null) {
+                                    LOG.debug("Back channel logout token is missing");
+                                    context.response().setStatusCode(400);
+                                } else {
+                                    try {
+                                        // Do the general validation of the logout token now, compare with the IDToken later
+                                        // Check the signature, as well the issuer and audience if it is configured
+                                        TokenVerificationResult result = tenantContext.provider
+                                                .verifyLogoutJwtToken(encodedLogoutToken);
+
+                                        if (verifyLogoutTokenClaims(result)) {
+                                            resolver.getBackChannelLogoutTokens().put(oidcTenantConfig.tenantId.get(),
+                                                    result);
+                                            context.response().setStatusCode(200);
+                                        } else {
+                                            context.response().setStatusCode(400);
+                                        }
+                                    } catch (InvalidJwtException e) {
+                                        LOG.debug("Back channel logout token is invalid");
+                                        context.response().setStatusCode(400);
+
+                                    }
+                                }
+                                context.response().end();
+                            }
+
+                        });
+
+            } else {
+                LOG.debug("HTTP POST and " + HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString()
+                        + " content type must be used with the Back channel logout request");
+                context.response().setStatusCode(400);
+                context.response().end();
+            }
+        }
+
+        private boolean verifyLogoutTokenClaims(TokenVerificationResult result) {
+            // events
+            JsonObject events = result.localVerificationResult.getJsonObject(OidcConstants.BACK_CHANNEL_EVENTS_CLAIM);
+            if (events == null || events.getJsonObject(OidcConstants.BACK_CHANNEL_EVENT_NAME) == null) {
+                LOG.debug("Back channel logout token does not have a valid 'events' claim");
+                return false;
+            }
+            if (!result.localVerificationResult.containsKey(Claims.sub.name())
+                    && !result.localVerificationResult.containsKey(OidcConstants.BACK_CHANNEL_LOGOUT_SID_CLAIM)) {
+                LOG.debug("Back channel logout token does not have 'sub' or 'sid' claim");
+                return false;
+            }
+            if (result.localVerificationResult.containsKey(Claims.nonce.name())) {
+                LOG.debug("Back channel logout token must not contain 'nonce' claim");
+                return false;
+            }
+            return true;
+        }
+
+        private TenantConfigContext getTenantConfigContext(RoutingContext context) {
+            String requestPath = context.request().path();
+            if (isMatchingTenant(requestPath, resolver.getTenantConfigBean().getDefaultTenant())) {
+                return resolver.getTenantConfigBean().getDefaultTenant();
+            }
+            for (TenantConfigContext tenant : resolver.getTenantConfigBean().getStaticTenantsConfig().values()) {
+                if (isMatchingTenant(requestPath, tenant)) {
+                    return tenant;
+                }
+            }
+            return null;
+        }
+
+        private boolean isMatchingTenant(String requestPath, TenantConfigContext tenant) {
+            return tenant.oidcConfig.isTenantEnabled()
+                    && tenant.oidcConfig.getTenantId().get().equals(oidcTenantConfig.getTenantId().get())
+                    && requestPath.equals(tenant.oidcConfig.logout.backchannel.path.orElse(null));
+        }
+    }
+}

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/DefaultTenantConfigResolver.java
@@ -1,5 +1,7 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import javax.annotation.PostConstruct;
@@ -59,6 +61,8 @@ public class DefaultTenantConfigResolver {
     private final BlockingTaskRunner<OidcTenantConfig> blockingRequestContext = new BlockingTaskRunner<OidcTenantConfig>();
 
     private volatile boolean securityEventObserved;
+
+    private ConcurrentHashMap<String, TokenVerificationResult> backChannelLogoutTokens = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void verifyResolvers() {
@@ -217,6 +221,14 @@ public class DefaultTenantConfigResolver {
 
     boolean isEnableHttpForwardedPrefix() {
         return enableHttpForwardedPrefix;
+    }
+
+    public Map<String, TokenVerificationResult> getBackChannelLogoutTokens() {
+        return backChannelLogoutTokens;
+    }
+
+    public TenantConfigBean getTenantConfigBean() {
+        return tenantConfigBean;
     }
 
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -74,6 +74,10 @@ public class OidcRecorder {
     private Uni<TenantConfigContext> createDynamicTenantContext(Vertx vertx,
             OidcTenantConfig oidcConfig, TlsConfig tlsConfig, String tenantId) {
 
+        if (oidcConfig.logout.backchannel.path.isPresent()) {
+            throw new ConfigurationException(
+                    "BackChannel Logout is currently not supported for dynamic tenants");
+        }
         if (!dynamicTenantsConfig.containsKey(tenantId)) {
             Uni<TenantConfigContext> uniContext = createTenantContext(vertx, oidcConfig, tlsConfig, tenantId);
             uniContext.onFailure().transform(t -> logTenantConfigContextFailure(t, tenantId));

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcUtils.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import javax.crypto.SecretKey;
@@ -40,6 +41,11 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity.Builder;
 import io.smallrye.jwt.algorithm.ContentEncryptionAlgorithm;
 import io.smallrye.jwt.algorithm.KeyEncryptionAlgorithm;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.impl.ServerCookie;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -428,5 +434,29 @@ public final class OidcUtils {
         jwe.setKey(key);
         jwe.setCompactSerialization(jweString);
         return jwe.getPlaintextString();
+    }
+
+    public static boolean isFormUrlEncodedRequest(RoutingContext context) {
+        String contentType = context.request().getHeader("Content-Type");
+        return context.request().method() == HttpMethod.POST
+                && contentType != null
+                && (contentType.equals(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                        || contentType.startsWith(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString() + ";"));
+    }
+
+    public static Uni<MultiMap> getFormUrlEncodedData(RoutingContext context) {
+        context.request().setExpectMultipart(true);
+        return Uni.createFrom().emitter(new Consumer<UniEmitter<? super MultiMap>>() {
+            @Override
+            public void accept(UniEmitter<? super MultiMap> t) {
+                context.request().endHandler(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        t.complete(context.request().formAttributes());
+                    }
+                });
+                context.request().resume();
+            }
+        });
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -32,6 +32,8 @@ quarkus.oidc.code-flow-form-post.authorization-path=/
 quarkus.oidc.code-flow-form-post.token-path=${keycloak.url}/realms/quarkus/token
 # reuse the wiremock JWK endpoint stub for the `quarkus` realm - it is the same for the query and form post response mode
 quarkus.oidc.code-flow-form-post.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
+quarkus.oidc.code-flow-form-post.logout.backchannel.path=/back-channel-logout
+
 
 quarkus.oidc.code-flow-user-info-only.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-user-info-only.discovery-enabled=false
@@ -98,3 +100,6 @@ quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level
 
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
+
+quarkus.http.auth.permission.backchannellogout.paths=/back-channel-logout
+quarkus.http.auth.permission.backchannellogout.policy=permit

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -17,6 +17,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+
 import org.jboss.logging.Logger;
 import org.jose4j.keys.X509Util;
 
@@ -281,9 +284,25 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .groups(groups)
                 .issuer(TOKEN_ISSUER)
                 .audience(TOKEN_AUDIENCE)
+                .subject("123456")
                 .jws()
                 .keyId("1")
                 .sign("privateKey.jwk");
+    }
+
+    public static String getLogoutToken() {
+        return Jwt.issuer(TOKEN_ISSUER)
+                .audience(TOKEN_AUDIENCE)
+                .subject("123456")
+                .claim("events", createEventsClaim())
+                .jws()
+                .keyId("1")
+                .sign("privateKey.jwk");
+    }
+
+    private static JsonObject createEventsClaim() {
+        return Json.createObjectBuilder().add("http://schemas.openid.net/event/backchannel-logout",
+                Json.createObjectBuilder().build()).build();
     }
 
     @Override


### PR DESCRIPTION
Fixes #23477.

This Draft PR introduces a support for OIDC `Back-Channel Logout`. The technical difficulty in supporting it in Quarkus OIDC is to do with it being stateless, with the session cookie keeping IdToken by default, therefore a map keeping the verified Logout tokens is used to check if the returning session IdToken matches a given logout token and the session has to be cleared.

Here is a summary of the changes:
* `BackChannelLogoutHandler` adds `Vert.x` routes for the default and static tenants if they have the back-channel path configured
*  `BackChannelLogoutHandler` also handles the back-channel logout requests, if it is a valid form url encoded POST request, by verifying that the logout token is generally valid (signature, optional `iss`, `audience`, has either `sub` or `sid`, has the `events` claim) and saves it in a concurrent map
* `CodeAuhenticationMechanism`, when reauthenticating `IdToken` checks if a matching verified Logout Token is available and if yes then compares the some of the `IdToken` and `LogoutToken` claims (`iss`, `sid` if set, etc) and if the match is confirmed then removes the session cookie
* Token age property is added to support `only` the logout tokens without the `exp` claim (CC @pedroigor). ID and access JWT tokens still must provide a valid `exp` claim.
* Wiremock based test is added

Current restrictions:
* It is not supported for Dynamic tenants (created with `TenantConfigResolver`) as it will involve the dynamic creation of Vert.x routes, and a need to restrict  a total number of tenants - it can be done in the next phase
* Logout token can only be verified with the keys fetched from OpenId Connect provider - the remote introspection (which would lead to a sequence like `Keycloak` -> `Quarkus BackChannel Logout Request` (and now `Quarkus callback to Keycloak` to verify logout token while holding the `Keycloak to Quarkus BackChannel Logout Request`) is not supported right now for the logout tokens