### PR TITLE
Show Enum constant description in documentation

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -23,6 +23,7 @@ final public class Constants {
     };
 
     public static final char DOT = '.';
+    public static final String CODE_DELIMITER = "`";
     public static final String EMPTY = "";
     public static final String DASH = "-";
     public static final String ADOC_EXTENSION = ".adoc";
@@ -113,5 +114,10 @@ final public class Constants {
             +
             "If no suffix is given, assume bytes.\n" +
             "====\n";
+
+    /**
+     * Tooltip is custom AsciiDoc inline macro that transforms inputs to a CSS Tooltip.
+     */
+    public static final String TOOLTIP = "tooltip:%s[%s]";
 
 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocKey.java
@@ -24,6 +24,7 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
     private boolean withinAConfigGroup;
     // if a key is "quarkus.kubernetes.part-of", then the value of this would be "kubernetes"
     private String topLevelGrouping;
+    private boolean isEnum;
 
     public ConfigDocKey() {
     }
@@ -172,6 +173,14 @@ final public class ConfigDocKey implements ConfigDocElement, Comparable<ConfigDo
 
     public String getTopLevelGrouping() {
         return topLevelGrouping;
+    }
+
+    public boolean isEnum() {
+        return isEnum;
+    }
+
+    public void setEnum(boolean anEnum) {
+        isEnum = anEnum;
     }
 
     @Override

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
@@ -19,6 +19,7 @@ import javax.lang.model.type.TypeMirror;
 import io.quarkus.annotation.processor.Constants;
 
 public class DocGeneratorUtil {
+    private static final String NEW_LINE = "\n";
     private static final String CORE = "core";
     private static final String CONFIG = "Config";
     private static final String CONFIGURATION = "Configuration";
@@ -273,7 +274,16 @@ public class DocGeneratorUtil {
             return "";
         }
 
-        return acceptedValues.stream().collect(Collectors.joining("`, `", "`", "`"));
+        return acceptedValues.stream().collect(Collectors.joining("`, `", Constants.CODE_DELIMITER, Constants.CODE_DELIMITER));
+    }
+
+    static String joinEnumValues(List<String> enumValues) {
+        if (enumValues == null || enumValues.isEmpty()) {
+            return Constants.EMPTY;
+        }
+
+        // nested macros are only detected when cell starts with a new line, e.g. a|\n myMacro::[]
+        return NEW_LINE + String.join(", ", enumValues);
     }
 
     static String getTypeFormatInformationNote(ConfigDocKey configDocKey) {

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -10,7 +10,7 @@ final class SummaryTableDocFormatter implements DocFormatter {
     private static final String TABLE_CLOSING_TAG = "\n|===";
     public static final String SEARCHABLE_TABLE_CLASS = ".searchable"; // a css class indicating if a table is searchable
     public static final String CONFIGURATION_TABLE_CLASS = ".configuration-reference";
-    private static final String TABLE_ROW_FORMAT = "\n\na|%s [[%s]]`link:#%s[%s]`\n\n[.description]\n--\n%s\n--|%s %s\n|%s\n";
+    private static final String TABLE_ROW_FORMAT = "\n\na|%s [[%s]]`link:#%s[%s]`\n\n[.description]\n--\n%s\n--%s|%s %s\n|%s\n";
     private static final String SECTION_TITLE = "[[%s]]link:#%s[%s]";
     private static final String TABLE_SECTION_ROW_FORMAT = "\n\nh|%s\n%s\nh|Type\nh|Default";
     private static final String TABLE_HEADER_FORMAT = "[.configuration-legend]%s\n[%s, cols=\"80,.^10,.^10\"]\n|===";
@@ -53,7 +53,11 @@ final class SummaryTableDocFormatter implements DocFormatter {
     public void format(Writer writer, ConfigDocKey configDocKey) throws IOException {
         String typeContent = "";
         if (configDocKey.hasAcceptedValues()) {
-            typeContent = DocGeneratorUtil.joinAcceptedValues(configDocKey.getAcceptedValues());
+            if (configDocKey.isEnum()) {
+                typeContent = DocGeneratorUtil.joinEnumValues(configDocKey.getAcceptedValues());
+            } else {
+                typeContent = DocGeneratorUtil.joinAcceptedValues(configDocKey.getAcceptedValues());
+            }
         } else if (configDocKey.hasType()) {
             typeContent = configDocKey.computeTypeSimpleName();
             final String javaDocLink = configDocKey.getJavaDocSiteLink();
@@ -84,6 +88,8 @@ final class SummaryTableDocFormatter implements DocFormatter {
                 key,
                 // make sure nobody inserts a table cell separator here
                 doc.replace("|", "\\|"),
+                // if ConfigDocKey is enum, cell style operator must support block elements
+                configDocKey.isEnum() ? " a" : Constants.EMPTY,
                 typeContent, typeDetail,
                 defaultValue.isEmpty() ? required
                         : String.format("`%s`", defaultValue.replace("|", "\\|")

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -249,11 +249,28 @@ public class JavaDocConfigDescriptionParserTest {
     public void escape(String ch) {
         final String javaDoc = "Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch + " " + ch + ch
                 + "</code>, {@code JavaDoc tag " + ch + " " + ch + ch + "}";
-        final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
-                + " " + ch + ch + "</code>, <code>JavaDoc tag " + ch + " " + ch + ch + "</code></p>\n</div>";
 
         final String asciiDoc = parser.parseConfigDescription(javaDoc);
         final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+        final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
+                + " " + ch + ch + "</code>, <code>JavaDoc tag " + ch + " " + ch + ch + "</code></p>\n</div>";
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "#", "*", "\\", "[", "]", "|" })
+    public void escapeInsideInlineElement(String ch) {
+        final String javaDoc = "Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch + " " + ch + ch
+                + "</code>, {@code JavaDoc tag " + ch + " " + ch + ch + "}";
+
+        final String asciiDoc = new JavaDocParser(true).parseConfigDescription(javaDoc);
+        final String actual = Factory.create().convert(asciiDoc, Collections.emptyMap());
+
+        if (ch.equals("]")) {
+            ch = "&#93;";
+        }
+        final String expected = "<div class=\"paragraph\">\n<p>Inline " + ch + " " + ch + ch + ", <code>HTML tag glob " + ch
+                + " " + ch + ch + "</code>, <code>JavaDoc tag " + ch + " " + ch + ch + "</code></p>\n</div>";
         assertEquals(expected, actual);
     }
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -54,6 +54,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Required by Tooltip inline macro -->
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>${asciidoctorj.version}</version>
+        </dependency>
 
         <!-- Minimal test dependencies for consistent build order -->
         <!-- START update-extension-dependencies.sh -->
@@ -2881,6 +2887,13 @@
                                 <linkcss>true</linkcss>
                                 <copycss>true</copycss>
                             </attributes>
+                            <extensions>
+                                <extension>
+                                    <!--  Register custom inline macro  -->
+                                    <className>io.quarkus.docs.generation.TooltipInlineMacroProcessor</className>
+                                    <blockName>tooltip</blockName>
+                                </extension>
+                            </extensions>
                         </configuration>
                     </execution>
                 </executions>
@@ -2889,6 +2902,12 @@
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
                         <version>${asciidoctorj.version}</version>
+                    </dependency>
+                    <!-- Tooltip inline macro is provided by quarkus-documentation -->
+                    <dependency>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>${project.artifactId}</artifactId>
+                        <version>${project.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/TooltipInlineMacroProcessor.java
@@ -1,0 +1,24 @@
+package io.quarkus.docs.generation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+/**
+ *
+ * Tooltip inline macro implementation for PDF (HTML) files where tooltip is not supported.
+ * Enum constant name is wrapped in `<code></code>` and constant description is ignored.
+ */
+@Name("tooltip")
+public class TooltipInlineMacroProcessor extends InlineMacroProcessor {
+
+    @Override
+    public Object process(ContentNode contentNode, String target, Map<String, Object> map) {
+        var attributes = new HashMap<String, Object>();
+        attributes.put("subs", ":normal");
+        return createPhraseNode(contentNode, "quoted", String.format("`%s`", target), attributes);
+    }
+}


### PR DESCRIPTION
Currently Enum constant Javadoc is not included in generated documentation. This PR adds a constant description to the documentation in a form of a CSS Tooltip ([Tooltip was added by this PR](https://github.com/quarkusio/quarkusio.github.io/pull/1406)). PDF generation won't be affected by this PR.