### PR TITLE
Implement a prototype for how to selectively (and manually) eliminate Service Loading

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/ServiceProviderBuildItem.java
@@ -154,6 +154,10 @@ public final class ServiceProviderBuildItem extends MultiBuildItem {
         return providers;
     }
 
+    public String getServiceInterface() {
+        return serviceInterface;
+    }
+
     /**
      * @return the resource path for the service descriptor file
      */

--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/ServiceLoadingRemovalProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/ServiceLoadingRemovalProcessor.java
@@ -1,0 +1,291 @@
+package io.quarkus.deployment.configuration;
+
+import static org.objectweb.asm.Opcodes.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.runtime.configuration.QuarkusConfigFactory;
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.ConfigValidator;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigProviderResolver;
+
+public class ServiceLoadingRemovalProcessor {
+
+    private static final String CTOR_NAME = "<init>";
+
+    private static final String ARRAYLIST_BINARY_NAME = "java/util/ArrayList";
+    private static final String LIST_BINARY_NAME = "java/util/List";
+
+    private static final String CONFIG_VALIDATOR_CLASS_NAME = ConfigValidator.class.getName();
+    private static final String CONFIG_VALIDATOR_BINARY_NAME = CONFIG_VALIDATOR_CLASS_NAME.replace('.', '/');
+
+    private static final String CONFIG_SOURCE_INTERCEPTOR_CLASS_NAME = ConfigSourceInterceptor.class.getName();
+    private static final String CONFIG_SOURCE_INTERCEPTOR_BINARY_NAME = CONFIG_SOURCE_INTERCEPTOR_CLASS_NAME.replace('.', '/');
+
+    private static final String CONFIG_SOURCE_INTERCEPTOR_FACTORY_CLASS_NAME = ConfigSourceInterceptorFactory.class.getName();
+    private static final String CONFIG_SOURCE_INTERCEPTOR_FACTORY_BINARY_NAME = CONFIG_SOURCE_INTERCEPTOR_FACTORY_CLASS_NAME
+            .replace('.', '/');
+
+    private static final String INTERCEPTOR_WITH_PRIORITY_CLASS_NAME = "io/smallrye/config/SmallRyeConfigBuilder$InterceptorWithPriority";
+    private static final String INTERCEPTOR_WITH_PRIORITY_BINARY_NAME = INTERCEPTOR_WITH_PRIORITY_CLASS_NAME.replace('.', '/');
+
+    private static final String CONVERTER_CLASS_NAME = Converter.class.getName();
+    private static final String CONVERTER_BINARY_NAME = CONVERTER_CLASS_NAME
+            .replace('.', '/');
+
+    // only done in normal mode since there is not much benefit for tests and dev mode
+    // moreover, by doing it only for normal mode, we can instantiate the classes without
+    // having to using reflection and the TCCL
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformSmallRyeConfigBuilder(List<ServiceProviderBuildItem> servicesItems,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+
+        Services services = determineValidatorImplementation(servicesItems);
+        producer.produce(new BytecodeTransformerBuildItem(SmallRyeConfigBuilder.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+                                if (name.equals("discoverValidator")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (services.validator == null) {
+                                                visitFieldInsn(Opcodes.GETSTATIC, CONFIG_VALIDATOR_BINARY_NAME, "EMPTY",
+                                                        "L" + CONFIG_VALIDATOR_BINARY_NAME + ";");
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else {
+                                                String validatorImplBinaryName = services.validator.replace('.', '/');
+                                                visitTypeInsn(NEW, validatorImplBinaryName);
+                                                visitInsn(Opcodes.DUP);
+                                                visitMethodInsn(Opcodes.INVOKESPECIAL, validatorImplBinaryName,
+                                                        CTOR_NAME, "()V",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            }
+
+                                        }
+                                    };
+                                } else if (name.equals("discoverInterceptors")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (services.interceptorFactoryImpls.isEmpty()
+                                                    && services.interceptorImpls.isEmpty()) {
+                                                visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                        "()Ljava/util/List;",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else {
+                                                visitTypeInsn(NEW, ARRAYLIST_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitIntInsn(BIPUSH,
+                                                        services.interceptorImpls.size()
+                                                                + services.interceptorFactoryImpls.size());
+                                                visitMethodInsn(INVOKESPECIAL, ARRAYLIST_BINARY_NAME, CTOR_NAME, "(I)V", false);
+                                                visitVarInsn(ASTORE, 1);
+                                                visitVarInsn(ALOAD, 1);
+                                                for (String interceptorImpl : services.interceptorImpls) {
+                                                    String binaryName = interceptorImpl.replace('.', '/');
+                                                    visitTypeInsn(NEW, INTERCEPTOR_WITH_PRIORITY_BINARY_NAME);
+                                                    visitInsn(DUP);
+                                                    visitTypeInsn(NEW, binaryName);
+                                                    visitInsn(DUP);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            binaryName, CTOR_NAME, "()V", false);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            INTERCEPTOR_WITH_PRIORITY_BINARY_NAME, CTOR_NAME,
+                                                            "(L" + CONFIG_SOURCE_INTERCEPTOR_BINARY_NAME + ";)V", false);
+                                                    visitMethodInsn(INVOKEINTERFACE, LIST_BINARY_NAME, "add",
+                                                            "(Ljava/lang/Object;)Z", true);
+                                                    visitInsn(POP);
+                                                    visitVarInsn(ALOAD, 1);
+                                                }
+                                                for (String interceptorFactoryImpl : services.interceptorFactoryImpls) {
+                                                    String binaryName = interceptorFactoryImpl.replace('.', '/');
+                                                    visitTypeInsn(NEW, INTERCEPTOR_WITH_PRIORITY_BINARY_NAME);
+                                                    visitInsn(DUP);
+                                                    visitTypeInsn(NEW, binaryName);
+                                                    visitInsn(DUP);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            binaryName, CTOR_NAME, "()V", false);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            INTERCEPTOR_WITH_PRIORITY_BINARY_NAME, CTOR_NAME,
+                                                            "(L" + CONFIG_SOURCE_INTERCEPTOR_FACTORY_BINARY_NAME + ";)V",
+                                                            false);
+                                                    visitMethodInsn(INVOKEINTERFACE, LIST_BINARY_NAME, "add",
+                                                            "(Ljava/lang/Object;)Z", true);
+                                                    visitInsn(POP);
+                                                    visitVarInsn(ALOAD, 1);
+                                                }
+                                                visitInsn(ARETURN);
+                                            }
+                                        }
+                                    };
+                                } else if (name.equals("discoverConverters")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (services.converters.isEmpty()) {
+                                                visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                        "()Ljava/util/List;",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else {
+                                                visitTypeInsn(NEW, ARRAYLIST_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitIntInsn(BIPUSH,
+                                                        services.converters.size());
+                                                visitMethodInsn(INVOKESPECIAL, ARRAYLIST_BINARY_NAME, CTOR_NAME, "(I)V", false);
+                                                visitVarInsn(ASTORE, 1);
+                                                visitVarInsn(ALOAD, 1);
+                                                for (String converterImpl : services.converters) {
+                                                    String binaryName = converterImpl.replace('.', '/');
+                                                    visitTypeInsn(NEW, binaryName);
+                                                    visitInsn(DUP);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            binaryName, CTOR_NAME, "()V", false);
+                                                    visitMethodInsn(INVOKEINTERFACE, LIST_BINARY_NAME, "add",
+                                                            "(Ljava/lang/Object;)Z", true);
+                                                    visitInsn(POP);
+                                                    visitVarInsn(ALOAD, 1);
+                                                }
+                                                visitInsn(ARETURN);
+                                            }
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+
+        producer.produce(new BytecodeTransformerBuildItem(ConfigProviderResolver.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadSpi")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            String binaryName = SmallRyeConfigProviderResolver.class.getName().replace('.',
+                                                    '/');
+                                            visitTypeInsn(NEW, binaryName);
+                                            visitInsn(DUP);
+                                            visitMethodInsn(INVOKESPECIAL,
+                                                    binaryName, CTOR_NAME, "()V", false);
+                                            visitInsn(ARETURN);
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+
+        producer.produce(new BytecodeTransformerBuildItem(SmallRyeConfigProviderResolver.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("getFactoryFor")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            String binaryName = QuarkusConfigFactory.class.getName().replace('.',
+                                                    '/');
+                                            visitTypeInsn(NEW, binaryName);
+                                            visitInsn(DUP);
+                                            visitMethodInsn(INVOKESPECIAL,
+                                                    binaryName, CTOR_NAME, "()V", false);
+                                            visitInsn(ARETURN);
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+
+    private Services determineValidatorImplementation(List<ServiceProviderBuildItem> services) {
+        String validatorImpl = null;
+        List<String> interceptorImpls = new ArrayList<>();
+        List<String> interceptorFactoryImpls = new ArrayList<>();
+        List<String> converters = new ArrayList<>();
+        for (ServiceProviderBuildItem service : services) {
+            String serviceInterface = service.getServiceInterface();
+            if (CONFIG_VALIDATOR_CLASS_NAME.equals(serviceInterface)) {
+                if (service.providers().size() == 1) {
+                    validatorImpl = service.providers().get(0);
+                }
+            } else if (CONFIG_SOURCE_INTERCEPTOR_CLASS_NAME.equals(serviceInterface)) {
+                interceptorImpls.addAll(service.providers());
+            } else if (CONFIG_SOURCE_INTERCEPTOR_FACTORY_CLASS_NAME.equals(serviceInterface)) {
+                interceptorFactoryImpls.addAll(service.providers());
+            } else if (CONVERTER_CLASS_NAME.equals(serviceInterface)) {
+                converters.addAll(service.providers());
+            }
+        }
+        return new Services(validatorImpl, interceptorImpls, interceptorFactoryImpls, converters);
+    }
+
+    private static class Services {
+        final String validator;
+        final List<String> interceptorImpls;
+        final List<String> interceptorFactoryImpls;
+        final List<String> converters;
+
+        private Services(String validator, List<String> interceptorImpls,
+                List<String> interceptorFactoryImpls, List<String> converters) {
+            this.validator = validator;
+            this.interceptorImpls = interceptorImpls;
+            this.interceptorFactoryImpls = interceptorFactoryImpls;
+            this.converters = converters;
+        }
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedComponentProviderBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/GeneratedComponentProviderBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.deployment;
+
+import java.util.List;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Contains the names of the generated implementations of {@link io.quarkus.arc.ComponentsProvider}
+ */
+public final class GeneratedComponentProviderBuildItem extends SimpleBuildItem {
+
+    private final List<String> implNames;
+
+    public GeneratedComponentProviderBuildItem(List<String> implNames) {
+        this.implNames = implNames;
+    }
+
+    public List<String> getImplNames() {
+        return implNames;
+    }
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ServiceLoadingRemovalProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ServiceLoadingRemovalProcessor.java
@@ -1,0 +1,126 @@
+package io.quarkus.arc.deployment;
+
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.BIPUSH;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.objectweb.asm.Opcodes.POP;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.arc.ResourceReferenceProvider;
+import io.quarkus.arc.impl.ArcContainerImpl;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.gizmo.Gizmo;
+
+public class ServiceLoadingRemovalProcessor {
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformArcContainerImpl(GeneratedComponentProviderBuildItem generatedComponentProviders,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformer) {
+
+        List<String> resourceProviders = ServiceProviderBuildItem
+                .allProvidersFromClassPath(ResourceReferenceProvider.class.getName()).providers();
+        List<String> componentProviders = generatedComponentProviders.getImplNames();
+
+        bytecodeTransformer.produce(new BytecodeTransformerBuildItem(ArcContainerImpl.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            private static final String CTOR_NAME = "<init>";
+
+                            private static final String ARRAYLIST_BINARY_NAME = "java/util/ArrayList";
+                            private static final String LIST_BINARY_NAME = "java/util/List";
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadComponentsProviders")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (componentProviders.isEmpty()) {
+                                                visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                        "()Ljava/util/List;",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else {
+                                                visitTypeInsn(NEW, ARRAYLIST_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitIntInsn(BIPUSH, componentProviders.size());
+                                                visitMethodInsn(INVOKESPECIAL, ARRAYLIST_BINARY_NAME, CTOR_NAME, "(I)V", false);
+                                                visitVarInsn(ASTORE, 1);
+                                                visitVarInsn(ALOAD, 1);
+                                                for (String component : componentProviders) {
+                                                    String binaryName = component.replace('.', '/');
+                                                    visitTypeInsn(NEW, binaryName);
+                                                    visitInsn(DUP);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            binaryName, CTOR_NAME, "()V", false);
+                                                    visitMethodInsn(INVOKEINTERFACE, LIST_BINARY_NAME, "add",
+                                                            "(Ljava/lang/Object;)Z", true);
+                                                    visitInsn(POP);
+                                                    visitVarInsn(ALOAD, 1);
+                                                }
+                                                visitInsn(ARETURN);
+                                            }
+                                        }
+                                    };
+                                } else if (name.equals("loadResourceProviders")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (resourceProviders.isEmpty()) {
+                                                visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                        "()Ljava/util/List;",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else {
+                                                visitTypeInsn(NEW, ARRAYLIST_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitIntInsn(BIPUSH, resourceProviders.size());
+                                                visitMethodInsn(INVOKESPECIAL, ARRAYLIST_BINARY_NAME, CTOR_NAME, "(I)V", false);
+                                                visitVarInsn(ASTORE, 1);
+                                                visitVarInsn(ALOAD, 1);
+                                                for (String resourceProvider : resourceProviders) {
+                                                    String binaryName = resourceProvider.replace('.', '/');
+                                                    visitTypeInsn(NEW, binaryName);
+                                                    visitInsn(DUP);
+                                                    visitMethodInsn(INVOKESPECIAL,
+                                                            binaryName, CTOR_NAME, "()V", false);
+                                                    visitMethodInsn(INVOKEINTERFACE, LIST_BINARY_NAME, "add",
+                                                            "(Ljava/lang/Object;)Z", true);
+                                                    visitInsn(POP);
+                                                    visitVarInsn(ALOAD, 1);
+                                                }
+                                                visitInsn(ARETURN);
+                                            }
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+}

--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/ServiceLoadingRemovalProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/ServiceLoadingRemovalProcessor.java
@@ -1,0 +1,87 @@
+package io.quarkus.mutiny.deployment;
+
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.gizmo.Gizmo;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+
+public class ServiceLoadingRemovalProcessor {
+
+    //TODO: this simply returns empty lists because we don't currently register the implementations with ServiceProviderBuildItem
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformSmallRyeConfigBuilder(List<ServiceProviderBuildItem> servicesItems,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        producer.produce(new BytecodeTransformerBuildItem(Infrastructure.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadExecutorConfiguration")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitInsn(ACONST_NULL);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                } else if (name.equals("loadUniInterceptors")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                    "()Ljava/util/List;",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                } else if (name.equals("loadMultiInterceptors")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                    "()Ljava/util/List;",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                } else if (name.equals("loadCallbackDecorators")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                    "()Ljava/util/List;",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ServiceLoadingRemovalProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/deployment/src/main/java/io/quarkus/resteasy/reactive/common/deployment/ServiceLoadingRemovalProcessor.java
@@ -1,0 +1,122 @@
+package io.quarkus.resteasy.reactive.common.deployment;
+
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.NEW;
+
+import java.util.function.BiFunction;
+
+import javax.ws.rs.ext.RuntimeDelegate;
+
+import org.jboss.resteasy.reactive.common.jaxrs.RuntimeDelegateImpl;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.gizmo.Gizmo;
+
+public class ServiceLoadingRemovalProcessor {
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformArcContainerImpl(Capabilities capabilities,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformer) {
+
+        boolean isServerPresent = capabilities.isPresent(Capability.RESTEASY_REACTIVE);
+        boolean isClientPresent = capabilities.isPresent(Capability.REST_CLIENT);
+
+        if (!(isServerPresent || isClientPresent)) {
+            return;
+        }
+        bytecodeTransformer.produce(new BytecodeTransformerBuildItem(RuntimeDelegateImpl.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            private static final String CTOR_NAME = "<init>";
+
+                            private static final String SERVER_FACTORY_BINARY_NAME = "org/jboss/resteasy/reactive/server/core/ServerResponseBuilderFactory";
+                            private static final String CLIENT_FACTORY_BINARY_NAME = "io/quarkus/jaxrs/client/reactive/runtime/ClientResponseBuilderFactory";
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadAndDetermineResponseBuilderFactory")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            if (isServerPresent) {
+                                                visitTypeInsn(NEW, SERVER_FACTORY_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitMethodInsn(Opcodes.INVOKESPECIAL, SERVER_FACTORY_BINARY_NAME,
+                                                        CTOR_NAME, "()V",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            } else if (isClientPresent) {
+                                                visitTypeInsn(NEW, CLIENT_FACTORY_BINARY_NAME);
+                                                visitInsn(DUP);
+                                                visitMethodInsn(Opcodes.INVOKESPECIAL, CLIENT_FACTORY_BINARY_NAME,
+                                                        CTOR_NAME, "()V",
+                                                        false);
+                                                visitInsn(Opcodes.ARETURN);
+                                            }
+                                        }
+                                    };
+                                }
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformRuntimeDelegate(Capabilities capabilities,
+            BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformer) {
+        if (!capabilities.isPresent(Capability.RESTEASY_REACTIVE)) {
+            return;
+        }
+        bytecodeTransformer.produce(new BytecodeTransformerBuildItem(RuntimeDelegate.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            private static final String CTOR_NAME = "<init>";
+
+                            private static final String RUNTIME_DELEGATE_IMPL_BINARY_NAME = "org/jboss/resteasy/reactive/common/jaxrs/RuntimeDelegateImpl";
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("findDelegate")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitTypeInsn(NEW, RUNTIME_DELEGATE_IMPL_BINARY_NAME);
+                                            visitInsn(DUP);
+                                            visitMethodInsn(Opcodes.INVOKESPECIAL, RUNTIME_DELEGATE_IMPL_BINARY_NAME,
+                                                    CTOR_NAME, "()V",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                }
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+}

--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/SmallRyeOpenApiProcessor.java
@@ -84,6 +84,7 @@ import io.quarkus.smallrye.openapi.deployment.filter.AutoTagFilter;
 import io.quarkus.smallrye.openapi.deployment.filter.SecurityConfigFilter;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 import io.quarkus.smallrye.openapi.deployment.spi.IgnoreStaticDocumentBuildItem;
+import io.quarkus.smallrye.openapi.runtime.OpenApiConfigMapping;
 import io.quarkus.smallrye.openapi.runtime.OpenApiConstants;
 import io.quarkus.smallrye.openapi.runtime.OpenApiDocumentService;
 import io.quarkus.smallrye.openapi.runtime.OpenApiRecorder;

--- a/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/extensions/smallrye-openapi/deployment/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,1 +1,0 @@
-io.quarkus.smallrye.openapi.deployment.OpenApiConfigMapping

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiConfigMapping.java
@@ -1,4 +1,4 @@
-package io.quarkus.smallrye.openapi.deployment;
+package io.quarkus.smallrye.openapi.runtime;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/extensions/smallrye-openapi/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.quarkus.smallrye.openapi.runtime.OpenApiConfigMapping

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/ServiceLoadingRemovalProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/ServiceLoadingRemovalProcessor.java
@@ -1,0 +1,86 @@
+package io.quarkus.vertx.deployment;
+
+import static org.objectweb.asm.Opcodes.ARETURN;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.gizmo.Gizmo;
+import io.vertx.core.impl.VerticleManager;
+import io.vertx.core.impl.VertxBuilder;
+
+public class ServiceLoadingRemovalProcessor {
+
+    //TODO: this simply returns empty lists because we don't currently register the implementations with ServiceProviderBuildItem
+
+    @BuildStep(onlyIf = IsNormal.class)
+    public void transformSmallRyeConfigBuilder(List<ServiceProviderBuildItem> servicesItems,
+            BuildProducer<BytecodeTransformerBuildItem> producer) {
+        producer.produce(new BytecodeTransformerBuildItem(VertxBuilder.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadProviders")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                    "()Ljava/util/List;",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+
+        producer.produce(new BytecodeTransformerBuildItem(VerticleManager.class.getName(),
+                new BiFunction<>() {
+                    @Override
+                    public ClassVisitor apply(String s, ClassVisitor classVisitor) {
+                        return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+
+                            @Override
+                            public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                    String signature, String[] exceptions) {
+                                MethodVisitor original = super.visitMethod(access, name, descriptor, signature, exceptions);
+                                if (name.equals("loadFactories")) {
+                                    return new MethodVisitor(Gizmo.ASM_API_VERSION, original) {
+                                        @Override
+                                        public void visitCode() {
+                                            super.visitCode();
+                                            visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Collections", "emptyList",
+                                                    "()Ljava/util/List;",
+                                                    false);
+                                            visitInsn(Opcodes.ARETURN);
+                                        }
+                                    };
+                                }
+
+                                return original;
+                            }
+                        };
+                    }
+                }));
+    }
+}


### PR DESCRIPTION
The reason for doing this is to (somewhat) improve Quarkus' runtime performance 
by leveraging the fact that all the providers are actually known
at build time.
Thus, we can "fold" service loading into normal class constructor invocation

See also: https://groups.google.com/g/quarkus-dev/c/tH_K4XJR5Lo/m/H97jYwZFAAAJ 