### PR TITLE
Create duplicated context in the DevConsole virtual server

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleFilter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/DevConsoleFilter.java
@@ -34,6 +34,7 @@ public class DevConsoleFilter implements Handler<RoutingContext> {
         for (Map.Entry<String, String> entry : event.request().headers()) {
             headers.put(entry.getKey(), event.request().headers().getAll(entry.getKey()));
         }
+        event.request().resume();
         if (event.getBody() != null) {
             DevConsoleRequest request = new DevConsoleRequest(event.request().method().name(), event.request().uri(), headers,
                     event.getBody().getBytes());


### PR DESCRIPTION
Also, resume the request before accessing the body. 

This later change is required in the next Vert.x version (and should have been required before). 