### PR TITLE
Replicate relevant parts of https://github.com/jbangdev/jbang/pull/1269 to enable M1 support

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/tooling/jbang-wrapper/base/jbang
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-jbang/tooling/jbang-wrapper/base/jbang
@@ -2,7 +2,7 @@
 
 #
 # To run this script remotely type this in your shell
-# (where <args>... are the arguments you want to pass to Jbang):
+# (where <args>... are the arguments you want to pass to JBang):
 #   curl -Ls https://sh.jbang.dev | bash -s - <args>...
 #
 
@@ -17,21 +17,21 @@ absolute_path() {
 
 resolve_symlink() {
   if [[ $OSTYPE != darwin* ]]; then minusFarg="-f"; fi
-  sym_resolved=$(readlink ${minusFarg} $1)
+  sym_resolved=$(readlink ${minusFarg} "$1")
 
   if [[ -n $sym_resolved ]]; then
-    echo $sym_resolved
+    echo "$sym_resolved"
   else
-    echo $1
+    echo "$1"
   fi
 }
 
 download() {
   if [ -x "$(command -v curl)" ]; then
-    curl -sLf -H "Accept: application/gzip, application/octet-stream" -o "$2" $1
+    curl -sLf -o "$2" "$1"
     retval=$?
   elif [ -x "$(command -v wget)" ]; then
-    wget -q --header="Accept: application/gzip, application/octet-stream" -O "$2" $1
+    wget -q -O "$2" "$1"
     retval=$?
   else
     echo "Error: curl or wget not found, please make sure one of them is installed" 1>&2
@@ -39,16 +39,52 @@ download() {
   fi
 }
 
-abs_jbang_path=$(resolve_symlink $(absolute_path $0))
+unpack() {
+  if [[ "$1" == *.tar.gz ]]; then
+    gzip -cd "$1" | tar xf - -C "$2"
+    retval=$?
+    if [[ $os == mac && $retval -eq 0 ]]; then
+      mv "$TDIR/jdks/$javaVersion.tmp/"*/Contents/Home/* "$TDIR/jdks/$javaVersion.tmp/"
+      retval=$?
+    else
+      mv "$TDIR/jdks/$javaVersion.tmp/"*/* "$TDIR/jdks/$javaVersion.tmp/"
+    fi
+  else
+    unzip -qq -o "$1" -d "$2"
+    retval=$?
+    mv "$TDIR/jdks/$javaVersion.tmp/"*/* "$TDIR/jdks/$javaVersion.tmp/"
+  fi
+}
+
+javacInPath() {
+  [[ -x "$(command -v javac)" && ( $os != "mac" || $(/usr/libexec/java_home &> /dev/null) ) ]]
+}
+
+abs_jbang_dir=$(dirname "$(resolve_symlink "$(absolute_path "$0")")")
+
+# todo might vary by os so can be overwritten below
+libc_type=glibc
+file_type=tar.gz
 
 case "$(uname -s)" in
   Linux*)
-    os=linux;;
+    os=linux
+    if [ -f /etc/alpine-release ]; then
+      os=alpine-linux
+      javaVersion=16
+    fi
+    ;;
   Darwin*)
-    os=mac;;
+    os=mac
+    libc_type=libc;;
   CYGWIN*|MINGW*|MSYS*)
-    os=windows;;
-  *)        echo "Unsupported Operating System: $(uname -s)" 1>&2; exit 1;;
+    os=windows
+    libc_type=c_std_lib
+    file_type=zip;;
+  AIX)
+    os=aix;;
+  *)
+    os=
 esac
 
 case "$(uname -m)" in
@@ -60,26 +96,55 @@ case "$(uname -m)" in
     arch=aarch64;;
   armv7l)
     arch=arm;;
+  ppc64le)
+    arch=ppc64le;;
+  s390x)
+    arch=s390x;;
+  arm64)
+    if [ "$os" = "mac" ]; then
+      arch=arm64
+      ## force use of 17 as 11 not yet available https://github.com/adoptium/adoptium/issues/96
+      javaVersion=17
+    else
+      arch=arm64
+    fi
+    ;;
   *)
-    echo "Unsupported Architecture: $(uname -m)" 1>&2; exit 1;;
+    ## AIX gives a machine ID for `uname -m` but it only supports ppc64
+    if [ "$os" = "aix" ]; then
+      arch=ppc64
+    else
+      arch=
+    fi
+    ;;
 esac
 
-## when mingw/git bash or cygwin fall out to just running the bat file.
-if [[ $os == windows ]]; then
-  $(dirname $abs_jbang_path)/jbang.cmd $*
+## when using cygwin fall out to just running the bat file.
+if [[ $os == windows && -f "$abs_jbang_dir/jbang.cmd" && "$(uname -s)" == CYGWIN* ]]; then
+  cmd /c "$(cygpath -m "$abs_jbang_dir"/jbang.cmd)" "$@"
   exit $?
 fi
+
+if [[ -z "$JBANG_JDK_VENDOR" ]]; then
+  if [[ "$javaVersion" -eq 8 || "$javaVersion" -eq 11 || "$javaVersion" -ge 17 ]]; then
+    distro="temurin";
+  else
+    distro="aoj"; fi
+else
+  distro=$JBANG_JDK_VENDOR
+fi
+if [[ -z "$JBANG_JDK_RELEASE" ]]; then release="ga"; else release="$JBANG_JDK_RELEASE"; fi
 
 if [[ -z "$JBANG_DIR" ]]; then JBDIR="$HOME/.jbang"; else JBDIR="$JBANG_DIR"; fi
 if [[ -z "$JBANG_CACHE_DIR" ]]; then TDIR="$JBDIR/cache"; else TDIR="$JBANG_CACHE_DIR"; fi
 
 ## resolve application jar path from script location
-if [ -f "$(dirname $abs_jbang_path)/jbang.jar" ]; then
-  jarPath=$(dirname $abs_jbang_path)/jbang.jar
-elif [ -f "$(dirname $abs_jbang_path)/.jbang/jbang.jar" ]; then
-  jarPath=$(dirname $abs_jbang_path)/.jbang/jbang.jar
+if [ -f "$abs_jbang_dir/jbang.jar" ]; then
+  jarPath=$abs_jbang_dir/jbang.jar
+elif [ -f "$abs_jbang_dir/.jbang/jbang.jar" ]; then
+  jarPath=$abs_jbang_dir/.jbang/jbang.jar
 else
-  if [ ! -f "$JBDIR/bin/jbang.jar" ]; then
+  if [[ ! -f "$JBDIR/bin/jbang.jar" || ! -f "$JBDIR/bin/jbang" ]]; then
     echo "Downloading JBang..." 1>&2
     mkdir -p "$TDIR/urls"
     jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar"
@@ -93,46 +158,55 @@ else
     rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
     cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
   fi
-  eval "exec $JBDIR/bin/jbang $*"
+  "$JBDIR"/bin/jbang "$@"
+  exit $?
+fi
+if [ -f "$jarPath.new" ]; then
+  # a new jbang version was found, we replace the old one with it
+  mv "$jarPath.new" "$jarPath"
 fi
 
 # Find/get a JDK
 unset JAVA_EXEC
 if [[ -n "$JAVA_HOME" ]]; then
   # Determine if a (working) JDK is available in JAVA_HOME
-  if [ -x "$(command -v $JAVA_HOME/bin/javac)" ]; then
-    JAVA_EXEC="$JAVA_HOME/bin/java";
+  if [ -x "$(command -v "$JAVA_HOME"/bin/javac)" ]; then
+    JAVA_EXEC="$JAVA_HOME/bin/java"
   else
     echo "JAVA_HOME is set but does not seem to point to a valid Java JDK" 1>&2
   fi
 fi
 if [[ -z "$JAVA_EXEC" ]]; then
   # Determine if a (working) JDK is available on the PATH
-  if [ -x "$(command -v javac)" ]; then
-    JAVA_EXEC="java";
+  if javacInPath; then
+    unset JAVA_HOME
+    JAVA_EXEC="java"
   elif [ -x "$JBDIR/currentjdk/bin/javac" ]; then
     export JAVA_HOME="$JBDIR/currentjdk"
-    JAVA_EXEC="$JBDIR/currentjdk/bin/java";
+    JAVA_EXEC="$JBDIR/currentjdk/bin/java"
   else
     export JAVA_HOME="$TDIR/jdks/$javaVersion"
     JAVA_EXEC="$JAVA_HOME/bin/java"
     # Check if we installed a JDK before
     if [ ! -d "$TDIR/jdks/$javaVersion" ]; then
       # If not, download and install it
+      if [[ $os == "" ]]; then
+        echo "Unable to download JDK, unsupported Operating System: $(uname -s)" 1>&2
+        exit 1
+      fi
+      if [[ $arch == "" ]]; then
+        echo "Unable to download JDK, unsupported Architecture: $(uname -m)" 1>&2
+        exit 1
+      fi
       mkdir -p "$TDIR/jdks"
       echo "Downloading JDK $javaVersion. Be patient, this can take several minutes..." 1>&2
-      jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
-      download $jdkurl "$TDIR/bootstrap-jdk.tgz"
+      jdkurl="https://api.foojay.io/disco/v2.0/directuris?distro=$distro&javafx_bundled=false&libc_type=$libc_type&archive_type=$file_type&operating_system=$os&package_type=jdk&version=$javaVersion&release_status=$release&architecture=$arch&latest=available"
+      download "$jdkurl" "$TDIR/bootstrap-jdk.$file_type"
       if [ $retval -ne 0 ]; then echo "Error downloading JDK" 1>&2; exit $retval; fi
       echo "Installing JDK $javaVersion..." 1>&2
       rm -rf "$TDIR/jdks/$javaVersion.tmp/"
       mkdir -p "$TDIR/jdks/$javaVersion.tmp"
-      tar xf "$TDIR/bootstrap-jdk.tgz" -C "$TDIR/jdks/$javaVersion.tmp" --strip-components=1
-      retval=$?
-      if [[ $os == mac && $retval -eq 0 ]]; then
-        mv "$TDIR/jdks/$javaVersion.tmp/Contents/Home/"* "$TDIR/jdks/$javaVersion.tmp/"
-        retval=$?
-      fi
+      unpack "$TDIR/bootstrap-jdk.$file_type" "$TDIR/jdks/$javaVersion.tmp"
       if [ $retval -ne 0 ]; then
         # Check if the JDK was installed properly
         javac -version > /dev/null 2>&1
@@ -142,7 +216,7 @@ if [[ -z "$JAVA_EXEC" ]]; then
       # Activate the downloaded JDK giving it its proper name
       mv "$TDIR/jdks/$javaVersion.tmp" "$TDIR/jdks/$javaVersion"
       # Set the current JDK
-      ${JAVA_EXEC} -classpath ${jarPath} dev.jbang.Main jdk default $javaVersion
+      ${JAVA_EXEC} -classpath "${jarPath}" dev.jbang.Main jdk default $javaVersion
     fi
   fi
 fi
@@ -151,11 +225,13 @@ fi
 ## attempt to ensure each argument keeps its original quoting
 
 ## run it using command substitution to have just the user process once jbang is done
-output=$(CLICOLOR_FORCE=1 ${JAVA_EXEC} ${JBANG_JAVA_OPTIONS} -classpath ${jarPath} dev.jbang.Main "$@")
+export JBANG_RUNTIME_SHELL=bash
+export JBANG_STDIN_NOTTY=$([ -t 0 ] && echo "false" || echo "true")
+output=$(CLICOLOR_FORCE=1 ${JAVA_EXEC} ${JBANG_JAVA_OPTIONS} -classpath "${jarPath}" dev.jbang.Main "$@")
 err=$?
 if [ $err -eq 255 ]; then
   eval "exec $output"
-elif [ ! -z "$output" ]; then
+elif [ -n "$output" ]; then
   echo "$output"
   exit $err
 else


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/25180. 

I've pulled in the script sections of https://github.com/jbangdev/jbang/pull/1269, which adds M1 support to jbang. 

Before the changes, `./mvnw -Dquickly -DskipTests=false -f devtools/cli` fails on M1 (and people would also see failures running manually). 

To apply the changes, run `./mvnw -f ./independent-projects/tools/base-codestarts -Dquickly` and then `./mvnw -Dquickly -DskipTests=false -f devtools/cli` will pass. 