### PR TITLE
Do not run NativeImageBuildContainerRunnerTest test unless -Dtest-containers is set

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -134,6 +134,15 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Give tests a hint to not use containers, by default -->
+                        <avoid-containers>true</avoid-containers>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>
@@ -179,4 +188,28 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>test-native-container-build</id>
+            <activation>
+                <property>
+                    <name>start-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Enable the container-based tests -->
+                                <avoid-containers>false</avoid-containers>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/pkg/steps/NativeImageBuildContainerRunnerTest.java
@@ -7,11 +7,14 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.deployment.pkg.NativeConfig;
 
 class NativeImageBuildContainerRunnerTest {
 
+    // This will default to false in the maven build and true in the IDE, so this will still run if invoked explicitly
+    @DisabledIfSystemProperty(named = "avoid-containers", matches = "true")
     @Test
     void testBuilderImageBeingPickedUp() {
         NativeConfig nativeConfig = new NativeConfig();


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/25108. 

This is a slightly more elaborate fix than I did for https://github.com/quarkusio/quarkus/issues/25141. Only one test in the `core/deployment` module needs containers, so I didn't want to disable the whole module unless `start-containers` was set. I could have just let the test read the `start-containers` system property, but that would result in it being disabled by default if run within an IDE. I figure if you're running a test within an IDE you want it to run, without any extra configuration, so I inverted the properties in the pom so the test is disabled by default when run in maven, but enabled by default when run 'loose'. 

With the changes, on a docker/podman-free system, 
- Running in an IDE runs the test and gives a failure 
- `./mvnw -Dquickly -DskipTests=false -Dstart-containers -f core/deployment` runs the test and gives a failure 
- `./mvnw -Dquickly -DskipTests=false -f core/deployment` runs all the other tests in the module, and runs clean
