### PR TITLE
Fix potential NPE

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -236,6 +236,10 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         if (providers != null) {
             for (ClassPathElement element : providers) {
                 ClassPathResource res = element.getResource(name);
+                // If resource was not found, ignore
+                if (res == null) {
+                    continue;
+                }
                 //if the requested name ends with a trailing / we make sure
                 //that the resource is a directory, and return a URL that ends with a /
                 //this matches the behaviour of URLClassLoader


### PR DESCRIPTION
An NPE may be thrown if the requested resource in QuarkusClassLoader.getResources() cannot be resolved by the existing ClassPathElement providers

- Fixes #25294