### PR TITLE
Allow to inline UserInfo in internal IdToken

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -522,6 +522,7 @@ Note this user session can not be extended forever - the returning user with the
 
 `io.quarkus.oidc.OidcSession` is a wrapper around the current `IdToken`. It can help to perform a <<local-logout, Local Logout>>, retrieve the current session's tenant identifier and check when the session will expire. More useful methods will be added to it over time.
 
+[[token-state-manager]]
 ==== TokenStateManager
 
 OIDC `CodeAuthenticationMechanism` is using the default `io.quarkus.oidc.TokenStateManager` interface implementation to keep the ID, access and refresh tokens returned in the authorization code or refresh grant responses in a session cookie. It makes Quarkus OIDC endpoints completely stateless.
@@ -697,6 +698,8 @@ Configuring the endpoint to request <<user-info,UserInfo>> is the only way `quar
 
 Note that requiring <<user-info,UserInfo>> involves making a remote call on every request - therefore you may want to consider caching `UserInfo` data, see <<token-introspection-userinfo-cache,Token Introspection and UserInfo Cache> for more details.
 
+Alternatively, you may want to request that `UserInfo` is embedded into the internal generated `IdToken`with the `quarkus.oidc.cache-user-info-in-idtoken=true` property - the advantage of this approach is that by default no cached `UserInfo` state will be kept with the endpoint - instead it will be stored in a session cookie. You may also want to consider encrypting `IdToken` in this case if `UserInfo` contains sensitive data, please see <<token-state-manager,Encrypt Tokens With TokenStateManager>> for more information.
+
 Also, OAuth2 servers may not support a well-known configuration endpoint in which case the discovery has to be disabled and the authorization, token, and introspection and/or userinfo endpoint paths have to be configured manually.
 
 Here is how you can integrate `quarkus-oidc` with `GitHub` after you have link:https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app[created a GitHub OAuth application]. Configure your Quarkus endpoint like this:
@@ -713,6 +716,9 @@ quarkus.oidc.credentials.secret=github_app_clientsecret
 # Consider enabling UserInfo Cache 
 # quarkus.oidc.token-cache.max-size=1000
 # quarkus.oidc.token-cache.time-to-live=5M
+#
+# Or having UserInfo cached inside IdToken itself
+# quarkus.oidc.cache-user-info-in-idtoken=true
 ----
 
 This is all what is needed for an endpoint like this one to return the currently authenticated user's profile with `GET http://localhost:8080/github/userinfo` and access it as the individual `UserInfo` properties:

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -132,6 +132,15 @@ public class OidcTenantConfig extends OidcCommonConfig {
     @ConfigItem(defaultValue = "true")
     public boolean allowUserInfoCache = true;
 
+    /**
+     * Allow inlining UserInfo in IdToken instead of caching it in the token cache.
+     * This property is only checked when an internal IdToken is generated when Oauth2 providers do not return IdToken.
+     * Inlining UserInfo in the generated IdToken allows to store it in the session cookie and avoids introducing a cached
+     * state.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean cacheUserInfoInIdtoken = false;
+
     @ConfigGroup
     public static class Logout {
 
@@ -637,7 +646,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
         /**
          * Requires that ID token is available when the authorization code flow completes.
          * Disable this property only when you need to use the authorization code flow with OAuth2 providers which do not return
-         * ID token.
+         * ID token - an internal IdToken will be generated in such cases.
          */
         @ConfigItem(defaultValueDocumentation = "true")
         public Optional<Boolean> idTokenRequired = Optional.empty();
@@ -1089,5 +1098,13 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
     public void setAllowUserInfoCache(boolean allowUserInfoCache) {
         this.allowUserInfoCache = allowUserInfoCache;
+    }
+
+    public boolean isCacheUserInfoInIdtoken() {
+        return cacheUserInfoInIdtoken;
+    }
+
+    public void setCacheUserInfoInIdtoken(boolean cacheUserInfoInIdtoken) {
+        this.cacheUserInfoInIdtoken = cacheUserInfoInIdtoken;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -134,8 +134,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
     private Uni<SecurityIdentity> createSecurityIdentityWithOidcServer(RoutingContext vertxContext,
             TokenAuthenticationRequest request, TenantConfigContext resolvedContext, final UserInfo userInfo) {
         Uni<TokenVerificationResult> tokenUni = null;
-        if ((request.getToken() instanceof IdTokenCredential) && ((IdTokenCredential) request.getToken()).isInternal()) {
-            tokenUni = verifySelfSignedTokenUni(resolvedContext, request.getToken().getToken());
+        if (isInternalIdToken(request)) {
+            if (vertxContext.get(NEW_AUTHENTICATION) == Boolean.TRUE) {
+                // No need to verify it in this case as 'CodeAuthenticationMechanism' has just created it
+                tokenUni = Uni.createFrom()
+                        .item(new TokenVerificationResult(OidcUtils.decodeJwtContent(request.getToken().getToken()), null));
+            } else {
+                tokenUni = verifySelfSignedTokenUni(resolvedContext, request.getToken().getToken());
+            }
         } else {
             tokenUni = verifyTokenUni(resolvedContext, request.getToken().getToken());
         }
@@ -216,6 +222,10 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                         }
                     }
                 });
