### PR TITLE
Docs: Replace reference to db store in QuartzBuildTimeConfig.java

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -43,7 +43,7 @@ public class QuartzBuildTimeConfig {
     /**
      * The name of the datasource to use.
      * <p>
-     * Optionally needed when using the `db` store type.
+     * Optionally needed when using the `jdbc-tx` or `jdbc-cmt` store types.
      * If not specified, defaults to using the default datasource.
      */
     @ConfigItem(name = "datasource")


### PR DESCRIPTION
Update the javadoc to refer to jdbc-tx or jdbc-cmt job stores as an alternative to db, db has since been removed.

Fix #24542