### PR TITLE
Switch quarkusIntTest task dependency from check to test

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
@@ -263,7 +262,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                     tasks.register(INTEGRATION_TEST_TASK_NAME, Test.class, intTestTask -> {
                         intTestTask.setGroup("verification");
                         intTestTask.setDescription("Runs Quarkus integration tests");
-                        intTestTask.dependsOn(quarkusBuild, tasks.named(JavaBasePlugin.CHECK_TASK_NAME));
+                        intTestTask.dependsOn(quarkusBuild, tasks.named(JavaPlugin.TEST_TASK_NAME));
                         intTestTask.setClasspath(intTestSourceSet.getRuntimeClasspath());
                         intTestTask.setTestClassesDirs(intTestSourceSet.getOutput().getClassesDirs());
                     });
@@ -283,7 +282,7 @@ public class QuarkusPlugin implements Plugin<Project> {
                     tasks.register(TEST_NATIVE_TASK_NAME, Test.class, testNative -> {
                         testNative.setDescription("Runs native image tests");
                         testNative.setGroup("verification");
-                        testNative.dependsOn(quarkusBuild, tasks.named(JavaBasePlugin.CHECK_TASK_NAME));
+                        testNative.dependsOn(quarkusBuild, tasks.named(JavaPlugin.TEST_TASK_NAME));
 
                         testNative.setTestClassesDirs(project.files(nativeTestSourceSet.getOutput().getClassesDirs(),
                                 intTestSourceSet.getOutput().getClassesDirs()));

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/IntegrationTestBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/IntegrationTestBuildTest.java
@@ -15,7 +15,6 @@ public class IntegrationTestBuildTest extends QuarkusGradleWrapperTestBase {
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusIntTest");
 
         assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
-        assertThat(buildResult.getTasks().get(":check")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
         assertThat(buildResult.getTasks().get(":quarkusIntTest")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
     }
 


### PR DESCRIPTION
This update `quarkusIntTest` and `nativeTest` tasks dependency. Instead of dependency on `check` they depend on `test`

close #24704 
