### PR TITLE
Make sure test-extension artifacts are installed

### DIFF
--- a/integration-tests/test-extension/extension/deployment/disable-unbind-executions
+++ b/integration-tests/test-extension/extension/deployment/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/test-extension/extension/disable-unbind-executions
+++ b/integration-tests/test-extension/extension/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.

--- a/integration-tests/test-extension/extension/runtime/disable-unbind-executions
+++ b/integration-tests/test-extension/extension/runtime/disable-unbind-executions
@@ -1,0 +1,1 @@
+This file disables the unbind-executions profile in the quarkus-integration-tests-parent.


### PR DESCRIPTION
Follows up on #24574. Required if building the `tests` module sibling individually.

Not entirely sure why it only happens sporadically, e.g. https://github.com/quarkusio/quarkus/pull/24634#issuecomment-1084447459