### PR TITLE
Improve Podman compatibility

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -80,7 +80,7 @@
         <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss:${elasticsearch-server.version}</elasticsearch.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>1.2.3</opensearch-server.version>
-        <opensearch.image>opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
+        <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>
         <opensearch.protocol>http</opensearch.protocol>
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml
@@ -14,7 +14,6 @@
 
     <!-- Defaults, to simplify local testing -->
     <properties>
-        <postgres.image>postgres:14.1</postgres.image>
         <postgres.reactive.url>vertx-reactive:postgresql://localhost:5432/hibernate_orm_test</postgres.reactive.url>
     </properties>
 

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -183,7 +183,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -224,7 +224,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -224,7 +224,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -244,7 +244,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -201,7 +201,7 @@
                                         </wait>
 <!--                                         <volumes> -->
 <!--                                             <bind> -->
-<!--                                                 <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume> -->
+<!--                                                 <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume> -->
 <!--                                             </bind> -->
 <!--                                         </volumes> -->
                                     </run>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -190,7 +190,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -211,7 +211,7 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d/:Z</volume>
+                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
                                             </bind>
                                         </volumes>
                                     </run>


### PR DESCRIPTION
These two commits address two additional quirks of podman; also avoids downloading multiple container version for postgresql, which should be welcome for everyone.

## avoid the short name `postgres:14.1`

The image name was being overriden in `extensions/panache/hibernate-reactive-rest-data-panache/deployment/pom.xml` ; on top of this being unnecessary, it was forcing the use of a short name for the image, so it would fail the build unless the image had already been downloaded previously.

## avoid volume mount definitions with trailing /

This was just not working when experimenting with podman. It's odd as I'm sure it worked in the past.
