### PR TITLE
Docs: Diataxis framework templates

### DIFF
--- a/docs/src/main/asciidoc/_examples/acme-serve-http-requests-MyAcmeApplication.java
+++ b/docs/src/main/asciidoc/_examples/acme-serve-http-requests-MyAcmeApplication.java
@@ -1,0 +1,26 @@
+// tag::application[]
+package org.acme;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.acme.corp.Anvil;
+import org.acme.corp.Toaster;
+
+import io.smallrye.mutiny.Multi;
+
+@ApplicationScoped // <1>
+public class MyAcmeApplication {
+
+    @Anvil(optional = {"name"}) // <2>
+    public String hello(String name) {
+        return String.format("Hello, %s!", (name == null ? "World" : name));
+    }
+
+    // tag::goodbye[]
+    @Toaster // <1>
+    public Multi<String> longGoodbye(String name) {
+        return Multi.createFrom().items("Goodbye", ",", "Sweet", "Planet", "!"); // <2>
+    }
+    // end::goodbye[]
+}
+// end::application[]

--- a/docs/src/main/asciidoc/_examples/acme-serve-http-requests-MyAcmeApplicationTest.java
+++ b/docs/src/main/asciidoc/_examples/acme-serve-http-requests-MyAcmeApplicationTest.java
@@ -1,0 +1,33 @@
+// tag::test[]
+package org.acme.getting.started.testing;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class MyAcmeApplicationTest {
+
+    @Test
+    void testHelloEndpoint() {
+        when().get("/hello").then().statusCode(200)
+                .body(is("Hello, World!"));
+    }
+
+    // tag::goodbye[]
+    @Test
+    void testGoodbyeEndpoint() {
+        when().get("/longGoodbye").then().statusCode(200)
+                .body(containsString(
+                        "data: Goodbye\nid: 0\n\n"
+                                + "data: ,\nid: 1\n\n"))
+                                + "data: Sweet\nid: 2\n\n"
+                                + "data: World\nid: 3\n\n"
+                                + "data: !\nid: 4\n\n"))
+                .header("content-type", "text/event-stream");
+    }
+    // end::goodbye[]
+}
+// end::test[]

--- a/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
+++ b/docs/src/main/asciidoc/_examples/acme-serve-http-requests-tutorial.adoctxt
@@ -1,0 +1,125 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="tutorial-acme-serve-http-requests"]
+= Serve Http requests using the Acme extension
+:extension-status: experimental
+include::attributes.adoc[]
+
+In this tutorial, we will create an application that uses unique annotations from the experimental acme extension to define two endpoints:
+a simple Http endpoint and an endpoint that emits Server-Sent Events (SSE).
+We will also use Quarkus dev mode for iterative development and test.
+
+include::{includes}/extension-status.adoc[]
+
+== Prerequisites
+
+:prerequisites-time: 30 minutes
+:prerequisites-docker:
+:prerequisites-no-graalvm:
+
+include::{includes}/prerequisites.adoc[]
+
+The `curl` command line utility is also used to manually test the endpoint.
+
+:sectnums:
+:sectnumlevels: 3
+== Create a new project
+
+Create a new project with the following command:
+
+:create-app-artifact-id: acme-quickstart
+:create-app-extensions: acme
+include::{includes}/devtools/create-app.adoc[]
+
+== Hello, World! as an Acme Http service
+
+Let's create a Http endpoint using the `@Anvil` annotation.
+
+Create a new source file, `src/main/java/org/acme/MyAcmeApplication.java`,
+and define the `MyAcmeApplication` bean as follows:
+
+[source,java]
+----
+include::{examples}/acme-serve-http-requests-MyAcmeApplication.java[tags=*;!goodbye]
+----
+
+<1> Specify the CDI lifecycle of this bean.
+An `@ApplicationScoped` bean has a single bean instance that is used for the application.
+<2> The `@Anvil` annotation always implies a simple Http GET request with the uri derived from the method name, `/hello` in this case.
+The `optional` value indicates that the `name` parameter is not required.
+
+== Dev Mode: Hello, World!
+
+Let's run our application using Quarkus' iterative development mode:
+
+include::{includes}/devtools/dev.adoc[]
+
+Once the console output from dev mode indicates that things are ready, use `curl` to invoke the `hello` endpoint:
+
+[source,shell]
+----
+$ curl -w "\n" http://localhost:8080/hello
+Hello, World!
+----
+
+Pass the name as a parameter:
+
+[source,bash,subs=attributes+]
+----
+$ curl localhost:8080/hello -d '{"name": "bananas"}'
+Hello, bananas!
+----
+
+You can leave dev mode running throughout the rest of the tutorial for continuous feedback as you make changes to code.
+Use `CTRL-C` to exit dev mode.
+
+== Testing: Hello, World!
+
+Let's create a test to work with our `@Anvil` endpoint.
+
+Create a new source file, `src/test/java/org/acme/MyAcmeApplicationTest.java`, and define `MyAcmeApplicationTest` as follows:
+
+[source,java]
+----
+include::{examples}/acme-serve-http-requests-MyAcmeApplicationTest.java[tags=*;!goodbye]
+----
+
+After saving, the dev console should detect the presence of tests, but it isn't running by default.
+The bottom of the console screen will display a message indicating that running tests have been paused.
+
+Press `r` to resume testing.
+You should see the status change as they are running, and it should finish with a message indicating that 1 test was run and that it was successful.
+
+== Goodbye, Sweet Planet! Server sent events with Acme
+
+Let's add an endpoint that supports Server Sent Events using the `@Toaster` annotation:
+
+[source,java]
+----
+include::{examples}/acme-serve-http-requests-MyAcmeApplication.java[tag=goodbye]
+----
+<1> The `@Toaster` annotation indicates that this method emits Server-Sent Events.
+<2> A `Multi` is an asynchronous publisher of multiple events provided by Mutiny, the event-driven reactive streams library used by Quarkus.
+
+== Testing: Goodbye, Sweet Planet!
+
+Let's create a test to work with our `@Toaster` endpoint.
+
+Add the following method to `src/test/java/org/acme/MyAcmeApplicationTest.java`:
+
+[source,java]
+----
+include::{examples}/acme-serve-http-requests-MyAcmeApplicationTest.java[tag=goodbye]
+----
+
+After saving, the dev console should detect the presence of the additional test, and run both.
+You should see a message that 2 tests were run, and both were successful.
+
+:sectnums!:
+== Summary
+
+Congratulations!
+You have created a project that uses the acme extension to create fanciful endpoints using the `@Anvil` and `@Toaster` annotations.

