### PR TITLE
Always restore query params on OIDC redirect URIs

### DIFF
--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -629,7 +629,7 @@ public class CodeFlowTest {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/web-app2/callback-before-redirect?tenantId=tenant-2");
             assertNotNull(getStateCookieStateParam(webClient, "tenant-2"));
-            assertNull(getStateCookieSavedPath(webClient, "tenant-2"));
+            assertEquals("?tenantId=tenant-2", getStateCookieSavedPath(webClient, "tenant-2"));
 
             assertEquals("Sign in to quarkus", page.getTitleText());
 


### PR DESCRIPTION
Fixes #24882.

This PR only makes sure that the custom query parameters submitted with the original request are restored when an authenticated user is redirected back to Quarkus.

Right now such query parameters are already restored but only if a somewhat obscure Quarkus specific feature is utilized, for example:
```
Request URI: /hello?a=b
```

while the redirect URI is configured as `/callback`, but only for the purpose of while listing the client in OIDC provider console since the redirect URI may have to be the same one for all the users for a given OIDC client, and when the user is redirected back to `/callback`, the user is finally redirected to `/hello?a=b` in order to restore the original request URI.

However if the user is just redirected back to `/callback` then the original `?a=b` is lost.

So this PR makes it work for all the cases which also helps to use `quarkus-oidc` in cases where an endpoint would like to use the `state` to capture the original request details - right now `quarkus-oidc` does generate the `state` itself so the application endpoints don't have a chance to store the request specific details. This PR does not completely address this specific state customization point but we can follow up later with introducing an interface to make it more advanced.



