### PR TITLE
Define quarkus.tls.trust-all as run time property

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/TlsConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/TlsConfig.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 /**
  * Configuration class allowing to globally set TLS properties.
  */
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public class TlsConfig {
 
     /**


### PR DESCRIPTION
Convert `quarkus.tls.trust-all` property to a runtime property

close #23680