--- a/docs/src/main/asciidoc/_examples/attributes.adoc
+++ b/docs/src/main/asciidoc/_examples/attributes.adoc
@@ -1,0 +1,10 @@
+// Allow examples to render correctly in previews despite being
+// a nested directory
+:idprefix:
+:idseparator: -
+:icons: font
+:doc-guides: ..
+:doc-examples: .
+:imagesdir: ./images
+:includes: ../includes
+:root: ../../asciidoc

--- a/docs/src/main/asciidoc/_templates/attributes.adoc
+++ b/docs/src/main/asciidoc/_templates/attributes.adoc
@@ -1,0 +1,10 @@
+// Allow examples to render correctly in previews despite being
+// a nested directory
+:idprefix:
+:idseparator: -
+:icons: font
+:doc-guides: ../
+:doc-examples: ../_examples
+:imagesdir: ../../asciidoc/images
+:includes: ../includes
+:root: ../../asciidoc/

--- a/docs/src/main/asciidoc/_templates/template-concepts.adoc
+++ b/docs/src/main/asciidoc/_templates/template-concepts.adoc
@@ -1,0 +1,41 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="concept-..."]
+= Title using sentence capitalization
+////
+TODO: If this is a concept related to an experimental or tech-preview extension, uncomment the following and set the appropriate status (otherwise delete)
+:extension-status: preview
+////
+include::attributes.adoc[]
+
+A short introduction that summarizes or frames the concept.
+This summary should help a reader determine whether or not this document is what they want to read.
+
+////
+TODO: If this is a concept related to an experimental or tech-preview extension, uncomment the following (otherwise delete)
+include::{includes}/extension-status.adoc[]
+////
+
+== Create additional sections
+
+- xref:{doc-guides}/doc-concepts.adoc#concept[Documentation concepts: Concept guides]
+- xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference]
+
+== Guidelines for a good Concept doc
+
+Explanation/Concept documents should do things that the other parts of the documentation do not.
+
+- Make connections to other things, even to things outside the immediate topic, if that helps explain the concept.
+- Provide background and context in your explanation: explain why things are so - design decisions, historical reasons, technical constraints - draw implications, mention specific examples.
+- Consider alternatives, counter-examples or multiple different approaches to the same question.
+
+== Language tips:
+
+- Explain: "The reason for x is because historically, y…"
+- Offer judgements and even opinions where appropriate.., "W is better than z, because…"
+- Provide context that helps the reader: "An x in system y is analogous to a w in system z. However…"
+- Weigh up alternatives: "Some users prefer w (because z). This can be a good approach, but…"
+- Unfold the machinery’s internal secrets, to help understand why something does what it does: "An x interacts with a y as follows:…"

--- a/docs/src/main/asciidoc/_templates/template-howto.adoc
+++ b/docs/src/main/asciidoc/_templates/template-howto.adoc
@@ -1,0 +1,43 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+////
+TODO: Title should have an implied "How to.." in front. See
+////
+[id="howto-..."]
+= Title using sentence capitalization
+////
+TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following and set the appropriate status (otherwise delete)
+:extension-status: preview
+////
+include::attributes.adoc[]
+
+How-to guides are goal-oriented, and should help the reader accomplish a task (where there may be forks in the path).
+
+////
+TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following (otherwise delete)
+include::{includes}/extension-status.adoc[]
+////
+
+== Define the problem
+
+Your user will also be in the middle of something: define the starting-point that they know how to reach and a conclusion that answers a real question.
+
+== Resources
+
+- xref:{doc-guides}/doc-create-howto-tutorial.adoc[Tutorial: Create a How-To]
+- xref:{doc-guides}/doc-concepts.adoc#howto-guide[Documentation concepts: How-to guides]
+- xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference]
+
+== Guidelines for good How-To guides
+
+- Don’t explain concepts; link to a related concept/explainer
+- Be flexible; a how-to guide needs to be adaptable to real-world use-cases.
+- Omit the unnecessary; practical usability is more helpful than completeness.
+
+== Examples
+
+Baeldung tutorials provide solid examples of How-To guides.
+For example, "How to use Jackson annotations" is answered (with variations) here: https://www.baeldung.com/jackson-annotations

--- a/docs/src/main/asciidoc/_templates/template-reference.adoc
+++ b/docs/src/main/asciidoc/_templates/template-reference.adoc
@@ -1,0 +1,47 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="reference-..."]
+= Title using sentence capitalization
+////
+TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following and set the appropriate status (otherwise delete)
+:extension-status: preview
+////
+include::attributes.adoc[]
+
+A short introduction that describes the content of this reference.
+This summary should help a reader determine if this document is likely to contain the information they are looking for.
+
+////
+TODO: If this is a reference for an experimental or tech-preview extension, uncomment the following (otherwise delete)
+include::{includes}/extension-status.adoc[]
+////
+
+== Add additional sections
+
+- xref:{doc-guides}/doc-concepts.adoc#reference[Documentation concepts: Reference guides]
+- xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference]
+
+== Guidelines for a good reference
+
+- Be consistent
+- Be accurate
+- Do nothing but describe
+    - Include examples where appropriate, e.g. an example usage of a command
+    - Link to tutorials, how-to guides, or concepts/explainers as necessary
+
+.Language tips:
+--
+- State facts about how things work: X is an example of Y.
+- List commands, options, operations, features, flags, limitations, error messages, etc.
+- Provide warnings where appropriate
+--
+
+////
+TODO: If this is an extension reference, include the relevant configuration
+== Configuration Reference
+
+include::{generated-dir}/config/<<generated-filename>>.adoc[opts=optional, leveloffset=+1]
+////

