### PR TITLE
Include Spotify OIDC provider

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1081,6 +1081,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
         GITHUB,
         GOOGLE,
         MICROSOFT,
+        SPOTIFY,
         TWITTER
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/providers/KnownOidcProviders.java
@@ -20,6 +20,8 @@ public class KnownOidcProviders {
             return microsoft();
         } else if (OidcTenantConfig.Provider.FACEBOOK == provider) {
             return facebook();
+        } else if (OidcTenantConfig.Provider.SPOTIFY == provider) {
+            return spotify();
         } else if (OidcTenantConfig.Provider.TWITTER == provider) {
             return twitter();
         }
@@ -96,6 +98,26 @@ public class KnownOidcProviders {
         ret.getCredentials().getClientSecret().setMethod(Method.POST_JWT);
         ret.getCredentials().getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
         ret.getCredentials().getJwt().setAudience("https://appleid.apple.com/");
+        return ret;
+    }
+
+    private static OidcTenantConfig spotify() {
+        // See https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
+        OidcTenantConfig ret = new OidcTenantConfig();
+        ret.setDiscoveryEnabled(false);
+        ret.setAuthServerUrl("https://accounts.spotify.com");
+        ret.setApplicationType(OidcTenantConfig.ApplicationType.WEB_APP);
+        ret.setAuthorizationPath("authorize");
+        ret.setTokenPath("api/token");
+        ret.setUserInfoPath("https://api.spotify.com/v1/me");
+
+        OidcTenantConfig.Authentication authentication = ret.getAuthentication();
+        authentication.setAddOpenidScope(false);
+        authentication.setScopes(List.of("user-read-email"));
+        authentication.setUserInfoRequired(true);
+        authentication.setIdTokenRequired(false);
+        authentication.setPkceRequired(true);
+
         return ret;
     }
 }

--- a/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
+++ b/extensions/oidc/runtime/src/test/java/io/quarkus/oidc/runtime/OidcUtilsTest.java
@@ -292,6 +292,39 @@ public class OidcUtilsTest {
     }
 
     @Test
+    public void testAcceptSpotifyProperties() {
+        OidcTenantConfig tenant = new OidcTenantConfig();
+        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+        OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SPOTIFY));
+
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
+        assertEquals(ApplicationType.WEB_APP, config.getApplicationType().get());
+        assertEquals("https://accounts.spotify.com", config.getAuthServerUrl().get());
+        assertEquals(List.of("user-read-email"), config.authentication.scopes.get());
+    }
+
+    @Test
+    public void testOverrideSpotifyProperties() {
+        OidcTenantConfig tenant = new OidcTenantConfig();
+        tenant.setTenantId(OidcUtils.DEFAULT_TENANT_ID);
+
+        tenant.setApplicationType(ApplicationType.HYBRID);
+        tenant.setAuthServerUrl("http://localhost/wiremock");
+        tenant.getToken().setIssuer("http://localhost/wiremock");
+        tenant.authentication.setScopes(List.of("write"));
+        tenant.authentication.setForceRedirectHttpsScheme(false);
+
+        OidcTenantConfig config = OidcUtils.mergeTenantConfig(tenant, KnownOidcProviders.provider(Provider.SPOTIFY));
+
+        assertEquals(OidcUtils.DEFAULT_TENANT_ID, config.getTenantId().get());
+        assertEquals(ApplicationType.HYBRID, config.getApplicationType().get());
+        assertEquals("http://localhost/wiremock", config.getAuthServerUrl().get());
+        assertEquals(List.of("write"), config.authentication.scopes.get());
+        assertEquals("http://localhost/wiremock", config.getToken().getIssuer().get());
+        assertFalse(config.authentication.forceRedirectHttpsScheme.get());
+    }
+
+    @Test
     public void testCorrectTokenType() throws Exception {
         OidcTenantConfig.Token tokenClaims = new OidcTenantConfig.Token();
         tokenClaims.setTokenType("access_token");


### PR DESCRIPTION
Fixes #24793

To enable it:
- [Create a Spotify application](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) - don't forget to add `http://localhost:8080` as a redirect URI for testing during development purposes
 
<img width="1274" alt="Screen Shot 2022-04-10 at 21 38 15" src="https://user-images.githubusercontent.com/54133/162647481-f5935657-90bf-43d9-bc1d-521e0e3c4fc7.png">

<img width="1274" alt="Screen Shot 2022-04-10 at 21 41 33" src="https://user-images.githubusercontent.com/54133/162647579-d7721762-1b29-4086-ae29-275850215d6c.png">

- Add this to your `application.properties`:

```properties
quarkus.oidc.provider=spotify
quarkus.oidc.client-id=<client id from previous step>
quarkus.oidc.credentials.secret=<client secret from previous step>
```
