### PR TITLE
Add packaging example for Picocli documentation

### DIFF
--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -41,11 +41,11 @@ This will add the following to your build file:
 implementation("io.quarkus:quarkus-picocli")
 ----
 
-== Simple command line application
+== Building a command line application
 
-=== Example code
+=== Simple application
 
-Simple PicocliApplication with only one `Command` can be created as follows:
+A simple Picocli application with only one `Command` can be created as follows:
 
 [source,java]
 ----
@@ -81,12 +81,13 @@ class GreetingService {
     }
 }
 ----
-<1> If there is only one class annotated with `picocli.CommandLine.Command` it will be used as entry point to Picocli CommandLine.
+<1> If there is only one class annotated with `picocli.CommandLine.Command`, it will be used automatically as the entry point of the command line application.
 <2> All classes annotated with `picocli.CommandLine.Command` are registered as CDI beans.
 
-IMPORTANT: Beans with `@CommandLine.Command` should not use proxied scopes (e.g. do not use `@ApplicationScope`)
-because Picocli will not be able to set field values in such beans. This extension will register classes with `@CommandLine.Command` annotation
-using `@Depended` scope. If you need to use proxied scope, then annotate setter and not field, for example:
+IMPORTANT: Beans annotated with `@CommandLine.Command` should not use proxied scopes (e.g. do not use `@ApplicationScoped`)
+because Picocli will not be able to set field values in such beans.
+By default, this Picocli extension registers classes annotated with `@CommandLine.Command`
+with the `@Dependent` scope. If you need to use a proxied scope, then annotate the setters and not the fields, for example:
 
 [source,java]
 ----
@@ -101,66 +102,6 @@ public class EntryCommand {
     }
 }
 ----
-
-=== Packaging
-
-Picocli provides different ways to package your application in such a way that end users can invoke it by its command name.
-
-If you want to distribute a single executable file that runs without installing a JDK see <<#native-mode,Native mode support>>. Notice that this executable will be platform specific.
-
-If you want a platform independent solution you can create an executable uber-jar. This uber-jar will contain all dependencies of your app, but still requires an installed JDK to work. You can create an uber-jar via a single property in your `pom.xml`. With the https://github.com/brianm/really-executable-jars-maven-plugin[really-executable-jar-maven-plugin] you can make the uber-jar executable.
-
-[source, xml]
-----
-<properties>
-  <quarkus.package.type>uber-jar</quarkus.package.type> <1>
-  <jar.finalName>${project.name}</jar.finalName> <2>
-</properties>
-
-<!-- make the jar chmod +x style executable -->
-<!-- more options at https://github.com/brianm/really-executable-jars-maven-plugin -->
-<build>
-  <plugins>
-    <plugin>
-      <groupId>org.skife.maven</groupId>
-      <artifactId>really-executable-jar-maven-plugin</artifactId>
-      <version>1.4.1</version>
-      <configuration>
-        <flags>-Xmx1G</flags>
-        <programFile>my-command</programFile> <3>
-      </configuration>
-      <executions>
-        <execution>
-          <phase>package</phase>
-          <goals>
-            <goal>really-executable-jar</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-</build>
-----
-<1> Define that you want to build an uber-jar. See xref:maven-tooling.adoc#uber-jar-maven[Uber-Jar Creation] for more details.
-<2> By default Quarkus will append `-runner` to the uber-jar. This would make the `really-executable-jar-maven-plugin` fail, because it cannot find the file. Therefore, we must define the uber-jar name to be equal to the project name.
-<3> Define the name of the final, executable uber-jar. This might be the name of your command.
-
-=== Executing the command
-
-Add the `my-command` file to your PATH, so you can run it directly from the command line. For instance on Linux run:
-
-[source,text,subs=attributes+]
-----
-# update PATH. This change is only temporary for the current terminal session
-export PATH="/path/to/my-command:$PATH"
-
-my-command -n Quarkus
-# will print: Hello Quarkus
-----
-
-Remember this requires a suitable JDK version to be installed. For a single executable file that runs without installing a JDK see <<#native-mode,Native mode support>>. For even more packaging options check the https://picocli.info/#_packaging_your_application[official Picocli documentation].
-
-== Advanced command line application
 
 === Command line application with multiple Commands
 
