### PR TITLE
Avoid checking Docker environment multiple times for Dev Services

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/DockerStatusProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/DockerStatusProcessor.java
@@ -1,0 +1,13 @@
+package io.quarkus.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+
+public class DockerStatusProcessor {
+
+    @BuildStep
+    DockerStatusBuildItem IsDockerWorking(LaunchModeBuildItem launchMode) {
+        return new DockerStatusBuildItem(new IsDockerWorking(launchMode.getLaunchMode().isDevOrTest()));
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/IsDockerWorking.java
@@ -7,9 +7,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
@@ -25,6 +27,8 @@ import io.quarkus.deployment.util.ExecUtil;
 public class IsDockerWorking implements BooleanSupplier {
 
     private static final Logger LOGGER = Logger.getLogger(IsDockerWorking.class.getName());
+    public static final int DOCKER_HOST_CHECK_TIMEOUT = 1000;
+    public static final int DOCKER_CMD_CHECK_TIMEOUT = 3000;
 
     private final List<Strategy> strategies;
 
@@ -40,6 +44,7 @@ public class IsDockerWorking implements BooleanSupplier {
     @Override
     public boolean getAsBoolean() {
         for (Strategy strategy : strategies) {
+            LOGGER.debugf("Checking Docker Environment using strategy %s", strategy.getClass().getName());
             Result result = strategy.get();
             if (result == Result.AVAILABLE) {
                 return true;
@@ -113,7 +118,8 @@ public class IsDockerWorking implements BooleanSupplier {
             if (dockerHost != null && !dockerHost.startsWith("unix:")) {
                 try {
                     URI url = new URI(dockerHost);
-                    try (Socket s = new Socket(url.getHost(), url.getPort())) {
+                    try (Socket s = new Socket()) {
+                        s.connect(new InetSocketAddress(url.getHost(), url.getPort()), DOCKER_HOST_CHECK_TIMEOUT);
                         return Result.AVAILABLE;
                     } catch (IOException e) {
                         LOGGER.warnf(
@@ -143,7 +149,7 @@ public class IsDockerWorking implements BooleanSupplier {
         @Override
         public Result get() {
             try {
-                if (!ExecUtil.execSilent(binary, "-v")) {
+                if (!ExecUtil.execSilentWithTimeout(Duration.ofMillis(DOCKER_CMD_CHECK_TIMEOUT), binary, "-v")) {
                     LOGGER.warnf("'%s -v' returned an error code. Make sure your Docker binary is correct", binary);
                     return Result.UNKNOWN;
                 }
@@ -154,7 +160,8 @@ public class IsDockerWorking implements BooleanSupplier {
 
             try {
                 OutputFilter filter = new OutputFilter();
-                if (ExecUtil.exec(new File("."), filter, "docker", "version", "--format", "'{{.Server.Version}}'")) {
+                if (ExecUtil.execWithTimeout(new File("."), filter, Duration.ofMillis(DOCKER_CMD_CHECK_TIMEOUT),
+                        "docker", "version", "--format", "'{{.Server.Version}}'")) {
                     LOGGER.debugf("Docker daemon found. Version: %s", filter.getOutput());
                     return Result.AVAILABLE;
                 } else {

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DockerStatusBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DockerStatusBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.deployment.IsDockerWorking;
+
+public final class DockerStatusBuildItem extends SimpleBuildItem {
+
+    private final IsDockerWorking isDockerWorking;
+    private Boolean cachedStatus;
+
+    public DockerStatusBuildItem(IsDockerWorking isDockerWorking) {
+        this.isDockerWorking = isDockerWorking;
+    }
+
+    public synchronized boolean isDockerAvailable() {
+        if (cachedStatus == null) {
+            cachedStatus = isDockerWorking.getAsBoolean();
+        }
+        return cachedStatus;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ExecUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ExecUtil.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.jboss.logging.Logger;
@@ -16,6 +18,8 @@ public class ExecUtil {
 
     private static final Function<InputStream, Runnable> PRINT_OUTPUT = i -> new HandleOutput(i);
     private static final Function<InputStream, Runnable> SILENT = i -> new HandleOutput(i, Logger.Level.DEBUG);
+
+    private static final int PROCESS_CHECK_INTERVAL = 500;
 
     private static class HandleOutput implements Runnable {
 
@@ -61,6 +65,18 @@ public class ExecUtil {
     }
 
     /**
+     * Execute the specified command until the given timeout from within the current directory.
+     *
+     * @param timeout The timeout
+     * @param command The command
+     * @param args The command arguments
+     * @return true if commands where executed successfully
+     */
+    public static boolean execWithTimeout(Duration timeout, String command, String... args) {
+        return execWithTimeout(new File("."), timeout, command, args);
+    }
+
+    /**
      * Execute the specified command from within the current directory and hide the output.
      *
      * @param command The command
@@ -69,6 +85,18 @@ public class ExecUtil {
      */
     public static boolean execSilent(String command, String... args) {
         return execSilent(new File("."), command, args);
+    }
+
+    /**
+     * Execute the specified command until the given timeout from within the current directory and hide the output.
+     *
+     * @param timeout The timeout
+     * @param command The command
+     * @param args The command arguments
+     * @return true if commands where executed successfully
+     */
+    public static boolean execSilentWithTimeout(Duration timeout, String command, String... args) {
+        return execSilentWithTimeout(new File("."), timeout, command, args);
     }
 
     /**
@@ -84,6 +112,19 @@ public class ExecUtil {
     }
 
     /**
+     * Execute the specified command until the given timeout from within the specified directory.
+     *
+     * @param directory The directory
+     * @param timeout The timeout
+     * @param command The command
+     * @param args The command arguments
+     * @return true if commands where executed successfully
+     */
+    public static boolean execWithTimeout(File directory, Duration timeout, String command, String... args) {
+        return execWithTimeout(directory, PRINT_OUTPUT, timeout, command, args);
+    }
+
+    /**
      * Execute the specified command from within the specified directory and hide the output.
      *
      * @param directory The directory
@@ -93,6 +134,19 @@ public class ExecUtil {
      */
     public static boolean execSilent(File directory, String command, String... args) {
         return exec(directory, SILENT, command, args);
+    }
+
+    /**
+     * Execute the specified command until the given timeout from within the specified directory and hide the output.
+     *
+     * @param directory The directory
+     * @param timeout The timeout
+     * @param command The command
+     * @param args The command arguments
+     * @return true if commands where executed successfully
+     */
+    public static boolean execSilentWithTimeout(File directory, Duration timeout, String command, String... args) {
+        return execWithTimeout(directory, SILENT, timeout, command, args);
     }
 
     /**
@@ -107,27 +161,87 @@ public class ExecUtil {
      */
     public static boolean exec(File directory, Function<InputStream, Runnable> outputFilterFunction, String command,
             String... args) {
-        Process process = null;
+        try {
+            Process process = startProcess(directory, command, args);
+            outputFilterFunction.apply(process.getInputStream());
+            process.waitFor();
+            return process.exitValue() == 0;
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Execute the specified command until the given timeout from within the specified directory.
+     * The method allows specifying an output filter that processes the command output.
+     *
+     * @param directory The directory
+     * @param outputFilterFunction A {@link Function} that gets an {@link InputStream} and returns an outputFilter.
+     * @param timeout The timeout
+     * @param command The command
+     * @param args The command arguments
+     * @return true if commands where executed successfully
+     */
+    public static boolean execWithTimeout(File directory, Function<InputStream, Runnable> outputFilterFunction,
+            Duration timeout, String command, String... args) {
+        try {
+            Process process = startProcess(directory, command, args);
+            Thread t = new Thread(outputFilterFunction.apply(process.getInputStream()));
+            t.setName("Process stdout");
+            t.setDaemon(true);
+            t.start();
+            process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            destroyProcess(process);
+            return process.exitValue() == 0;
+        } catch (InterruptedException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Start a process executing given command with arguments within the specified directory.
+     *
+     * @param directory The directory
+     * @param command The command
+     * @param args The command arguments
+     * @return the process
+     */
+    public static Process startProcess(File directory, String command, String... args) {
         try {
             String[] cmd = new String[args.length + 1];
             cmd[0] = command;
             if (args.length > 0) {
                 System.arraycopy(args, 0, cmd, 1, args.length);
             }
-            process = new ProcessBuilder()
+            return new ProcessBuilder()
                     .directory(directory)
                     .command(cmd)
                     .redirectErrorStream(true)
                     .start();
-
-            outputFilterFunction.apply(process.getInputStream()).run();
-            process.waitFor();
         } catch (IOException e) {
             throw new RuntimeException("Input/Output error while executing command.", e);
-        } catch (InterruptedException e) {
-            return false;
         }
-        return process != null && process.exitValue() == 0;
+    }
+
+    /**
+     * Kill the process, if still alive, kill it forcibly
+     *
+     * @param process the process to kill
+     */
+    public static void destroyProcess(Process process) {
+        process.destroy();
+        int i = 0;
+        while (process.isAlive() && i++ < 10) {
+            try {
+                process.waitFor(PROCESS_CHECK_INTERVAL, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (process.isAlive()) {
+            process.destroyForcibly();
+        }
     }
 
 }

--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -30,10 +30,10 @@ import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageBuilderBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
-import io.quarkus.deployment.IsDockerWorking;
 import io.quarkus.deployment.IsNormalNotRemoteDev;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.AppCDSResultBuildItem;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
@@ -55,8 +55,6 @@ public class DockerProcessor {
     private static final String DOCKER_DIRECTORY_NAME = "docker";
     static final String DOCKER_CONTAINER_IMAGE_NAME = "docker";
 
-    private final IsDockerWorking isDockerWorking = new IsDockerWorking();
-
     @BuildStep
     public AvailableContainerImageExtensionBuildItem availability() {
         return new AvailableContainerImageExtensionBuildItem(DOCKER);
@@ -64,6 +62,7 @@ public class DockerProcessor {
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, DockerBuild.class }, onlyIfNot = NativeBuild.class)
     public void dockerBuildFromJar(DockerConfig dockerConfig,
+            DockerStatusBuildItem dockerStatusBuildItem,
             ContainerImageConfig containerImageConfig,
             OutputTargetBuildItem out,
             ContainerImageInfoBuildItem containerImageInfo,
@@ -83,7 +82,7 @@ public class DockerProcessor {
             return;
         }
 
-        if (!isDockerWorking.getAsBoolean()) {
+        if (!dockerStatusBuildItem.isDockerAvailable()) {
             throw new RuntimeException("Unable to build docker image. Please check your docker installation");
         }
 
@@ -116,6 +115,7 @@ public class DockerProcessor {
 
     @BuildStep(onlyIf = { IsNormalNotRemoteDev.class, NativeBuild.class, DockerBuild.class })
     public void dockerBuildFromNativeImage(DockerConfig dockerConfig,
+            DockerStatusBuildItem dockerStatusBuildItem,
             ContainerImageConfig containerImageConfig,
             ContainerImageInfoBuildItem containerImage,
             Optional<ContainerImageBuildRequestBuildItem> buildRequest,
@@ -134,7 +134,7 @@ public class DockerProcessor {
             return;
         }
 
-        if (!isDockerWorking.getAsBoolean()) {
+        if (!dockerStatusBuildItem.isDockerAvailable()) {
             throw new RuntimeException("Unable to build docker image. Please check your docker installation");
         }
 


### PR DESCRIPTION
With this change dev mode should fail faster when the Docker environment is not found.

Adds `DockerStatusBuildItem` for caching Docker Working status.
Adds timeout for checks on DOCKER_HOST and docker cli.

Checking for docker environment is still done on the first call to the `isDockerAvailable`.