--- a/docs/src/main/asciidoc/_templates/template-tutorial.adoc
+++ b/docs/src/main/asciidoc/_templates/template-tutorial.adoc
@@ -1,0 +1,55 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="tutorial-..."]
+= Title using sentence capitalization
+////
+TODO: If this is a tutorial for an experimental or tech-preview extension, uncomment the following and set the appropriate status (otherwise delete)
+:extension-status: preview
+////
+include::attributes.adoc[]
+
+Describe what the learner will accomplish (examples: build, create, construct, deploy; not: “you will learn...”).
+This short summary should help a reader determine if they want to engage with the content.
+
+////
+TODO: If this is a tutorial for an experimental or tech-preview extension, uncomment the following (otherwise delete)
+include::{includes}/extension-status.adoc[]
+////
+
+== Prerequisites
+
+////
+TODO: If this tutorial will use dev tools, use the following common include:
+include::{includes}/devtools/prerequisites.adoc[]
+This file offers a few different variables that can be used to tweak what is shown.
+////
+
+- Materials, software, ...
+- Whatever they should already have in hand to complete this set of steps
+
+:sectnums:
+:sectnumlevels: 3
+== Outline steps
+
+- xref:{doc-guides}/doc-create-tutorial.adoc[Tutorial: Create a tutorial]
+- xref:{doc-guides}/doc-concepts.adoc#tutorial[Documentation concepts: Tutorials]
+- xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference]
+
+Each step should conclude with a comprehensible/observable result.
+
+== Use the right language
+
+- Give your learner plenty of clues to help confirm they are on the right track and orient themselves.
+    - "Notice that...", "Remember that..."
+
+- Provide minimal explanation of actions in the most basic language possible.
+Link to more detailed explanation.
+    - "We must always do x before we do y because… (see Explanation for more details)."
+
+:sectnums!:
+== Summary
+
+In closing, describe (and admire, in a mild way) what your learner has accomplished (not: “you have learned…”).

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -1,8 +1,11 @@
-// for rendering the final website the attributes are set by
-// https://github.com/quarkusio/quarkusio.github.io/blob/develop/_guides/pom.xml
+// for rendering the final website the attributes are set in the appropriate
+// location based on source versions in https://github.com/quarkusio/quarkusio.github.io/
 // they are duplicated here to ease the preview when editing in the IDE
 :idprefix:
 :idseparator: -
 :icons: font
+// tag::xref-attributes[]
+:doc-examples: ./_examples
 :imagesdir: ./images
 :includes: ./includes
+// end::xref-attributes[]

