### PR TITLE
Skip Keycloak DevService if quarkus.oidc.provider is set

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -75,6 +75,7 @@ public class KeycloakDevServicesProcessor {
     private static final String CONFIG_PREFIX = "quarkus.oidc.";
     private static final String TENANT_ENABLED_CONFIG_KEY = CONFIG_PREFIX + "tenant-enabled";
     private static final String AUTH_SERVER_URL_CONFIG_KEY = CONFIG_PREFIX + "auth-server-url";
+    private static final String PROVIDER_CONFIG_KEY = CONFIG_PREFIX + "provider";
     // avoid the Quarkus prefix in order to prevent warnings when the application starts in container integration tests
     private static final String CLIENT_AUTH_SERVER_URL_CONFIG_KEY = "client." + CONFIG_PREFIX + "auth-server-url";
     private static final String APPLICATION_TYPE_CONFIG_KEY = CONFIG_PREFIX + "application-type";
@@ -284,6 +285,10 @@ public class KeycloakDevServicesProcessor {
         }
         if (ConfigUtils.isPropertyPresent(AUTH_SERVER_URL_CONFIG_KEY)) {
             LOG.debug("Not starting Dev Services for Keycloak as 'quarkus.oidc.auth-server-url' has been provided");
+            return null;
+        }
+        if (ConfigUtils.isPropertyPresent(PROVIDER_CONFIG_KEY)) {
+            LOG.debug("Not starting Dev Services for Keycloak as 'quarkus.oidc.provider' has been provided");
             return null;
         }
 


### PR DESCRIPTION
`quarkus.oidc.provider` composes several properties, for example, `quarkus.oidc.provider=google` configures `OidcTenantConfig` with `quarkus.auth-server-url` and 2 more properties in `OidcRecorder`. `Keycloak DevService` thinks `quarkus.auth-server-url`  is not set and launches a container. This PR updates `KeycloakDevServicesProcessor` to check `quarkus.oidc.provider` and skip further processing if it is set