### PR TITLE
Knative: fix clusterLocal property

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeConfig.java
@@ -388,6 +388,7 @@ public class KnativeConfig implements PlatformConfiguration {
     /**
      * Whether or not this service is cluster-local.
      * Cluster local services are not exposed to the outside world.
+     * More information in <a href="https://knative.dev/docs/serving/services/private-services/">this link</a>.
      */
     @ConfigItem
     public boolean clusterLocal;

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeProcessor.java
@@ -175,7 +175,7 @@ public class KnativeProcessor {
 
         if (config.clusterLocal) {
             result.add(new DecoratorBuildItem(KNATIVE,
-                    new AddLabelDecorator(name, "serving.knative.dev/visibility", "cluster-local")));
+                    new AddLabelDecorator(name, "networking.knative.dev/visibility", "cluster-local")));
         }
 
         /**

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeClusterLocalTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeClusterLocalTest.java
@@ -38,7 +38,7 @@ public class KnativeClusterLocalTest {
 
         assertThat(getKNativeService(kubernetesDir)).satisfies(service -> {
             assertThat(service.getMetadata()).satisfies(m -> {
-                assertThat(m.getLabels()).contains(entry("serving.knative.dev/visibility", "cluster-local"));
+                assertThat(m.getLabels()).contains(entry("networking.knative.dev/visibility", "cluster-local"));
             });
         });
     }


### PR DESCRIPTION
According to https://knative.dev/docs/serving/services/private-services/, the right property is `networking.knative.dev/visibility`, not `serving.knative.dev/visibility`.