### PR TITLE
Documentation: fix typo

### DIFF
--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -38,7 +38,7 @@ include::includes/devtools/create-app.adoc[]
 
 == Expose a REST Resource
 
-We will create a `Fruit` bean and a `FruitResouce` REST resource
+We will create a `Fruit` bean and a `FruitResource` REST resource
 (feel free to take a look to the xref:rest-json.adoc[Writing JSON REST services guide] if your want more details on how to build a REST API with Quarkus).
 
 [source,java]


### PR DESCRIPTION
Fixed small typo in the guide documentation. 😉 