### PR TITLE
Unify devservices datatabase, username and password and allow configuration

### DIFF
--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-When testing or running in dev mode Quarkus can provide you with a zero config database out of the box, a feature we refer to as Dev Services.
+When testing or running in dev mode Quarkus can provide you with a zero-config database out of the box, a feature we refer to as Dev Services.
 Depending on your database type you may need Docker installed in order to use this feature.
 Dev Services is supported for the following databases:
 
@@ -75,46 +75,67 @@ quarkus.datasource.devservices.container-properties.TC_MY_CNF=testcontainers/mys
 
 This support is database specific and needs to be implemented in each dev service specifically.
 
-== Connect To Dev Service Database
+== Connect To Database Run as a Dev Service
 
-You can connect to a database running as Dev Service like you would do with any dockerized database.
-The login credentials are:
+You can connect to a database running as a Dev Service as you would do with any database running inside a Docker container.
+
+Login credentials are the same for most databases, except when the database requirements don't allow it:
 
 |===
 |Database |Username |Password |Database name
 
-|PostgreSQL, MariaDB, MySQL, DB2, H2
+|PostgreSQL, MariaDB, MySQL, IBM Db2, H2
 |quarkus
 |quarkus
 |quarkus
 
-|MSSQL
+|Microsoft SQL Server
 |SA
 |Quarkuspassword1
 |
 
 |===
 
-Keep in mind that a Dev Service runs on a random port.
-For instance, when you run PostgreSQL as Dev Service and have `psql` installed on the host, you can connect via:
+[NOTE]
+====
+The Microsoft SQL Server Testcontainer doesn't support defining the username or database name.
+It also requires a strong password.
+====
 
-```
+Keep in mind that, except if configured otherwise (see below), a Dev Service runs on a random port.
+For instance, when you run PostgreSQL as a Dev Service and have `psql` installed on the host, you can connect via:
+
+[source, bash]
+----
 psql -h localhost -p <random port> -U quarkus
-```
+----
 
 The random port can be found with `docker ps`
 
-```
+[source, bash]
+----
 docker ps
 
 # returns something like this:
 
 CONTAINER ID   IMAGE           [..]    PORTS                                         [..]
-b826e3a168c4   postgres:14.2   [..]    0.0.0.0:49174->5432/tcp, :::49174->5432/tcp   [..]
-```
+b826e3a168c4   postgres:14.2   [..]    0.0.0.0:49174->5432/tcp, :::49174->5432/tcp   [..] <1>
+----
+<1> The random port is `49174`.
+
+You can require a fixed port for a database Dev Service using:
+
+[source,properties]
+----
+quarkus.datasource.devservices.port=<your fixed port> <1>
+
+quarkus.datasource."datasource-name".devservices.port=<your fixed port> <2>
+----
+<1> Fixed port for the default datasource.
+<2> Fixed port for a named datasource.
 
 == Configuration Reference
 
-Datasource Dev Services support the following config options:
+Dev Services for Databases support the following configuration options:
 
 include::{generated-dir}/config/quarkus-datasource-config-group-dev-services-build-time-config.adoc[opts=optional,leveloffset=+1]

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -75,6 +75,44 @@ quarkus.datasource.devservices.container-properties.TC_MY_CNF=testcontainers/mys
 
 This support is database specific and needs to be implemented in each dev service specifically.
 
+== Connect To Dev Service Database
+
+You can connect to a database running as Dev Service like you would do with any dockerized database.
+The login credentials are:
+
+|===
+|Database |Username |Password |Database name
+
+|PostgreSQL, MariaDB, MySQL, DB2, H2
+|quarkus
+|quarkus
+|quarkus
+
+|MSSQL
+|SA
+|Quarkuspassword1
+|
+
+|===
+
+Keep in mind that a Dev Service runs on a random port.
+For instance, when you run PostgreSQL as Dev Service and have `psql` installed on the host, you can connect via:
+
+```
+psql -h localhost -p <random port> -U quarkus
+```
+
+The random port can be found with `docker ps`
+
+```
+docker ps
+
+# returns something like this:
+
+CONTAINER ID   IMAGE           [..]    PORTS                                         [..]
+b826e3a168c4   postgres:14.2   [..]    0.0.0.0:49174->5432/tcp, :::49174->5432/tcp   [..]
+```
+
 == Configuration Reference
 
 Datasource Dev Services support the following config options:

