### PR TITLE
Kafka Serde discovery for direct implementations

### DIFF
--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -1455,6 +1455,8 @@ The full set of types supported by the serializer/deserializer autodetection is:
 * `io.vertx.core.buffer.Buffer`
 * `io.vertx.core.json.JsonObject`
 * `io.vertx.core.json.JsonArray`
+* classes for which a direct implementation of `org.apache.kafka.common.serialization.Serializer<T>` / `org.apache.kafka.common.serialization.Deserializer<T>` is present.
+** the implementation needs to specify the type argument `T` as the (de-)serialized type.
 * classes generated from Avro schemas, as well as Avro `GenericRecord`, if Confluent or Apicurio Registry _serde_ is present
 ** in case multiple Avro serdes are present, serializer/deserializer must be configured manually for Avro-generated classes, because autodetection is impossible
 ** see xref:kafka-schema-registry-avro.adoc[Using Apache Kafka with Schema Registry and Avro] for more information about using Confluent or Apicurio Registry libraries

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DefaultSerdeDiscoveryState.java
@@ -191,6 +191,18 @@ class DefaultSerdeDiscoveryState {
                 .orElse(null);
     }
 
+    ClassInfo getImplementorOfWithTypeArgument(DotName implementedInterface, DotName expectedTypeArgument) {
+        return index.getKnownDirectImplementors(implementedInterface)
+                .stream()
+                .filter(ci -> ci.interfaceTypes().stream()
+                        .anyMatch(it -> it.name().equals(implementedInterface)
+                                && it.kind() == Type.Kind.PARAMETERIZED_TYPE
+                                && it.asParameterizedType().arguments().size() == 1
+                                && it.asParameterizedType().arguments().get(0).name().equals(expectedTypeArgument)))
+                .findAny()
+                .orElse(null);
+    }
+
     List<AnnotationInstance> findAnnotationsOnMethods(DotName annotation) {
         return index.getAnnotations(annotation)
                 .stream()

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/DotNames.java
@@ -30,6 +30,8 @@ final class DotNames {
 
     static final DotName AVRO_GENERATED = DotName.createSimple("org.apache.avro.specific.AvroGenerated");
     static final DotName AVRO_GENERIC_RECORD = DotName.createSimple("org.apache.avro.generic.GenericRecord");
+    static final DotName KAFKA_SERIALIZER = DotName.createSimple(org.apache.kafka.common.serialization.Serializer.class.getName());
+    static final DotName KAFKA_DESERIALIZER = DotName.createSimple(org.apache.kafka.common.serialization.Deserializer.class.getName());
     static final DotName OBJECT_MAPPER_DESERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.ObjectMapperDeserializer.class.getName());
     static final DotName OBJECT_MAPPER_SERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.ObjectMapperSerializer.class.getName());
     static final DotName JSONB_DESERIALIZER = DotName.createSimple(io.quarkus.kafka.client.serialization.JsonbDeserializer.class.getName());

--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/SmallRyeReactiveMessagingKafkaProcessor.java
@@ -669,6 +669,13 @@ public class SmallRyeReactiveMessagingKafkaProcessor {
         }
         DotName typeName = type.name();
 
+        // Serializer/deserializer implementations
+        ClassInfo implementation = discovery.getImplementorOfWithTypeArgument(
+                serializer ? DotNames.KAFKA_SERIALIZER : DotNames.KAFKA_DESERIALIZER, typeName);
+        if (implementation != null) {
+            return Result.of(implementation.name().toString());
+        }
+
         // statically known serializer/deserializer
         Map<DotName, String> map = serializer ? KNOWN_SERIALIZERS : KNOWN_DESERIALIZERS;
         if (map.containsKey(typeName)) {


### PR DESCRIPTION
Only direct implementations of Serializer and Deserializer are supported. 
Precedes Jackson, Jsonb and Avro Serde's existing auto-discovery.