### PR TITLE
Use created wiremock instance for stub creation

### DIFF
--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -685,7 +685,7 @@ public class WireMockExtensions implements QuarkusTestResourceLifecycleManager {
         wireMockServer = new WireMockServer();
         wireMockServer.start(); // <3>
 
-        stubFor(get(urlEqualTo("/extensions?id=io.quarkus:quarkus-rest-client"))   // <4>
+        wireMockServer.stubFor(get(urlEqualTo("/extensions?id=io.quarkus:quarkus-rest-client"))   // <4>
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(
@@ -695,7 +695,7 @@ public class WireMockExtensions implements QuarkusTestResourceLifecycleManager {
                             "}]"
                         )));
 
-        stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom("https://stage.code.quarkus.io/api")));   // <5>
+        wireMockServer.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom("https://stage.code.quarkus.io/api")));   // <5>
 
         return Collections.singletonMap("quarkus.rest-client.\"org.acme.rest.client.ExtensionsService\".url", wireMockServer.baseUrl()); // <6>
     }


### PR DESCRIPTION
Using static method `stubFor` stubs for default wiremock instance. This will cause issues when user decides to provide custom options when creating wiremock instance, like `wireMockServer = new WireMockServer(9090)`. Change the example so it uses the created wiremock instance to avoid such problems.