--- a/docs/src/main/asciidoc/databases-dev-services.adoc
+++ b/docs/src/main/asciidoc/databases-dev-services.adoc
@@ -85,13 +85,13 @@ Login credentials are the same for most databases, except when the database requ
 |Database |Username |Password |Database name
 
 |PostgreSQL, MariaDB, MySQL, IBM Db2, H2
-|quarkus
-|quarkus
-|quarkus
+|`quarkus` for the default datasource or name of the datasource
+|`quarkus`
+|`quarkus`
 
 |Microsoft SQL Server
-|SA
-|Quarkuspassword1
+|`SA`
+|`Quarkus123`
 |
 
 |===
@@ -100,6 +100,15 @@ Login credentials are the same for most databases, except when the database requ
 ====
 The Microsoft SQL Server Testcontainer doesn't support defining the username or database name.
 It also requires a strong password.
+====
+
+[TIP]
+====
+For databases supporting it
+(i.e. all of them except Microsoft SQL Server for which it is only possible to override the password),
+you can override the database name, username and password used by the Dev Service.
+
+See <<configuration-reference>> for more information.
 ====
 
 Keep in mind that, except if configured otherwise (see below), a Dev Service runs on a random port.
@@ -134,6 +143,8 @@ quarkus.datasource."datasource-name".devservices.port=<your fixed port> <2>
 <1> Fixed port for the default datasource.
 <2> Fixed port for a named datasource.
 
+
+[[configuration-reference]]
 == Configuration Reference
 
 Dev Services for Databases support the following configuration options:

--- a/docs/src/main/asciidoc/datasource.adoc
+++ b/docs/src/main/asciidoc/datasource.adoc
@@ -473,7 +473,7 @@ You can override this by setting the `transactions` configuration property - see
 
 When using Dev Services the default datasource will always be created, but to specify a named datasource you need to have
 at least one build time property so Quarkus knows to create the datasource. You will usually either specify
