### PR TITLE
Do not require the main module sources to be present in when resolving the app model

### DIFF
--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -179,20 +179,22 @@ public class BootstrapAppModelResolver implements AppModelResolver {
      */
     public ApplicationModel resolveModel(WorkspaceModule module)
             throws AppModelResolverException {
-        if (!module.getMainSources().isOutputAvailable()) {
-            throw new AppModelResolverException("");
-        }
         final PathList.Builder resolvedPaths = PathList.builder();
-        module.getMainSources().getSourceDirs().forEach(s -> {
-            if (!resolvedPaths.contains(s.getOutputDir())) {
-                resolvedPaths.add(s.getOutputDir());
+        if (module.hasMainSources()) {
+            if (!module.getMainSources().isOutputAvailable()) {
+                throw new AppModelResolverException("The application module hasn't been built yet");
             }
-        });
-        module.getMainSources().getResourceDirs().forEach(s -> {
-            if (!resolvedPaths.contains(s.getOutputDir())) {
-                resolvedPaths.add(s.getOutputDir());
-            }
-        });
+            module.getMainSources().getSourceDirs().forEach(s -> {
+                if (!resolvedPaths.contains(s.getOutputDir())) {
+                    resolvedPaths.add(s.getOutputDir());
+                }
+            });
+            module.getMainSources().getResourceDirs().forEach(s -> {
+                if (!resolvedPaths.contains(s.getOutputDir())) {
+                    resolvedPaths.add(s.getOutputDir());
+                }
+            });
+        }
         final Artifact mainArtifact = new DefaultArtifact(module.getId().getGroupId(), module.getId().getArtifactId(), null,
                 ArtifactCoords.TYPE_JAR,
                 module.getId().getVersion());


### PR DESCRIPTION
This fixes an NPE when the main sources aren't actually present.
This code path (including the `resolveModel(WorkspaceModule module)` method) isn't actually used currently during bootstrap. This is for the "buildless" bootstrap experiments.