### PR TITLE
Added more detail to some error cases in the VertxHttpRecorder

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/QuarkusBindException.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/QuarkusBindException.java
@@ -1,8 +1,9 @@
 package io.quarkus.runtime;
 
 import java.net.BindException;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * An exception that is meant to stand in for {@link BindException} and provide information
@@ -12,14 +13,33 @@ public class QuarkusBindException extends BindException {
 
     private final List<Integer> ports;
 
-    public QuarkusBindException(int port) {
-        this(Collections.singletonList(port));
+    private static String createMessage(List<Integer> ports) {
+        return "Port(s) already bound: " + ports.stream().map(i -> Integer.toString(i)).collect(Collectors.joining(", "));
     }
 
-    public QuarkusBindException(List<Integer> ports) {
+    private static void assertPortsNotEmpty(List<Integer> ports) {
         if (ports.isEmpty()) {
             throw new IllegalStateException("ports must not be empty");
         }
+    }
+
+    public QuarkusBindException(Integer... ports) {
+        this(Arrays.asList(ports));
+    }
+
+    public QuarkusBindException(List<Integer> ports) {
+        super(createMessage(ports));
+        assertPortsNotEmpty(ports);
+        this.ports = ports;
+    }
+
+    public QuarkusBindException(BindException e, Integer... ports) {
+        this(e, Arrays.asList(ports));
+    }
+
+    public QuarkusBindException(BindException e, List<Integer> ports) {
+        super(createMessage(ports) + ": " + e.getMessage());
+        assertPortsNotEmpty(ports);
         this.ports = ports;
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
@@ -30,6 +30,7 @@ public class ShutdownRecorder {
     }
 
     public static void runShutdown() {
+        log.debug("Attempting to gracefully shutdown.");
         try {
             CountDownLatch preShutdown = new CountDownLatch(shutdownListeners.size());
             for (ShutdownListener i : shutdownListeners) {


### PR DESCRIPTION
There were some extremely generic and identical errors being thrown, making startup issues much harder to debug.

I added log statements and more descriptive errors.

If there is some detail I missed on why these were bind exceptions in stead of configuration exceptions, let me know and I can tweak back to something.

Additionally, some clarification would be great for the exact error cases and reasons in the L608 if block, to be more descriptive.