-the `db-kind` property, or explicitly enable DevDb: `quarkus.datasource."name".devservices.enabled=true`.
+the `db-kind` property, or explicitly enable Dev Services: `quarkus.datasource."name".devservices.enabled=true`.
 
 [[in-memory-databases]]
 == Testing with in-memory databases

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DevServicesH2DatasourceTestCase.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/DevServicesH2DatasourceTestCase.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration.ExceptionSorter;
+import io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class DevServicesH2DatasourceTestCase {
@@ -40,7 +41,8 @@ public class DevServicesH2DatasourceTestCase {
     public void testDatasource() throws Exception {
         AgroalConnectionPoolConfiguration configuration = dataSource.getConfiguration().connectionPoolConfiguration();
         assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:h2:"));
-        assertEquals("sa", configuration.connectionFactoryConfiguration().principal().getName());
+        assertEquals(DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME,
+                configuration.connectionFactoryConfiguration().principal().getName());
         assertEquals(20, configuration.maxSize());
         assertThat(configuration.exceptionSorter()).isInstanceOf(ExceptionSorter.emptyExceptionSorter().getClass());
 

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDevServicesDataSourcesConfigTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/MultipleDevServicesDataSourcesConfigTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.agroal.DataSource;
+import io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class MultipleDevServicesDataSourcesConfigTest {
@@ -38,12 +39,16 @@ public class MultipleDevServicesDataSourcesConfigTest {
 
     @Test
     public void testDataSourceInjection() throws SQLException {
-        testDataSource("default", defaultDataSource,
-                "jdbc:h2:tcp://localhost:" + extractPort(defaultDataSource) + "/mem:default;DB_CLOSE_DELAY=-1", "sa", 20);
+        testDataSource(DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME, defaultDataSource,
+                "jdbc:h2:tcp://localhost:" + extractPort(defaultDataSource) + "/mem:"
+                        + DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME + ";DB_CLOSE_DELAY=-1",
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
         testDataSource("users", dataSource1,
-                "jdbc:h2:tcp://localhost:" + extractPort(dataSource1) + "/mem:users;DB_CLOSE_DELAY=-1", "sa", 20);
+                "jdbc:h2:tcp://localhost:" + extractPort(dataSource1) + "/mem:users;DB_CLOSE_DELAY=-1",
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
         testDataSource("inventory", dataSource2,
-                "jdbc:h2:tcp://localhost:" + extractPort(dataSource2) + "/mem:inventory;DB_CLOSE_DELAY=-1", "sa", 20);
+                "jdbc:h2:tcp://localhost:" + extractPort(dataSource2) + "/mem:inventory;DB_CLOSE_DELAY=-1",
+                DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME, 20);
     }
 
     public int extractPort(AgroalDataSource ds) {

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseDefaultSetupConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseDefaultSetupConfig.java
@@ -1,0 +1,15 @@
+package io.quarkus.datasource.deployment.spi;
+
+public final class DatabaseDefaultSetupConfig {
+
+    private DatabaseDefaultSetupConfig() {
+    }
+
+    public static final String DEFAULT_DATABASE_USERNAME = "quarkus";
+
+    public static final String DEFAULT_DATABASE_PASSWORD = "quarkus";
+
+    // mssql container enforces a 'strong' password with min 8 chars, upper/lowercase, number or special char
+    public static final String DEFAULT_DATABASE_STRONG_PASSWORD = "Quarkuspassword1";
+    public static final String DEFAULT_DATABASE_NAME = "quarkus";
+}

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseDefaultSetupConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseDefaultSetupConfig.java
@@ -8,8 +8,8 @@ public final class DatabaseDefaultSetupConfig {
     public static final String DEFAULT_DATABASE_USERNAME = "quarkus";
 
     public static final String DEFAULT_DATABASE_PASSWORD = "quarkus";
-
     // mssql container enforces a 'strong' password with min 8 chars, upper/lowercase, number or special char
-    public static final String DEFAULT_DATABASE_STRONG_PASSWORD = "Quarkuspassword1";
+    public static final String DEFAULT_DATABASE_STRONG_PASSWORD = "Quarkus123";
+
     public static final String DEFAULT_DATABASE_NAME = "quarkus";
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -11,17 +11,26 @@ public class DevServicesDatasourceContainerConfig {
     private final Map<String, String> additionalJdbcUrlProperties;
     private final OptionalInt fixedExposedPort;
     private final Optional<String> command;
+    private final Optional<String> dbName;
+    private final Optional<String> username;
+    private final Optional<String> password;
 
     public DevServicesDatasourceContainerConfig(Optional<String> imageName,
             Map<String, String> containerProperties,
             Map<String, String> additionalJdbcUrlProperties,
             OptionalInt port,
-            Optional<String> command) {
+            Optional<String> command,
+            Optional<String> dbName,
+            Optional<String> username,
+            Optional<String> password) {
         this.imageName = imageName;
         this.containerProperties = containerProperties;
         this.additionalJdbcUrlProperties = additionalJdbcUrlProperties;
         this.fixedExposedPort = port;
         this.command = command;
+        this.dbName = dbName;
+        this.username = username;
+        this.password = password;
     }
 
     public Optional<String> getImageName() {
@@ -42,5 +51,17 @@ public class DevServicesDatasourceContainerConfig {
 
     public Optional<String> getCommand() {
         return command;
+    }
+
+    public Optional<String> getDbName() {
+        return dbName;
+    }
+
+    public Optional<String> getUsername() {
+        return username;
+    }
+
+    public Optional<String> getPassword() {
+        return password;
     }
 }

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -267,7 +267,10 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices.containerProperties,
                     dataSourceBuildTimeConfig.devservices.properties,
                     dataSourceBuildTimeConfig.devservices.port,
-                    dataSourceBuildTimeConfig.devservices.command);
+                    dataSourceBuildTimeConfig.devservices.command,
+                    dataSourceBuildTimeConfig.devservices.dbName,
+                    dataSourceBuildTimeConfig.devservices.username,
+                    dataSourceBuildTimeConfig.devservices.password);
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(ConfigProvider.getConfig().getOptionalValue(prefix + "username", String.class),

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -59,4 +59,21 @@ public class DevServicesBuildTimeConfig {
     @ConfigItem
     public Optional<String> command;
 
+    /**
+     * The name of the database to use if this Dev Service supports overriding it.
+     */
+    @ConfigItem
+    public Optional<String> dbName;
+
+    /**
+     * The username to use if this Dev Service supports overriding it.
+     */
+    @ConfigItem
+    public Optional<String> username;
+
+    /**
+     * The password to use if this Dev Service supports overriding it.
+     */
+    @ConfigItem
+    public Optional<String> password;
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -39,9 +39,14 @@ public class DB2DevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
-                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
-                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
+
+                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
+                container.withUsername(effectiveUsername)
+                        .withPassword(effectivePassword)
+                        .withDatabaseName(effectiveDbName)
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.db2.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -35,9 +39,9 @@ public class DB2DevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse("quarkus"))
-                        .withUsername(username.orElse("quarkus"))
-                        .withDatabaseName(datasourceName.orElse("default"))
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
+                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
+                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
+++ b/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.devservices.derby.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -36,6 +38,9 @@ public class DerbyDevServicesProcessor {
                     int port = containerConfig.getFixedExposedPort().isPresent()
                             ? containerConfig.getFixedExposedPort().getAsInt()
                             : 1527 + (launchMode == LaunchMode.TEST ? 0 : 1);
+
+                    String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
                     NetworkServerControl server = new NetworkServerControl(InetAddress.getByName("localhost"), port);
                     server.start(new PrintWriter(System.out));
                     for (int i = 1; i <= NUMBER_OF_PINGS; i++) {
@@ -65,7 +70,7 @@ public class DerbyDevServicesProcessor {
                         additionalArgs.append(i.getValue());
                     }
                     return new RunningDevServicesDatasource(null,
-                            "jdbc:derby://localhost:" + port + "/memory:" + datasourceName.orElse("quarkus") + ";create=true"
+                            "jdbc:derby://localhost:" + port + "/memory:" + effectiveDbName + ";create=true"
                                     + additionalArgs.toString(),
                             null,
                             null,

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -43,6 +43,10 @@ public class H2DevServicesProcessor {
                             "-ifNotExists");
                     tcpServer.start();
 
+                    String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                    String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                    String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
                     StringBuilder additionalArgs = new StringBuilder();
                     for (Map.Entry<String, String> i : containerConfig.getAdditionalJdbcUrlProperties().entrySet()) {
                         additionalArgs.append(";");
@@ -54,13 +58,13 @@ public class H2DevServicesProcessor {
                     LOG.info("Dev Services for H2 started.");
 
                     String connectionUrl = "jdbc:h2:tcp://localhost:" + tcpServer.getPort() + "/mem:"
-                            + datasourceName.orElse(DEFAULT_DATABASE_NAME)
+                            + effectiveDbName
                             + ";DB_CLOSE_DELAY=-1" + additionalArgs.toString();
                     return new RunningDevServicesDatasource(null,
                             connectionUrl,
                             null,
-                            DEFAULT_DATABASE_USERNAME,
-                            DEFAULT_DATABASE_PASSWORD,
+                            effectiveUsername,
+                            effectivePassword,
                             new Closeable() {
                                 @Override
                                 public void close() throws IOException {
@@ -70,8 +74,8 @@ public class H2DevServicesProcessor {
                                         //make sure the DB is removed on close
                                         try (Connection connection = DriverManager.getConnection(
                                                 connectionUrl,
-                                                DEFAULT_DATABASE_USERNAME,
-                                                DEFAULT_DATABASE_PASSWORD)) {
+                                                effectiveUsername,
+                                                effectivePassword)) {
                                             try (Statement statement = connection.createStatement()) {
                                                 statement.execute("SET DB_CLOSE_DELAY 0");
                                             }

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.h2.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.sql.Connection;
@@ -50,13 +54,13 @@ public class H2DevServicesProcessor {
                     LOG.info("Dev Services for H2 started.");
 
                     String connectionUrl = "jdbc:h2:tcp://localhost:" + tcpServer.getPort() + "/mem:"
-                            + datasourceName.orElse("default")
+                            + datasourceName.orElse(DEFAULT_DATABASE_NAME)
                             + ";DB_CLOSE_DELAY=-1" + additionalArgs.toString();
                     return new RunningDevServicesDatasource(null,
                             connectionUrl,
                             null,
-                            "sa",
-                            "sa",
+                            DEFAULT_DATABASE_USERNAME,
+                            DEFAULT_DATABASE_PASSWORD,
                             new Closeable() {
                                 @Override
                                 public void close() throws IOException {
@@ -66,8 +70,8 @@ public class H2DevServicesProcessor {
                                         //make sure the DB is removed on close
                                         try (Connection connection = DriverManager.getConnection(
                                                 connectionUrl,
-                                                "sa",
-                                                "sa")) {
+                                                DEFAULT_DATABASE_USERNAME,
+                                                DEFAULT_DATABASE_PASSWORD)) {
                                             try (Statement statement = connection.createStatement()) {
                                                 statement.execute("SET DB_CLOSE_DELAY 0");
                                             }

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.mariadb.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -38,9 +42,9 @@ public class MariaDBDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse("quarkus"))
-                        .withUsername(username.orElse("quarkus"))
-                        .withDatabaseName(datasourceName.orElse("default"))
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
+                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
+                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
                         .withReuse(true);
 
                 if (containerConfig.getContainerProperties().containsKey(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME)) {

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -42,9 +42,14 @@ public class MariaDBDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
-                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
-                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
+
+                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
+                container.withUsername(effectiveUsername)
+                        .withPassword(effectivePassword)
+                        .withDatabaseName(effectiveDbName)
                         .withReuse(true);
 
                 if (containerConfig.getContainerProperties().containsKey(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME)) {

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -37,7 +37,12 @@ public class MSSQLDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse(DEFAULT_DATABASE_STRONG_PASSWORD))
+
+                String effectivePassword = containerConfig.getPassword()
+                        .orElse(password.orElse(DEFAULT_DATABASE_STRONG_PASSWORD));
+
+                // Defining the database name and the username is not supported by this container yet
+                container.withPassword(effectivePassword)
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkus.devservices.mssql.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_STRONG_PASSWORD;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +37,7 @@ public class MSSQLDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse("Quarkuspassword1"))
+                container.withPassword(password.orElse(DEFAULT_DATABASE_STRONG_PASSWORD))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.mysql.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -37,9 +41,9 @@ public class MySQLDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse("quarkus"))
-                        .withUsername(username.orElse("quarkus"))
-                        .withDatabaseName(datasourceName.orElse("default"))
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
+                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
+                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
                         .withReuse(true);
 
                 if (containerConfig.getContainerProperties().containsKey(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME)) {

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -41,9 +41,14 @@ public class MySQLDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
-                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
-                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
+
+                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
+                container.withUsername(effectiveUsername)
+                        .withPassword(effectivePassword)
+                        .withDatabaseName(effectiveDbName)
                         .withReuse(true);
 
                 if (containerConfig.getContainerProperties().containsKey(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME)) {

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -42,9 +42,14 @@ public class OracleDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
-                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
-                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
+
+                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
+                container.withUsername(effectiveUsername)
+                        .withPassword(effectivePassword)
+                        .withDatabaseName(effectiveDbName)
                         .withReuse(true);
 
                 // We need to limit the maximum amount of CPUs being used by the container;

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.oracle.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -24,9 +28,6 @@ public class OracleDevServicesProcessor {
     private static final Logger LOG = Logger.getLogger(OracleDevServicesProcessor.class);
 
     public static final String IMAGE = "gvenzl/oracle-xe";
-    public static final String DEFAULT_DATABASE_USER = "quarkus";
-    public static final String DEFAULT_DATABASE_PASSWORD = "quarkus";
-    public static final String DEFAULT_DATABASE_NAME = "quarkusdb";
     public static final int PORT = 1521;
 
     @BuildStep
@@ -41,7 +42,7 @@ public class OracleDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USER))
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
                         .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
                         .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
                         .withReuse(true);

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.devservices.postgresql.deployment;
 
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_NAME;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_PASSWORD;
+import static io.quarkus.datasource.deployment.spi.DatabaseDefaultSetupConfig.DEFAULT_DATABASE_USERNAME;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -42,9 +46,9 @@ public class PostgresqlDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withPassword(password.orElse("quarkus"))
-                        .withUsername(username.orElse("quarkus"))
-                        .withDatabaseName(datasourceName.orElse("default"))
+                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
+                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
+                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -46,9 +46,14 @@ public class PostgresqlDevServicesProcessor {
                         containerConfig.getFixedExposedPort(),
                         !devServicesSharedNetworkBuildItem.isEmpty());
                 startupTimeout.ifPresent(container::withStartupTimeout);
-                container.withUsername(username.orElse(DEFAULT_DATABASE_USERNAME))
-                        .withPassword(password.orElse(DEFAULT_DATABASE_PASSWORD))
-                        .withDatabaseName(datasourceName.orElse(DEFAULT_DATABASE_NAME))
+
+                String effectiveUsername = containerConfig.getUsername().orElse(username.orElse(DEFAULT_DATABASE_USERNAME));
+                String effectivePassword = containerConfig.getPassword().orElse(password.orElse(DEFAULT_DATABASE_PASSWORD));
+                String effectiveDbName = containerConfig.getDbName().orElse(datasourceName.orElse(DEFAULT_DATABASE_NAME));
+
+                container.withUsername(effectiveUsername)
+                        .withPassword(effectivePassword)
+                        .withDatabaseName(effectiveDbName)
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
                 containerConfig.getCommand().ifPresent(container::setCommand);

--- a/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
+++ b/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/SqlClientTest.java
@@ -100,7 +100,7 @@ public class SqlClientTest {
         assertEquals("h2", spans.get(1).getAttributes().get(DB_SYSTEM));
         assertEquals("SELECT", spans.get(1).getAttributes().get(DB_OPERATION));
         assertEquals("SELECT * FROM USERS", spans.get(1).getAttributes().get(DB_STATEMENT));
-        assertEquals("sa", spans.get(1).getAttributes().get(DB_USER));
+        assertEquals("quarkus", spans.get(1).getAttributes().get(DB_USER));
         assertNotNull(spans.get(1).getAttributes().get(DB_CONNECTION_STRING));
         //noinspection ConstantConditions
         assertTrue(spans.get(1).getAttributes().get(DB_CONNECTION_STRING).startsWith("jdbc:h2:tcp://localhost"));


### PR DESCRIPTION
I wanted to inspect the Postgres database started by devservices. While searching for the login credentials I noticed that different databases use different credentials and db names. I think it is nicer to use the same for all. Bonus, at least for Postgres the login via `psql` becomes shorter when the username and db name are equal

```psql -h localhost -p <randomPort> -U quarkus```

instead of

```psql -h localhost -p <randomPort> -U quarkus -d default```

I did not find the information how to connect to the devservices datasources in the docu. Would be worth to add it IMO. Any hints where I should put it?