### PR TITLE
Update jakarta websocket link

### DIFF
--- a/docs/src/main/asciidoc/websockets.adoc
+++ b/docs/src/main/asciidoc/websockets.adoc
@@ -237,6 +237,6 @@ public class ChatTest {
 
 == More WebSocket Information
 
-The Quarkus WebSocket implementation is an implementation of link:https://eclipse-ee4j.github.io/websocket-api/[Jakarta Websockets].
+The Quarkus WebSocket implementation is an implementation of link:https://jakarta.ee/specifications/websocket/[Jakarta Websockets].
 
 


### PR DESCRIPTION
The current link to the jakarta websocket github page is broken and returns a 404. I made a guess what could be the new one.