### PR TITLE
GraphQL Non blocking support

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-health.version>3.2.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.4</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.22</smallrye-open-api.version>
-        <smallrye-graphql.version>1.4.5</smallrye-graphql.version>
+        <smallrye-graphql.version>1.5.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.4.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.4.0</smallrye-jwt.version>

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -141,14 +141,15 @@ class HibernateValidatorProcessor {
         // The CDI interceptor which will validate the methods annotated with @MethodValidated
         additionalBeans.produce(new AdditionalBeanBuildItem(MethodValidationInterceptor.class));
 
+        additionalBeans.produce(new AdditionalBeanBuildItem(
+                "io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper"));
+
         if (capabilities.isPresent(Capability.RESTEASY)) {
             // The CDI interceptor which will validate the methods annotated with @JaxrsEndPointValidated
             additionalBeans.produce(new AdditionalBeanBuildItem(
                     "io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor"));
             additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper"));
-            additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.ResteasyContextLocaleResolver"));
+                    "io.quarkus.hibernate.validator.runtime.locale.ResteasyClassicLocaleResolver"));
             syntheticBeanBuildItems.produce(SyntheticBeanBuildItem.configure(ResteasyConfigSupport.class)
                     .scope(Singleton.class)
                     .unremovable()
@@ -160,15 +161,7 @@ class HibernateValidatorProcessor {
             additionalBeans.produce(new AdditionalBeanBuildItem(
                     "io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveEndPointValidationInterceptor"));
             additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper"));
-            additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.VertxLocaleResolver"));
-        }
-        if (capabilities.isPresent(Capability.SMALLRYE_GRAPHQL)) {
-            additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper"));
-            additionalBeans.produce(new AdditionalBeanBuildItem(
-                    "io.quarkus.hibernate.validator.runtime.locale.VertxLocaleResolver"));
+                    "io.quarkus.hibernate.validator.runtime.locale.ResteasyReactiveLocaleResolver"));
         }
 
         // A constraint validator with an injection point but no scope is added as @Dependent

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/LocaleResolversWrapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/LocaleResolversWrapper.java
@@ -18,14 +18,16 @@ import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
 public class LocaleResolversWrapper implements LocaleResolver {
 
     @Inject
-    Instance<AbstractLocaleResolver> resolvers;
+    Instance<LocaleResolver> resolvers;
 
     @Override
     public Locale resolve(LocaleResolverContext context) {
-        for (AbstractLocaleResolver resolver : resolvers) {
-            Locale locale = resolver.resolve(context);
-            if (locale != null) {
-                return locale;
+        for (LocaleResolver resolver : resolvers) {
+            if (!resolver.equals(this)) {
+                Locale locale = resolver.resolve(context);
+                if (locale != null) {
+                    return locale;
+                }
             }
         }
         return context.getDefaultLocale();

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyClassicLocaleResolver.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyClassicLocaleResolver.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.HttpHeaders;
 import org.jboss.resteasy.core.ResteasyContext;
 
 @Singleton
-public class ResteasyContextLocaleResolver extends AbstractLocaleResolver {
+public class ResteasyClassicLocaleResolver extends AbstractLocaleResolver {
 
     @Override
     protected Map<String, List<String>> getHeaders() {

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyReactiveLocaleResolver.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/locale/ResteasyReactiveLocaleResolver.java
@@ -16,7 +16,7 @@ import io.vertx.ext.web.RoutingContext;
  * Currently used for handling GraphQL requests.
  */
 @Singleton
-public class VertxLocaleResolver extends AbstractLocaleResolver {
+public class ResteasyReactiveLocaleResolver extends AbstractLocaleResolver {
 
     @Inject
     CurrentVertxRequest currentVertxRequest;

--- a/extensions/smallrye-graphql-client/deployment/pom.xml
+++ b/extensions/smallrye-graphql-client/deployment/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-graphql-client</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/model/TestingGraphQLApi.java
+++ b/extensions/smallrye-graphql-client/deployment/src/test/java/io/quarkus/smallrye/graphql/client/deployment/model/TestingGraphQLApi.java
@@ -12,6 +12,9 @@ import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 @GraphQLApi
 public class TestingGraphQLApi {
 
+    @Inject
+    CurrentVertxRequest request;
+
     @Query
     public List<Person> people() {
         Person person1 = new Person();
@@ -24,9 +27,6 @@ public class TestingGraphQLApi {
 
         return List.of(person1, person2);
     }
-
-    @Inject
-    CurrentVertxRequest request;
 
     /**
      * Returns the value of the HTTP header denoted by 'key'.

--- a/extensions/smallrye-graphql-client/runtime/pom.xml
+++ b/extensions/smallrye-graphql-client/runtime/pom.xml
@@ -30,7 +30,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-client-implementation-vertx</artifactId>

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -53,6 +53,13 @@
             <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
         </dependency>
         
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+        
         <!--  Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -92,11 +99,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-validator-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/ErrorTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/ErrorTest.java
@@ -1,0 +1,83 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class ErrorTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ErrorApi.class, Foo.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testNonBlockingError() {
+        String query = getPayload("{ foo { message} }");
+        RestAssured.given()
+                .body(query)
+                .contentType(MEDIATYPE_JSON)
+                .post("/graphql/")
+                .then()
+                .assertThat()
+                .statusCode(500);
+    }
+
+    @Test
+    public void testBlockingError() {
+        String query = getPayload("{ blockingFoo { message} }");
+        RestAssured.given()
+                .body(query)
+                .contentType(MEDIATYPE_JSON)
+                .post("/graphql/")
+                .then()
+                .log().everything()
+                .assertThat()
+                .statusCode(500);
+    }
+
+    public static class Foo {
+
+        private String message;
+
+        public Foo(String foo) {
+            this.message = foo;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+    }
+
+    @GraphQLApi
+    @ApplicationScoped
+    public static class ErrorApi {
+
+        @Query
+        @NonBlocking
+        public Foo foo() {
+            throw new OutOfMemoryError("a SuperHero has used all the memory");
+        }
+
+        @Query
+        public Foo blockingFoo() {
+            throw new OutOfMemoryError("a SuperHero has used all the memory");
+        }
+
+    }
+
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLBlockingModeTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLBlockingModeTest.java
@@ -1,0 +1,447 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Testing the tread used.
+ */
+public class GraphQLBlockingModeTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((JavaArchive jar) -> jar
+                    .addClasses(TestThreadResource.class, TestThread.class)
+                    .addAsResource(new StringAsset("quarkus.smallrye-graphql.nonblocking.enabled=false"),
+                            "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testOnlyObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.onlyObject.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedNonBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testOnlyReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyReactiveUni.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.onlyReactiveUni.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingReactiveUni.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingReactiveUni.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedNonBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testOnlyCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyCompletionStage.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.onlyCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingCompletionStage.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingCompletionStage.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedNonBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @GraphQLApi
+    public static class TestThreadResource {
+
+        @Inject
+        Vertx vertx;
+
+        // Return type Object
+        @Query
+        public TestThread onlyObject() {
+            return getTestThread();
+        }
+
+        // Return type Object, Annotated with @NonBlocking
+        @Query
+        @NonBlocking
+        public TestThread annotatedNonBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Object with @Blocking (default)
+        @Query
+        @Blocking
+        public TestThread annotatedBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Uni
+        @Query
+        public Uni<TestThread> onlyReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Reactive with @Blocking
+        @Query
+        @Blocking
+        public Uni<TestThread> annotatedBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Reactive with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public Uni<TestThread> annotatedNonBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        @Query
+        public CompletionStage<TestThread> onlyCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @Blocking
+        @Query
+        @Blocking
+        public CompletionStage<TestThread> annotatedBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public CompletionStage<TestThread> annotatedNonBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        private TestThread getTestThread() {
+            Thread t = Thread.currentThread();
+            long id = t.getId();
+            String name = t.getName();
+            int priority = t.getPriority();
+            String state = t.getState().name();
+            String group = t.getThreadGroup().getName();
+            return new TestThread(id, name, priority, state, group);
+        }
+    }
+
+    /**
+     * Hold info about a thread
+     */
+    public static class TestThread {
+
+        private long id;
+        private String name;
+        private int priority;
+        private String state;
+        private String group;
+
+        public TestThread() {
+            super();
+        }
+
+        public TestThread(long id, String name, int priority, String state, String group) {
+            this.id = id;
+            this.name = name;
+            this.priority = priority;
+            this.state = state;
+            this.group = group;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public void setState(String state) {
+            this.state = state;
+        }
+
+        public String getGroup() {
+            return group;
+        }
+
+        public void setGroup(String group) {
+            this.group = group;
+        }
+
+        public String getVertxContextClassName() {
+            Context vc = Vertx.currentContext();
+            return vc.getClass().getName();
+        }
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLCDIContextPropagationTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLCDIContextPropagationTest.java
@@ -149,7 +149,8 @@ public class GraphQLCDIContextPropagationTest extends AbstractGraphQLTest {
         @Name("duplicatedMessage")
         public List<String> duplicatedMessage(@Source List<TestPojo> pojos) {
             if (!this.injectedBean.getId().equals(this.injectedBeanId)) {
-                throw new IllegalStateException("duplicatedMessage must be executed in the same request context as getPojos");
+                throw new IllegalStateException("duplicatedMessage must be executed in the same request context as getPojos ["
+                        + this.injectedBean.getId() + " != " + this.injectedBeanId);
             }
             return pojos.stream()
                     .map(pojo -> pojo.getMessage() + pojo.getMessage())
@@ -163,7 +164,8 @@ public class GraphQLCDIContextPropagationTest extends AbstractGraphQLTest {
         public CompletionStage<List<String>> duplicatedMessageAsync(@Source List<TestPojo> pojos) {
             if (!this.injectedBean.getId().equals(this.injectedBeanId)) {
                 throw new IllegalStateException(
-                        "duplicatedMessageAsync must be executed in the same request context as getPojos");
+                        "duplicatedMessageAsync must be executed in the same request context as getPojos ["
+                                + this.injectedBean.getId() + " != " + this.injectedBeanId);
             }
             return CompletableFuture.completedFuture(pojos.stream()
                     .map(pojo -> pojo.getMessage() + pojo.getMessage())

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLThreadTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLThreadTest.java
@@ -1,0 +1,482 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Testing the tread used.
+ */
+public class GraphQLThreadTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((JavaArchive jar) -> jar
+                    .addClasses(TestThreadResource.class, TestThread.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testOnlyObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.onlyObject.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingObject.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingObject() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingObject {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingObject.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingObject.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testOnlyReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyReactiveUni.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyReactiveUni.vertxContextClassName", Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testOnlyReactiveUniWithDelay() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyReactiveUniWithDelay {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyReactiveUniWithDelay.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyReactiveUniWithDelay.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+    }
+
+    @Test
+    public void testAnnotatedBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingReactiveUni.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingReactiveUni() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingReactiveUni {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingReactiveUni.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingReactiveUni.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testOnlyCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  onlyCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.onlyCompletionStage.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.onlyCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedBlockingCompletionStage.name", Matchers.startsWith("executor-thread"))
+                .and()
+                .body("data.annotatedBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @Test
+    public void testAnnotatedNonBlockingCompletionStage() {
+
+        String fooRequest = getPayload("{\n" +
+                "  annotatedNonBlockingCompletionStage {\n" +
+                "    name\n" +
+                "    priority\n" +
+                "    state\n" +
+                "    group\n" +
+                "    vertxContextClassName\n" +
+                "  }\n" +
+                "}");
+
+        RestAssured.given().when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(fooRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .log().body().and()
+                .body("data.annotatedNonBlockingCompletionStage.name", Matchers.startsWith("vert.x-eventloop-thread"))
+                .and()
+                .body("data.annotatedNonBlockingCompletionStage.vertxContextClassName",
+                        Matchers.equalTo("io.vertx.core.impl.DuplicatedContext"));
+
+    }
+
+    @GraphQLApi
+    public static class TestThreadResource {
+
+        @Inject
+        Vertx vertx;
+
+        // Return type Object
+        @Query
+        public TestThread onlyObject() {
+            return getTestThread();
+        }
+
+        // Return type Object, Annotated with @NonBlocking
+        @Query
+        @NonBlocking
+        public TestThread annotatedNonBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Object with @Blocking (default)
+        @Query
+        @Blocking
+        public TestThread annotatedBlockingObject() {
+            return getTestThread();
+        }
+
+        // Return type Uni
+        @Query
+        public Uni<TestThread> onlyReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Uni With Delay
+        @Query
+        public Uni<TestThread> onlyReactiveUniWithDelay() {
+            return Uni.createFrom().emitter(
+                    emitter -> {
+                        vertx.setTimer(1000, x -> emitter.complete(getTestThread()));
+                    });
+        }
+
+        // Return type Reactive with @Blocking
+        @Query
+        @Blocking
+        public Uni<TestThread> annotatedBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        // Return type Reactive with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public Uni<TestThread> annotatedNonBlockingReactiveUni() {
+            return Uni.createFrom().item(() -> getTestThread());
+        }
+
+        @Query
+        public CompletionStage<TestThread> onlyCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @Blocking
+        @Query
+        @Blocking
+        public CompletionStage<TestThread> annotatedBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        // Return type CompletionStage with @NonBlocking (default)
+        @Query
+        @NonBlocking
+        public CompletionStage<TestThread> annotatedNonBlockingCompletionStage() {
+            return Uni.createFrom().item(() -> getTestThread()).subscribeAsCompletionStage();
+        }
+
+        private TestThread getTestThread() {
+            Thread t = Thread.currentThread();
+            long id = t.getId();
+            String name = t.getName();
+            int priority = t.getPriority();
+            String state = t.getState().name();
+            String group = t.getThreadGroup().getName();
+            return new TestThread(id, name, priority, state, group);
+        }
+    }
+
+    /**
+     * Hold info about a thread
+     */
+    public static class TestThread {
+
+        private long id;
+        private String name;
+        private int priority;
+        private String state;
+        private String group;
+
+        public TestThread() {
+            super();
+        }
+
+        public TestThread(long id, String name, int priority, String state, String group) {
+            this.id = id;
+            this.name = name;
+            this.priority = priority;
+            this.state = state;
+            this.group = group;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public void setState(String state) {
+            this.state = state;
+        }
+
+        public String getGroup() {
+            return group;
+        }
+
+        public void setGroup(String group) {
+            this.group = group;
+        }
+
+        public String getVertxContextClassName() {
+            Context vc = Vertx.currentContext();
+            return vc.getClass().getName();
+        }
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTracingTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTracingTest.java
@@ -28,7 +28,7 @@ public class GraphQLTracingTest extends AbstractGraphQLTest {
     static MockTracer mockTracer = new MockTracer();
 
     static {
-        GlobalTracer.register(mockTracer);
+        GlobalTracer.registerIfAbsent(mockTracer);
     }
 
     @BeforeEach

--- a/extensions/smallrye-graphql/deployment/src/test/resources/application-secured.properties
+++ b/extensions/smallrye-graphql/deployment/src/test/resources/application-secured.properties
@@ -3,3 +3,7 @@ quarkus.security.users.file.plain-text=true
 quarkus.security.users.file.users=users.properties
 quarkus.security.users.file.roles=roles.properties
 quarkus.http.auth.basic=true
+
+quarkus.smallrye-graphql.log-payload=queryAndVariables
+quarkus.smallrye-graphql.print-data-fetcher-exception=true
+quarkus.smallrye-graphql.error-extension-fields=exception,classification,code,description,validationErrorType,queryPath

--- a/extensions/smallrye-graphql/runtime/pom.xml
+++ b/extensions/smallrye-graphql/runtime/pom.xml
@@ -47,6 +47,12 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
@@ -24,6 +24,7 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
 
     private final CurrentIdentityAssociation currentIdentityAssociation;
     private final CurrentVertxRequest currentVertxRequest;
+    private final ManagedContext currentManagedContext;
 
     private volatile ExecutionService executionService;
 
@@ -35,24 +36,26 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
 
         this.currentIdentityAssociation = currentIdentityAssociation;
         this.currentVertxRequest = currentVertxRequest;
+        this.currentManagedContext = Arc.container().requestContext();
     }
 
     @Override
     public void handle(final RoutingContext ctx) {
-        ManagedContext requestContext = Arc.container().requestContext();
-        if (requestContext.isActive()) {
+
+        if (currentManagedContext.isActive()) {
             handleWithIdentity(ctx);
         } else {
-            try {
-                requestContext.activate();
-                handleWithIdentity(ctx);
-            } finally {
-                requestContext.terminate();
-            }
+
+            currentManagedContext.activate();
+            handleWithIdentity(ctx);
+
+            ctx.response().bodyEndHandler((e) -> {
+                currentManagedContext.terminate();
+            });
         }
     }
 
-    private void handleWithIdentity(final RoutingContext ctx) {
+    private Void handleWithIdentity(final RoutingContext ctx) {
         if (currentIdentityAssociation != null) {
             QuarkusHttpUser existing = (QuarkusHttpUser) ctx.user();
             if (existing != null) {
@@ -64,6 +67,7 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
         }
         currentVertxRequest.setCurrent(ctx);
         doHandle(ctx);
+        return null;
     }
 
     protected abstract void doHandle(final RoutingContext ctx);

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -45,6 +45,12 @@ public class SmallRyeGraphQLConfig {
     public boolean eventsEnabled;
 
     /**
+     * Enable non-blocking support. Default is true.
+     */
+    @ConfigItem(name = "nonblocking.enabled")
+    public Optional<Boolean> nonBlockingEnabled;
+
+    /**
      * Enable GET Requests. Allow queries via HTTP GET.
      */
     @ConfigItem(name = "http.get.enabled")

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLExecutionHandler.java
@@ -5,7 +5,10 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import javax.json.Json;
@@ -13,9 +16,14 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
 
+import graphql.ErrorType;
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.smallrye.graphql.execution.ExecutionResponse;
+import io.smallrye.graphql.execution.ExecutionResponseWriter;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
@@ -28,8 +36,9 @@ import io.vertx.ext.web.RoutingContext;
  * Handler that does the execution of GraphQL Requests
  */
 public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHandler {
-    private boolean allowGet = false;
-    private boolean allowPostWithQueryParameters = false;
+    private final boolean allowGet;
+    private final boolean allowPostWithQueryParameters;
+    private final boolean runBlocking;
     private static final String QUERY = "query";
     private static final String OPERATION_NAME = "operationName";
     private static final String VARIABLES = "variables";
@@ -42,12 +51,13 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
             + StandardCharsets.UTF_8.name();
     private static final String MISSING_OPERATION = "Missing operation body";
 
-    public SmallRyeGraphQLExecutionHandler(boolean allowGet, boolean allowPostWithQueryParameters,
+    public SmallRyeGraphQLExecutionHandler(boolean allowGet, boolean allowPostWithQueryParameters, boolean runBlocking,
             CurrentIdentityAssociation currentIdentityAssociation,
             CurrentVertxRequest currentVertxRequest) {
         super(currentIdentityAssociation, currentVertxRequest);
         this.allowGet = allowGet;
         this.allowPostWithQueryParameters = allowPostWithQueryParameters;
+        this.runBlocking = runBlocking;
     }
 
     @Override
@@ -90,7 +100,6 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
     private void handlePost(HttpServerResponse response, RoutingContext ctx, String requestedCharset) {
         try {
             JsonObject jsonObjectFromBody = getJsonObjectFromBody(ctx);
-            String postResponse;
             if (hasQueryParameters(ctx) && allowPostWithQueryParameters) {
                 JsonObject jsonObjectFromQueryParameters = getJsonObjectFromQueryParameters(ctx);
                 JsonObject mergedJsonObject;
@@ -104,15 +113,14 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
                     response.setStatusCode(400).end(MISSING_OPERATION);
                     return;
                 }
-                postResponse = doRequest(mergedJsonObject);
+                doRequest(mergedJsonObject, response, ctx, requestedCharset);
             } else {
                 if (jsonObjectFromBody == null) {
                     response.setStatusCode(400).end(MISSING_OPERATION);
                     return;
                 }
-                postResponse = doRequest(jsonObjectFromBody);
+                doRequest(jsonObjectFromBody, response, ctx, requestedCharset);
             }
-            response.setStatusCode(200).setStatusMessage(OK).end(Buffer.buffer(postResponse, requestedCharset));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
@@ -124,11 +132,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
                 JsonObject input = getJsonObjectFromQueryParameters(ctx);
 
                 if (input.containsKey(QUERY)) {
-                    String getResponse = doRequest(input);
-                    response.setStatusCode(200)
-                            .setStatusMessage(OK)
-                            .end(Buffer.buffer(getResponse, requestedCharset));
-
+                    doRequest(input, response, ctx, requestedCharset);
                 } else {
                     response.setStatusCode(400).end(MISSING_OPERATION);
                 }
@@ -281,10 +285,7 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
     private boolean hasQueryParameter(RoutingContext ctx, String parameterName) {
         List<String> all = ctx.queryParam(parameterName);
-        if (all != null && !all.isEmpty()) {
-            return true;
-        }
-        return false;
+        return all != null && !all.isEmpty();
     }
 
     private String getAllowedMethods() {
@@ -295,12 +296,23 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
         }
     }
 
-    private String doRequest(JsonObject jsonInput) {
-        ExecutionResponse executionResponse = getExecutionService().execute(jsonInput);
-        if (executionResponse != null) {
-            return executionResponse.getExecutionResultAsString();
+    private void doRequest(JsonObject jsonInput, HttpServerResponse response, RoutingContext ctx,
+            String requestedCharset) {
+        VertxExecutionResponseWrtiter writer = new VertxExecutionResponseWrtiter(response, ctx, requestedCharset);
+        // Add some context to dfe
+        Map<String, Object> metaData = new ConcurrentHashMap<>();
+        metaData.put("httpHeaders", getHeaders(ctx));
+        metaData.put("runBlocking", runBlocking);
+        getExecutionService().executeAsync(jsonInput, metaData, writer);
+    }
+
+    private Map<String, List<String>> getHeaders(RoutingContext ctx) {
+        Map<String, List<String>> h = new HashMap<>();
+        MultiMap headers = ctx.request().headers();
+        for (String header : headers.names()) {
+            h.put(header, headers.getAll(header));
         }
-        return null;
+        return h;
     }
 
     private static JsonObject toJsonObject(String jsonString) {
@@ -310,6 +322,51 @@ public class SmallRyeGraphQLExecutionHandler extends SmallRyeGraphQLAbstractHand
 
         try (JsonReader jsonReader = jsonReaderFactory.createReader(new StringReader(jsonString))) {
             return jsonReader.readObject();
+        }
+    }
+
+    class VertxExecutionResponseWrtiter implements ExecutionResponseWriter {
+
+        HttpServerResponse response;
+        String requestedCharset;
+        RoutingContext ctx;
+
+        VertxExecutionResponseWrtiter(HttpServerResponse response, RoutingContext ctx, String requestedCharset) {
+            this.response = response;
+            this.ctx = ctx;
+            this.requestedCharset = requestedCharset;
+        }
+
+        @Override
+        public void write(ExecutionResponse er) {
+
+            if (shouldFail(er)) {
+                response.setStatusCode(500)
+                        .end();
+            } else {
+                response.setStatusCode(200)
+                        .setStatusMessage(OK)
+                        .end(Buffer.buffer(er.getExecutionResultAsString(), requestedCharset));
+            }
+        }
+
+        @Override
+        public void fail(Throwable t) {
+            ctx.fail(t);
+        }
+
+        private boolean shouldFail(ExecutionResponse er) {
+            ExecutionResult executionResult = er.getExecutionResult();
+
+            if (executionResult.isDataPresent() && executionResult.getErrors().size() > 0) {
+                // See if there was a httpfailure
+                for (GraphQLError error : executionResult.getErrors()) {
+                    if (error.getErrorType().equals(ErrorType.ExecutionAborted)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLLocaleResolver.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLLocaleResolver.java
@@ -1,0 +1,56 @@
+package io.quarkus.smallrye.graphql.runtime;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Singleton;
+
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.execution.context.SmallRyeContext;
+import io.smallrye.graphql.execution.context.SmallRyeContextManager;
+
+/**
+ * Resolving BV messages for SmallRye GraphQL
+ */
+@Singleton
+public class SmallRyeGraphQLLocaleResolver implements LocaleResolver {
+
+    private static final String ACCEPT_HEADER = "Accept-Language";
+
+    @Override
+    public Locale resolve(LocaleResolverContext context) {
+        Optional<List<Locale.LanguageRange>> localePriorities = getAcceptableLanguages();
+        if (!localePriorities.isPresent()) {
+            return null;
+        }
+        List<Locale> resolvedLocales = Locale.filter(localePriorities.get(), context.getSupportedLocales());
+        if (!resolvedLocales.isEmpty()) {
+            return resolvedLocales.get(0);
+        }
+
+        return null;
+    }
+
+    private Optional<List<Locale.LanguageRange>> getAcceptableLanguages() {
+        Map<String, List<String>> httpHeaders = getHeaders();
+        if (httpHeaders != null) {
+            List<String> acceptLanguageList = httpHeaders.get(ACCEPT_HEADER);
+            if (acceptLanguageList != null && !acceptLanguageList.isEmpty()) {
+                return Optional.of(Locale.LanguageRange.parse(acceptLanguageList.get(0)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, List<String>> getHeaders() {
+        SmallRyeContext smallRyeContext = SmallRyeContextManager.getCurrentSmallRyeContext();
+        DataFetchingEnvironment dfe = smallRyeContext.unwrap(DataFetchingEnvironment.class);
+        return (Map<String, List<String>>) dfe.getGraphQlContext().get("httpHeaders");
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLOverWebSocketHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLOverWebSocketHandler.java
@@ -34,11 +34,11 @@ public class SmallRyeGraphQLOverWebSocketHandler extends SmallRyeGraphQLAbstract
                     switch (subprotocol) {
                         case "graphql-transport-ws":
                             handler = new GraphQLTransportWSSubprotocolHandler(
-                                    new QuarkusVertxWebSocketSession(serverWebSocket), getExecutionService());
+                                    new QuarkusVertxWebSocketSession(serverWebSocket));
                             break;
                         case "graphql-ws":
                             handler = new GraphQLWSSubprotocolHandler(
-                                    new QuarkusVertxWebSocketSession(serverWebSocket), getExecutionService());
+                                    new QuarkusVertxWebSocketSession(serverWebSocket));
                             break;
                         default:
                             log.warn("Unknown graphql-over-websocket protocol: " + subprotocol);

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -3,10 +3,9 @@ package io.quarkus.smallrye.graphql.runtime;
 import java.util.List;
 import java.util.function.Consumer;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.CDI;
-
 import graphql.schema.GraphQLSchema;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
@@ -33,10 +32,11 @@ public class SmallRyeGraphQLRecorder {
     }
 
     public Handler<RoutingContext> executionHandler(RuntimeValue<Boolean> initialized, boolean allowGet,
-            boolean allowPostWithQueryParameters) {
+            boolean allowPostWithQueryParameters, boolean runBlocking) {
         if (initialized.getValue()) {
-            return new SmallRyeGraphQLExecutionHandler(allowGet, allowPostWithQueryParameters, getCurrentIdentityAssociation(),
-                    CDI.current().select(CurrentVertxRequest.class).get());
+            return new SmallRyeGraphQLExecutionHandler(allowGet, allowPostWithQueryParameters, runBlocking,
+                    getCurrentIdentityAssociation(),
+                    Arc.container().instance(CurrentVertxRequest.class).get());
         } else {
             return new SmallRyeGraphQLNoEndpointHandler();
         }
@@ -44,7 +44,7 @@ public class SmallRyeGraphQLRecorder {
 
     public Handler<RoutingContext> graphqlOverWebsocketHandler(BeanContainer beanContainer, RuntimeValue<Boolean> initialized) {
         return new SmallRyeGraphQLOverWebSocketHandler(getCurrentIdentityAssociation(),
-                CDI.current().select(CurrentVertxRequest.class).get());
+                Arc.container().instance(CurrentVertxRequest.class).get());
     }
 
     public Handler<RoutingContext> schemaHandler(RuntimeValue<Boolean> initialized, boolean schemaAvailable) {
@@ -89,9 +89,9 @@ public class SmallRyeGraphQLRecorder {
     }
 
     private CurrentIdentityAssociation getCurrentIdentityAssociation() {
-        Instance<CurrentIdentityAssociation> identityAssociations = CDI.current()
-                .select(CurrentIdentityAssociation.class);
-        if (identityAssociations.isResolvable()) {
+        InstanceHandle<CurrentIdentityAssociation> identityAssociations = Arc.container()
+                .instance(CurrentIdentityAssociation.class);
+        if (identityAssociations.isAvailable()) {
             return identityAssociations.get();
         }
         return null;

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/AbstractAsyncDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/AbstractAsyncDataFetcher.java
@@ -1,0 +1,85 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.graphql.GraphQLException;
+
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.smallrye.graphql.SmallRyeGraphQLServerMessages;
+import io.smallrye.graphql.execution.datafetcher.AbstractDataFetcher;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.transformation.AbstractDataFetcherException;
+import io.smallrye.mutiny.Uni;
+
+public abstract class AbstractAsyncDataFetcher<K, T> extends AbstractDataFetcher<K, T> {
+
+    public AbstractAsyncDataFetcher(Operation operation, Type type) {
+        super(operation, type);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <O> O invokeAndTransform(
+            DataFetchingEnvironment dfe,
+            DataFetcherResult.Builder<Object> resultBuilder,
+            Object[] transformedArguments) throws Exception {
+
+        Uni<?> uni = handleUserMethodCall(dfe, transformedArguments);
+        return (O) uni
+                .onItemOrFailure()
+                .transformToUni((result, throwable, emitter) -> {
+                    if (throwable != null) {
+                        eventEmitter.fireOnDataFetchError(dfe.getExecutionId().toString(), throwable);
+                        if (throwable instanceof GraphQLException) {
+                            GraphQLException graphQLException = (GraphQLException) throwable;
+                            errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+                        } else if (throwable instanceof Exception) {
+                            emitter.fail(SmallRyeGraphQLServerMessages.msg.dataFetcherException(operation, throwable));
+                            return;
+                        } else if (throwable instanceof Error) {
+                            emitter.fail(throwable);
+                            return;
+                        }
+                    } else {
+                        try {
+                            resultBuilder.data(fieldHelper.transformOrAdaptResponse(result, dfe));
+                        } catch (AbstractDataFetcherException te) {
+                            te.appendDataFetcherResult(resultBuilder, dfe);
+                        }
+                    }
+
+                    emitter.complete(resultBuilder.build());
+                })
+                .subscribe()
+                .asCompletionStage();
+    }
+
+    protected abstract Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, final Object[] transformedArguments)
+            throws Exception;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <O> O invokeFailure(DataFetcherResult.Builder<Object> resultBuilder) {
+        return (O) Uni.createFrom()
+                .item(resultBuilder::build)
+                .subscribe()
+                .asCompletionStage();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected CompletionStage<List<T>> invokeBatch(DataFetchingEnvironment dfe, Object[] arguments) {
+        try {
+            return handleUserBatchLoad(dfe, arguments)
+                    .subscribe().asCompletionStage();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected abstract Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, final Object[] arguments)
+            throws Exception;
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/BlockingHelper.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import java.util.concurrent.Callable;
+
+import io.smallrye.graphql.schema.model.Execute;
+import io.smallrye.graphql.schema.model.Operation;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+
+public class BlockingHelper {
+
+    public static boolean blockingShouldExecuteNonBlocking(Operation operation, Context vc) {
+        // Rule is that by default this should execute blocking except if marked as non blocking)
+        return operation.getExecute().equals(Execute.NON_BLOCKING);
+    }
+
+    public static boolean nonBlockingShouldExecuteBlocking(Operation operation, Context vc) {
+        // Rule is that by default this should execute non-blocking except if marked as blocking)
+        return operation.getExecute().equals(Execute.BLOCKING) && vc.isEventLoopContext();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void runBlocking(Context vc, Callable<Object> contextualCallable, Promise result) {
+        // Here call blocking with context
+        vc.executeBlocking(future -> {
+            try {
+                future.complete(contextualCallable.call());
+            } catch (Exception ex) {
+                future.fail(ex);
+            }
+        }, result);
+    }
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusCompletionStageDataFetcher.java
@@ -1,0 +1,96 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.quarkus.arc.Arc;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class QuarkusCompletionStageDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> {
+
+    public QuarkusCompletionStageDataFetcher(Operation operation, Type type) {
+        super(operation, type);
+    }
+
+    @Override
+    protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+            return handleUserMethodCallNonBlocking(transformedArguments);
+        } else {
+            return handleUserMethodCallBlocking(transformedArguments, vc);
+        }
+    }
+
+    @Override
+    protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+            return handleUserBatchLoadNonBlocking(arguments);
+        } else {
+            return handleUserBatchLoadBlocking(arguments, vc);
+        }
+    }
+
+    private Uni<?> handleUserMethodCallNonBlocking(Object[] transformedArguments)
+            throws Exception {
+        return Uni.createFrom()
+                .completionStage((CompletionStage<?>) operationInvoker.invoke(transformedArguments));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments, Context vc)
+            throws Exception {
+
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<T> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            CompletionStage<?> resultFromMethodCall = (CompletionStage<?>) operationInvoker
+                    .invoke(transformedArguments);
+            return resultFromMethodCall.toCompletableFuture().get();
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return Uni.createFrom().completionStage(result.future().toCompletionStage());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Uni<List<T>> handleUserBatchLoadNonBlocking(Object[] arguments) throws Exception {
+        return Uni.createFrom().completionStage((CompletionStage<List<T>>) operationInvoker.invoke(arguments));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Uni<List<T>> handleUserBatchLoadBlocking(Object[] arguments, Context vc)
+            throws Exception {
+
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<List<T>> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            @SuppressWarnings("unchecked")
+            CompletionStage<List<T>> resultFromMethodCall = (CompletionStage<List<T>>) operationInvoker
+                    .invoke(arguments);
+            return resultFromMethodCall.toCompletableFuture().get();
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return Uni.createFrom().completionStage(result.future().toCompletionStage());
+    }
+
+    private boolean runBlocking(DataFetchingEnvironment dfe) {
+        return dfe.getGraphQlContext().get("runBlocking");
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDataFetcherService.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDataFetcherService.java
@@ -1,0 +1,35 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import io.smallrye.graphql.execution.datafetcher.PlugableDataFetcher;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.spi.DataFetcherService;
+
+/**
+ * Some Quarkus specific datafetchers to execute reactive on the correct thread
+ */
+public class QuarkusDataFetcherService implements DataFetcherService {
+
+    private final int priority = 1;
+
+    @Override
+    public Integer getPriority() {
+        return priority;
+    }
+
+    @Override
+    public PlugableDataFetcher getUniDataFetcher(Operation operation, Type type) {
+        return new QuarkusUniDataFetcher(operation, type);
+    }
+
+    @Override
+    public PlugableDataFetcher getDefaultDataFetcher(Operation operation, Type type) {
+        return new QuarkusDefaultDataFetcher(operation, type);
+    }
+
+    @Override
+    public PlugableDataFetcher getCompletionStageDataFetcher(Operation operation, Type type) {
+        return new QuarkusCompletionStageDataFetcher(operation, type);
+    }
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusDefaultDataFetcher.java
@@ -1,0 +1,101 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.graphql.GraphQLException;
+
+import graphql.execution.AbortExecutionException;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.quarkus.arc.Arc;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.graphql.execution.datafetcher.DefaultDataFetcher;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.graphql.transformation.AbstractDataFetcherException;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class QuarkusDefaultDataFetcher<K, T> extends DefaultDataFetcher<K, T> {
+
+    public QuarkusDefaultDataFetcher(Operation operation, Type type) {
+        super(operation, type);
+    }
+
+    @Override
+    public <T> T invokeAndTransform(DataFetchingEnvironment dfe, DataFetcherResult.Builder<Object> resultBuilder,
+            Object[] transformedArguments) throws Exception {
+
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
+            return super.invokeAndTransform(dfe, resultBuilder, transformedArguments);
+        } else {
+            return invokeAndTransformBlocking(dfe, resultBuilder, transformedArguments, vc);
+        }
+    }
+
+    @Override
+    public CompletionStage<List<T>> invokeBatch(DataFetchingEnvironment dfe, Object[] arguments) {
+
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || BlockingHelper.blockingShouldExecuteNonBlocking(operation, vc)) {
+            return super.invokeBatch(dfe, arguments);
+        } else {
+            return invokeBatchBlocking(arguments, vc);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T invokeAndTransformBlocking(final DataFetchingEnvironment dfe, DataFetcherResult.Builder<Object> resultBuilder,
+            Object[] transformedArguments, Context vc) throws Exception {
+
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<T> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        @SuppressWarnings("unchecked")
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            try {
+                Object resultFromMethodCall = operationInvoker.invoke(transformedArguments);
+                Object resultFromTransform = fieldHelper.transformOrAdaptResponse(resultFromMethodCall, dfe);
+                resultBuilder.data(resultFromTransform);
+                return (T) resultBuilder.build();
+            } catch (AbstractDataFetcherException te) {
+                te.appendDataFetcherResult(resultBuilder, dfe);
+                return (T) resultBuilder.build();
+            } catch (GraphQLException graphQLException) {
+                errorResultHelper.appendPartialResult(resultBuilder, dfe, graphQLException);
+                return (T) resultBuilder.build();
+            } catch (Error e) {
+                resultBuilder.clearErrors().data(null).error(new AbortExecutionException(e));
+                return (T) resultBuilder.build();
+            }
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return (T) result.future().toCompletionStage();
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletionStage<List<T>> invokeBatchBlocking(Object[] arguments, Context vc) {
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<List<T>> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            return (List<T>) operationInvoker.invokePrivileged(arguments);
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return result.future().toCompletionStage();
+    }
+
+    private boolean runBlocking(DataFetchingEnvironment dfe) {
+        return dfe.getGraphQlContext().get("runBlocking");
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/spi/datafetcher/QuarkusUniDataFetcher.java
@@ -1,0 +1,93 @@
+package io.quarkus.smallrye.graphql.runtime.spi.datafetcher;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.quarkus.arc.Arc;
+import io.smallrye.context.SmallRyeThreadContext;
+import io.smallrye.graphql.schema.model.Operation;
+import io.smallrye.graphql.schema.model.Type;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class QuarkusUniDataFetcher<K, T> extends AbstractAsyncDataFetcher<K, T> {
+
+    public QuarkusUniDataFetcher(Operation operation, Type type) {
+        super(operation, type);
+    }
+
+    @Override
+    protected Uni<?> handleUserMethodCall(DataFetchingEnvironment dfe, Object[] transformedArguments) throws Exception {
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+            return handleUserMethodCallNonBlocking(transformedArguments);
+        } else {
+            return handleUserMethodCallBlocking(transformedArguments, vc);
+        }
+    }
+
+    @Override
+    protected Uni<List<T>> handleUserBatchLoad(DataFetchingEnvironment dfe, Object[] arguments) throws Exception {
+        Context vc = Vertx.currentContext();
+        if (runBlocking(dfe) || !BlockingHelper.nonBlockingShouldExecuteBlocking(operation, vc)) {
+            return handleUserBatchLoadNonBlocking(arguments);
+        } else {
+            return handleUserBatchLoadBlocking(arguments, vc);
+        }
+    }
+
+    private Uni<?> handleUserMethodCallNonBlocking(final Object[] transformedArguments)
+            throws Exception {
+        return (Uni<?>) operationInvoker.invoke(transformedArguments);
+    }
+
+    private Uni<?> handleUserMethodCallBlocking(Object[] transformedArguments, Context vc)
+            throws Exception {
+
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<T> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            Object resultFromMethodCall = operationInvoker.invoke(transformedArguments);
+            Uni<?> uniFromMethodCall = (Uni<?>) resultFromMethodCall;
+            return uniFromMethodCall.subscribeAsCompletionStage().get();
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return Uni.createFrom().completionStage(result.future().toCompletionStage());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Uni<List<T>> handleUserBatchLoadNonBlocking(final Object[] arguments)
+            throws Exception {
+        return ((Uni<List<T>>) operationInvoker.invoke(arguments));
+    }
+
+    private Uni<List<T>> handleUserBatchLoadBlocking(Object[] arguments, Context vc)
+            throws Exception {
+
+        SmallRyeThreadContext threadContext = Arc.container().select(SmallRyeThreadContext.class).get();
+        final Promise<List<T>> result = Promise.promise();
+
+        // We need some make sure that we call given the context
+        Callable<Object> contextualCallable = threadContext.contextualCallable(() -> {
+            Object resultFromMethodCall = operationInvoker.invoke(arguments);
+            @SuppressWarnings("unchecked")
+            Uni<List<T>> uniFromMethodCall = (Uni<List<T>>) resultFromMethodCall;
+            return uniFromMethodCall.subscribeAsCompletionStage().get();
+        });
+
+        // Here call blocking with context
+        BlockingHelper.runBlocking(vc, contextualCallable, result);
+        return Uni.createFrom().completionStage(result.future().toCompletionStage());
+    }
+
+    private boolean runBlocking(DataFetchingEnvironment dfe) {
+        return dfe.getGraphQlContext().get("runBlocking");
+    }
+}

--- a/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/services/io.smallrye.graphql.spi.DataFetcherService
+++ b/extensions/smallrye-graphql/runtime/src/main/resources/META-INF/services/io.smallrye.graphql.spi.DataFetcherService
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.graphql.runtime.spi.datafetcher.QuarkusDataFetcherService


### PR DESCRIPTION
This PR pulls in a new release from SmallRye (https://github.com/smallrye/smallrye-graphql/releases/tag/1.5.0) and adds supports for Non blocking operations. The same rule applies as with RESTEasy Reactive. 

- By default, normal response objects will execute blocking, except if marked with `@NonBlocking`
- By default, Uni and CompletionStage response objects will execute non-blocking, except if marked with `@Blocking`

Breaking change: The ExecutionService has changed to not respond with a result, but rather a writer needs to be passed in. a default [JsonObjectResponseWriter](https://github.com/smallrye/smallrye-graphql/blob/main/server/implementation/src/main/java/io/smallrye/graphql/execution/JsonObjectResponseWriter.java) exist to get the same result as before. 

Because this is a major new feature, non-blocking can be turned off using a config: `quarkus.smallrye-graphql.nonblocking.enabled=false`. By default it will be enabled

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>