### PR TITLE
Use single key JWK Set if neither kid nor x5t header is set

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProvider.java
@@ -250,6 +250,10 @@ public class OidcProvider implements Closeable {
                 }
             }
 
+            if (key == null && kid == null && thumbprint == null) {
+                key = jwks.getKeyWithoutKeyIdAndThumbprint();
+            }
+
             if (key == null) {
                 throw new UnresolvableKeyException(
                         String.format("JWK is not available, neither 'kid' nor 'x5t' token headers are set", kid));

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -34,6 +34,14 @@ public class AdminResource {
         return "granted:" + identity.getRoles();
     }
 
+    @Path("bearer-key-without-kid-thumbprint")
+    @GET
+    @RolesAllowed("admin")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String adminNoKidandThumprint() {
+        return "granted:" + identity.getRoles();
+    }
+
     @Path("bearer-wrong-role-path")
     @GET
     @RolesAllowed("admin")

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -35,6 +35,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("bearer-no-introspection")) {
             return "bearer-no-introspection";
         }
+        if (path.endsWith("bearer-key-without-kid-thumbprint")) {
+            return "bearer-key-without-kid-thumbprint";
+        }
         if (path.endsWith("bearer-wrong-role-path")) {
             return "bearer-wrong-role-path";
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -77,6 +77,15 @@ quarkus.oidc.bearer-no-introspection.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer-no-introspection.token.audience=https://service.example.com
 quarkus.oidc.bearer-no-introspection.token.allow-jwt-introspection=false
 
+quarkus.oidc.bearer-key-without-kid-thumbprint.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer-key-without-kid-thumbprint.discovery-enabled=false
+quarkus.oidc.bearer-key-without-kid-thumbprint.jwks-path=single-key-without-kid-thumbprint
+quarkus.oidc.bearer-key-without-kid-thumbprint.client-id=quarkus-app
+quarkus.oidc.bearer-key-without-kid-thumbprint.credentials.secret=secret
+quarkus.oidc.bearer-key-without-kid-thumbprint.authentication.scopes=profile,email,phone
+quarkus.oidc.bearer-key-without-kid-thumbprint.token.audience=https://service.example.com
+quarkus.oidc.bearer-key-without-kid-thumbprint.token.allow-jwt-introspection=false
+
 quarkus.oidc.bearer-wrong-role-path.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-wrong-role-path.client-id=quarkus-app
 quarkus.oidc.bearer-wrong-role-path.credentials.secret=secret

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -58,6 +58,31 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testAccessAdminResourceWithoutKidAndThumbprint() {
+        RestAssured.given().auth().oauth2(getAccessTokenWithoutKidAndThumbprint("admin", Set.of("admin")))
+                .when().get("/api/admin/bearer-no-introspection")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testTokenAndKeyWithoutKidAndThumbprint() {
+        RestAssured.given().auth().oauth2(getAccessTokenWithoutKidAndThumbprint("admin", Set.of("admin")))
+                .when().get("/api/admin/bearer-key-without-kid-thumbprint")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("admin"));
+    }
+
+    @Test
+    public void testTokenWithKidAndKeyWithoutKidAndThumbprint() {
+        RestAssured.given().auth().oauth2(getAccessToken("admin", Set.of("admin")))
+                .when().get("/api/admin/bearer-key-without-kid-thumbprint")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
     public void testSecureAccessSuccessPreferredUsernameWrongRolePath() {
         for (String username : Arrays.asList("alice", "admin")) {
             RestAssured.given().auth().oauth2(getAccessToken(username, Set.of("user", "admin")))
@@ -160,6 +185,14 @@ public class BearerTokenAuthorizationTest {
                 .issuer("https://server.example.com")
                 .audience("https://service.example.com")
                 .jws().thumbprint(OidcWiremockTestResource.getCertificate())
+                .sign("privateKeyWithoutKid.jwk");
+    }
+
+    private String getAccessTokenWithoutKidAndThumbprint(String userName, Set<String> groups) {
+        return Jwt.preferredUserName(userName)
+                .groups(groups)
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
                 .sign("privateKeyWithoutKid.jwk");
     }
 

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -104,6 +104,21 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                                         "}")));
 
         server.stubFor(
+                get(urlEqualTo("/auth/realms/quarkus/single-key-without-kid-thumbprint"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\n" +
+                                        "  \"keys\" : [\n" +
+                                        "    {\n" +
+                                        "      \"kty\":\"RSA\",\n" +
+                                        "      \"n\":\"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ\",\n"
+                                        +
+                                        "      \"e\":\"AQAB\"\n" +
+                                        "    }" +
+                                        "  ]\n" +
+                                        "}")));
+
+        server.stubFor(
                 get(urlEqualTo("/auth/realms/quarkus/protocol/openid-connect/userinfo"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Fixes #24678

This simple PR records a single JWK set key only if it is the only key in the set, and no `kid` or certificate thumbprint properties are set.
This key is used if the incoming token has no `kid` or certificate thumbprint.

3 tests are added: 1) verifies that a token with kid can't be verified with JWK key without kid 2) 1) verifies that a token without kid can't be verified with JWK with kid 3) token without kid is verified with the key without kid