### PR TITLE
Correct typo in writing-extensions.adoc

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -3125,7 +3125,7 @@ Before publishing your extension to the xref:tooling.adoc[Quarkus tooling], make
 
 * The `quarkus-extension.yaml` file (in the extension's `runtime/` module) has the minimum metadata set:
 ** `name`
-** `description` (unless you have it already set in the `runtime/pom.xml`'s `<description>` element, which is the recommended approach)
+** `description` (unless you have it already set in the ``runtime/pom.xml``'s `<description>` element, which is the recommended approach)
 
 * Your extension is published in Maven Central
 


### PR DESCRIPTION
Add a space to conform Asciidoc inline code syntax
![image](https://user-images.githubusercontent.com/2139672/166633171-ab50c89d-d98b-4d44-a762-4654057f5ca1.png)
