### PR TITLE
Export application name and version in tests

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiDefaultPathTestCase.java
@@ -34,7 +34,7 @@ public class OpenApiDefaultPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("tags.name[0]", Matchers.equalTo("test"))
                 .body("paths.'/resource'.get.servers[0]", Matchers.hasKey("url"))
                 .body("paths.'/resource'.get.security[0]", Matchers.hasKey("securityRequirement"))

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiHttpRootDefaultPathTestCase.java
@@ -33,7 +33,7 @@ public class OpenApiHttpRootDefaultPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/foo/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathHttpRootDefaultPathTestCase.java
@@ -26,7 +26,7 @@ public class OpenApiWithResteasyPathHttpRootDefaultPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/http-root-path/resteasy-path/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithResteasyPathTestCase.java
@@ -25,7 +25,7 @@ public class OpenApiWithResteasyPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/foo/bar/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
@@ -31,7 +31,7 @@ public class OpenApiDefaultPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/resource"));
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
@@ -33,7 +33,7 @@ public class OpenApiHttpRootDefaultPathTestCase {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/foo/resource"));
     }
 }

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/dev/KafkaDevServicesDevModeTestCase.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/dev/KafkaDevServicesDevModeTestCase.java
@@ -28,7 +28,8 @@ public class KafkaDevServicesDevModeTestCase {
             "mp.messaging.outgoing.generated-price.topic=prices\n" +
             "mp.messaging.incoming.prices.connector=smallrye-kafka\n" +
             "mp.messaging.incoming.prices.health-readiness-enabled=false\n" +
-            "mp.messaging.incoming.prices.topic=prices\n";
+            "mp.messaging.incoming.prices.topic=prices\n" +
+            "quarkus.application.name=\n";
 
     @RegisterExtension
     public static QuarkusDevModeTest test = new QuarkusDevModeTest()

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/java/org/acme/ApplicationConfigResource.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/java/org/acme/ApplicationConfigResource.java
@@ -1,0 +1,25 @@
+package org.acme;
+
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/app-config")
+public class ApplicationConfigResource {
+
+    @ConfigProperty(name = "quarkus.application.name")
+    String name;
+
+    @ConfigProperty(name = "quarkus.application.version")
+    String version;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return String.format("%s:%s", name, version);
+    }
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/test/java/org/acme/ApplicationConfigResourceTest.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/test/java/org/acme/ApplicationConfigResourceTest.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class ApplicationConfigResourceTest {
+
+    @Test
+    public void testAppConfigEndpoint() {
+        given()
+          .when().get("/app-config")
+          .then()
+             .statusCode(200)
+             .body(is("application:1.0.0-SNAPSHOT"));
+    }
+
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ApplicationConfigurationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ApplicationConfigurationTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class ApplicationConfigurationTest extends QuarkusGradleWrapperTestBase {
+
+    @Test
+    public void shouldSuccessfullyInjectApplicationConfigInTest() throws Exception {
+        File projectDir = getProjectDir("basic-java-library-module");
+
+        BuildResult testResult = runGradleWrapper(projectDir, "clean", ":application:test");
+
+        assertThat(testResult.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+    }
+
+}

--- a/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/openapi/OpenApiDefaultPathPMT.java
+++ b/integration-tests/spring-web/src/test/java/io/quarkus/it/spring/web/openapi/OpenApiDefaultPathPMT.java
@@ -34,7 +34,7 @@ public class OpenApiDefaultPathPMT {
                 .then()
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .body("openapi", Matchers.startsWith("3.0"))
-                .body("info.title", Matchers.equalTo("Generated API"))
+                .body("info.title", Matchers.equalTo("quarkus-integration-test-spring-web API"))
                 .body("paths", Matchers.hasKey("/resource"));
     }
 }


### PR DESCRIPTION
This export `quarkus.application.name` and `quarkus.application.version` properties. This used to resolved model to extract data in the boostrap phase. 

close #15013 