### PR TITLE
Documentation - Correct Mutual TLS abbreviation - decapitalize first letter

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -637,9 +637,9 @@ quarkus.oidc-client.credentials.jwt.issuer=${apple.issuer}
 
 ==== Mutual TLS
 
-Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`MTLS`) authentication process.
+Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`mTLS`) authentication process.
 
-`quarkus-oidc-client` can be configured as follows to support `MTLS`:
+`quarkus-oidc-client` can be configured as follows to support `mTLS`:
 
 [source,properties]
 ----

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -1042,9 +1042,9 @@ quarkus.oidc.credentials.jwt.issuer=${apple.issuer}
 
 ==== Mutual TLS
 
-Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`MTLS`) authentication process.
+Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`mTLS`) authentication process.
 
-`quarkus-oidc` can be configured as follows to support `MTLS`:
+`quarkus-oidc` can be configured as follows to support `mTLS`:
 
 [source,properties]
 ----


### PR DESCRIPTION
Mutual TLS is commonly abbreviated to mTLS, I found but a small handful using MTLS (that were imho typos). Quarkus already used mTLS form in past f.e. https://quarkus.io/blog/quarkus-mutual-tls/, https://quarkus.io/guides/security-built-in-authentication