### PR TITLE
Update OidcClientReactiveFilter to ensure only a single Authorization header is set

### DIFF
--- a/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
+++ b/extensions/oidc-client-reactive-filter/runtime/src/main/java/io/quarkus/oidc/client/reactive/filter/OidcClientRequestReactiveFilter.java
@@ -41,7 +41,8 @@ public class OidcClientRequestReactiveFilter extends AbstractTokensProducer impl
         super.getTokens().subscribe().with(new Consumer<Tokens>() {
             @Override
             public void accept(Tokens tokens) {
-                requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, BEARER_SCHEME_WITH_SPACE + tokens.getAccessToken());
+                requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION,
+                        BEARER_SCHEME_WITH_SPACE + tokens.getAccessToken());
                 requestContext.resume();
             }
         }, new Consumer<Throwable>() {


### PR DESCRIPTION
Fixes #25029