### PR TITLE
Do not disable DevServicesElasticsearchDevModeTestCase on Windows

### DIFF
--- a/extensions/elasticsearch-rest-client/deployment/src/test/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/DevServicesElasticsearchDevModeTestCase.java
+++ b/extensions/elasticsearch-rest-client/deployment/src/test/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/DevServicesElasticsearchDevModeTestCase.java
@@ -3,14 +3,11 @@ package io.quarkus.elasticsearch.restclient.lowlevel.runtime;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
-@DisabledOnOs(OS.WINDOWS)
 public class DevServicesElasticsearchDevModeTestCase {
     @RegisterExtension
     static QuarkusDevModeTest test = new QuarkusDevModeTest()


### PR DESCRIPTION
This was not the proper fix: the Docker run should have been guarded
against.

The issue has been fixed by Holly here:
https://github.com/quarkusio/quarkus/pull/25147

So let's enable the test.