### PR TITLE
Make templates adjust with scala version

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/scala/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/scala/pom.tpl.qute.xml
@@ -52,7 +52,12 @@
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-explaintypes</arg>
+                        {#if scala.version.startsWith("2.12.")}
+                        <arg>-target:jvm-1.8</arg>
+                        <arg>-Ypartial-unification</arg>
+                        {#else}
                         <arg>-target:jvm-11</arg>
+                        {/if}
                     </args>
                 </configuration>
             </plugin>

--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/reader/QuteCodestartFileReader.java
@@ -3,19 +3,23 @@ package io.quarkus.devtools.codestarts.core.reader;
 import io.quarkus.devtools.codestarts.CodestartException;
 import io.quarkus.devtools.codestarts.CodestartResource;
 import io.quarkus.devtools.codestarts.CodestartResource.Source;
+import io.quarkus.qute.CompletedStage;
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.Expression;
 import io.quarkus.qute.ResultMapper;
 import io.quarkus.qute.Results;
 import io.quarkus.qute.TemplateException;
 import io.quarkus.qute.TemplateLocator;
 import io.quarkus.qute.TemplateNode;
+import io.quarkus.qute.ValueResolver;
 import io.quarkus.qute.Variant;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.apache.commons.io.FilenameUtils;
 
 final class QuteCodestartFileReader implements CodestartFileReader {
@@ -49,6 +53,7 @@ final class QuteCodestartFileReader implements CodestartFileReader {
         final String content = source.read();
         final String templateId = source.absolutePath();
         final Engine engine = Engine.builder().addDefaults()
+                .addValueResolver(new StringValueResolver())
                 .addResultMapper(new MissingValueMapper())
                 .removeStandaloneLines(true)
                 // For now we need to disable strict rendering for codestarts
@@ -142,4 +147,38 @@ final class QuteCodestartFileReader implements CodestartFileReader {
      * }
      * }
      **/
+
+    private static class StringValueResolver implements ValueResolver {
+        @Override
+        public boolean appliesTo(EvalContext context) {
+            return ValueResolver.matchClass(context, String.class);
+        }
+
+        @Override
+        public CompletionStage<Object> resolve(EvalContext context) {
+            String value = (String) context.getBase();
+            switch (context.getName()) {
+                case "startsWith":
+                    if (context.getParams().size() == 1) {
+                        return context.evaluate(context.getParams().get(0)).thenCompose(e -> {
+                            return CompletedStage.of(value.startsWith((String) e));
+                        });
+                    }
+                case "contains":
+                    if (context.getParams().size() == 1) {
+                        return context.evaluate(context.getParams().get(0)).thenCompose(e -> {
+                            return CompletedStage.of(value.contains((CharSequence) e));
+                        });
+                    }
+                case "endsWith":
+                    if (context.getParams().size() == 1) {
+                        return context.evaluate(context.getParams().get(0)).thenCompose(e -> {
+                            return CompletedStage.of(value.endsWith((String) e));
+                        });
+                    }
+                default:
+                    return Results.notFound(context);
+            }
+        }
+    }
 }


### PR DESCRIPTION
The template is now different depending on the given scala version.

I added the possibility to use `startsWith`, `endsWith` and `contains` on String in codestarts templates thanks to @mkouba :)