### PR TITLE
Provide link for Vert.x API @ConsumerEvent alternative

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -312,7 +312,7 @@ public class GreetingService {
 }
 ----
 <1> Declaring a CDI Bean in the Application scope. Quarkus will create a single instance of this class.
-<2> Use the `@ConsumeEvent` annotation to declare a consumer. It is possible to use the Vert.x API directly too. TODO LINK REF
+<2> Use the `@ConsumeEvent` annotation to declare a consumer. It is possible to use the Vert.x API https://vertx.io/docs/vertx-core/java/#_acknowledging_messages_sending_replies[directly] too.
 <3> Receive the message payload as a method parameter. The returned object will be the reply.
 <4> Return the response. This response is sent back to the `VertxResource` class
 


### PR DESCRIPTION
This PR resolve `TODO LINK REF`, provided link hints how to use Vert.x API directly. "Quarkus way" looks [`like this`](https://github.com/quarkusio/quarkus-quickstarts/blob/main/vertx-quickstart/src/main/java/org/acme/GreetingService.java), while direct usage of Vert.x API would work like this
``
@Startup
@ApplicationScoped
public class GreetingService {

    public GreetingService(EventBus eb) {

        eb.consumer("greetings").handler(message -> message.reply("Hello " + message.body()));
    }

}
``
I checked, works fine. Please feel free to stylize my changes according to your preference.