### PR TITLE
Update security-keycloak-authorization.adoc - added a note for AuthzClient Injection

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -368,6 +368,8 @@ public class ProtectedResource {
 }
 ----
 
+Note: If you want to use the `AuthzClient` directly make sure to to set `quarkus.keycloak.policy-enforcer.enable=true` otherwise there is no Bean available for injection.
+
 == Mapping Protected Resources
 
 By default, the extension is going to fetch resources on-demand from Keycloak where their `URI` are used to map the resources in your application that should be protected.


### PR DESCRIPTION
Added Note for proper Injection of AuthzClient which is only available if policy enforcer is enabled, otherwise Quarkus will not be able to inject the bean resulting into a startup error.