### PR TITLE
Override Gradle output format

### DIFF
--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusGradleWrapperTestBase.java
@@ -32,6 +32,7 @@ public class QuarkusGradleWrapperTestBase extends QuarkusGradleTestBase {
         List<String> command = new LinkedList<>();
         command.add(getGradleWrapperCommand());
         command.addAll(getSytemProperties());
+        command.add("-Dorg.gradle.console=plain");
         command.add("--stacktrace");
         command.add("--info");
         command.addAll(Arrays.asList(args));


### PR DESCRIPTION
A lot of Gradle integration tests fail if user have `org.gradle.console=verbose` (likely `rich` too) since `QuarkusGradleWrapperTestBase` can't parse task outcomes and interprets it as if no task were executed.

See also: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Gradle.20Tests.20Failing/near/279749440