--- a/docs/src/main/asciidoc/doc-concepts.adoc
+++ b/docs/src/main/asciidoc/doc-concepts.adoc
@@ -1,0 +1,83 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="concepts-quarkus-documentation"]
+= Quarkus documentation concepts
+include::attributes.adoc[]
+:keywords: contributing, docs
+:fn-diataxis: footnote:diataxis[Procida, D. Diátaxis documentation framework. https://diataxis.fr/]
+
+Overview of concepts underlying the structure and composition of Quarkus docs.
+
+== Content Types
+
+We are aligning Quarkus docs with the Diátaxis documentation framework{fn-diataxis}, which defines a core content structure that addresses the different needs users have when consulting docs. 
+What follows is a brief summary of the different document types, but their site is worth a read if you want to understand more of the reasoning behind this classification.
+
+[[concept]]
+=== Concept guides (Explanation)
+
+> Explanation is _discussion_ that clarifies and illuminates a particular topic. Explanation is _understanding-oriented_.
+
+Good concept guides: 
+
+- are about a topic, and aim to provide the reader with information that helps 
+  establish a deeper understanding of that topic.
+- make connections to other things, if it helps explain the topic.
+- provide background and context to help explain _why_.
+- can consider alternatives or counter-examples, if it helps explain the topic.
+- do things other parts of the documentation do not; rely on references, tutorials, and 
+  how-to guides to perform their roles.
+
+[[howto-guide]]
+=== How-To guides
+
+> How-to guides are _directions_ that take the reader through the steps required to solve a real-world problem. How-to guides are _goal-oriented_.
+
+Good how-to guides: 
+
+- guide (walk-through) or demonstrate how to complete a task.
+- assume you have enough context to begin the task. 
+- describes the concrete steps necessary to complete a task, but these steps 
+  could be in the middle of a larger task.
+- do not explain concepts, they rely on other documents (like concepts) to do that.
+- are adaptable to real-world use cases.
+- are practical (rather than complete).
+
+[[reference]]
+=== Reference guides
+
+> Reference guides are _technical descriptions_ of the machinery and how to operate it. Reference material is _information-oriented_.
+
+Good reference guides: 
+
+- are concise and to the point. They state, describe, and inform.
+- are consistent (to the extent possible) with other reference guides. 
+  Following the template helps here.
+- remain focused on describing their topic. 
+  They don't explain or provide additional context from other sources.
+- provide examples or illustrations that help readers understand what is being described.
+- are kept up to date. While configuration reference material is generated, 
+  extension references that describe how configuration should be applied must be accurate to be useful.
+
+
+[[tutorial]]
+=== Tutorials
+
+> Tutorials are _lessons_ that take the reader by the hand through a series of steps to complete a project of some kind. Tutorials are _learning-oriented_.
+
+Good tutorials: 
+
+- provide a learning experience, giving the reader something they can do.
+- get the reader started (they do not create an expert).
+- provide the reader with concrete steps to follow that each have a comprehensible result.
+- are reliable and consistent (they work for all users, every time).
+- include only enough information to complete the task. 
+  They delegate to other documentation types (concepts or reference) to provide additional context.
+- focus on one way of doing the task. Alternative approaches are explored in other document types
+  (e.g. a how-to guide).
+
+
+

--- a/docs/src/main/asciidoc/doc-contribute-quarkus-docs-howto.adoc
+++ b/docs/src/main/asciidoc/doc-contribute-quarkus-docs-howto.adoc
@@ -1,0 +1,77 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="howto-contribute-quarkus-docs"]
+= How to contribute to Quarkus documentation
+include::attributes.adoc[]
+:toc: preamble
+:asciidoc: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/
+:keywords: contributing, docs
+:quarkus-docs: https://github.com/quarkusio/quarkus/tree/main/docs
+:fn-diataxis: footnote:diataxis[Procida, D. Diátaxis documentation framework. https://diataxis.fr/]
+
+Outline the recommended steps for making successful contributions to Quarkus documentation.
+
+== Prerequisites
+
+Quarkus docs are built from source written using {asciidoc}[Asciidoc], a lightweight markup language.
+
+We suggest you have the following materials nearby:
+
+- An editor or IDE that provides syntax highlighting and previews for asciidoc, either natively or using a plugin.
+- An https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/[Asciidoc syntax reference]
+- The xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference] for required syntax and other conventions.
+
+== Sources
+
+- Documentation for Quarkus core and most extensions is located in the `docs` directory of the {quarkus-docs}[Quarkus GitHub repository].
+- Docs for Quarkiverse or other third-party extensions are pulled directly from those repositories.
+
+== Building and previewing Quarkus documentation
+
+Asciidoc syntax highlighting and the preview provided by an IDE can be sufficient for minor documentation changes.
+For significant changes or any changes related to Quarkus configuration documentation,
+we recommend that you run the build and view the resulting output before submitting your changes for review.
+
+include::{includes}/compile-quarkus-quickly.adoc[tag=quickly-install-docs]
+
+This will produce a few things:
+
+- Generated configuration properties documentation will be located in the  `target/asciidoc/generated/config/` directory.
+- Asciidoc output (html files) will be found in the `docs/target/generated-docs/` directory.
+
+As you make additional changes, you can build the `docs` module specifically to update the generated HTML:
+
+[source,shell]
+----
+$ ./mvnw -f docs clean install
+----
+
+If you change the configuration properties of an extension,
+rebuild that extension first (to regenerate the associated config docs in `target/asciidoc/generated/config/`),
+and then rebuild the `docs` module.
+
+== Creating pull requests for doc updates
+
+:gh-pull-requests-fork: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+:gh-about-forks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks
+
+Submit your proposed changes to the core Quarkus docs by {gh-pull-requests-fork}[creating a pull request] against the `main` branch of the Quarkus repository from your own {gh-about-forks}[repository fork].
+
+[TIP]
+Changes to docs for Quarkiverse or other third-party extensions should be submitted as pull requests in respective repository according to its contribution guide.
+
+Reviews for code and documentation have different (but overlapping) participants.
+To simplify collaborative review, either isolate changes to docs in their own PRs,
+or ensure that the PRs has a single, focused purpose.
+For example:
+
+- A single PR that adds a configuration option for an extension and updates related materials (how-to, reference) to explain the change.
+- A single PR for related changes to several docs,
+e.g. updates to ensure a term is used consistently, correcting a recurring error, or moving repeated content into a shared file.
+- If there are extensive code changes as well as documentation changes,
+make a separate PR for the documentation changes and indicate the relationship in the issue description.
+
+Once created, the PR will be tagged automatically as something containing documentation changes.

