### PR TITLE
Add 'gradle' to sample Dockerfile for building with Gradle

### DIFF
--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -567,7 +567,7 @@ Sample Dockerfile for building with Gradle:
 ## Stage 1 : build with maven builder image with native capabilities
 FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
 COPY --chown=quarkus:quarkus gradlew /code/gradlew
-COPY --chown=quarkus:quarkus /code/gradle
+COPY --chown=quarkus:quarkus gradle /code/gradle
 COPY --chown=quarkus:quarkus build.gradle /code/
 COPY --chown=quarkus:quarkus settings.gradle /code/
 COPY --chown=quarkus:quarkus gradle.properties /code/


### PR DESCRIPTION
Added 'gradle' to sample Dockerfile for building with Gradle, in building-native-image.adoc.

#24727

___
**Testing:**
Follow the guide from [building native image](https://quarkus.io/guides/building-native-image) @ `Sample Dockerfile for building with Gradle:`
Using this dockerfile :)

```dockerfile
## Stage 1 : build with maven builder image with native capabilities
FROM quay.io/quarkus/ubi-quarkus-native-image:21.3.1-java11 AS build
COPY --chown=quarkus:quarkus gradlew /code/gradlew
COPY --chown=quarkus:quarkus gradle /code/gradle
COPY --chown=quarkus:quarkus build.gradle /code/
COPY --chown=quarkus:quarkus settings.gradle /code/
COPY --chown=quarkus:quarkus gradle.properties /code/
USER quarkus
WORKDIR /code
COPY src /code/src
RUN gradle -b /code/build.gradle buildNative

## Stage 2 : create the docker final image
FROM quay.io/quarkus/quarkus-micro-image:1.0
WORKDIR /work/
COPY --from=build /code/build/*-runner /work/application
RUN chmod 775 /work
EXPOSE 8080
CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

```