### PR TITLE
Prevent filtering of resources at build time for Amazon lambda http and rest

### DIFF
--- a/extensions/amazon-lambda-http/deployment/pom.xml
+++ b/extensions/amazon-lambda-http/deployment/pom.xml
@@ -45,6 +45,15 @@
         </dependency>
     </dependencies>
     <build>
+      <resources>
+          <resource>
+              <directory>src/main/resources</directory>
+          </resource>
+          <resource>
+              <directory>src/main/resources/http</directory>
+              <filtering>false</filtering>
+          </resource>
+      </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/extensions/amazon-lambda-rest/deployment/pom.xml
+++ b/extensions/amazon-lambda-rest/deployment/pom.xml
@@ -41,6 +41,15 @@
         </dependency>
     </dependencies>
     <build>
+      <resources>
+          <resource>
+              <directory>src/main/resources</directory>
+          </resource>
+          <resource>
+              <directory>src/main/resources/http</directory>
+              <filtering>false</filtering>
+          </resource>
+      </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This is done in order to avoid to early replacement

This fixes too early replacement of `${artifactId}` in `sam.jvm.yaml` and `sam.native.yaml` files for both `amazon-lambda-http` and `amazon-lambda-rest`

Without this fix, generated files have following:

````
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Description: AWS Serverless Quarkus HTTP - quarkus-amazon-lambda-http-deployment
````

note `quarkus-amazon-lambda-http-deployment` that is actually the artifact of the extension and not the app it is built for.