### PR TITLE
The OIDC Response mode is corrected in the query string when specified

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -336,7 +336,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                         // response_mode
                         if (ResponseMode.FORM_POST == configContext.oidcConfig.authentication.responseMode
                                 .orElse(ResponseMode.QUERY)) {
-                            codeFlowParams.append(OidcConstants.CODE_FLOW_RESPONSE_MODE).append(EQ)
+                            codeFlowParams.append(AMP).append(OidcConstants.CODE_FLOW_RESPONSE_MODE).append(EQ)
                                     .append(configContext.oidcConfig.authentication.responseMode.get().toString()
                                             .toLowerCase());
                         }


### PR DESCRIPTION
The `response_mode` parameter during an OIDC challenge is missing an ampersand(&) to separate from the rest of the parameters