### PR TITLE
Update the image version used by the MongoDB dev service

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -90,6 +90,7 @@
         <mssql.image>mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
+        <mongo.image>docker.io/mongo:4.4.13</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->
         <junit4.version>4.13.2</junit4.version>

--- a/extensions/mongodb-client/deployment/pom.xml
+++ b/extensions/mongodb-client/deployment/pom.xml
@@ -115,6 +115,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -213,7 +213,8 @@ public class DevServicesMongoProcessor {
         DevServicesBuildTimeConfig devServicesConfig = mongoClientBuildTimeConfig.devservices;
         boolean devServicesEnabled = devServicesConfig.enabled.orElse(true);
         return new CapturedProperties(databaseName, connectionString, devServicesEnabled,
-                devServicesConfig.imageName.orElse(null), devServicesConfig.port.orElse(null), devServicesConfig.properties);
+                devServicesConfig.imageName.orElseGet(() -> ConfigureUtil.getDefaultImageNameFor("mongo")),
+                devServicesConfig.port.orElse(null), devServicesConfig.properties);
     }
 
     private static final class CapturedProperties {

--- a/extensions/mongodb-client/deployment/src/main/resources/mongo-devservice.properties
+++ b/extensions/mongodb-client/deployment/src/main/resources/mongo-devservice.properties
@@ -1,0 +1,1 @@
+default.image=${mongo.image}


### PR DESCRIPTION
The MongoDB dev service doesn't currently have any specific config, which means it falls back to the default version used by Testcontainers, which currently is `4.0.10`.

Version `4.0.10` is [> 3 years old](https://hub.docker.com/_/mongo?tab=tags&page=1&name=4.0.10) and hasn't even been scanned for the Log4Shell vulnerability. This PR updates it to version `5.0.6`, which is the current version.