### PR TITLE
Support for OIDC FrontChannel logout

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -508,6 +508,25 @@ Absolute `Back-Channel Logout` URL is calculated by adding `quarkus.oidc.back-ch
 
 Note that you will also need to configure a token age property for the logout token verification to succeed if your OpenID Connect Provider does not set an expiry claim in the current logout token, for example, `quarkus.oidc.token.age=10S` sets a number of seconds that must not elapse since the logout token's `iat` (issued at) time to 10.
 
+[[front-channel-logout]]
+==== Front-Channel Logout
+
+link:https://openid.net/specs/openid-connect-frontchannel-1_0.html[Front-Channel Logout] can be used to logout the current user directly from the user agent.
+
+You can configure Quarkus to support `Front-Channel Logout` as follows:
+
+[source,properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.client-id=frontend
+quarkus.oidc.credentials.secret=secret
+quarkus.oidc.application-type=web-app
+
+quarkus.oidc.logout.frontchannel.path=/front-channel-logout
+----
+
+This path will be compared against the current request's path and the user willbe logged out if these paths match.
+
 [[local-logout]]
 ==== Local Logout
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -65,4 +65,6 @@ public final class OidcConstants {
     public static final String BACK_CHANNEL_EVENTS_CLAIM = "events";
     public static final String BACK_CHANNEL_EVENT_NAME = "http://schemas.openid.net/event/backchannel-logout";
     public static final String BACK_CHANNEL_LOGOUT_SID_CLAIM = "sid";
+    public static final String FRONT_CHANNEL_LOGOUT_SID_PARAM = "sid";
+    public static final String ID_TOKEN_SID_CLAIM = "sid";
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -157,7 +157,7 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Token token = new Token();
 
     /**
-     * RP Initiated and BackChannel Logout configuration
+     * RP Initiated, BackChannel and FrontChannel Logout configuration
      */
     @ConfigItem
     public Logout logout = new Logout();
@@ -241,6 +241,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Backchannel backchannel = new Backchannel();
 
+        /**
+         * Front-Channel Logout configuration
+         */
+        @ConfigItem
+        public Frontchannel frontchannel = new Frontchannel();
+
         public void setPath(Optional<String> path) {
             this.path = path;
         }
@@ -280,12 +286,37 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public void setBackchannel(Backchannel backchannel) {
             this.backchannel = backchannel;
         }
+
+        public Frontchannel getFrontchannel() {
+            return frontchannel;
+        }
+
+        public void setFrontchannel(Frontchannel frontchannel) {
+            this.frontchannel = frontchannel;
+        }
     }
 
     @ConfigGroup
     public static class Backchannel {
         /**
          * The relative path of the Back-Channel Logout endpoint at the application.
+         */
+        @ConfigItem
+        public Optional<String> path = Optional.empty();
+
+        public void setPath(Optional<String> path) {
+            this.path = path;
+        }
+
+        public String getPath() {
+            return path.get();
+        }
+    }
+
+    @ConfigGroup
+    public static class Frontchannel {
+        /**
+         * The relative path of the Front-Channel Logout endpoint at the application.
          */
         @ConfigItem
         public Optional<String> path = Optional.empty();

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/SecurityEvent.java
@@ -1,5 +1,7 @@
 package io.quarkus.oidc;
 
+import java.util.Map;
+
 import io.quarkus.security.identity.SecurityIdentity;
 
 /**
@@ -26,15 +28,41 @@ public class SecurityEvent {
         /**
          * OIDC Logout event is reported when the current user has started an RP-initiated OIDC logout flow.
          */
-        OIDC_LOGOUT_RP_INITIATED
+        OIDC_LOGOUT_RP_INITIATED,
+
+        /**
+         * OIDC BackChannel Logout initiated event is reported when the BackChannel logout request to logout the current user
+         * has been received.
+         */
+        OIDC_BACKCHANNEL_LOGOUT_INITIATED,
+
+        /**
+         * OIDC BackChannel Logout completed event is reported when the current user's session has been removed due to a pending
+         * OIDC
+         * BackChannel logout request.
+         */
+        OIDC_BACKCHANNEL_LOGOUT_COMPLETED,
+        /**
+         * OIDC FrontChannel Logout event is reported when the current user's session has been removed due to an OIDC
+         * FrontChannel logout request.
+         */
+        OIDC_FRONTCHANNEL_LOGOUT_COMPLETED
     }
 
     private final Type eventType;
     private final SecurityIdentity securityIdentity;
+    private final Map<String, Object> eventProperties;
 
     public SecurityEvent(Type eventType, SecurityIdentity securityIdentity) {
         this.eventType = eventType;
         this.securityIdentity = securityIdentity;
+        this.eventProperties = Map.of();
+    }
+
+    public SecurityEvent(Type eventType, Map<String, Object> eventProperties) {
+        this.eventType = eventType;
+        this.securityIdentity = null;
+        this.eventProperties = eventProperties;
     }
 
     public Type getEventType() {
@@ -43,5 +71,9 @@ public class SecurityEvent {
 
     public SecurityIdentity getSecurityIdentity() {
         return securityIdentity;
+    }
+
+    public Map<String, Object> getEventProperties() {
+        return eventProperties;
     }
 }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.runtime;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.enterprise.event.Observes;
@@ -10,6 +11,8 @@ import org.jboss.logging.Logger;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 
 import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.SecurityEvent;
+import io.quarkus.oidc.SecurityEvent.Type;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -84,6 +87,11 @@ public class BackChannelLogoutHandler {
                                         if (verifyLogoutTokenClaims(result)) {
                                             resolver.getBackChannelLogoutTokens().put(oidcTenantConfig.tenantId.get(),
                                                     result);
+                                            if (resolver.isSecurityEventObserved()) {
+                                                resolver.getSecurityEvent().fire(
+                                                        new SecurityEvent(Type.OIDC_BACKCHANNEL_LOGOUT_INITIATED,
+                                                                Map.of(OidcConstants.BACK_CHANNEL_LOGOUT_TOKEN, result)));
+                                            }
                                             context.response().setStatusCode(200);
                                         } else {
                                             context.response().setStatusCode(400);

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LogoutException.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/LogoutException.java
@@ -1,0 +1,5 @@
+package io.quarkus.oidc.runtime;
+
+public class LogoutException extends RuntimeException {
+
+}

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -23,7 +23,7 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("code-flow-encrypted-id-token-pem")) {
             return "code-flow-encrypted-id-token-pem";
         }
-        if (path.endsWith("code-flow-form-post")) {
+        if (path.endsWith("code-flow-form-post") || path.endsWith("code-flow-form-post/front-channel-logout")) {
             return "code-flow-form-post";
         }
         if (path.endsWith("code-flow-user-info-only")) {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -47,6 +47,7 @@ quarkus.oidc.code-flow-form-post.token-path=${keycloak.url}/realms/quarkus/token
 # reuse the wiremock JWK endpoint stub for the `quarkus` realm - it is the same for the query and form post response mode
 quarkus.oidc.code-flow-form-post.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-form-post.logout.backchannel.path=/back-channel-logout
+quarkus.oidc.code-flow-form-post.logout.frontchannel.path=/code-flow-form-post/front-channel-logout
 
 
 quarkus.oidc.code-flow-user-info-only.auth-server-url=${keycloak.url}/realms/quarkus/
@@ -126,6 +127,9 @@ quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
 
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated
+
+quarkus.http.auth.permission.front-channel-logout.paths=/code-flow-form-post/front-channel-logout
+quarkus.http.auth.permission.front-channel-logout.policy=authenticated
 
 quarkus.http.auth.permission.backchannellogout.paths=/back-channel-logout
 quarkus.http.auth.permission.backchannellogout.policy=permit

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -329,6 +329,7 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .groups(groups)
                 .issuer(TOKEN_ISSUER)
                 .audience(TOKEN_AUDIENCE)
+                .claim("sid", "session-id")
                 .subject("123456")
                 .jws()
                 .keyId("1")
@@ -340,6 +341,7 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
                 .audience(TOKEN_AUDIENCE)
                 .subject("123456")
                 .claim("events", createEventsClaim())
+                .claim("sid", "session-id")
                 .jws()
                 .keyId("1")
                 .sign("privateKey.jwk");


### PR DESCRIPTION
Fixes #23478

This PR supports a front-channel logout request. If the current request path matches the configured frontchannel logout URL then the `sid` and `iss` query parameters are compared against the verified ID token's values and if all is good then the session cookie is removed.

As part of this work I also moved the backchannel logout check from the earlier PR to the same stage where frontchannel logout URL is checked, after id token has been verified (instead of doing a limited token validation in the backchannel check code) - this allowed to include sending both the backchannel and frontchannel logout CDI events, referencing the identity of the now logged out user.

Wiremock based test has been added.

I can also try to do a manual verification directly against Keycloak (it is not possible to set up the frontchannel URL in the Client using the admin API)