### PR TITLE
Misc cleanup - use Files.readString and .addAll for collections

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DisposerInfo.java
@@ -74,8 +74,7 @@ public class DisposerInfo implements InjectionTargetInfo {
     Collection<AnnotationInstance> getDisposedParameterQualifiers() {
         Set<AnnotationInstance> resultingQualifiers = new HashSet<>();
         Annotations.getParameterAnnotations(declaringBean.getDeployment(), disposerMethod, disposedParameter.position())
-                .stream().forEach(a -> declaringBean.getDeployment().extractQualifiers(a)
-                        .forEach(resultingQualifiers::add));
+                .stream().forEach(a -> resultingQualifiers.addAll(declaringBean.getDeployment().extractQualifiers(a)));
         return resultingQualifiers;
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -293,7 +293,7 @@ public class ObserverInfo implements InjectionTargetInfo {
         Set<AnnotationInstance> qualifiers = new HashSet<>();
         for (AnnotationInstance annotation : getParameterAnnotations(beanDeployment, observerMethod,
                 eventParameter.position())) {
-            beanDeployment.extractQualifiers(annotation).forEach(qualifiers::add);
+            qualifiers.addAll(beanDeployment.extractQualifiers(annotation));
         }
         return qualifiers;
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PathsCollection.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/PathsCollection.java
@@ -86,18 +86,14 @@ public class PathsCollection implements PathCollection, Serializable {
     public PathsCollection add(Path... paths) {
         final List<Path> list = new ArrayList<>(this.paths.size() + paths.length);
         list.addAll(this.paths);
-        for (int i = 0; i < paths.length; ++i) {
-            list.add(paths[i]);
-        }
+        Collections.addAll(list, paths);
         return new PathsCollection(list);
     }
 
     @Override
     public PathsCollection addFirst(Path... paths) {
         final List<Path> list = new ArrayList<>(this.paths.size() + paths.length);
-        for (int i = 0; i < paths.length; ++i) {
-            list.add(paths[i]);
-        }
+        Collections.addAll(list, paths);
         list.addAll(this.paths);
         return new PathsCollection(list);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathList.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathList.java
@@ -95,17 +95,13 @@ public class PathList implements PathCollection, Serializable {
     public PathList add(Path... paths) {
         final List<Path> list = new ArrayList<>(this.paths.size() + paths.length);
         list.addAll(this.paths);
-        for (int i = 0; i < paths.length; ++i) {
-            list.add(paths[i]);
-        }
+        Collections.addAll(list, paths);
         return new PathList(list);
     }
 
     public PathList addFirst(Path... paths) {
         final List<Path> list = new ArrayList<>(this.paths.size() + paths.length);
-        for (int i = 0; i < paths.length; ++i) {
-            list.add(paths[i]);
-        }
+        Collections.addAll(list, paths);
         list.addAll(this.paths);
         return new PathList(list);
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/IfSectionHelper.java
@@ -535,7 +535,7 @@ public class IfSectionHelper implements SectionHelper {
                     if (prevIdx > lastGroupdIdx) {
                         int from = lastGroupdIdx > 0 ? lastGroupdIdx + 1 : 0;
                         int to = op.isBinary() ? prevIdx : prevIdx + 1;
-                        params.subList(from, to).forEach(ret::add);
+                        ret.addAll(params.subList(from, to));
                     }
                 } else if (op.precedence < highestPrecedence) {
                     if (highestGroup != null) {
@@ -555,7 +555,7 @@ public class IfSectionHelper implements SectionHelper {
         } else {
             // Add all remaining non-grouped elements
             if (lastGroupdIdx + 1 != params.size()) {
-                params.subList(lastGroupdIdx + 1, params.size()).forEach(ret::add);
+                ret.addAll(params.subList(lastGroupdIdx + 1, params.size()));
             }
         }
         return parseParams(ret, parserDelegate);

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Qute.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Qute.java
@@ -235,7 +235,7 @@ public final class Qute {
         }
 
         public Fmt dataMap(Map<String, Object> data) {
-            data.forEach(dataMap::put);
+            dataMap.putAll(data);
             return this;
         }
 

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartResource.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/CodestartResource.java
@@ -2,7 +2,6 @@ package io.quarkus.devtools.codestarts;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -93,7 +92,7 @@ public interface CodestartResource {
         @Override
         public String read(String codestartRelativePath) {
             try {
-                return new String(Files.readAllBytes(codestartDir.resolve(codestartRelativePath)), StandardCharsets.UTF_8);
+                return Files.readString(codestartDir.resolve(codestartRelativePath));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/PomTransformer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/PomTransformer.java
@@ -75,7 +75,7 @@ public class PomTransformer {
     public void transform(Collection<Transformation> transformations) {
         transform(transformations, path, () -> {
             try {
-                return new String(Files.readAllBytes(path), charset);
+                return Files.readString(path, charset);
             } catch (IOException e) {
                 throw new RuntimeException(String.format("Could not read DOM from [%s]", path), e);
             }

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/SnapshotTesting.java
@@ -269,7 +269,7 @@ public class SnapshotTesting {
 
     public static String getTextContent(Path file) {
         try {
-            return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+            return Files.readString(file);
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to read " + file.toString(), e);
         }


### PR DESCRIPTION
Misc cleanup - use Files.readString and .addAll for collections

 - Use Files.readString shortcut
 - Use .addAll method instead of the for-each construct 