### PR TITLE
ArC: avoid using Class.forName to load classes from the java. package

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -239,13 +239,18 @@ public final class Types {
     }
 
     private static ResultHandle doLoadClass(BytecodeCreator creator, String className, ResultHandle tccl) {
-        //we need to use Class.forName as the class may be package private
-        if (tccl == null) {
-            ResultHandle currentThread = creator
-                    .invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
-            tccl = creator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
+        if (className.startsWith("java.")) {
+            return creator.loadClass(className);
+        } else {
+            //we need to use Class.forName as the class may be package private
+            if (tccl == null) {
+                ResultHandle currentThread = creator
+                        .invokeStaticMethod(MethodDescriptors.THREAD_CURRENT_THREAD);
+                tccl = creator.invokeVirtualMethod(MethodDescriptors.THREAD_GET_TCCL, currentThread);
+            }
+            return creator.invokeStaticMethod(MethodDescriptors.CL_FOR_NAME, creator.load(className), creator.load(false),
+                    tccl);
         }
-        return creator.invokeStaticMethod(MethodDescriptors.CL_FOR_NAME, creator.load(className), creator.load(false), tccl);
     }
 
     static Type getProviderType(ClassInfo classInfo) {


### PR DESCRIPTION
really trival small change, I was playing with this locally.

The comment about private classes make me wonder if it's safe ? But for the `java.` package I don't see why someone would refer to a non public type.