### PR TITLE
ComponentsProviderGenerator - lower group limit for addRemovedBeans()

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -411,6 +411,11 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         }
 
         @Override
+        protected int groupLimit() {
+            return 5;
+        }
+
+        @Override
         MethodCreator newAddMethod() {
             // Clear the shared maps for each addRemovedBeansX() method
             sharedQualifers.clear();
@@ -687,7 +692,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
         void addComponent(T component) {
 
-            if (addMethod == null || componentsAdded >= GROUP_LIMIT) {
+            if (addMethod == null || componentsAdded >= groupLimit()) {
                 if (addMethod != null) {
                     addMethod.returnValue(null);
                 }
@@ -708,6 +713,10 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
         abstract void invokeAddMethod();
 
         abstract void addComponentInternal(T component);
+
+        protected int groupLimit() {
+            return GROUP_LIMIT;
+        }
 
     }
 


### PR DESCRIPTION
- to eliminate the perf regression caused by
MethodWriter#computeAllFrames() and Frame#merge()
- resolves #24712