### PR TITLE
Update opentelemetry.adoc

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -135,8 +135,7 @@ receivers:
 exporters:
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    tls:
-      insecure: true
+    insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
I could not run locally due to incorrect Jaeger Exporter configuration.

See https://github.com/open-telemetry/opentelemetry-collector/issues/1049.

I was receiving the error:
```
otel-collector_1     | 2022-05-04T15:25:26.820Z	info	service/collector.go:242	Loading configuration...
otel-collector_1     | Error: cannot load configuration: error reading exporters configuration for jaeger: 1 error(s) decoding:
otel-collector_1     | 
otel-collector_1     | * '' has invalid keys: tls
```
The linked issue illustrates that the `tls` key seems not to be needed.

Making the change locally everything worked OK.