### PR TITLE
Revert PathMatchingHttpSecurityPolicy update which prepends quarkus.http.root-path to policy paths

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
@@ -25,7 +25,7 @@ public class PathWithHttpRootTestCase {
     private static final String APP_PROPS = "" +
             "# Add your application.properties here, if applicable.\n" +
             "quarkus.http.root-path=/root\n" +
-            "quarkus.http.auth.permission.authenticated.paths=/admin\n" +
+            "quarkus.http.auth.permission.authenticated.paths=${quarkus.http.root-path}/admin\n" +
             "quarkus.http.auth.permission.authenticated.policy=authenticated\n";
 
     @RegisterExtension

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -99,10 +99,6 @@ public class PathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
             if (entry.getValue().enabled.orElse(Boolean.TRUE)) {
                 for (String path : entry.getValue().paths.orElse(Collections.emptyList())) {
                     path = path.trim();
-                    if (!config.rootPath.equals("/")) {
-                        path = (config.rootPath.endsWith("/") ? config.rootPath.substring(0, config.rootPath.length() - 1)
-                                : config.rootPath) + path;
-                    }
                     if (tempMap.containsKey(path)) {
                         HttpMatcher m = new HttpMatcher(entry.getValue().authMechanism.orElse(null),
                                 new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),


### PR DESCRIPTION
As it can cause migration problems from earlier versions of Quarkus, instead users should prepend `${quarkus.http.root-path}` to extension specific path properties.

Note I'm not totally reverting #24794, keeping the test checking that  prepending `${quarkus.http.root-path}` configuration works.
Guillaume, if it is not too late then please backport to `2.8.2`, otherwise to `2.8.3` if it happens.
Thanks 