### PR TITLE
Check quarkus.http.root-path for security policy paths

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/AdminPathHandler.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/AdminPathHandler.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.http.security;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class AdminPathHandler {
+
+    public void setup(@Observes Router router) {
+        router.route("/admin").handler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                QuarkusHttpUser user = (QuarkusHttpUser) event.user();
+                StringBuilder ret = new StringBuilder();
+                if (user != null) {
+                    ret.append(user.getSecurityIdentity().getPrincipal().getName());
+                }
+                ret.append(":");
+                ret.append(event.normalizedPath());
+                event.response().end(ret.toString());
+            }
+        });
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
@@ -1,0 +1,65 @@
+package io.quarkus.vertx.http.security;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class PathWithHttpRootTestCase {
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("test", "test", "test");
+    }
+
+    private static final String APP_PROPS = "" +
+            "# Add your application.properties here, if applicable.\n" +
+            "quarkus.http.root-path=/root\n" +
+            "quarkus.http.auth.permission.authenticated.paths=/admin\n" +
+            "quarkus.http.auth.permission.authenticated.policy=authenticated\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<JavaArchive>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityController.class, TestIdentityProvider.class, AdminPathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @Test
+    public void testAdminPath() {
+
+        RestAssured
+                .given()
+                .when()
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(401);
+        RestAssured
+                .given()
+                .auth()
+                .preemptive()
+                .basic("test", "test")
+                .when()
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body(Matchers.equalTo("test:/root/admin"));
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -99,6 +99,10 @@ public class PathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
             if (entry.getValue().enabled.orElse(Boolean.TRUE)) {
                 for (String path : entry.getValue().paths.orElse(Collections.emptyList())) {
                     path = path.trim();
+                    if (!config.rootPath.equals("/")) {
+                        path = (config.rootPath.endsWith("/") ? config.rootPath.substring(0, config.rootPath.length() - 1)
+                                : config.rootPath) + path;
+                    }
                     if (tempMap.containsKey(path)) {
                         HttpMatcher m = new HttpMatcher(entry.getValue().authMechanism.orElse(null),
                                 new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),


### PR DESCRIPTION
Fixes #24728 

This PR updates `HttpSecurityRecorder` to take `quarkus.http.root-path` into consideration. While it took me only a few mins to update it, it took significantly longer to get a simple test working :-), `RestAssured` integration checks this root path too, I wanted to assert that sending a request to just `admin` would give me `404` but it would keep returning either 200 or 401 because the root is appended internally to both the client calls and the test vertx router. But at least the test confirms that the actual request path is `/root/admin`