--- a/docs/src/main/asciidoc/doc-create-tutorial.adoc
+++ b/docs/src/main/asciidoc/doc-create-tutorial.adoc
@@ -1,0 +1,406 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="tutorial-doc-create-tutorial"]
+= Creating a tutorial
+include::attributes.adoc[]
+
+Create a new tutorial that guides users through creating, running, and testing a Quarkus application that uses annotations from an imaginary extension.
+
+== Prerequisites
+
+- Roughly 15 minutes
+- An editor or IDE that provides syntax highlighting and previews for asciidoc, either natively or using a plugin.
+- You should be familiar with the overview of what a xref:doc-concepts.adoc#tutorial[Tutorial] is.
+- Have the xref:doc-reference.adoc[Quarkus documentation reference] handy as a reference for required syntax and other conventions.
+
+:sectnums:
+:sectnumlevels: 3
+== Decide on a title and file name
+
+1. Decide on a title for the tutorial.
+For this worked example, we will use  `Serve Http requests using the Acme extension`.
+
+2. Decide on a file name.
+For this example, we will use `acme-serve-http-requests-tutorial.adoc`:
+
+- `acme-` will group this guide with other resources related to the acme extension
+- `serve-http-requests` is a derivative of the document title
+- `-tutorial.adoc` will indicate that this document is a tutorial
+
+== Copy the tutorial template
+
+Copy `docs/src/main/diataxis/_templates/template-tutorial.adoc` from the Quarkus repository into a new file called `acme-serve-http-requests-tutorial.adoc`.
+
+== Update the document header
+
+[source,asciidoc]
+----
+[id="tutorial-acme-serve-http-requests"] // <1>
+= Serve Http requests using the Acme extension // <2>
+:extension-status: experimental // <3>
+include::attributes.adoc[] // <4>
+----
+
+<1> Specify a unique id for the section in lower-kebab-case.
+<2> Add the title as a top-level heading.
+<3> Our imaginary `acme` extension is experimental, so we include the extension status declaration in the header.
+<4> Include additional attributes that help define consistent formatting and provide source portability.
+
+.Document Preview
+--
+The preview of your document should contain the chosen title as a styled header at the top of the page.
+--
+
+== Add an abstract
+
+We want to let the readers of our tutorial know what they will achieve by following the steps in the tutorial.
+This abstract should be concise and should use appropriate verbs (create, build, deploy, ...) to set expectations.
+They should be able to determine if they want to engage with the content.
+
+[source,asciidoc]
+----
+In this tutorial, we will create an application that uses unique annotations from the experimental acme extension to define two endpoints:
+a simple Http endpoint and an endpoint that emits Server-Sent Events (SSE).
+We will also use Quarkus dev mode for iterative development and test.
+----
+
+.Document Preview
+--
+The preview of your document should contain the abstract as a paragraph immediately following the header.
+--
+
+== Include extension status descriptive text
+
+As the `acme` extension is experimental, we'll include `\{includes}/extension-status.adoc` that provides extension status text.
+It uses the extension status attribute defined in the header.
+
+[source,asciidoc]
+----
+\include::{includes}/extension-status.adoc[]
+----
+
+.Document Preview
+--
+The preview of your document should now include an admonition box below the abstract explaining that the plugin is experimental technology, and describing what can be expected in terms of stability and/or support for experimental technologies.
+--
+
+== Define Prerequisites
+
+We need to tell users what resources are required for completing the tutorial.
+
+Any tutorial describing development activity should use  `\{includes}/prerequisites.adoc` to ensure consistent language is used when describing prerequisites.
+Declared `prerequisites-` attributes can customize the final text.
+
+[source,asciidoc]
+----
+== Prerequisites
+
+:prerequisites-time: 30 minutes // <1>
+:prerequisites-docker: // <2>
+:prerequisites-no-graalvm: // <3>
+include::{includes}/prerequisites.adoc[] // <4>
+
+The `curl` command line utility is also used to manually test the endpoint.
+----
+
+<1> Declare that our hypothetical tutorial will take about 30 minutes to complete.
+<2> Declare that our nonsensical acme extension also requires a container runtime.
+<3> For simplicity in this tutorial, we will avoid graalvm/mandrel prerequisites
+<4> Include the common file that provides text describing prerequisites.
+
+.Document Preview
+--
+A second level `Prerequistes` heading should immediately follow the extension status box in your document preview.
+It should state:
+
+- that this tutorial will take roughly 30 minutes
+- that you need an IDE, JDK (with versions), maven (with a placeholder for the maven version), a working container runtime, and (optionally) the Quarkus CLI.
+--
+
+== Describe the steps for completing the tutorial
+
+There are a few parts to this process.
+Just remember that each step should conclude with a comprehensible/observable result: "The output should look something like this..."
+
+=== Define the first step
+
+Enable section numbering before specifying the header for the first step.
+
+[source,asciidoc]
+----
+:sectnums: // <1>
+:sectnumlevels: 3
+== Create a new project // <2>
+
+Create a new project with the following command: // <3>
+
+:create-app-artifact-id: acme-quickstart // <4>
+:create-app-extensions: acme // <5>
+include::{includes}/devtools/create-app.adoc[] // <6>
+----
+
+<1> Enable section numbering
+<2> Create a second level heading for the first step
+<3> Describe the step briefly
+<4> Define the maven/gradle artifact id
+<5> List the extensions required by this project
+<6> Use common text to describe how to create a project
+
+.Document Preview
+--
+The document preview should now include a new section called `1. Create a new project`, that contains steps for creating a new project using both the Quarkus CLI and maven.
+--
+
+=== Using a source file
+
+In this tutorial, we are going to include code from a separate Java file using tags.
+
+[NOTE]
+====
+Consider this an aspirational example. Source is more commonly included directly in the source code block.
+While there are advantages to including source from Java files,
+there are details that we have to work out regarding where referenced code should live.
+Help and ideas are welcome!
+====
+
+Let's create a file called `acme-serve-http-requests-MyAcmeApplication.java`.
+While this is not a valid Java file name, it does sit nicely next to our tutorial source.
+We're going to rely on IDE magic for syntax checking.
+
+Let's add the following code to that file:
+
+[source,java,subs="-callouts"]
+----
+// tag::application[]
+package org.acme;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.acme.corp.Anvil;
+import org.acme.corp.Toaster;
+
+import io.smallrye.mutiny.Multi;
+
+@ApplicationScoped // <1>
+public class MyAcmeApplication {
+
+    @Anvil(optional = {"name"}) // <2>
+    public String hello(String name) {
+        return String.format("Hello, %s!", (name == null ? "World" : name));
+    }
+
+    // tag::goodbye[]
+    @Toaster // <1>
+    public Multi<String> longGoodbye(String name) {
+        return Multi.createFrom().items("Goodbye", ",", "Sweet", "Planet", "!"); // <2>
+    }
+    // end::goodbye[]
+}
+// end::application[]
+----
+
+There are a few things to notice in this code sample:
+
+- There are callouts as comments on some lines, and their numbering is not sequential.
+
+- There are Asciidoc content regions defined by tag pairs (`tag::` and `end::`) in comments surrounding different sections of code.
+
+=== Provide concise subsequent steps
+
+Let's now instruct the learner to create a simple endpoint using the imaginary `@Anvil` annotation.
+
+==== Create a source code file
+
+We'll start with the steps required to create and add an endpoint to a file.
+
+[source,asciidoc,subs="-callouts"]
+-----
+== Hello, World! as an Acme REST service
+
+Let's create a Http endpoint using the `@Anvil` annotation.
+
+Create a new source file, `src/main/java/org/acme/MyAcmeApplication.java`, and define the `MyAcmeApplication` bean as follows:
+
+[source,java]
+----
+\include::{doc-examples}/acme-serve-http-requests-MyAcmeApplication.java[tags=*;!goodbye]
+----
+
+<1> Specify the CDI lifecycle of this bean.
+An `@ApplicationScoped` bean has a single bean instance that is used for the application.
+<2> The `@Anvil` annotation always implies a simple Http GET request with the uri derived from the method name, `/hello` in this case.
+The `optional` value indicates that the `name` parameter is not required.
+-----
+
+Some things to notice about these instructions:
+
+- We are including code from the source file while using Asciidoc tagged regions to exclude the `goodbye` method from the listing.
+- We put some context around what `@ApplicationScoped` means, without going into details about alternative CDI lifecycles
+- We describe what `@Anvil` is providing in the specific case covered by this tutorial.
+
+WARNING: Be careful with the amount of explanation given in a tutorial.
+Include enough information in the tutorial to help the user determine what other resource (howto, concept, or reference) they should look at next.
+
+.Document Preview
+--
+Your preview should contain a new section, `2. Hello, World! as an Acme REST service` that includes the contents of `src/main/java/org/acme/MyAcmeApplication.java` with the `goodbye` method omitted.
+--
+
+==== Explore continuous development and test
+
+It's now time to walk the user through starting Quarkus dev mode.
+A common include does most of the work for us:
+
+[source,asciidoc,subs="-callouts"]
+-----
+== Dev Mode: Hello, World!
+
+Let's run our application using Quarkus' iterative development mode:
+
+\include::{includes}/devtools/dev.adoc[]
+
+Once the console output from dev mode indicates that things are ready, use `curl` to invoke the `hello` endpoint:
+
+[source,shell]
+----
+$ curl -w "\n" http://localhost:8080/hello
+Hello, World!
+----
+
+Pass the name as a parameter:
+
+[source,bash,subs=attributes+]
+----
+$ curl localhost:8080/hello -d '{"name": "bananas"}'
+Hello, bananas!
+----
+
+You can leave dev mode running throughout the rest of the tutorial for continuous feedback as you make changes to code.
+Use `CTRL-C` to exit dev mode.
+-----
+
+We're providing a few things here:
+
+- We're using common text that describes how to start dev mode.
+- We describe how to use `curl` to test the output of our defined endpoint.
+
+.Document Preview
+--
+Your preview should contain a new section, "3. Dev Mode: Hello, World!"
+That section should include three methods of launching Quarkus dev mode (cli, maven, gradle).
+It should have codeblocks containing curl console commands and output, and instructions for how to exit dev mode.
+--
+
+==== Adding tests
+
+Now let's walk users through adding a test to their application:
+
+[source,asciidoc,subs="-callouts"]
+-----
+== Testing: Hello, World!
+
+Let's create a test to work with our `@Anvil` endpoint.
+
+Create a new source file, `src/test/java/org/acme/MyAcmeApplicationTest.java`, and define `MyAcmeApplicationTest` as follows:
+
+[source,java]
+----
+\include::{doc-examples}/acme-serve-http-requests-MyAcmeApplicationTest.java[tags=*;!goodbye]
+----
+
+After saving, the dev console should detect the presence of tests, but it isn't running by default.
+The bottom of the console screen will display a message indicating that running tests have been paused.
+
+Press `r` to resume testing.
+You should see the status change as tests are running, and it should finish with a message indicating that 1 test was run and that it was successful.
+-----
+
+We're using Asciidoc region tags to exclude a method from the listing (that we will be adding later).
+
+.Document Preview
+--
+Your preview should contain a new section, `4. Testing: Hello, World!` that includes the contents of `src/main/java/org/acme/MyAcmeApplicationTest.java` with the `testGoodbyeEndpoint` method omitted.
+--
+
+==== Add additional capabilities
+
+Let's add another step for creating a different endpoint using the imaginary `@Toaster` annotation, and for providing a corresponding test.
+
+[source,asciidoc,subs="-callouts"]
+-----
+== Goodbye, Sweet Planet! Server sent events with Acme
+
+Let's add an endpoint that supports Server Sent Events using the `@Toaster` annotation:
+
+[source,java]
+----
+\include::{doc-examples}/acme-serve-http-requests-MyAcmeApplication.java[tag=goodbye]
+----
+<1> The `@Toaster` annotation indicates that this method emits Server-Sent Events.
+<2> A `Multi` is an asynchronous publisher of multiple events provided by Mutiny, the event-driven reactive streams library used by Quarkus.
+
+== Testing: Goodbye, Sweet Planet!
+
+Let's create a test to work with our `@Toaster` endpoint.
+
+Add the following method to `src/test/java/org/acme/MyAcmeApplicationTest.java`:
+
+[source,java]
+----
+\include::{doc-examples}/acme-serve-http-requests-MyAcmeApplicationTest.java[tag=goodbye]
+----
+
+After saving, the dev console should detect the presence of the additional test, and run both.
+You should see a message that 2 tests were run, and both were successful.
+-----
+
+A few things to note:
+
+- We're using the asciidoc region tag to include only one region of the target file.
+
+- We do not go into detail explaining concepts:
+
+    * We talk about what the `@Toaster` annotation is doing in this example.
+    * We define the term `Multi` in a way that helps a user find their way to other related materials (How to, Concept, or Reference).
+
+.Document preview
+--
+Your preview should now contain two new sections, `5. Goodbye, Sweet Planet! Server sent events with Acme` and `6. Testing: Goodbye, Sweet Planet!`.
+
+The two new code listings should be focused on the methods that were omitted before:
+`goodbye` from `src/main/java/org/acme/MyAcmeApplication.java`, and `testGoodbyeEndpoint` from `src/main/java/org/acme/MyAcmeApplicationTest.java`.
+--
+
+== Provide a Summary section
+
+[source,asciidoc]
+----
+:sectnums!: // <1>
+== Summary
+
+Congratulations! You have created a project that uses the acme extension to create fanciful endpoints using the `@Anvil` and `@Toaster` annotations. // <2>
+----
+
+<1> Turn off section numbering
+<2> Congratulate the user on a job well done!
+
+.Document preview
+--
+Your preview should now contain an unnumbered `Summary` section.
+--
+
+:sectnums!:
+== Summary
+
+Congratulations!
+You have created a tutorial that describes how to create an application that uses annotations of dubious merit from a hypothetical extension.
+
+If you wish, you may compare your result against the complete worked example:
+
+[NOTE]
+-----
+include::{doc-examples}/acme-serve-http-requests-tutorial.adoctxt[]
+-----

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -1,0 +1,156 @@
+////
+This document is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+[id="reference-doc-quarkus-documentation"]
+= About Quarkus documentation
+include::attributes.adoc[]
+:toc: preamble
+
+A detailed reference for the structure and composition of Quarkus documentation.
+
+== Source locations
+
+Quarkus doc sources are built and synced to the https://quarkus.io/guides/[Quarkus.io website] at release time.
+
+- Documentation for Quarkus core and most extensions is located in the `docs` module of the https://github.com/quarkusio/quarkus/tree/main/docs[Quarkus GitHub repository].
+- Docs for Quarkiverse or other third-party extensions are pulled directly from those repositories.
+
+The Asciidoc files can be found in the `src/main/asciidoc` directory within the docs module.
+
+== Templates
+
+Create new documentation files using the appropriate template for the content type: 
+
+Concepts:: Use `src/main/asciidoc/_templates/template-concepts.adoc`
+How-To Guides:: Use `src/main/asciidoc/_templates/template-howto.adoc`
+Reference:: Use `src/main/asciidoc/_templates/template-reference.adoc`
+Tutorials:: Use `src/main/asciidoc/_templates/template-tutorial.adoc`
+
+== Output locations
+
+Configuration references:: Javadoc comments discovered in MicroProfile Config source files are used to generate config reference documentation.
+These generated files are found in `target/asciidoc/generated/config/` (from the project root).
+
+Asciidoc output as HTML:: A locally-rendered result of asciidoc processing (which is similar, but not identical, to that used to generate website documentation) is found in `docs/target/generated-docs/`
+
+== Titles
+
+The title should use sentence case and the active tense.
+Search engines like good titles, too!
+
+Concepts:: Concept documents give context and provide explanations.
+A title for a concept doc might finish this thought, "Understanding ... "
+
+How-To Guides:: The title should state exactly what the how-to guide shows. Consider starting with "How to... " and complete the sentence with a concise description of the task. 
+
+Reference:: A reference guide title should concisely summarize the content of the document.
+It should not include the word 'reference'. Consider starting with "About ..."
+
+Tutorials:: The title of the tutorial should state what task the user will complete, with emphasis on the key topic or demonstrated activity.
+Creating an app, for example, is rarely the focus of a tutorial, though it is often a step along the path.
+An example title might complete this (long) sentence, "You will create an application that [uses x extension to] ..."
+
+== File naming conventions
+
+Quarkus docs are stored in a fairly flat structure in an effort to make things easier to discover.
+The bulk of the file name should be some representation of its title.
+Use all lowercase letters, separate words with hyphens, and don't use symbols or special characters.
+
+Prefix:: Use a common prefix to group related documents, e.g. all of the documents related to writing Quarkus docs are prefixed with `doc-`.
+
+Suffix:: The file name should reflect the type of document:
+
+- Concept documents should end in `-concepts.adoc`
+- How-to guides should end in `-howto.adoc`
+- References should end in `-reference.adoc`
+- Tutorials should end in `-tutorial.adoc`
+
+== Asciidoc syntax
+
+Quarkus docs are built from source written using https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/[Asciidoc] syntax.
+
+=== Semantic line breaks
+
+:semantic-line-breaks: footnote:smbl[Rhodes, B. Semantic Linefeeds. https://rhodesmill.org/brandon/2012/one-sentence-per-line/]
+
+Text in paragraphs, lists, and tables should be broken into pieces that are easier to review{semantic-line-breaks}.
+Start a new line at the end of each sentence, and
+split sentences themselves at natural breaks between clauses.
+
+=== Automatic Table of Contents (TOC)
+
+Use `:toc: preamble` in the document header to insert an automatically generated TOC after the abstract (or preamble) to the document.
+For example, this document has the following in its header:
+
+[source,asciidoc]
+----
+[id="reference-doc-quarkus-documentation"]
+= Quarkus documentation reference
+\include::attributes.adoc[]
+:toc: preamble
+----
+
+=== Using sections
+
+Section titles should be written in sentence case, rather than title case.
+
+All documents should start with a Title (a `= Level 0` heading), and should 
+be broken into subsections as appropriate
+(`== Level 1` to `====== Level 5`)
+without skipping any levels.
+
+[TIP]
+====
+Deep nesting (`====== Level 4`, `====== Level 5`)
+should be avoided whenever possible.
+If you end up with deeply nested sections, think about the following:
+
+- Is this information in the right place?
+For example, if this is a reference, should some of this content be moved to a concept doc or how-to guide instead?
+- Can the content be re-organized to make it simpler to consume?
+
+See xref:{doc-guides}/doc-concepts.adoc[Quarkus documentation concepts] for more information about content types and organization.
+====
+
+=== Links
+
+In general, prefer using https://docs.asciidoctor.org/asciidoc/latest/macros/url-macro/[url macros] to using bare or automatic links.
+Provide human-readable text for the link, especially if it is included in the middle of other text.
+
+.A URL Macro link with attributes
+[NOTE]
+=====
+The URL macro also supports https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro-ref/[additional attributes] that may be relevant, like opening a link in a different window.
+
+[source,asciidoc]
+----
+https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/[Asciidoc Syntax Quick Reference,window=_blank,opts=nofollow]
+----
+
+The above source produces this link: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/[Asciidoc Syntax Quick Reference,window=_blank,opts=nofollow].
+=====
+
+=== Cross-references
+
+Quarkus documentation is built from source in a few different environments.
+We use attributes in our cross-references to ensure our docs can be built across these environments.
+
+.Cross-reference source attributes
+[source,asciidoc]
+----
+include::attributes.adoc[tag=xref-attributes]
+----
+
+When cross-referencing content, always use the inter-document `xref:` syntax and supply a human-readable label to your link.
+
+.Cross-reference example
+[source,asciidoc]
+----
+xref:{doc-guides}/doc-concepts.adoc[Quarkus Documentation concepts] <1>
+----
+<1> The cross reference starts with `xref:`, uses a cross-reference source attribute(`\{doc-guides}`), and provides a readable description: `[Quarkus Documentation concepts]`
+
+
+

--- a/docs/src/main/asciidoc/includes/compile-quarkus-quickly.adoc
+++ b/docs/src/main/asciidoc/includes/compile-quarkus-quickly.adoc
@@ -1,0 +1,34 @@
+// tag::quickly-install[]
+The following will build all modules in the Quarkus repository except docs and test modules and install them in your local maven repository with the `999-SNAPSHOT` version:
+
+[source,shell]
+----
+$ ./mvnw clean install -Dquickly \ #<1>
+  -DskipTests \ # <2>
+  -DskipITs \ # <3>
+  -Dno-test-modules # <4>
+----
+<1> `-Dquickly` skips building documentation
+<2> `-DskipTests` Skip maven surefire tests
+<3> `-DskipITs` Skip maven failsafe integration tests
+<4> `-Dno-test-modules` Do not build integration test modules
+// end::quickly-install[]
+
+// tag::quickly-install-docs[]
+The following will build all modules in the Quarkus repository (except test modules) and install them in your local maven repository with the `999-SNAPSHOT` version:
+
+[source,shell]
+----
+$ ./mvnw clean install -Dquickly \ #<1>
+  -DskipTests \ # <2>
+  -DskipITs \ # <3>
+  -Dno-test-modules \ # <4>
+  -DskipDocs=false # <5>
+----
+<1> `-Dquickly` skips building documentation
+<2> `-DskipTests` Skip maven surefire tests
+<3> `-DskipITs` Skip maven failsafe integration tests
+<4> `-Dno-test-modules` Do not build integration test modules
+<5> `-DskipDocs=false` re-enable the documentation build
+// end::quickly-install-docs[]
+

--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ $BRANCH == "main" ]]; then
-  TARGET_GUIDES=target/web-site/_guides
+  TARGET_GUIDES=target/web-site/_versions/main/guides
   TARGET_CONFIG=target/web-site/_generated-config/latest
 else
   TARGET_GUIDES=target/web-site/_versions/${BRANCH}/guides
