### PR TITLE
Logging - set default value for quarkus.log.file.rotation.max-file-size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ ObjectStore
 docker/distroless/bazel-*
 /.apt_generated_tests/
 quarkus.log
+quarkus.log*
 replay_*.logß
 nbactions.xml
 nb-configuration.xml

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/FileConfig.java
@@ -58,13 +58,13 @@ public class FileConfig {
         /**
          * The maximum file size of the log file after which a rotation is executed.
          */
-        @ConfigItem(defaultValueDocumentation = "10")
-        Optional<MemorySize> maxFileSize;
+        @ConfigItem(defaultValue = "10M")
+        MemorySize maxFileSize;
 
         /**
          * The maximum number of backups to keep.
          */
-        @ConfigItem(defaultValue = "1")
+        @ConfigItem(defaultValue = "5")
         int maxBackupIndex;
 
         /**

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/logging/CategoryConfiguredHandlerTest.java
@@ -3,11 +3,15 @@ package io.quarkus.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
-import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
-import org.jboss.logmanager.handlers.FileHandler;
+import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -39,7 +43,7 @@ public class CategoryConfiguredHandlerTest {
         Logger categoryLogger = logManager.getLogger("io.quarkus.category");
         assertThat(categoryLogger).isNotNull();
         assertThat(categoryLogger.getHandlers()).hasSize(2).extracting("class").containsExactlyInAnyOrder(ConsoleHandler.class,
-                FileHandler.class);
+                SizeRotatingFileHandler.class);
 
         Logger otherCategoryLogger = logManager.getLogger("io.quarkus.othercategory");
         assertThat(otherCategoryLogger).isNotNull();


### PR DESCRIPTION
- also change the default value for
quarkus.log.file.rotation.max-backup-index

The current behavior is a bit misleading. The docs say that `quarkus.log.file.rotation.max-file-size` has the _default value_ `10` which is not correct, because no default value is set and so no rotation happens (and the log file is growing and growing..) unless you set the `quarkus.log.file.rotation.file-suffix`, but then the default value from the `org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler` is taken which is `0xa0000`, i.e. approx. 650KB (it's actually a bug, because the comment is clear that it should be `0xa00000`). Therefore, we set the default `max-file-size` to `10M`, so the file size is always limited. 

We also change the default value for `max-backup-index` from `1` to `5` which is IMO a more reasonable default.