### PR TITLE
Leverage java 17 when available in kotlin codestart projet

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/kotlin/build.tpl.qute.gradle.kts
@@ -15,10 +15,6 @@ allOpen {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    {#if java.version == "11"}
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
-    {#else}
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
-    {/if}
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_{java.version}.toString()
     kotlinOptions.javaParameters = true
 }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/kotlin/build.tpl.qute.gradle
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/kotlin/build.tpl.qute.gradle
@@ -15,10 +15,10 @@ allOpen {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_{java.version}
     kotlinOptions.javaParameters = true
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_{java.version}
 }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/kotlin/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/kotlin/pom.tpl.qute.xml
@@ -40,7 +40,7 @@
                 </executions>
                 <configuration>
                     <javaParameters>true</javaParameters>
-                    <jvmTarget>11</jvmTarget>
+                    <jvmTarget>{java.version}</jvmTarget>
                     <!-- Soon to be replaced by plugin that will pre-configure all necessary annotations -->
                     <compilerPlugins>
                         <plugin>all-open</plugin>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/codegen/CreateProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/codegen/CreateProjectHelper.java
@@ -25,6 +25,7 @@ public class CreateProjectHelper {
     // ordering is important here, so let's keep them ordered
     public static final SortedSet<Integer> JAVA_VERSIONS_LTS = new TreeSet<>(List.of(11, 17));
     private static final int DEFAULT_JAVA_VERSION = 11;
+    private static final int MAX_LTS_SUPPORTED_BY_KOTLIN = 17;
     public static final String DETECT_JAVA_RUNTIME_VERSION = "<<detect java runtime version>>";
     private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("(\\d+)(?:\\..*)?");
 
@@ -98,7 +99,14 @@ public class CreateProjectHelper {
             javaFeatureVersionTarget = Runtime.version().feature();
         }
 
-        values.put(ProjectGenerator.JAVA_TARGET, String.valueOf(determineBestJavaLtsVersion(javaFeatureVersionTarget)));
+        int bestJavaLtsVersion = determineBestJavaLtsVersion(javaFeatureVersionTarget);
+
+        if (SourceType.KOTLIN.equals(values.get(ProjectGenerator.SOURCE_TYPE))
+                && bestJavaLtsVersion > MAX_LTS_SUPPORTED_BY_KOTLIN) {
+            bestJavaLtsVersion = MAX_LTS_SUPPORTED_BY_KOTLIN;
+        }
+
+        values.put(ProjectGenerator.JAVA_TARGET, String.valueOf(bestJavaLtsVersion));
     }
 
     public static int determineBestJavaLtsVersion() {

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/codegen/CreateProjectHelperTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/codegen/CreateProjectHelperTest.java
@@ -62,4 +62,13 @@ class CreateProjectHelperTest {
         assertEquals(17, CreateProjectHelper.determineBestJavaLtsVersion(17));
         assertEquals(17, CreateProjectHelper.determineBestJavaLtsVersion(18));
     }
+
+    @Test
+    public void givenKotlinProjectWithVersion18ShouldReturn17() {
+        Map<String, Object> values = new HashMap<>();
+        values.put(ProjectGenerator.SOURCE_TYPE, SourceType.KOTLIN);
+
+        CreateProjectHelper.setJavaVersion(values, "18");
+        assertEquals("17", values.get("java_target"));
+    }
 }


### PR DESCRIPTION
This set java 17 as target is the current version is java 17, 11 is set otherwise.


close #23235
