### PR TITLE
Upgrade to ByteBuddy 1.12.9

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -87,7 +87,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.6.7.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
-        <bytebuddy.version>1.12.8</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.4.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.3.Final</hibernate-search.version>


### PR DESCRIPTION
Fixes #24494

Credit to @yrodiere as this relates to 

- https://github.com/raphw/byte-buddy/issues/1224
- https://github.com/hibernate/hibernate-orm/pull/4969

Technically doesn't require an Hibernate ORM release and version bump as it's all in Byte Buddy