### PR TITLE
OIDC: truncate PKCE secrets to the right size

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -687,6 +687,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
             try {
                 return OidcUtils.encryptJson(json, configContext.getPkceSecretKey());
             } catch (Exception ex) {
+                LOG.debugf(ex, "Failed to encrypt JSON with PKCE secret key");
                 throw new AuthenticationFailedException(ex);
             }
         } else {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/TenantConfigContext.java
@@ -49,6 +49,9 @@ public class TenantConfigContext {
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
             if (pkceSecret.length() < 32) {
                 throw new RuntimeException("Secret key for encrypting PKCE code verifier must be at least 32 characters long");
+            } else if (pkceSecret.length() > 32) {
+                // truncate it down nicely, especially if it comes from the client secret, because anything over 32 throws
+                pkceSecret = pkceSecret.substring(0, 32);
             }
             return KeyUtils.createSecretKeyFromSecret(pkceSecret);
         }
@@ -61,6 +64,9 @@ public class TenantConfigContext {
                     .orElse(OidcCommonUtils.clientSecret(config.credentials));
             if (encSecret.length() < 32) {
                 throw new RuntimeException("Secret key for encrypting tokens must be at least 32 characters long");
+            } else if (encSecret.length() > 32) {
+                // truncate it down nicely, especially if it comes from the client secret, because anything over 32 throws
+                encSecret = encSecret.substring(0, 32);
             }
             return KeyUtils.createSecretKeyFromSecret(encSecret);
         }


### PR DESCRIPTION
Otherwise this throws and the user doesn't know what went wrong.

For example, Twitter's secrets are more than 32 chars long, thus requiring me to explicitly set a PKCE secret otherwise.