### PR TITLE
Exclude hamcrest from testcontainers

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -317,6 +317,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!-- OpenTelemetry components, imported as a BOM -->
             <dependency>


### PR DESCRIPTION
Exclude hamcrest from testcontainers to avoid collision with hamcrest from rest-assured

Fixes https://github.com/quarkusio/quarkus/issues/25171

I did local verification with 2.8.2.Final and 999-SNAPSHOT

2.8.2.Final
```
[INFO] +- io.rest-assured:rest-assured:jar:4.5.1:test
[INFO] |  +- org.codehaus.groovy:groovy:jar:3.0.9:test
[INFO] |  +- org.codehaus.groovy:groovy-xml:jar:3.0.9:test
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.13:test
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:test
[INFO] |  |  \- commons-codec:commons-codec:jar:1.15:test
[INFO] |  +- org.apache.httpcomponents:httpmime:jar:4.5.13:test
[INFO] |  +- org.hamcrest:hamcrest:jar:2.1:test             <== HERE
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:test
[INFO] |  +- io.rest-assured:json-path:jar:4.5.1:test
[INFO] |  |  +- org.codehaus.groovy:groovy-json:jar:3.0.9:test
[INFO] |  |  \- io.rest-assured:rest-assured-common:jar:4.5.1:test
[INFO] |  \- io.rest-assured:xml-path:jar:4.5.1:test
[INFO] |     \- org.apache.commons:commons-lang3:jar:3.12.0:test
[INFO] \- org.testcontainers:testcontainers:jar:1.17.1:test
[INFO]    +- junit:junit:jar:4.13.2:test
[INFO]    |  \- org.hamcrest:hamcrest-core:jar:1.3:test             <== and HERE
[INFO]    +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO]    +- org.apache.commons:commons-compress:jar:1.21:test
[INFO]    +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO]    |  \- org.jetbrains:annotations:jar:17.0.0:test
[INFO]    +- com.github.docker-java:docker-java-api:jar:3.2.13:test
[INFO]    |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.2:test
[INFO]    \- com.github.docker-java:docker-java-transport-zerodep:jar:3.2.13:test
[INFO]       +- com.github.docker-java:docker-java-transport:jar:3.2.13:test
[INFO]       \- net.java.dev.jna:jna:jar:5.8.0:test
```

999-SNAPSHOT
```
NFO] +- io.rest-assured:rest-assured:jar:4.5.1:test
[INFO] |  +- org.codehaus.groovy:groovy:jar:3.0.9:test
[INFO] |  +- org.codehaus.groovy:groovy-xml:jar:3.0.9:test
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.13:test
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:test
[INFO] |  |  \- commons-codec:commons-codec:jar:1.15:test
[INFO] |  +- org.apache.httpcomponents:httpmime:jar:4.5.13:test
[INFO] |  +- org.hamcrest:hamcrest:jar:2.1:test             <== just HERE
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:test
[INFO] |  +- io.rest-assured:json-path:jar:4.5.1:test
[INFO] |  |  +- org.codehaus.groovy:groovy-json:jar:3.0.9:test
[INFO] |  |  \- io.rest-assured:rest-assured-common:jar:4.5.1:test
[INFO] |  \- io.rest-assured:xml-path:jar:4.5.1:test
[INFO] |     \- org.apache.commons:commons-lang3:jar:3.12.0:test
[INFO] \- org.testcontainers:testcontainers:jar:1.17.1:test
[INFO]    +- junit:junit:jar:4.13.2:test
[INFO]    +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO]    +- org.apache.commons:commons-compress:jar:1.21:test
[INFO]    +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO]    |  \- org.jetbrains:annotations:jar:17.0.0:test
[INFO]    +- com.github.docker-java:docker-java-api:jar:3.2.13:test
[INFO]    |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.2:test
[INFO]    \- com.github.docker-java:docker-java-transport-zerodep:jar:3.2.13:test
[INFO]       +- com.github.docker-java:docker-java-transport:jar:3.2.13:test
[INFO]       \- net.java.dev.jna:jna:jar:5.8.0:test
```
