### PR TITLE
Fix IT main for GraalVM >= 22.1

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationConfig.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/corestuff/serialization/SerializationConfig.java
@@ -1,11 +1,10 @@
 package io.quarkus.it.corestuff.serialization;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
-@RegisterForReflection(targets = { List.class, ArrayList.class, String.class }, serialization = true)
+@RegisterForReflection(targets = { ArrayList.class, String.class }, serialization = true)
 public class SerializationConfig {
 
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RegisterForReflectionITCase.java
@@ -4,6 +4,9 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMNewerThan;
+import io.quarkus.test.junit.DisableIfBuiltWithGraalVMOlderThan;
+import io.quarkus.test.junit.GraalVMVersion;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 
@@ -35,7 +38,20 @@ public class RegisterForReflectionITCase {
     }
 
     @Test
-    public void testTargetWithNested() {
+    @DisableIfBuiltWithGraalVMOlderThan(GraalVMVersion.GRAALVM_22_1)
+    public void testTargetWithNestedPost22_1() {
+        final String resourceC = BASE_PKG + ".ResourceC";
+
+        // Starting with GraalVM 22.1 ResourceC implicitly gets registered by GraalVM
+        // (see https://github.com/oracle/graal/pull/4414)
+        assertRegistration("ResourceC", resourceC);
+        assertRegistration("InaccessibleClassOfC", resourceC + "$InaccessibleClassOfC");
+        assertRegistration("OtherInaccessibleClassOfC", resourceC + "$InaccessibleClassOfC$OtherInaccessibleClassOfC");
+    }
+
+    @Test
+    @DisableIfBuiltWithGraalVMNewerThan(GraalVMVersion.GRAALVM_22_0)
+    public void testTargetWithNestedPre22_1() {
         final String resourceC = BASE_PKG + ".ResourceC";
 
         assertRegistration("FAILED", resourceC);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThan.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThan.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(DisableIfBuiltWithGraalVMOlderThanCondition.class)
-public @interface DisableIfBuiltWithGraalVMOlderThan {
+@ExtendWith(DisableIfBuiltWithGraalVMNewerThanCondition.class)
+public @interface DisableIfBuiltWithGraalVMNewerThan {
     GraalVMVersion value();
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThanCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThanCondition.java
@@ -5,9 +5,6 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -20,8 +17,8 @@ public class DisableIfBuiltWithGraalVMNewerThanCondition implements ExecutionCon
 
     private static final String QUARKUS_INTEGRATION_TEST_NAME = QuarkusIntegrationTest.class.getName();
     private static final String NATIVE_IMAGE_TEST_NAME = NativeImageTest.class.getName();
-    private static final Set<String> SUPPORTED_INTEGRATION_TESTS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(QUARKUS_INTEGRATION_TEST_NAME, NATIVE_IMAGE_TEST_NAME)));
+    private static final Set<String> SUPPORTED_INTEGRATION_TESTS = Set.of(QUARKUS_INTEGRATION_TEST_NAME,
+            NATIVE_IMAGE_TEST_NAME);
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThanCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMNewerThanCondition.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCondition {
+public class DisableIfBuiltWithGraalVMNewerThanCondition implements ExecutionCondition {
 
     private static final String QUARKUS_INTEGRATION_TEST_NAME = QuarkusIntegrationTest.class.getName();
     private static final String NATIVE_IMAGE_TEST_NAME = NativeImageTest.class.getName();
@@ -26,13 +26,13 @@ public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCon
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         Optional<AnnotatedElement> element = context.getElement();
-        Optional<DisableIfBuiltWithGraalVMOlderThan> optional = findAnnotation(element,
-                DisableIfBuiltWithGraalVMOlderThan.class);
+        Optional<DisableIfBuiltWithGraalVMNewerThan> optional = findAnnotation(element,
+                DisableIfBuiltWithGraalVMNewerThan.class);
         if (!optional.isPresent()) {
-            return ConditionEvaluationResult.enabled("@DisableIfBuiltWithGraalVMOlderThan was not found");
+            return ConditionEvaluationResult.enabled("@DisableIfBuiltWithGraalVMNewerThan was not found");
         }
         if (!isIntegrationTest(context.getRequiredTestClass())) {
-            return ConditionEvaluationResult.enabled("@DisableIfBuiltWithGraalVMOlderThan was added to an unsupported test");
+            return ConditionEvaluationResult.enabled("@DisableIfBuiltWithGraalVMNewerThan was added to an unsupported test");
         }
 
         GraalVMVersion annotationValue = optional.get().value();
@@ -41,9 +41,9 @@ public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCon
             org.graalvm.home.Version version = org.graalvm.home.Version
                     .parse(quarkusArtifactProperties.getProperty("metadata.graalvm.version.version"));
             int comparison = annotationValue.compareTo(version);
-            if (comparison > 0) {
+            if (comparison < 0) {
                 return ConditionEvaluationResult.disabled("Native binary was built with GraalVM{version=" + version.toString()
-                        + "} but the test is disabled for GraalVM versions older than " + annotationValue);
+                        + "} but the test is disabled for GraalVM versions newer than " + annotationValue);
             }
             return ConditionEvaluationResult
                     .enabled("Native binary was built with a GraalVM version compatible with the required version by the test");

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/DisableIfBuiltWithGraalVMOlderThanCondition.java
@@ -5,9 +5,6 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -20,8 +17,8 @@ public class DisableIfBuiltWithGraalVMOlderThanCondition implements ExecutionCon
 
     private static final String QUARKUS_INTEGRATION_TEST_NAME = QuarkusIntegrationTest.class.getName();
     private static final String NATIVE_IMAGE_TEST_NAME = NativeImageTest.class.getName();
-    private static final Set<String> SUPPORTED_INTEGRATION_TESTS = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(QUARKUS_INTEGRATION_TEST_NAME, NATIVE_IMAGE_TEST_NAME)));
+    private static final Set<String> SUPPORTED_INTEGRATION_TESTS = Set.of(QUARKUS_INTEGRATION_TEST_NAME,
+            NATIVE_IMAGE_TEST_NAME);
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/GraalVMVersion.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.junit;
+
+public enum GraalVMVersion {
+    GRAALVM_21_0(org.graalvm.home.Version.create(21, 0)),
+    GRAALVM_22_0(org.graalvm.home.Version.create(22, 0)),
+    GRAALVM_22_1(org.graalvm.home.Version.create(22, 1));
+
+    private final org.graalvm.home.Version version;
+
+    GraalVMVersion(org.graalvm.home.Version version) {
+        this.version = version;
+    }
+
+    public org.graalvm.home.Version getVersion() {
+        return version;
+    }
+
+    /**
+     * Compares this version with another GraalVM version
+     *
+     * @return {@code -1} if this version is older than the other version,
+     *         {@code +1} if it's newer and {@code 0} if they represent the same version
+     */
+    public int compareTo(org.graalvm.home.Version version) {
+        return this.version.compareTo(version);
+    }
+
+    @Override
+    public String toString() {
+        return "GraalVMVersion{" +
+                "version=" + version.toString() +
+                '}';
+    }
+}


### PR DESCRIPTION
https://github.com/oracle/graal/pull/4222 introduces some changes in the way that reflection metadata are added to native image resulting in some additional metadata landing in the native image with GraalVM 22.1, that were previously not included.

This PR makes Quarkus' integration test `main` to accept this new behavior.