### PR TITLE
Fix potential NPE when PKCE secret is missing

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -47,6 +47,9 @@ public class TenantConfigContext {
         if (config.authentication.pkceRequired.orElse(false)) {
             String pkceSecret = config.authentication.pkceSecret
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
+            if (pkceSecret == null) {
+                throw new RuntimeException("Secret key for encrypting PKCE code verifier is missing");
+            }
             if (pkceSecret.length() < 32) {
                 throw new RuntimeException("Secret key for encrypting PKCE code verifier must be at least 32 characters long");
             }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -62,6 +62,9 @@ public class TenantConfigContext {
         if (config.tokenStateManager.encryptionRequired.orElse(false)) {
             String encSecret = config.tokenStateManager.encryptionSecret
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
+            if (encSecret == null) {
+                throw new RuntimeException("Secret key for encrypting tokens is missing");
+            }
             if (encSecret.length() < 32) {
                 throw new RuntimeException("Secret key for encrypting tokens must be at least 32 characters long");
             }


### PR DESCRIPTION
This prevents the following NPE from happening:

```java
java.lang.NullPointerException: Cannot invoke "String.length()" because "pkceSecret" is null
		at io.quarkus.oidc.runtime.TenantConfigContext.createPkceSecretKey(TenantConfigContext.java:50)
		at io.quarkus.oidc.runtime.TenantConfigContext.<init>(TenantConfigContext.java:42)
```