### PR TITLE
Bump kubernetes-client-bom from 5.12.1 to 5.12.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,7 +161,7 @@
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.12.1</kubernetes-client.version>
+        <kubernetes-client.version>5.12.2</kubernetes-client.version>
         <flapdoodle.mongo.version>3.3.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP6</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>


### PR DESCRIPTION
Kubernetes Client 5.12.2 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.12.2

Just speeding up the dependabot process to see if CI reports any issue.

/cc @metacosm
