### PR TITLE
Documents dependencies for fonts and locales tests on systems with C.UTF-8 default locale

### DIFF
--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -11,6 +11,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.quarkus.test.junit.NativeImageTest;
 import io.restassured.RestAssured;
 
+/**
+ * For the Native test cases to function, the operating system has to have locales
+ * support installed. A barebone system with only C.UTF-8 default locale available
+ * won't be able to pass the tests.
+ *
+ * For example, this package satisfies the dependency on a RHEL 9 type of OS:
+ * glibc-all-langpacks
+ *
+ */
 @NativeImageTest
 public class LocalesIT {
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/RestClientTestCase.java
@@ -47,6 +47,14 @@ public class RestClientTestCase {
                 .body(is("TEST"));
     }
 
+    /**
+     * This test in Native won't work on a barebone system,
+     * just with C.UTF-8 default fallback locale.
+     *
+     * For example, this package satisfies the dependency on a RHEL 9 type of OS:
+     * glibc-all-langpacks
+     *
+     */
     @DisabledOnOs(OS.WINDOWS)
     @Test
     public void testEmojis() {


### PR DESCRIPTION
These tests in the TS require additional system packages. It might not be apparent on a full fledged desktop Linux, but it shows on a barebone system, e.g. on a RHEL 9 minimal installation.

Thinking about GH issues, JIRA, Knowledge Base, asciidoc documentation, web pages....I believe the best place to preserve the information is right here, in those actual test cases.

e.g.
```
$ ./mvnw verify -Dnative -pl integration-tests/main -Dtest=RestClientTestCase#testEmojis
...
[ERROR] Failures: 
[ERROR]   RestClientTestCase.testEmojis:54 1 expectation failed.
Response body doesn't match expectation.
Expected: is "????????"
  Actual: ????????????????????????????????
```
To fix:
```
sudo dnf install glibc-all-langpacks
```
Works fine now.

Locales tests need the language pack too:

Before:
```
[ERROR] Failures: 
[ERROR]   LocalesIT.testCurrencies:53 1 expectation failed.
Response body doesn't match expectation.
Expected: is "?esk? koruna"
  Actual: ??esk?? koruna
```
After:
```
HTTP/1.1 200 OK
Content-Type: application/octet-stream
content-length: 14

česká koruna
```
