### PR TITLE
Add Vert.x MDC

### DIFF
--- a/extensions/vertx/deployment/pom.xml
+++ b/extensions/vertx/deployment/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/core/deployment/VertxCoreProcessor.java
@@ -28,6 +28,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.bootstrap.logging.LateBoundMDCProvider;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -44,6 +45,7 @@ import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.ThreadFactoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.gizmo.Gizmo;
@@ -67,8 +69,11 @@ class VertxCoreProcessor {
     );
 
     @BuildStep
-    NativeImageConfigBuildItem build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+    NativeImageConfigBuildItem build(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResources) {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, VertxLogDelegateFactory.class.getName()));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, LateBoundMDCProvider.class.getName()));
+        nativeImageResources.produce(new NativeImageResourceBuildItem("META-INF/services/org.jboss.logmanager.MDCProvider"));
         return NativeImageConfigBuildItem.builder()
                 .addRuntimeInitializedClass("io.vertx.core.buffer.impl.VertxByteBufAllocator")
                 .addRuntimeInitializedClass("io.vertx.core.buffer.impl.PartialPooledByteBufAllocator")

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/InMemoryLogHandler.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/InMemoryLogHandler.java
@@ -1,0 +1,55 @@
+package io.quarkus.vertx.mdc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.ErrorManager;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+
+public class InMemoryLogHandler extends Handler {
+    private static final PatternFormatter FORMATTER = new PatternFormatter("%X{requestId} ### %s");
+
+    private final List<String> recordList = new CopyOnWriteArrayList<>();
+
+    public List<String> logRecords() {
+        return Collections.unmodifiableList(recordList);
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        String loggerName = record.getLoggerName();
+        if (loggerName != null && (loggerName.endsWith("Verticle") || loggerName.endsWith("MDCTest"))) {
+            final String formatted;
+            final Formatter formatter = getFormatter();
+            try {
+                formatted = formatter.format(record);
+            } catch (Exception ex) {
+                reportError("Formatting error", ex, ErrorManager.FORMAT_FAILURE);
+                return;
+            }
+            if (formatted.length() == 0) {
+                return;
+            }
+            recordList.add(formatted);
+        }
+    }
+
+    @Override
+    public Formatter getFormatter() {
+        return FORMATTER;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() throws SecurityException {
+
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/InMemoryLogHandlerProducer.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/InMemoryLogHandlerProducer.java
@@ -1,0 +1,28 @@
+package io.quarkus.vertx.mdc;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class InMemoryLogHandlerProducer {
+
+    @Produces
+    @Singleton
+    public InMemoryLogHandler inMemoryLogHandler() {
+        return new InMemoryLogHandler();
+    }
+
+    void onStart(@Observes StartupEvent ev, InMemoryLogHandler inMemoryLogHandler) {
+        InitialConfigurator.DELAYED_HANDLER.addHandler(inMemoryLogHandler);
+    }
+
+    void onStop(@Observes ShutdownEvent ev, InMemoryLogHandler inMemoryLogHandler) {
+        InitialConfigurator.DELAYED_HANDLER.removeHandler(inMemoryLogHandler);
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VerticleDeployer.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VerticleDeployer.java
@@ -1,0 +1,74 @@
+package io.quarkus.vertx.mdc;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.mutiny.core.Vertx;
+
+@ApplicationScoped
+public class VerticleDeployer {
+    public static final String REQUEST_ID_HEADER = "x-request-id";
+    public static final int VERTICLE_PORT = 8097;
+
+    @Inject
+    Vertx vertx;
+
+    private volatile String deploymentId;
+
+    void onStart(@Observes StartupEvent ev) {
+        deploymentId = vertx.deployVerticle(new TestVerticle()).await().indefinitely();
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        if (deploymentId != null) {
+            vertx.undeploy(deploymentId).await().indefinitely();
+        }
+    }
+
+    private static class TestVerticle extends AbstractVerticle {
+        private static final Logger LOGGER = Logger.getLogger(TestVerticle.class);
+
+        private HttpRequest<JsonObject> request;
+
+        @Override
+        public void start(Promise<Void> startPromise) {
+            WebClient webClient = WebClient.create(vertx);
+            request = webClient.getAbs("http://worldclockapi.com/api/json/utc/now").as(BodyCodec.jsonObject());
+
+            Promise<HttpServer> httpServerPromise = Promise.promise();
+            httpServerPromise.future().<Void> mapEmpty().onComplete(startPromise);
+            vertx.createHttpServer()
+                    .requestHandler(req -> {
+                        String requestId = req.getHeader(REQUEST_ID_HEADER);
+
+                        MDC.put("requestId", requestId);
+                        LOGGER.info("Received HTTP request ### " + requestId);
+
+                        vertx.setTimer(50, l -> {
+                            LOGGER.info("Timer fired ### " + requestId);
+                            vertx.executeBlocking(fut -> {
+                                LOGGER.info("Blocking task executed ### " + requestId);
+                                fut.complete();
+                            }, false, bar -> request.send(rar -> {
+                                LOGGER.info("Received Web Client response ### " + requestId);
+                                req.response().end();
+                            }));
+                        });
+                    })
+                    .listen(VERTICLE_PORT, httpServerPromise);
+        }
+    }
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VertxMDCTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/mdc/VertxMDCTest.java
@@ -1,0 +1,162 @@
+package io.quarkus.vertx.mdc;
+
+import static io.quarkus.vertx.mdc.VerticleDeployer.REQUEST_ID_HEADER;
+import static io.quarkus.vertx.mdc.VerticleDeployer.VERTICLE_PORT;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+
+/*
+This test was mostly based on https://github.com/reactiverse/reactiverse-contextual-logging/blob/39e691d3a8fd78d19ee120cab8d8b38a4ef67813/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingIT.java
+ */
+
+public class VertxMDCTest {
+    private static final Logger LOGGER = Logger.getLogger(VertxMDCTest.class);
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClass(VerticleDeployer.class)
+                            .addClass(InMemoryLogHandler.class)
+                            .addClass(InMemoryLogHandlerProducer.class))
+            .overrideConfigKey("quarkus.log.console.format", "%d{HH:mm:ss} %-5p requestId=%X{requestId} [%c{2.}] (%t) %s%e%n");
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    InMemoryLogHandler inMemoryLogHandler;
+
+    @Inject
+    VerticleDeployer verticleDeployer;
+
+    static final CountDownLatch countDownLatch = new CountDownLatch(1);
+    static final AtomicReference<Throwable> errorDuringExecution = new AtomicReference<>();
+
+    @Test
+    void mdc() throws Throwable {
+        List<String> requestIds = IntStream.range(0, 10)
+                .mapToObj(i -> UUID.randomUUID().toString())
+                .collect(toList());
+
+        sendRequests(requestIds, onSuccess(v -> {
+            try {
+                Map<String, List<String>> allMessagesById = inMemoryLogHandler.logRecords()
+                        .stream()
+                        .map(line -> line.split(" ### "))
+                        .peek(split -> assertEquals(split[0], split[2]))
+                        .collect(groupingBy(split -> split[0],
+                                mapping(split -> split[1], toList())));
+
+                assertEquals(requestIds.size(), allMessagesById.size());
+                assertTrue(requestIds.containsAll(allMessagesById.keySet()));
+
+                List<String> expected = Stream.<String> builder()
+                        .add("Received HTTP request")
+                        .add("Timer fired")
+                        .add("Blocking task executed")
+                        .add("Received Web Client response")
+                        .build()
+                        .collect(toList());
+
+                for (List<String> messages : allMessagesById.values()) {
+                    assertEquals(expected, messages);
+                }
+            } catch (Throwable t) {
+                errorDuringExecution.set(t);
+            } finally {
+                countDownLatch.countDown();
+            }
+        }));
+
+        countDownLatch.await();
+
+        Throwable throwable = errorDuringExecution.get();
+        if (throwable != null) {
+            throw throwable;
+        }
+    }
+
+    @Test
+    public void mdcNonVertxThreadTest() {
+        String mdcValue = "Test MDC value";
+        MDC.put("requestId", mdcValue);
+        LOGGER.info("Test 1");
+
+        assertThat(inMemoryLogHandler.logRecords(),
+                hasItem(mdcValue + " ### Test 1"));
+
+        MDC.remove("requestId");
+        LOGGER.info("Test 2");
+
+        assertThat(inMemoryLogHandler.logRecords(),
+                hasItem(" ### Test 2"));
+
+        mdcValue = "New test MDC value";
+        MDC.put("requestId", mdcValue);
+        LOGGER.info("Test 3");
+
+        assertThat(inMemoryLogHandler.logRecords(),
+                hasItem(mdcValue + " ### Test 3"));
+    }
+
+    protected <T> Handler<AsyncResult<T>> onSuccess(Consumer<T> consumer) {
+        return result -> {
+            if (result.failed()) {
+                errorDuringExecution.set(result.cause());
+                countDownLatch.countDown();
+            } else {
+                consumer.accept(result.result());
+            }
+        };
+    }
+
+    @SuppressWarnings({ "rawtypes" })
+    private void sendRequests(List<String> ids, Handler<AsyncResult<Void>> handler) {
+        WebClient webClient = WebClient.create(vertx, new WebClientOptions().setDefaultPort(VERTICLE_PORT));
+
+        HttpRequest<Buffer> request = webClient.get("/")
+                .expect(ResponsePredicate.SC_OK);
+
+        List<Future> futures = ids.stream()
+                .map(id -> request.putHeader(REQUEST_ID_HEADER, id).send())
+                .collect(toList());
+
+        CompositeFuture.all(futures).<Void> mapEmpty().onComplete(handler);
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -32,6 +32,7 @@ import org.wildfly.common.cpu.ProcessorInfo;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.quarkus.bootstrap.logging.LateBoundMDCProvider;
 import io.quarkus.runtime.IOThreadDetector;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.ShutdownContext;
@@ -242,6 +243,9 @@ public class VertxCoreRecorder {
                 LOGGER.error("Uncaught exception received by Vert.x", error);
             }
         });
+
+        LateBoundMDCProvider.setMDCProviderDelegate(VertxMDC.INSTANCE);
+
         return logVertxInitialization(vertx);
     }
 

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxMDC.java
@@ -1,0 +1,311 @@
+package io.quarkus.vertx.core.runtime;
+
+import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
+import static io.smallrye.common.vertx.VertxContext.getOrCreateDuplicatedContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.jboss.logmanager.MDCProvider;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+public enum VertxMDC implements MDCProvider {
+    INSTANCE;
+
+    final InheritableThreadLocal<Map<String, Object>> inheritableThreadLocalMap = new InheritableThreadLocal<>() {
+        @Override
+        protected Map<String, Object> childValue(Map<String, Object> parentValue) {
+            if (parentValue == null) {
+                return null;
+            }
+            return new HashMap<>(parentValue);
+        }
+
+        @Override
+        protected Map<String, Object> initialValue() {
+            return new HashMap<>();
+        }
+    };
+
+    /**
+     * Get the value for a key, or {@code null} if there is no mapping.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @return the value
+     */
+    @Override
+    public String get(String key) {
+        return get(key, getContext());
+    }
+
+    /**
+     * Get the value for a key, or {@code null} if there is no mapping.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @return the value
+     */
+    @Override
+    public Object getObject(String key) {
+        return getObject(key, getContext());
+    }
+
+    /**
+     * Get the value for a key the in specified Context, or {@code null} if there is no mapping.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @param vertxContext the context
+     * @return the value
+     */
+    public String get(String key, Context vertxContext) {
+        Object value = getObject(key, vertxContext);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Get the value for a key the in specified Context, or {@code null} if there is no mapping.
+     * If the context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @param vertxContext the context
+     * @return the value
+     */
+    public Object getObject(String key, Context vertxContext) {
+        Objects.requireNonNull(key);
+        return contextualDataMap(vertxContext).get(key);
+    }
+
+    /**
+     * Set the value of a key, returning the old value (if any) or {@code null} if there was none.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @param value the new value
+     * @return the old value or {@code null} if there was none
+     */
+    @Override
+    public String put(String key, String value) {
+        return put(key, value, getContext());
+    }
+
+    /**
+     * Set the value of a key, returning the old value (if any) or {@code null} if there was none.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @param value the new value
+     * @return the old value or {@code null} if there was none
+     */
+    @Override
+    public Object putObject(String key, Object value) {
+        return putObject(key, value, getContext());
+    }
+
+    /**
+     * Set the value of a key, returning the old value (if any) or {@code null} if there was none.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @param value the new value
+     * @return the old value or {@code null} if there was none
+     */
+    public String put(String key, String value, Context vertxContext) {
+        Object oldValue = putObject(key, value, vertxContext);
+        return oldValue != null ? oldValue.toString() : null;
+    }
+
+    /**
+     * Set the value of a key, returning the old value (if any) or {@code null} if there was none.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @param value the new value
+     * @return the old value or {@code null} if there was none
+     */
+    public Object putObject(String key, Object value, Context vertxContext) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        return contextualDataMap(vertxContext).put(key, value);
+    }
+
+    /**
+     * Removes a key.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @return the old value or {@code null} if there was none
+     */
+    @Override
+    public String remove(String key) {
+        return remove(key, getContext());
+    }
+
+    /**
+     * Removes a key.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @param key the key
+     * @return the old value or {@code null} if there was none
+     */
+    @Override
+    public Object removeObject(String key) {
+        return removeObject(key, getContext());
+    }
+
+    /**
+     * Removes a key.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @return the old value or {@code null} if there was none
+     */
+    public String remove(String key, Context vertxContext) {
+        Object oldValue = removeObject(key, vertxContext);
+        return oldValue != null ? oldValue.toString() : null;
+    }
+
+    /**
+     * Removes a key.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @param key the key
+     * @return the old value or {@code null} if there was none
+     */
+    public Object removeObject(String key, Context vertxContext) {
+        Objects.requireNonNull(key);
+        return contextualDataMap(vertxContext).remove(key);
+    }
+
+    /**
+     * Get a copy of the MDC map. This is a relatively expensive operation.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @return a copy of the map
+     */
+    @Override
+    public Map<String, String> copy() {
+        return copy(getContext());
+    }
+
+    /**
+     * Get a copy of the MDC map. This is a relatively expensive operation.
+     *
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     *
+     * @return a copy of the map
+     */
+    @Override
+    public Map<String, Object> copyObject() {
+        return copyObject(getContext());
+    }
+
+    /**
+     * Get a copy of the MDC map. This is a relatively expensive operation.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @return a copy of the map
+     */
+    public Map<String, String> copy(Context vertxContext) {
+        final HashMap<String, String> result = new HashMap<>();
+        Map<String, Object> contextualDataMap = contextualDataMap(vertxContext);
+        for (Map.Entry<String, Object> entry : contextualDataMap.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().toString());
+        }
+        return result;
+    }
+
+    /**
+     * Get a copy of the MDC map. This is a relatively expensive operation.
+     * If the informed context is null it falls back to the thread local context map.
+     *
+     * @return a copy of the map
+     */
+    public Map<String, Object> copyObject(Context vertxContext) {
+        return new HashMap<>(contextualDataMap(vertxContext));
+    }
+
+    /**
+     * Clear the current MDC map.
+     * Tries to use the current Vert.x Context, if the context is non-existent
+     * meaning that it was called out of a Vert.x thread it will fall back to
+     * the thread local context map.
+     */
+    @Override
+    public void clear() {
+        clear(getContext());
+    }
+
+    /**
+     * Clear the current MDC map.
+     * If the informed context is null it falls back to the thread local context map.
+     */
+    public void clear(Context vertxContext) {
+        contextualDataMap(vertxContext).clear();
+    }
+
+    /**
+     * Gets the current duplicated context or a new duplicated context if a Vert.x Context exists. Multiple invocations
+     * of this method may return the same or different context. If the current context is a duplicate one, multiple
+     * invocations always return the same context. If the current context is not duplicated, a new instance is returned
+     * with each method invocation.
+     *
+     * @return a duplicated Vert.x Context or null.
+     */
+    private Context getContext() {
+        Context context = Vertx.currentContext();
+        if (context != null) {
+            Context dc = getOrCreateDuplicatedContext(context);
+            setContextSafe(dc, true);
+            return dc;
+        }
+        return null;
+    }
+
+    /**
+     * Gets the current Contextual Data Map from the current Vert.x Context if it is not null or the default
+     * ThreadLocal Data Map for use in non Vert.x Threads.
+     *
+     * @return the current Contextual Data Map.
+     */
+    @SuppressWarnings({ "unchecked" })
+    private Map<String, Object> contextualDataMap(Context ctx) {
+        if (ctx == null) {
+            return inheritableThreadLocalMap.get();
+        }
+
+        ConcurrentMap<Object, Object> lcd = Objects.requireNonNull((ContextInternal) ctx).localContextData();
+        return (ConcurrentMap<String, Object>) lcd.computeIfAbsent(VertxMDC.class.getName(),
+                k -> new ConcurrentHashMap<String, Object>());
+    }
+}

--- a/extensions/vertx/runtime/src/main/resources/META-INF/services/org.jboss.logmanager.MDCProvider
+++ b/extensions/vertx/runtime/src/main/resources/META-INF/services/org.jboss.logmanager.MDCProvider
@@ -1,0 +1,1 @@
+io.quarkus.bootstrap.logging.LateBoundMDCProvider

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/LateBoundMDCProvider.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/LateBoundMDCProvider.java
@@ -1,0 +1,101 @@
+package io.quarkus.bootstrap.logging;
+
+import java.util.Collections;
+import java.util.Map;
+import org.jboss.logmanager.MDCProvider;
+
+/**
+ * Class enabling Quarkus to instantiate a {@link MDCProvider}
+ * and set a delegate during runtime initialization.
+ *
+ * While no delegate is set it serves as a NOP MDC.
+ *
+ * LateBoundMDCProvider is an implementation of the MDC Provider SPI
+ * it will only be used/discovered if a provider configuration file
+ * {@code META-INF/services/org.jboss.logmanager.MDCProvider } is created.
+ */
+@SuppressWarnings({ "unused" })
+public class LateBoundMDCProvider implements MDCProvider {
+    private static volatile MDCProvider delegate;
+
+    /**
+     * Set the actual {@link MDCProvider} to use as the delegate.
+     *
+     * @param delegate Properly constructed {@link MDCProvider}.
+     */
+    public static void setMDCProviderDelegate(MDCProvider delegate) {
+        LateBoundMDCProvider.delegate = delegate;
+    }
+
+    @Override
+    public String get(String key) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.get(key);
+    }
+
+    @Override
+    public Object getObject(String key) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.getObject(key);
+    }
+
+    @Override
+    public String put(String key, String value) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.put(key, value);
+    }
+
+    @Override
+    public Object putObject(String key, Object value) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.putObject(key, value);
+    }
+
+    @Override
+    public String remove(String key) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.remove(key);
+    }
+
+    @Override
+    public Object removeObject(String key) {
+        if (delegate == null) {
+            return null;
+        }
+        return delegate.removeObject(key);
+    }
+
+    @Override
+    public Map<String, String> copy() {
+        if (delegate == null) {
+            return Collections.emptyMap();
+        }
+        return delegate.copy();
+    }
+
+    @Override
+    public Map<String, Object> copyObject() {
+        if (delegate == null) {
+            return Collections.emptyMap();
+        }
+        return delegate.copyObject();
+    }
+
+    @Override
+    public void clear() {
+        if (delegate == null) {
+            return;
+        }
+        delegate.clear();
+    }
+}


### PR DESCRIPTION
Updates jboss-logmanager to support a MDC adapter, and creates the Vert.x MDC adapter that can be used to provide MDC functionality with Vert.x context propagation.

It tries to use the current Vert.x context, and if the context is null, meaning that the logging was called outside a Vert.x thread, it will resort to the traditional MDC and use a thread local context map.


First part to fix https://github.com/quarkusio/quarkus/issues/18228 and also https://github.com/quarkusio/quarkus/issues/22724