### PR TITLE
Make sure Kafka serde autodetection doesn't override connector configuration

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -243,6 +243,10 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
             return;
         }
 
+        if (discovery.shouldNotConfigure(key)) {
+            return;
+        }
+
         discovery.ifNotYetConfigured(key, () -> {
             config.produce(new RunTimeConfigurationDefaultBuildItem(key, value));
         });


### PR DESCRIPTION
The SmallRye Reactive Messaging Kafka extension automatically detects
key and value serializer/deserializer and sets default config values
for the respective channel. That overrides connector configuration,
which is unexpected. If the user provides connector configuration
themselves, we should not override that. Unfortunately the extension
can only detect connector configuration if it's present during build,
but that will be the case 99.9% of time.

With this commit, if connector configuration is present for key/value
serde, the respective channel configuration is not emitted.

Fixes #24322