### PR TITLE
Bump Keycloak version to 18.0.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -171,7 +171,7 @@
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
-        <keycloak.version>17.0.1</keycloak.version>
+        <keycloak.version>18.0.0</keycloak.version>
         <logstash-gelf.version>1.15.0</logstash-gelf.version>
         <checker-qual.version>3.21.4</checker-qual.version>
         <error-prone-annotations.version>2.13.1</error-prone-annotations.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -97,7 +97,7 @@
 
         <!-- The image to use for tests that run Keycloak -->
         <!-- IMPORTANT: If this is changed you must also update bom/application/pom.xml and KeycloakBuildTimeConfig/DevServicesConfig in quarkus-oidc/deployment to match the version -->
-        <keycloak.version>17.0.1</keycloak.version>
+        <keycloak.version>18.0.0</keycloak.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.version}-legacy</keycloak.docker.legacy.image>
         

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -28,7 +28,7 @@ public class DevServicesConfig {
      *
      * Image with a Quarkus based distribution is used by default.
      * Image with a WildFly based distribution can be selected instead, for example:
-     * 'quay.io/keycloak/keycloak:17.0.1-legacy'.
+     * 'quay.io/keycloak/keycloak:18.0.0-legacy'.
      * <p>
      * Note Keycloak Quarkus and Keycloak WildFly images are initialized differently.
      * By default, Dev Services for Keycloak will assume it is a Keycloak Quarkus image if the image version does not end with a
@@ -36,7 +36,7 @@ public class DevServicesConfig {
      * string.
      * Set 'quarkus.keycloak.devservices.keycloak-x-image' to override this check.
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:17.0.1")
+    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:18.0.0")
     public String imageName;
 
     /**


### PR DESCRIPTION
I've run all (I think) OIDC tests (in native mode), nearly all works well except for `keycloak-authorization` tests.

@pedroigor `KeycloakTestResource` fails to create a realm [here](https://github.com/quarkusio/quarkus/blob/main/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/KeycloakTestResource.java#L49).

I've traced it, the token is created successfully but the realm creation fails with `401`:

```
1. Get Admin Token: 
 
Request:

POST /auth/realms/master/protocol/openid-connect/token HTTP/1.1
Accept: application/json
Content-Type: application/x-www-form-urlencoded

grant_type=password&username=admin&password=admin&client_id=admin-cli

Response:

HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 1837

{"access_token":"ey...Q", ..., "token_type":"Bearer",..."}

2. Create Realm 

Request:

POST /auth/admin/realms HTTP/1.1
Authorization: Bearer ey..Q
Content-Type: application/json
Content-Length: 11859

{realm data}

Response:

HTTP/1.1 401 Unauthorized
```

Note this is run against WildFly based distro.

Not sure what is specific here about `keycloak-authorization` since many other OIDC tests also create realms in WildFly based Keycloak. 

I suspect that the extra Keycloak authorization specific content which may be causing it. Oh, I think I know what it is about. Is it related to uploading scripts :-) ? If yes, please suggest how to replace [this method](https://github.com/quarkusio/quarkus/blob/main/extensions/keycloak-authorization/deployment/src/test/java/io/quarkus/keycloak/pep/test/KeycloakTestResource.java#L181).

Thanks