### PR TITLE
Prevent unnecessary parameter array allocations

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -175,7 +175,7 @@ public abstract class ResteasyReactiveRequestContext
     public void restart(RuntimeResource target, boolean setLocatorTarget) {
         this.handlers = target.getHandlerChain();
         position = 0;
-        parameters = new Object[target.getParameterTypes().length];
+        parameters = target.getParameterTypes().length == 0 ? EMPTY_ARRAY : new Object[target.getParameterTypes().length];
         if (setLocatorTarget) {
             previousResource = new PreviousResource(this.target, pathParamValues, previousResource);
         }
@@ -646,7 +646,7 @@ public abstract class ResteasyReactiveRequestContext
 
     @Override
     protected void restarted(boolean keepTarget) {
-        parameters = new Object[0];
+        parameters = EMPTY_ARRAY;
         if (!keepTarget) {
             target = null;
         }


### PR DESCRIPTION
We only need to actually allocate the object array that will hold
the Resource method parameters if that method actually has
parameters

This showed up in a sample profiling run I did with async-profiler