### PR TITLE
Change path to http://localhost:8080/tokens

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -232,7 +232,7 @@ After getting a cup of coffee, you'll be able to run this binary directly:
 
 To test the application, you should open your browser and access the following URL:
 
-* http://localhost:8080[http://localhost:8080]
+* http://localhost:8080/tokens[http://localhost:8080/tokens]
 
 If everything is working as expected, you should be redirected to the Keycloak server to authenticate.
 


### PR DESCRIPTION
Would make more sense to use /tokens here, otherwise you will see only a 404 which is not nice.