### PR TITLE
Register java plugin in Gradle plugins

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -105,6 +105,9 @@ public class QuarkusPlugin implements Plugin<Project> {
         // register extension
         final QuarkusPluginExtension quarkusExt = project.getExtensions().create(EXTENSION_NAME, QuarkusPluginExtension.class,
                 project);
+        // register plugin
+        project.getPluginManager().apply(JavaPlugin.class);
+
         registerTasks(project, quarkusExt);
     }
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -124,8 +124,6 @@ public class QuarkusBuild extends QuarkusTask {
 
     @TaskAction
     public void buildQuarkus() {
-        getLogger().lifecycle("building quarkus jar");
-
         final ApplicationModel appModel;
         try {
             appModel = extension().getAppModelResolver().resolveModel(new GACTV(getProject().getGroup().toString(),

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusGenerateCode.java
@@ -92,8 +92,6 @@ public class QuarkusGenerateCode extends QuarkusTask {
 
     @TaskAction
     public void prepareQuarkus() {
-        getLogger().lifecycle("preparing quarkus application");
-
         LaunchMode launchMode = test ? LaunchMode.TEST : devMode ? LaunchMode.DEVELOPMENT : LaunchMode.NORMAL;
         final ApplicationModel appModel = extension().getApplicationModel(launchMode);
         final Properties realProperties = getBuildSystemProperties(appModel.getAppArtifact());

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionPlugin.java
@@ -38,6 +38,7 @@ public class QuarkusExtensionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         final QuarkusExtensionConfiguration quarkusExt = project.getExtensions().create(EXTENSION_CONFIGURATION_NAME,
                 QuarkusExtensionConfiguration.class);
+        project.getPluginManager().apply(JavaPlugin.class);
         registerTasks(project, quarkusExt);
     }
 


### PR DESCRIPTION
As discussed on zulip, Quarkus Gradle plugins can't work without the java plugin. A build could fail if plugin are not applied in a correct order. This applies the java plugin by default to make sure no error can happen.

/cc @grossws @gastaldi 