### PR TITLE
Fix amazon-lambda-xray runtime artifact name

### DIFF
--- a/extensions/amazon-lambda-xray/runtime/pom.xml
+++ b/extensions/amazon-lambda-xray/runtime/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>quarkus-amazon-lambda-xray</artifactId>
-    <name>Quarkus - Amazon Lambda Xray - Runtime</name>
+    <name>Quarkus - Amazon Lambda X-Ray - Runtime</name>
     <description>Allow X-Ray to run with Quarkus Lambda support</description>
 
     <dependencies>


### PR DESCRIPTION
It was inconsistent with the other artifacts.

Noticed while working on Jakarta.