### PR TITLE
Prepend http.root-path to permission paths without '/'

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -78,7 +78,7 @@ TIP: By default, the following list of media types is compressed: `text/html`, `
 
 NOTE: If the client does not support HTTP compression then the response body is not compressed.
 
-
+[[context-path]]
 == Configuring the Context path
 
 By default Quarkus will serve content from under the root context. If you want to change this you can use the
@@ -93,6 +93,17 @@ will be served relative to `{quarkus.http.root-path}/{quarkus.servlet.context-pa
 
 If REST Assured is used for testing and `quarkus.http.root-path` is set then Quarkus will automatically configure the
 base URL for use in Quarkus tests, so test URL's should not include the root path.
+
+
+In general, path configurations for web content are interpreted relative to `quarkus.http.root-path` (which is / by default). 
+
+- To specify paths within this context root, use a relative path that does not begin with a forward slash.
+
+- If you want to specify the URI explicitly, so it is always the same regardless of the value of `quarkus.http.root-path`, use an absolute path that begins with a forward slash.
+
+As an example, if an extension configures a `service` path, that endpoint will be served from `${quarkus.http.root-path}/service`. If you change the configuration of that path to `/service`, that endpoint will be served from `/service`.
+
+The link:https://quarkus.io/blog/path-resolution-in-quarkus/[Path Resolution in Quarkus] blog post further explains how path resolution works for both user and extension defined paths.
 
 [[ssl]]
 == Supporting secure connections with SSL

--- a/docs/src/main/asciidoc/security-authorization.adoc
+++ b/docs/src/main/asciidoc/security-authorization.adoc
@@ -177,6 +177,35 @@ quarkus.http.auth.permission.permit1.methods=GET,HEAD
 
 and enabled at runtime with a system property or environment variable, for example: `-Dquarkus.http.auth.permission.permit1.enabled=true`.
 
+== Permission paths and http root path
+
+The `quarkus.http.root-path` configuration property is used to change the xref:http-reference.adoc#context-path[http endpoint context path].
+
+By default, `quarkus.http.root-path` is prepended automatically to configured permission paths then do not use a forward slash, for example:
+
+[source,properties]
+----
+quarkus.http.auth.permission.permit1.paths=public/*,css/*,js/*,robots.txt
+----
+
+This configuration is equivalent to the following: 
+
+[source,properties]
+----
+quarkus.http.auth.permission.permit1.paths=${quarkus.http.root-path}/public/*,${quarkus.http.root-path}/css/*,${quarkus.http.root-path}/js/*,${quarkus.http.root-path}/robots.txt
+----
+
+A leading slash will change how the configured permission path is interpreted. The configured URL will be used as-is, and paths will not be adjusted if the value of `quarkus.http.root-path` is changed. For example: 
+
+[source,properties]
+----
+quarkus.http.auth.permission.permit1.paths=/public/*,css/*,js/*,robots.txt
+----
+
+This configuration will only impact resources served from the fixed/static URL `/public`, which may not match your application resources if `quarkus.http.root-path` has been set to something other than `/`.
+
+See link:https://quarkus.io/blog/path-resolution-in-quarkus/[Path Resolution in Quarkus] for more information.
+
 [#standard-security-annotations]
 == Authorization using Annotations
 

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/PathWithHttpRootTestCase.java
@@ -25,7 +25,7 @@ public class PathWithHttpRootTestCase {
     private static final String APP_PROPS = "" +
             "# Add your application.properties here, if applicable.\n" +
             "quarkus.http.root-path=/root\n" +
-            "quarkus.http.auth.permission.authenticated.paths=${quarkus.http.root-path}/admin\n" +
+            "quarkus.http.auth.permission.authenticated.paths=admin\n" +
             "quarkus.http.auth.permission.authenticated.policy=authenticated\n";
 
     @RegisterExtension

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PathMatchingHttpSecurityPolicy.java
@@ -99,6 +99,9 @@ public class PathMatchingHttpSecurityPolicy implements HttpSecurityPolicy {
             if (entry.getValue().enabled.orElse(Boolean.TRUE)) {
                 for (String path : entry.getValue().paths.orElse(Collections.emptyList())) {
                     path = path.trim();
+                    if (!path.startsWith("/")) {
+                        path = config.rootPath + path;
+                    }
                     if (tempMap.containsKey(path)) {
                         HttpMatcher m = new HttpMatcher(entry.getValue().authMechanism.orElse(null),
                                 new HashSet<>(entry.getValue().methods.orElse(Collections.emptyList())),


### PR DESCRIPTION
This PR relates to #25154,  it does what I did for 2.8.1 then reverted for 2.8.2, in a better non-breaking way as recommended by Erin.

I will follow up with another PR where I'll go through various OIDC paths carefully and see if the same logic can be applied.