### PR TITLE
Use resteasy-reactive-jackson in spring-web codestart

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/codestart.yml
@@ -16,6 +16,6 @@ language:
       package-name: org.acme
     dependencies:
       - io.quarkus:quarkus-spring-web
-      - io.quarkus:quarkus-resteasy-jackson
+      - io.quarkus:quarkus-resteasy-reactive-jackson
     test-dependencies:
       - io.rest-assured:rest-assured


### PR DESCRIPTION
Fixes #23265 

This will break compatibility with resteasy-classic. This codestart dependency can be removed when making jackson as a conditional dependency in spring-web to completely fix this issue https://github.com/quarkusio/quarkus/issues/24888.

