### PR TITLE
Initial Support for SunPKCS11 provider in native image

### DIFF
--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -484,6 +484,40 @@ keytool -genkey -alias server -keyalg RSA -keystore server-keystore.jks -keysize
 `BCFIPSJSSE` provider option is currently not supported in native image.
 ====
 
+[[sun-pkcs11]]
+=== SunPKCS11
+
+`SunPKCS11` provider provides a bridge to specific `PKCS#11` implementations such as cryptographic smartcards and other Hardware Security Modules, Network Security Services in FIPS mode, etc.
+
+Typically, in order to work with `SunPKCS11`, one needs to install a `PKCS#11` implementation, generate a configuration which usually refers to a shared library, token slot, etc and write the following Java code:
+
+[source,java]
+----
+import java.security.Provider;
+import java.security.Security;
+
+String configuration = "pkcs11.cfg"
+
+Provider sunPkcs11 = Security.getProvider("SunPKCS11");
+Provider pkcsImplementation = sunPkcs11.configure(configuration);
+// or prepare configuration in the code or read it from the file such as "pkcs11.cfg" and do
+// sunPkcs11.configure("--" + configuration);
+Security.addProvider(pkcsImplementation);
+----
+
+In Quarkus you can achieve the same at the configuration level only without having to modify the code, for example:
+
+[source,properties]
+----
+quarkus.security.security-providers=SunPKCS11
+quarkus.security.security-provider-config.SunPKCS11=pkcs11.cfg
+----
+
+[NOTE]
+====
+Note that while accessing the `SunPKCS11` bridge provider is supported in native image, configuring `SunPKCS11` is currently not supported in native image at the Quarkus level.
+====
+
 == Reactive Security
 
 If you are going to use security in a reactive environment, you will likely need SmallRye Context Propagation:

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/JCAProviderBuildItem.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/JCAProviderBuildItem.java
@@ -6,13 +6,23 @@ import io.quarkus.builder.item.MultiBuildItem;
  * Metadata for the names of JCA {@linkplain java.security.Provider} to register for reflection
  */
 public final class JCAProviderBuildItem extends MultiBuildItem {
-    private String providerName;
+    final private String providerName;
+    final private String providerConfig;
 
     public JCAProviderBuildItem(String providerName) {
+        this(providerName, null);
+    }
+
+    public JCAProviderBuildItem(String providerName, String providerConfig) {
         this.providerName = providerName;
+        this.providerConfig = providerConfig;
     }
 
     public String getProviderName() {
         return providerName;
+    }
+
+    public String getProviderConfig() {
+        return providerConfig;
     }
 }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityConfig.java
@@ -1,7 +1,8 @@
 package io.quarkus.security.deployment;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -20,8 +21,14 @@ public final class SecurityConfig {
     public boolean authorizationEnabledInDevMode;
 
     /**
-     * List of security providers to enable for reflection
+     * List of security providers to register
      */
     @ConfigItem
-    public Optional<List<String>> securityProviders;
+    public Optional<Set<String>> securityProviders;
+
+    /**
+     * Security provider configuration
+     */
+    @ConfigItem
+    public Map<String, String> securityProviderConfig;
 }

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderUtils.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/SecurityProviderUtils.java
@@ -3,6 +3,7 @@ package io.quarkus.security.runtime;
 import java.lang.reflect.Constructor;
 import java.security.Provider;
 import java.security.Security;
+import java.util.Map;
 
 import io.quarkus.runtime.configuration.ConfigurationException;
 
@@ -18,8 +19,14 @@ public final class SecurityProviderUtils {
     public static final String BOUNCYCASTLE_JSSE_PROVIDER_CLASS_NAME = "org.bouncycastle.jsse.provider.BouncyCastleJsseProvider";
     public static final String BOUNCYCASTLE_FIPS_PROVIDER_CLASS_NAME = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
 
+    public static final Map<String, String> SUN_PROVIDERS = Map.of("SunPKCS11", "sun.security.pkcs11.SunPKCS11");
+
     private SecurityProviderUtils() {
 
+    }
+
+    public static void addProvider(String provider) {
+        addProvider(loadProvider(provider));
     }
 
     public static void addProvider(Provider provider) {

--- a/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
+++ b/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
@@ -26,8 +26,8 @@ public class BouncyCastleEndpoint {
     @Path("listProviders")
     public String listProviders() {
         return Arrays.asList(Security.getProviders()).stream()
-                .filter(p -> p.getName().equals("BC"))
-                .map(p -> p.getName()).collect(Collectors.joining());
+                .filter(p -> (p.getName().equals("BC") || p.getName().equals("SunPKCS11")))
+                .map(p -> p.getName()).collect(Collectors.joining(","));
     }
 
     @GET

--- a/integration-tests/bouncycastle/src/main/resources/application.properties
+++ b/integration-tests/bouncycastle/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-quarkus.security.security-providers=BC
+quarkus.security.security-providers=BC,SunPKCS11
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.pem

--- a/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
+++ b/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
@@ -17,7 +17,7 @@ public class BouncyCastleTestCase {
                 .get("/jca/listProviders")
                 .then()
                 .statusCode(200)
-                .body(equalTo("BC"));
+                .body(equalTo("SunPKCS11,BC"));
     }
 
     @Test

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -304,7 +304,6 @@
                 <module>logging-panache</module>
                 <module>locales</module>
                 <module>redis-devservices</module>
-
                 <!-- gRPC tests -->
                 <module>grpc-tls</module>
                 <module>grpc-plain-text-gzip</module>


### PR DESCRIPTION
At the moment this PR only registers `SunPKCS11` as an additional security provider (which ensures it is available in native image) and starts with a simple integration test. I'm not sure yet if it sufficient to address #21099 as it is hard to automate such tests. In general it is worth starting investing more time into `SunPKCS11`, as it can be used for default FIPS configuration as well.