### PR TITLE
Maven 3.8.5 compatibility, update maven-invoker to 3.1.0

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -363,6 +363,12 @@ jobs:
             os-name: "ubuntu-latest"
           }
           - {
+            name: "11 mvn 3.8.5",
+            java-version: 11,
+            os-name: "ubuntu-latest",
+            mvn-version: 3.8.5
+          }
+          - {
             name: "11 Windows",
             java-version: 11,
             os-name: "windows-latest"
@@ -382,6 +388,11 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
+      - name: Switch Maven version
+        if: "matrix.java.mvn-version != ''"
+        run: |
+          echo 'distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${{matrix.java.mvn-version}}/apache-maven-${{matrix.java.mvn-version}}-bin.zip' >> .mvn/wrapper/maven-wrapper.properties
+          ./mvnw -version
       - name: Build
         # Important: keep -pl ... in sync with "Calculate run flags"!
         run: ./mvnw $COMMON_MAVEN_ARGS $JVM_TEST_MAVEN_ARGS install -pl 'integration-tests/maven'

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -148,7 +148,7 @@
         <kotlin.coroutine.version>1.6.0</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.2</kotlin-serialization.version>
         <dekorate.version>2.9.0</dekorate.version>
-        <maven-invoker.version>3.0.1</maven-invoker.version>
+        <maven-invoker.version>3.1.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
         <flyway.version>8.5.5</flyway.version>
@@ -5040,6 +5040,12 @@
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-invoker</artifactId>
                 <version>${maven-invoker.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -29,6 +29,7 @@ import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.model.building.ModelProblemCollector;
 import org.apache.maven.model.building.ModelProblemCollectorRequest;
 import org.apache.maven.model.path.DefaultPathTranslator;
+import org.apache.maven.model.path.PathTranslator;
 import org.apache.maven.model.profile.DefaultProfileActivationContext;
 import org.apache.maven.model.profile.DefaultProfileSelector;
 import org.apache.maven.model.profile.activation.FileProfileActivator;
@@ -616,7 +617,7 @@ public class BootstrapMavenContext {
                 .addProfileActivator(new PropertyProfileActivator())
                 .addProfileActivator(new JdkVersionProfileActivator())
                 .addProfileActivator(new OperatingSystemProfileActivator())
-                .addProfileActivator(new FileProfileActivator().setPathTranslator(new DefaultPathTranslator()));
+                .addProfileActivator(createFileProfileActivator());
         modelProfiles = profileSelector.getActiveProfiles(modelProfiles, context, new ModelProblemCollector() {
             public void add(ModelProblemCollectorRequest req) {
                 log.error("Failed to activate a Maven profile: " + req.getMessage());
@@ -960,5 +961,28 @@ public class BootstrapMavenContext {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    private static FileProfileActivator createFileProfileActivator() throws BootstrapMavenException {
+        var activator = new FileProfileActivator();
+        var translator = new DefaultPathTranslator();
+        try {
+            activator.setPathTranslator(translator);
+        } catch (LinkageError e) {
+            // setPathTranslator() not found; Maven >= 3.8.5 (https://github.com/apache/maven/pull/649)
+            try {
+                var interpolatorClass = Thread.currentThread().getContextClassLoader()
+                        .loadClass("org.apache.maven.model.path.ProfileActivationFilePathInterpolator");
+                var interpolator = interpolatorClass.getDeclaredConstructor().newInstance();
+                interpolatorClass.getMethod("setPathTranslator", PathTranslator.class)
+                        .invoke(interpolator, translator);
+                activator.getClass().getMethod("setProfileActivationFilePathInterpolator", interpolatorClass)
+                        .invoke(activator, interpolator);
+            } catch (ReflectiveOperationException reflectionExc) {
+                throw new BootstrapMavenException("Failed to set up Maven 3.8.5+ ProfileActivationFilePathInterpolator",
+                        reflectionExc);
+            }
+        }
+        return activator;
     }
 }

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -47,7 +47,7 @@
         <sisu.version>0.3.5</sisu.version><!-- Keep in sync with maven-core.version -->
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
         <maven-resolver.version>1.6.3</maven-resolver.version>
-        <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- changed from the original version due to https://snyk.io/vuln/maven:org.apache.maven.shared:maven-shared-utils@3.2.1 -->
+        <maven-shared-utils.version>3.3.4</maven-shared-utils.version> <!-- Keep in sync with maven-core.version (force this version on maven-invoker) -->
         <maven-wagon.version>3.4.3</maven-wagon.version>
         <httpcore.version>4.4.15</httpcore.version><!-- Keep in sync with maven-wagon.version (wagon-http 3.4.3 brings in 4.4.13 and 4.4.14) -->
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>


### PR DESCRIPTION
Alternative to #24655; no bump of the api libs, only ensure upward compatibility.

See also: https://github.com/quarkusio/quarkus/pull/24655#issuecomment-1086942372

Fixes #24643