### PR TITLE
Revert "Bump dokka-maven-plugin from 1.6.10 to 1.6.20"

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,7 +21,7 @@
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <kotlin.version>1.6.20</kotlin.version>
-        <dokka.version>1.6.20</dokka.version>
+        <dokka.version>1.6.10</dokka.version>
         <scala.version>2.12.13</scala.version>
         <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>
         <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->


### PR DESCRIPTION
Reverts quarkusio/quarkus#24971

The test release build is failing with:

> Error:  Failed to execute goal org.jetbrains.dokka:dokka-maven-plugin:1.6.20:javadocJar (dokka) on project quarkus-scheduler-kotlin: Execution dokka of goal org.jetbrains.dokka:dokka-maven-plugin:1.6.20:javadocJar failed: DefaultDispatcher was terminated -> [Help 1]