@@ -43,7 +43,24 @@ then
     git push origin develop
     echo "Web Site updated - wait for CI build"
 else
-    echo "Run the following command to check the web site (if not done already)"
-    echo "(cd target/web-site  && bundle exec jekyll serve)"
-fi
+    echo "
+Run one of the following command to check the web site (if not done already):
 
+- If you have Jekyll set up locally:
+    (cd target/web-site && bundle exec jekyll serve)
+
+- If you have Docker or Podman:
+    cd target/web-site
+    docker run --rm --volume=\"$PWD:/srv/jekyll:Z\" \\
+        --publish 4000:4000 jekyll/jekyll:4.1.0 jekyll serve --incremental
+  
+- If you have Podman, something similar should work, but...
+  - you may need to set the Jekyll user/group id to match yours: -e JEKYLL_UID=501 -e JEKYLL_GID=503
+  - you may need to add an environment variable if you are running rootless: -e JEKYLL_ROOTLESS=1
+  - More: https://github.com/envygeeks/jekyll-docker/blob/master/README.md
+
+- For either docker/podman, you may want to add a volume to store built bundles:
+      docker volume create quarkus-jekyll-bundles
+  - Add the volume to the command: --volume quarkus-jekyll-bundles:/usr/local/bundle
+"
+fi


### PR DESCRIPTION
The directory structure: diataxis vs asciidoc is temporary, to identify what has been touched and what hasn't. Consider it an internal detail (not surfaced on the website).

the `doc-\*` pages are intended for those that will be contributing to Quarkus documentation, so they understand the intent/distinction between the four types of docs. This content also provides exemplars of each type: `doc-\*-tutorial.adoc` for tutorials, `doc-\*-howto.adoc` for how-tos, `doc-\*-concepts.adoc` for concepts, and `doc-\*-reference.adoc` for references.

Resolves #25355 

UPDATE: 
- Flattened back into the single `asciidoc` directory so we can make incremental progress on improving docs. See #25952 for a tool that will enumerate the docs that don't fit in any of the target categories or are missing required things so we know what still needs to be done.

ADDITIONAL NOTES (2022-06-29):
- This does not impact website publishing. New docs following templates will still need to be added manually to be included on the website. 
- Indexes are generated by tools introduced in #25952 may allow a bit more automation (to pick up descriptions, and or allow iteration over docs of different types), but that tool is essentially experimental, to allow us to figure out how to then improve the publication process and work towards James' updated design that breaks out documents by type. 

