### PR TITLE
Save empty array allocation when no path params exist

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -11,6 +11,8 @@ import org.jboss.resteasy.reactive.common.util.URIDecoder;
 
 public class RequestMapper<T> {
 
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
     private final PathMatcher<List<RequestPath<T>>> requestPaths;
     private final PathMatcher.Builder<List<RequestPath<T>>> pathMatcherBuilder;
     private final List<RequestPath<T>> templates;
@@ -59,7 +61,7 @@ public class RequestMapper<T> {
         List<RequestPath<T>> value = initialMatch.getValue();
         for (int index = 0; index < value.size(); index++) {
             RequestPath<T> potentialMatch = value.get(index);
-            String[] params = new String[maxParams];
+            String[] params = (maxParams > 0) ? new String[maxParams] : EMPTY_STRING_ARRAY;
             int paramCount = 0;
             boolean matched = true;
             boolean prefixAllowed = potentialMatch.prefixTemplate;


### PR DESCRIPTION
This showed up in a sample profiling run I did with async-profiler