### PR TITLE
Normalize uri template name to be a valid regex groupname

### DIFF
--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -303,11 +303,12 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
     private String sanitizePath(String path) {
         // this simply replaces the whitespace characters (not part of a path variable) with %20
         // TODO: this might have to be more complex, URL encoding maybe?
-        boolean inVariable = false;
+        // zero braces indicates we are outside of a variable
+        int bracesCount = 0;
         StringBuilder replaced = null;
         for (int i = 0; i < path.length(); i++) {
             char c = path.charAt(i);
-            if ((c == ' ') && (!inVariable)) {
+            if ((c == ' ') && (bracesCount == 0)) {
                 if (replaced == null) {
                     replaced = new StringBuilder(path.length() + 2);
                     replaced.append(path, 0, i);
@@ -319,9 +320,9 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                 replaced.append(c);
             }
             if (c == '{') {
-                inVariable = true;
+                bracesCount++;
             } else if (c == '}') {
-                inVariable = false;
+                bracesCount--;
             }
         }
         if (replaced == null) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -75,8 +75,8 @@ public class RequestMapper<T> {
                         break;
                     }
                     matchPos = matcher.end();
-                    for (String name : segment.names) {
-                        params[paramCount++] = URIDecoder.decodeURIComponent(matcher.group(name), false);
+                    for (String group : segment.groups) {
+                        params[paramCount++] = URIDecoder.decodeURIComponent(matcher.group(group), false);
                     }
                 } else if (segment.type == URITemplate.Type.LITERAL) {
                     //make sure the literal text is the same

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexResource.java
@@ -8,8 +8,8 @@ import javax.ws.rs.PathParam;
 public class RegexResource {
 
     @GET
-    @Path("/{pin:[A-Z0-9]{4}}")
-    public String hello(@PathParam("pin") String name) {
+    @Path("/{  1p-_in.  :  [A-Z0-9]{4}  }")
+    public String hello(@PathParam("1p-_in.") String name) {
         return "pin " + name;
     }
 


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/25258#issuecomment-1113714298 for a description of what is allowed in a uri template.

These changes add support for `_-.\d` in the component's name.

Previosly, the component name was directly used as a capture group name.
The above mentioned characters however are not allowed at some positions in groupnames however.

Therefore I added a simple normalization, making sure the component name only contains characters in the range `A-Za-z0-9`.

Also, I added support for spaces in before and after the name, and before and after the regex part.
The ABNF (see comment above) allows WSP in these cases, which is 0x09 (HTAB) or 0x20 (SPACE). I don't believe however that tabs are that often used inside an `@Path`.

fixes #25258