### PR TITLE
Ensure that user provided Json providers can override the included ones

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyReaderBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyReaderBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.spi;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.Priorities;
@@ -30,6 +31,15 @@ public final class MessageBodyReaderBuildItem extends MultiBuildItem implements 
         this.priority = priority;
     }
 
+    MessageBodyReaderBuildItem(Builder builder) {
+        this.className = builder.className;
+        this.handledClassName = builder.handledClassName;
+        this.mediaTypeStrings = builder.mediaTypeStrings;
+        this.runtimeType = builder.runtimeType;
+        this.builtin = builder.builtin;
+        this.priority = builder.priority;
+    }
+
     public String getClassName() {
         return className;
     }
@@ -53,5 +63,43 @@ public final class MessageBodyReaderBuildItem extends MultiBuildItem implements 
 
     public Integer getPriority() {
         return priority;
+    }
+
+    public static class Builder {
+        private final String className;
+        private final String handledClassName;
+        private List<String> mediaTypeStrings = Collections.emptyList();
+        private RuntimeType runtimeType = null;
+        private boolean builtin = false;
+        private Integer priority = Priorities.USER;
+
+        public Builder(String className, String handledClassName) {
+            this.className = className;
+            this.handledClassName = handledClassName;
+        }
+
+        public Builder setMediaTypeStrings(List<String> mediaTypeStrings) {
+            this.mediaTypeStrings = mediaTypeStrings;
+            return this;
+        }
+
+        public Builder setRuntimeType(RuntimeType runtimeType) {
+            this.runtimeType = runtimeType;
+            return this;
+        }
+
+        public Builder setBuiltin(boolean builtin) {
+            this.builtin = builtin;
+            return this;
+        }
+
+        public Builder setPriority(Integer priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        public MessageBodyReaderBuildItem build() {
+            return new MessageBodyReaderBuildItem(this);
+        }
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyWriterBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/MessageBodyWriterBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkus.resteasy.reactive.spi;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.Priorities;
@@ -30,6 +31,15 @@ public final class MessageBodyWriterBuildItem extends MultiBuildItem implements 
         this.priority = priority;
     }
 
+    MessageBodyWriterBuildItem(Builder builder) {
+        this.className = builder.className;
+        this.handledClassName = builder.handledClassName;
+        this.mediaTypeStrings = builder.mediaTypeStrings;
+        this.runtimeType = builder.runtimeType;
+        this.builtin = builder.builtin;
+        this.priority = builder.priority;
+    }
+
     public String getClassName() {
         return className;
     }
@@ -53,5 +63,43 @@ public final class MessageBodyWriterBuildItem extends MultiBuildItem implements 
 
     public Integer getPriority() {
         return priority;
+    }
+
+    public static class Builder {
+        private final String className;
+        private final String handledClassName;
+        private List<String> mediaTypeStrings = Collections.emptyList();
+        private RuntimeType runtimeType = null;
+        private boolean builtin = false;
+        private Integer priority = Priorities.USER;
+
+        public Builder(String className, String handledClassName) {
+            this.className = className;
+            this.handledClassName = handledClassName;
+        }
+
+        public Builder setMediaTypeStrings(List<String> mediaTypeStrings) {
+            this.mediaTypeStrings = mediaTypeStrings;
+            return this;
+        }
+
+        public Builder setRuntimeType(RuntimeType runtimeType) {
+            this.runtimeType = runtimeType;
+            return this;
+        }
+
+        public Builder setBuiltin(boolean builtin) {
+            this.builtin = builtin;
+            return this;
+        }
+
+        public Builder setPriority(Integer priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        public MessageBodyWriterBuildItem build() {
+            return new MessageBodyWriterBuildItem(this);
+        }
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/main/java/io/quarkus/resteasy/reactive/jackson/deployment/processor/ResteasyReactiveJacksonProcessor.java
@@ -25,7 +25,6 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
-import org.jboss.resteasy.reactive.common.util.RestMediaType;
 import org.jboss.resteasy.reactive.server.util.MethodId;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -80,6 +79,8 @@ public class ResteasyReactiveJacksonProcessor {
             .createSimple(EnableSecureSerialization.class.getName());
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
+    private static final List<String> HANDLED_MEDIA_TYPES = List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON,
+            APPLICATION_STREAM_JSON);
 
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> feature) {
@@ -127,31 +128,46 @@ public class ResteasyReactiveJacksonProcessor {
         boolean applicationNeedsSpecialJacksonFeatures = jacksonFeatureBuildItems.isEmpty();
 
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(ServerJacksonMessageBodyReader.class.getName(), Object.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(ServerJacksonMessageBodyReader.class.getName(),
+                                Object.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true).build());
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(VertxJsonArrayMessageBodyReader.class.getName(),
-                        JsonArray.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(VertxJsonArrayMessageBodyReader.class.getName(),
+                                JsonArray.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(VertxJsonObjectMessageBodyReader.class.getName(),
-                        JsonObject.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(VertxJsonObjectMessageBodyReader.class.getName(),
+                                JsonObject.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(getJacksonMessageBodyWriter(applicationNeedsSpecialJacksonFeatures),
-                        Object.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON,
-                                RestMediaType.APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(
+                                getJacksonMessageBodyWriter(applicationNeedsSpecialJacksonFeatures), Object.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(VertxJsonArrayMessageBodyWriter.class.getName(),
-                        JsonArray.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON,
-                                RestMediaType.APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(VertxJsonArrayMessageBodyWriter.class.getName(),
+                                JsonArray.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(VertxJsonObjectMessageBodyWriter.class.getName(),
-                        JsonObject.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON,
-                                RestMediaType.APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(VertxJsonObjectMessageBodyWriter.class.getName(),
+                                JsonObject.class.getName())
+                                        .setMediaTypeStrings(HANDLED_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
     }
 
     private String getJacksonMessageBodyWriter(boolean applicationNeedsSpecialJacksonFeatures) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomJsonProviderTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/CustomJsonProviderTest.java
@@ -1,0 +1,115 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class CustomJsonProviderTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(GreetingResource.class, Greeting.class, Greeting2.class, BaseCustomWriter.class,
+                                    CustomWriter.class);
+                }
+            });
+
+    @Test
+    public void customWriter() {
+        RestAssured.with().accept(ContentType.JSON).get("/greeting/custom")
+                .then().statusCode(200).body("message", equalTo("canned"));
+    }
+
+    @Test
+    public void standardWriter() {
+        RestAssured.with().accept(ContentType.JSON).get("/greeting/standard")
+                .then().statusCode(200).body("message", equalTo("test"));
+    }
+
+    @Path("greeting")
+    public static class GreetingResource {
+
+        @Path("custom")
+        @GET
+        public Greeting get() {
+            return new Greeting("test");
+        }
+
+        @Path("standard")
+        @GET
+        public Greeting2 standard() {
+            return new Greeting2("test");
+        }
+    }
+
+    public static class Greeting {
+
+        private final String message;
+
+        public Greeting(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public static class Greeting2 {
+
+        private final String message;
+
+        public Greeting2(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    @Produces({ MediaType.APPLICATION_JSON, "application/*+json" })
+    public static abstract class BaseCustomWriter implements MessageBodyWriter<Object> {
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return Greeting.class.isAssignableFrom(type);
+        }
+    }
+
+    @Provider
+    public static class CustomWriter extends BaseCustomWriter {
+        @Override
+        public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            entityStream.write("{\"message\": \"canned\"}".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/common/deployment/ResteasyReactiveJsonbCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jsonb/common/deployment/ResteasyReactiveJsonbCommonProcessor.java
@@ -38,10 +38,17 @@ public class ResteasyReactiveJsonbCommonProcessor {
                 .addBeanClass(JsonbMessageBodyWriter.class.getName())
                 .setUnremovable().build());
 
-        additionalReaders.produce(new MessageBodyReaderBuildItem(JsonbMessageBodyReader.class.getName(), Object.class.getName(),
-                Collections.singletonList(MediaType.APPLICATION_JSON)));
-        additionalWriters.produce(new MessageBodyWriterBuildItem(JsonbMessageBodyWriter.class.getName(), Object.class.getName(),
-                List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON, RestMediaType.APPLICATION_STREAM_JSON)));
+        additionalReaders.produce(
+                new MessageBodyReaderBuildItem.Builder(JsonbMessageBodyReader.class.getName(), Object.class.getName())
+                        .setMediaTypeStrings(Collections.singletonList(MediaType.APPLICATION_JSON))
+                        .setBuiltin(true)
+                        .build());
+        additionalWriters.produce(
+                new MessageBodyWriterBuildItem.Builder(JsonbMessageBodyWriter.class.getName(), Object.class.getName())
+                        .setMediaTypeStrings(List.of(MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_NDJSON,
+                                RestMediaType.APPLICATION_STREAM_JSON))
+                        .setBuiltin(true)
+                        .build());
     }
 
     @BuildStep

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
@@ -28,6 +28,10 @@ import io.vertx.core.json.JsonObject;
 
 public class RestClientReactiveJacksonProcessor {
 
+    private static final List<String> HANDLED_WRITE_MEDIA_TYPES = Collections.singletonList(MediaType.APPLICATION_JSON);
+    private static final List<String> HANDLED_READ_MEDIA_TYPES = List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON,
+            APPLICATION_STREAM_JSON);
+
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> features) {
         features.produce(new FeatureBuildItem(REST_CLIENT_REACTIVE_JACKSON));
@@ -49,26 +53,46 @@ public class RestClientReactiveJacksonProcessor {
                 .setUnremovable().build());
 
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(JacksonBasicMessageBodyReader.class.getName(), Object.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(JacksonBasicMessageBodyReader.class.getName(),
+                                Object.class.getName())
+                                        .setMediaTypeStrings(HANDLED_READ_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(VertxJsonArrayBasicMessageBodyReader.class.getName(),
-                        JsonArray.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(VertxJsonArrayBasicMessageBodyReader.class.getName(),
+                                JsonArray.class.getName())
+                                        .setMediaTypeStrings(HANDLED_READ_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalReaders
-                .produce(new MessageBodyReaderBuildItem(VertxJsonObjectBasicMessageBodyReader.class.getName(),
-                        JsonObject.class.getName(),
-                        List.of(MediaType.APPLICATION_JSON, APPLICATION_NDJSON, APPLICATION_STREAM_JSON)));
+                .produce(
+                        new MessageBodyReaderBuildItem.Builder(VertxJsonObjectBasicMessageBodyReader.class.getName(),
+                                JsonObject.class.getName())
+                                        .setMediaTypeStrings(HANDLED_READ_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(ClientJacksonMessageBodyWriter.class.getName(), Object.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(ClientJacksonMessageBodyWriter.class.getName(),
+                                Object.class.getName())
+                                        .setMediaTypeStrings(HANDLED_WRITE_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(VertxJsonArrayBasicMessageBodyWriter.class.getName(),
-                        JsonArray.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(VertxJsonArrayBasicMessageBodyWriter.class.getName(),
+                                JsonArray.class.getName())
+                                        .setMediaTypeStrings(HANDLED_WRITE_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
         additionalWriters
-                .produce(new MessageBodyWriterBuildItem(VertxJsonObjectBasicMessageBodyWriter.class.getName(),
-                        JsonObject.class.getName(),
-                        Collections.singletonList(MediaType.APPLICATION_JSON)));
+                .produce(
+                        new MessageBodyWriterBuildItem.Builder(VertxJsonObjectBasicMessageBodyWriter.class.getName(),
+                                JsonObject.class.getName())
+                                        .setMediaTypeStrings(HANDLED_WRITE_MEDIA_TYPES)
+                                        .setBuiltin(true)
+                                        .build());
     }
 }


### PR DESCRIPTION
The basic change here is that the JSON providers where erroneously
not marked as built-in, and thus were not being given priority
(as per the JAX-RS spec).
This change also introduces builders to make the code cleaner
and the built-in configuration more explicit

Resolves: #24738