+    }
+
+    private static boolean isInternalIdToken(TokenAuthenticationRequest request) {
+        return (request.getToken() instanceof IdTokenCredential) && ((IdTokenCredential) request.getToken()).isInternal();
     }
 
     private static boolean tokenAutoRefreshPrepared(JsonObject tokenJson, RoutingContext vertxContext,
@@ -350,6 +360,14 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
     private Uni<UserInfo> getUserInfoUni(RoutingContext vertxContext, TokenAuthenticationRequest request,
             TenantConfigContext resolvedContext) {
+        if (isInternalIdToken(request) && resolvedContext.oidcConfig.cacheUserInfoInIdtoken) {
+            JsonObject userInfo = OidcUtils.decodeJwtContent(request.getToken().getToken())
+                    .getJsonObject(OidcUtils.USER_INFO_ATTRIBUTE);
+            if (userInfo != null) {
+                return Uni.createFrom().item(new UserInfo(userInfo.encode()));
+            }
+        }
+
         String accessToken = vertxContext.get(OidcConstants.ACCESS_TOKEN_VALUE);
         if (accessToken == null) {
             accessToken = request.getToken().getToken();
@@ -369,7 +387,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
 
     private Uni<UserInfo> newUserInfoUni(TenantConfigContext resolvedContext, String accessToken) {
         Uni<UserInfo> userInfoUni = resolvedContext.provider.getUserInfo(accessToken);
-        if (tenantResolver.getUserInfoCache() == null || !resolvedContext.oidcConfig.allowUserInfoCache) {
+        if (tenantResolver.getUserInfoCache() == null || !resolvedContext.oidcConfig.allowUserInfoCache
+                || resolvedContext.oidcConfig.cacheUserInfoInIdtoken) {
             return userInfoUni;
         } else {
             return userInfoUni.call(new Function<UserInfo, Uni<?>>() {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CodeFlowUserInfoResource.java
@@ -38,6 +38,12 @@ public class CodeFlowUserInfoResource {
     }
 
     @GET
+    @Path("/code-flow-user-info-github-cached-in-idtoken")
+    public String accessGitHubCachedInIdToken() {
+        return access();
+    }
+
+    @GET
     @Path("/code-flow-user-info-dynamic-github")
     public String accessDynamicGitHub() {
         return access();

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomSecurityIdentityAugmentor.java
@@ -21,7 +21,8 @@ public class CustomSecurityIdentityAugmentor implements SecurityIdentityAugmento
         if (routingContext != null &&
                 (routingContext.normalizedPath().endsWith("code-flow-user-info-only")
                         || routingContext.normalizedPath().endsWith("code-flow-user-info-github")
-                        || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github"))) {
+                        || routingContext.normalizedPath().endsWith("code-flow-user-info-dynamic-github")
+                        || routingContext.normalizedPath().endsWith("code-flow-user-info-github-cached-in-idtoken"))) {
             QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
             UserInfo userInfo = identity.getAttribute("userinfo");
             builder.setPrincipal(new Principal() {

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -26,6 +26,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow-user-info-github")) {
             return "code-flow-user-info-github";
         }
+        if (path.endsWith("code-flow-user-info-github-cached-in-idtoken")) {
+            return "code-flow-user-info-github-cached-in-idtoken";
+        }
         if (path.endsWith("bearer")) {
             return "bearer";
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -51,6 +51,15 @@ quarkus.oidc.code-flow-user-info-github.user-info-path=protocol/openid-connect/u
 quarkus.oidc.code-flow-user-info-github.client-id=quarkus-web-app
 quarkus.oidc.code-flow-user-info-github.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.provider=github
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.authorization-path=/
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.user-info-path=protocol/openid-connect/userinfo
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.cache-user-info-in-idtoken=true
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.client-id=quarkus-web-app
+quarkus.oidc.code-flow-user-info-github-cached-in-idtoken.credentials.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+
+
 quarkus.oidc.token-cache.max-size=1
 
 quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/


### PR DESCRIPTION
Fixes #22030.

This PR allows to chose how to cache UserInfo when an internal IdToken is used. Users can request that UserInfo is kept as an internal `IdToken` claim in a session cookie instead of it being cached in the endpoint.

@FroMage IMHO it stretches GitHub workarounds to the limit :-), but I think your idea of avoiding the local cache in such cases allows to optimize nicely. I appreciate you were preferring to have some selected claims only stored in the id token but IMHO the solution offered by this PR is generic and as I said I'd like to avoid introducing some extra API/callbacks around this GitHub quasi-OIDC support.
As I said JSON wise you'd get for example:
```
{
  "iat":123456
  "exp":56789
  "userinfo": {
     "sub": "alice"
   }
}
``` 
vs

```
{
  "iat":123456
  "exp":56789
  "sub": "alice"
}
```

The former option is better IMHO - it shows UserInfo as it is - it is still available for `UserInfo` injection too. In the latter case we lose the `UserInfo` injection capability - as we don't know how the original one looked like