### PR TITLE
Allow reuse of containers needed by DevServices (opt-in)

### DIFF
--- a/docs/src/main/asciidoc/dev-services.adoc
+++ b/docs/src/main/asciidoc/dev-services.adoc
@@ -49,6 +49,13 @@ xref:datasource.adoc#dev-services[Datasource Guide].
 Quarkus provides Dev Services for all databases it supports. Most of these are run in a container, with the
 exception of H2 and Derby which are run in process. Dev Services are supported for both JDBC and reactive drivers.
 
+Those relational databases that are running in a container are started using Testcontainers and support "reusable instances";
+this implies that if you add the property `testcontainers.reuse.enable=true` in your Testcontainers configuration file,
+a property file named `.testcontainers.properties` in your user home, then the databases will not be stopped aggressively
+after each run, and can be reused.
+
+N.B. if you opt in for this feature, Quarkus will not reset the state of the database between runs unless you explicitly configure it to.
+
 include::{generated-dir}/config/quarkus-datasource-config-group-dev-services-build-time-config.adoc[opts=optional, leveloffset=+1]
 
 == Kafka

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerShutdownCloseable.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerShutdownCloseable.java
@@ -1,0 +1,51 @@
+package io.quarkus.devservices.common;
+
+import java.io.Closeable;
+import java.util.Objects;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+/**
+ * Helper to define the stop strategy for containers created by DevServices.
+ * In particular we don't want to actually stop the containers when they
+ * have been flagged for reuse, and when the Testcontainers configuration
+ * has been explicitly set to allow container reuse.
+ * To enable reuse, ass {@literal testcontainers.reuse.enable=true} in your
+ * {@literal .testcontainers.properties} file, to be stored in your home.
+ *
+ * @see <a href="https://www.testcontainers.org/features/configuration/">Testcontainers Configuration</a>.
+ */
+public final class ContainerShutdownCloseable implements Closeable {
+
+    private static final Logger LOG = Logger.getLogger(ContainerShutdownCloseable.class);
+
+    private final GenericContainer container;
+    private final String friendlyServiceName;
+
+    /**
+     * @param container the container to be eventually closed
+     * @param friendlyServiceName for logging purposes
+     */
+    public ContainerShutdownCloseable(GenericContainer container, String friendlyServiceName) {
+        Objects.requireNonNull(container);
+        Objects.requireNonNull(friendlyServiceName);
+        this.container = container;
+        this.friendlyServiceName = friendlyServiceName;
+    }
+
+    @Override
+    public void close() {
+        if (TestcontainersConfiguration.getInstance().environmentSupportsReuse()
+                && container.isShouldBeReused()) {
+            LOG.infof(
+                    "Dev Services for %s is no longer needed by this Quarkus instance, but is not shut down as 'testcontainers.reuse.enable' is enabled in your Testcontainers configuration file",
+                    friendlyServiceName);
+        } else {
+            container.stop();
+            LOG.infof("Dev Services for %s shut down.", this.friendlyServiceName);
+        }
+    }
+
+}

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkus.devservices.mariadb.deployment;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +16,7 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceProviderBuildIt
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
+import io.quarkus.devservices.common.ContainerShutdownCloseable;
 import io.quarkus.runtime.LaunchMode;
 
 public class MariaDBDevServicesProcessor {
@@ -41,7 +40,8 @@ public class MariaDBDevServicesProcessor {
                 startupTimeout.ifPresent(container::withStartupTimeout);
                 container.withPassword(password.orElse("quarkus"))
                         .withUsername(username.orElse("quarkus"))
-                        .withDatabaseName(datasourceName.orElse("default"));
+                        .withDatabaseName(datasourceName.orElse("default"))
+                        .withReuse(true);
 
                 if (containerProperties.containsKey(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME)) {
                     container.withConfigurationOverride(containerProperties.get(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME));
@@ -56,14 +56,7 @@ public class MariaDBDevServicesProcessor {
                         container.getEffectiveJdbcUrl(),
                         container.getUsername(),
                         container.getPassword(),
-                        new Closeable() {
-                            @Override
-                            public void close() throws IOException {
-                                container.stop();
-
-                                LOG.info("Dev Services for MariaDB shut down.");
-                            }
-                        });
+                        new ContainerShutdownCloseable(container, "MariaDB"));
             }
         });
     }


### PR DESCRIPTION
Fixes #25365 

To try it out, use any demo which is needing a container which is relatively slow to start; for example Oracle database, which will take ~ 1 minute to start.
Run it twice (not in dev-mode), the second time it will need to start the container again.

If you have a file named `.testcontainers.properties` in your ~ and add:
`testcontainers.reuse.enable=true`

you'll notice the container stays alive for some longer time, and the second run is allowed to reuse the same container instance.

I'm sure this workflow isn't for everyone, but since one has to explicitly opt-in I think it's very nice.