### PR TITLE
Enable custom postgres config in devservice

### DIFF
--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceContainerConfig.java
@@ -10,15 +10,18 @@ public class DevServicesDatasourceContainerConfig {
     private final Map<String, String> containerProperties;
     private final Map<String, String> additionalJdbcUrlProperties;
     private final OptionalInt fixedExposedPort;
+    private final Optional<String> command;
 
     public DevServicesDatasourceContainerConfig(Optional<String> imageName,
             Map<String, String> containerProperties,
             Map<String, String> additionalJdbcUrlProperties,
-            OptionalInt port) {
+            OptionalInt port,
+            Optional<String> command) {
         this.imageName = imageName;
         this.containerProperties = containerProperties;
         this.additionalJdbcUrlProperties = additionalJdbcUrlProperties;
         this.fixedExposedPort = port;
+        this.command = command;
     }
 
     public Optional<String> getImageName() {
@@ -35,5 +38,9 @@ public class DevServicesDatasourceContainerConfig {
 
     public OptionalInt getFixedExposedPort() {
         return fixedExposedPort;
+    }
+
+    public Optional<String> getCommand() {
+        return command;
     }
 }

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -266,7 +266,8 @@ public class DevServicesDatasourceProcessor {
                     dataSourceBuildTimeConfig.devservices.imageName,
                     dataSourceBuildTimeConfig.devservices.containerProperties,
                     dataSourceBuildTimeConfig.devservices.properties,
-                    dataSourceBuildTimeConfig.devservices.port);
+                    dataSourceBuildTimeConfig.devservices.port,
+                    dataSourceBuildTimeConfig.devservices.command);
 
             DevServicesDatasourceProvider.RunningDevServicesDatasource datasource = devDbProvider
                     .startDatabase(ConfigProvider.getConfig().getOptionalValue(prefix + "username", String.class),
@@ -276,6 +277,9 @@ public class DevServicesDatasourceProcessor {
 
             propertiesMap.put(prefix + "db-kind", dataSourceBuildTimeConfig.dbKind.orElse(null));
             String devServicesPrefix = prefix + "devservices.";
+            if (dataSourceBuildTimeConfig.devservices.command.isPresent()) {
+                propertiesMap.put(devServicesPrefix + "command", dataSourceBuildTimeConfig.devservices.command.get());
+            }
             if (dataSourceBuildTimeConfig.devservices.imageName.isPresent()) {
                 propertiesMap.put(devServicesPrefix + "image-name", dataSourceBuildTimeConfig.devservices.imageName.get());
             }

--- a/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
+++ b/extensions/datasource/runtime/src/main/java/io/quarkus/datasource/runtime/DevServicesBuildTimeConfig.java
@@ -51,4 +51,12 @@ public class DevServicesBuildTimeConfig {
     @ConfigItem
     public OptionalInt port;
 
+    /**
+     * The container start command to use, for container based DevServices providers.
+     *
+     * If the provider is not container based (e.g. a H2 Database) then this has no effect.
+     */
+    @ConfigItem
+    public Optional<String> command;
+
 }

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -40,6 +40,7 @@ public class DB2DevServicesProcessor {
                         .withDatabaseName(datasourceName.orElse("default"))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
                 container.start();
 
                 LOG.info("Dev Services for IBM Db2 started.");

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -49,6 +49,8 @@ public class MariaDBDevServicesProcessor {
                 }
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
+
                 container.start();
 
                 LOG.info("Dev Services for MariaDB started.");

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -38,6 +38,8 @@ public class MSSQLDevServicesProcessor {
                 container.withPassword(password.orElse("Quarkuspassword1"))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
+
                 container.start();
 
                 LOG.info("Dev Services for Microsoft SQL Server started.");

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -48,6 +48,7 @@ public class MySQLDevServicesProcessor {
                 }
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
 
                 container.start();
 

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -54,6 +54,8 @@ public class OracleDevServicesProcessor {
                 container.withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withNanoCPUs(2_000_000_000l));
 
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
+
                 container.start();
 
                 LOG.info("Dev Services for Oracle started.");

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -47,6 +47,7 @@ public class PostgresqlDevServicesProcessor {
                         .withDatabaseName(datasourceName.orElse("default"))
                         .withReuse(true);
                 containerConfig.getAdditionalJdbcUrlProperties().forEach(container::withUrlParam);
+                containerConfig.getCommand().ifPresent(container::setCommand);
 
                 container.start();
 


### PR DESCRIPTION
I missed a way to configure Postgres in dev services. So far it is only possible for MariaDB/MySQL. So I added a similar approach.

Additionally, the dev services docu is scattered in quiet a lot of places. I created a new common page. similar to the other (much simpler) dev services. This is more or less independent from the code change - except for the added config example for postgres.