### PR TITLE
Do not run elasticsearch-rest-client-deployment tests unless -Dtest-containers is set

### DIFF
--- a/extensions/elasticsearch-rest-client/deployment/pom.xml
+++ b/extensions/elasticsearch-rest-client/deployment/pom.xml
@@ -68,7 +68,34 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>test-elasticsearch</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Fixes [#25141](https://github.com/quarkusio/quarkus/issues/25141)