@@ -304,7 +245,7 @@ class DatasourceConfiguration {
 ----
 <1> `@ApplicationScoped` used for lazy initialization
 
-=== Providing own QuarkusMain
+=== Providing your own QuarkusMain
 
 You can also provide your own application entry point annotated with `QuarkusMain` (as described in xref:command-mode-reference.adoc[Command Mode reference guide]).
 
@@ -337,27 +278,6 @@ public class ExampleApp implements Runnable, QuarkusApplication {
 ----
 <1> Quarkus-compatible `CommandLine.IFactory` bean created by `picocli` extension.
 
-[#native-mode]
-== Native mode support
-
-This extension uses the Quarkus standard build steps mechanism to support GraalVM Native images. In the exceptional case that incompatible changes in a future picocli release cause any issue, the following configuration can be used to fall back to the annotation processor from the picocli project as a temporary workaround:
-
-[source,xml]
-----
-<dependency>
-  <groupId>info.picocli</groupId>
-  <artifactId>picocli-codegen</artifactId>
-</dependency>
-----
-
-For Gradle, you need to add the following in `dependencies` section of the `build.gradle` file:
-
-[source,groovy,subs=attributes+]
-----
-annotationProcessor enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-annotationProcessor 'info.picocli:picocli-codegen'
-----
-
 == Development Mode
 
 In the development mode, i.e. when running `mvn quarkus:dev`, the application is executed and restarted every time the `Space bar` key is pressed. You can also pass arguments to your command line app via the `quarkus.args` system property, e.g. `mvn quarkus:dev -Dquarkus.args='--help'` and `mvn quarkus:dev -Dquarkus.args='-c -w --val 1'`.
@@ -367,6 +287,42 @@ For Gradle projects, arguments can be passed using `--quarkus-args`.
 ====
 If you're creating a typical Quarkus application (e.g., HTTP-based services) that includes command-line functionality, you'll need to handle the application's lifecycle differently. In the `Runnable.run()` method of your command, make sure to use `Quarkus.waitForExit()` or `Quarkus.asyncExit()`. This will prevent the application from shutting down prematurely and ensure a proper shutdown process.
 ====
+
+== Packaging your application
+
+A Picocli command line application can be packaged in multiple formats (e.g. a JAR, a native executable) and can be published to various repositories (e.g. Homebrew, Chocolatey, SDKMAN!).
+
+=== As a jar
+
+A Picocli command line application is a standard Quarkus application and as such can be published as a JAR in various packaging formats (e.g. fast-jar, uber-jar).
+
+In the context of a command line application, building an uber-jar is more practical if you plan on publishing the JAR as is.
+
+For more information about how to build an uber-jar, see our documentation:
+
+- For https://quarkus.io/guides/maven-tooling#uber-jar-maven[Maven]
+- For https://quarkus.io/guides/gradle-tooling#building-uber-jars[Gradle]
+
+You can then execute the application by using the standard `java -jar your-application.jar` command.
+
+Using plugins such as the https://github.com/brianm/really-executable-jars-maven-plugin[really-executable-jar-maven-plugin] can be handy to simplify the execution of your command line application.
+
+=== As a native executable
+
+You can also build a https://quarkus.io/guides/building-native-image[native executable] but keep in mind that native executables are not portable and that you need one binary per supported platform.
+
+=== Publishing the application
+
+Publishing your command line application to a repository makes it a lot easier to consume.
+Various application repositories are available depending on your requirements such as https://sdkman.io/[SDKMAN!], https://brew.sh/[Homebrew] for macOS, or https://chocolatey.org/[Chocolatey] for Windows.
+
+To publish to these repositories, we recommend the usage of https://jreleaser.org/[JReleaser].
+
+JReleaser adds executable wrappers around your JAR for your application to be easily executable.
+
+=== More information
+
+You can also consult the https://picocli.info/#_packaging_your_application[Picocli official documentation] for more general information about how to package Picocli applications.
 
 == Kubernetes support
 

--- a/docs/src/main/asciidoc/picocli.adoc
+++ b/docs/src/main/asciidoc/picocli.adoc
@@ -43,6 +43,8 @@ implementation("io.quarkus:quarkus-picocli")
 
 == Simple command line application
 
+=== Example code
+
 Simple PicocliApplication with only one `Command` can be created as follows:
 
 [source,java]
@@ -85,6 +87,7 @@ class GreetingService {
 IMPORTANT: Beans with `@CommandLine.Command` should not use proxied scopes (e.g. do not use `@ApplicationScope`)
 because Picocli will not be able to set field values in such beans. This extension will register classes with `@CommandLine.Command` annotation
 using `@Depended` scope. If you need to use proxied scope, then annotate setter and not field, for example:
+
 [source,java]
 ----
 @CommandLine.Command
@@ -96,11 +99,70 @@ public class EntryCommand {
     public void setName(String name) {
         this.name = name;
     }
-
 }
 ----
 
-== Command line application with multiple Commands
+=== Packaging
+
+Picocli provides different ways to package your application in such a way that end users can invoke it by its command name.
+
+If you want to distribute a single executable file that runs without installing a JDK see <<#native-mode,Native mode support>>. Notice that this executable will be platform specific.
+
+If you want a platform independent solution you can create an executable uber-jar. This uber-jar will contain all dependencies of your app, but still requires an installed JDK to work. You can create an uber-jar via a single property in your `pom.xml`. With the https://github.com/brianm/really-executable-jars-maven-plugin[really-executable-jar-maven-plugin] you can make the uber-jar executable.
+
+[source, xml]
+----
+<properties>
+  <quarkus.package.type>uber-jar</quarkus.package.type> <1>
+  <jar.finalName>${project.name}</jar.finalName> <2>
+</properties>
+
+<!-- make the jar chmod +x style executable -->
+<!-- more options at https://github.com/brianm/really-executable-jars-maven-plugin -->
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.skife.maven</groupId>
+      <artifactId>really-executable-jar-maven-plugin</artifactId>
+      <version>1.4.1</version>
+      <configuration>
+        <flags>-Xmx1G</flags>
+        <programFile>my-command</programFile> <3>
+      </configuration>
+      <executions>
+        <execution>
+          <phase>package</phase>
+          <goals>
+            <goal>really-executable-jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+----
+<1> Define that you want to build an uber-jar. See xref:maven-tooling.adoc#uber-jar-maven[Uber-Jar Creation] for more details.
+<2> By default Quarkus will append `-runner` to the uber-jar. This would make the `really-executable-jar-maven-plugin` fail, because it cannot find the file. Therefore, we must define the uber-jar name to be equal to the project name.
+<3> Define the name of the final, executable uber-jar. This might be the name of your command.
+
+=== Executing the command
+
+Add the `my-command` file to your PATH, so you can run it directly from the command line. For instance on Linux run:
+
+[source,text,subs=attributes+]
+----
+# update PATH. This change is only temporary for the current terminal session
+export PATH="/path/to/my-command:$PATH"
+
+my-command -n Quarkus
+# will print: Hello Quarkus
+----
+
+Remember this requires a suitable JDK version to be installed. For a single executable file that runs without installing a JDK see <<#native-mode,Native mode support>>. For even more packaging options check the https://picocli.info/#_packaging_your_application[official Picocli documentation].
+
+== Advanced command line application
+
+=== Command line application with multiple Commands
 
 When multiple classes have the `picocli.CommandLine.Command` annotation, then one of them needs to be also annotated with `io.quarkus.picocli.runtime.annotations.TopCommand`.
 This can be overwritten with the `quarkus.picocli.top-command` property.
@@ -136,7 +198,7 @@ class GoodByeCommand implements Runnable {
 }
 ----
 
-== Customizing Picocli CommandLine instance
+=== Customizing Picocli CommandLine instance
 
 You can customize CommandLine classes used by the `picocli` extension by producing your own bean instance:
 
@@ -174,7 +236,7 @@ class CustomConfiguration {
 ----
 <1> `PicocliCommandLineFactory` will create an instance of CommandLine with `TopCommand` and `CommandLine.IFactory` injected.
 
-== Different entry command for each profile
+=== Different entry command for each profile
 
 It is possible to create different entry command for each profile, using `@IfBuildProfile`:
 
@@ -201,7 +263,7 @@ public class Config {
 ----
 <1> You can return instance of `java.lang.Class` here. In such case `CommandLine` will try to instantiate this class using `CommandLine.IFactory`.
 
-== Configure CDI Beans with parsed arguments
+=== Configure CDI Beans with parsed arguments
 
 You can use `Event<CommandLine.ParseResult>` or just `CommandLine.ParseResult` to configure CDI beans based on arguments parsed by Picocli.
 This event will be generated in `QuarkusApplication` class created by this extension. If you are providing your own `@QuarkusMain` this event will not be raised.
@@ -242,7 +304,7 @@ class DatasourceConfiguration {
 ----
 <1> `@ApplicationScoped` used for lazy initialization
 
-== Providing own QuarkusMain
+=== Providing own QuarkusMain
 
 You can also provide your own application entry point annotated with `QuarkusMain` (as described in xref:command-mode-reference.adoc[Command Mode reference guide]).
 
@@ -275,6 +337,7 @@ public class ExampleApp implements Runnable, QuarkusApplication {
 ----
 <1> Quarkus-compatible `CommandLine.IFactory` bean created by `picocli` extension.
 
+[#native-mode]
 == Native mode support
 
 This extension uses the Quarkus standard build steps mechanism to support GraalVM Native images. In the exceptional case that incompatible changes in a future picocli release cause any issue, the following configuration can be used to fall back to the annotation processor from the picocli project as a temporary workaround:


### PR DESCRIPTION
I was initially a bit lost how to turn the example into something actually runnable on the cmd. The native executable works fine, but might not be suitable in all cases. So I added an example with an uber-jar and combined it with a maven plugin as described in the official Picocli docu. 