### PR TITLE
Update Kotlin to 1.6.20

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -144,7 +144,7 @@
         <aws-lambda-java-events.version>3.11.0</aws-lambda-java-events.version>
         <aws-xray.version>2.11.0</aws-xray.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.6.20</kotlin.version>
         <kotlin.coroutine.version>1.6.0</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.2</kotlin-serialization.version>
         <dekorate.version>2.9.0</dekorate.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.6.20</kotlin.version>
         <dokka.version>1.6.10</dokka.version>
         <scala.version>2.12.13</scala.version>
         <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.6.10</version>
+            <version>1.6.20</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Notes about this:
- Dokka version seems to follow Kotlin, but no `1.6.20` stable release is published yet. Don't think it's an issue but just something to remember to update probably once available: https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-core

https://github.com/quarkusio/quarkus/blob/dde360d397b5ef0d6c26102134122dddafb6c521/build-parent/pom.xml#L24

- There's script that uses Kotlin 1.6.10 by what appears to be building it from source. Does this need to be migrated to 1.6.20 as well?

https://github.com/quarkusio/quarkus/blob/1dafb4feb8442c7c36a43ee886447b51123e8c9d/jakarta/transform.sh#L51-L57