### PR TITLE
Apicurio registry version update to 2.2.3.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -186,8 +186,8 @@
         <log4j2-api.version>2.17.2</log4j2-api.version>
         <log4j-jboss-logmanager.version>1.3.0.Final</log4j-jboss-logmanager.version>
         <avro.version>1.11.0</avro.version>
-        <apicurio-registry.version>2.2.1.Final</apicurio-registry.version>
-        <apicurio-common-rest-client.version>0.1.7.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
+        <apicurio-registry.version>2.2.3.Final</apicurio-registry.version>
+        <apicurio-common-rest-client.version>0.1.9.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <jacoco.version>0.8.8</jacoco.version>
         <testcontainers.version>1.17.1</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.2.13</docker-java.version> <!-- must be the version Testcontainers use -->

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
@@ -30,7 +30,7 @@ public class ApicurioRegistryDevServicesBuildTimeConfig {
      * The Apicurio Registry image to use.
      * Note that only Apicurio Registry 2.x images are supported.
      */
-    @ConfigItem(defaultValue = "quay.io/apicurio/apicurio-registry-mem:2.2.0.Final")
+    @ConfigItem(defaultValue = "quay.io/apicurio/apicurio-registry-mem:2.2.3.Final")
     public String imageName;
 
     /**

--- a/integration-tests/kafka-avro-apicurio2/pom.xml
+++ b/integration-tests/kafka-avro-apicurio2/pom.xml
@@ -21,10 +21,6 @@
       - the tests for Confluent schema registry.
       -->
 
-    <properties>
-        <apicurio.version>2.2.1.Final</apicurio.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
`integration-tests/kafka-avro-apicurio2` uses dev services so no need to synchronize apicurio version.