### PR TITLE
Fix NPE when returning null CloudEvent in Knative Funqy

### DIFF
--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/ExposedCloudEventTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/ExposedCloudEventTest.java
@@ -81,6 +81,18 @@ public class ExposedCloudEventTest {
                 .body(equalTo("6"));
     }
 
+    @Test
+    public void testNullResponse() {
+        RestAssured.given().contentType("application/json")
+                .header("ce-id", "test-id")
+                .header("ce-specversion", "1.0")
+                .header("ce-type", "test-null-response")
+                .header("ce-source", "test-source")
+                .post()
+                .then()
+                .statusCode(204);
+    }
+
     @ParameterizedTest
     @MethodSource("provideBinaryEncodingTestArgs")
     public void testBinaryEncoding(Map<String, String> headers, String specversion, String dataSchemaHdrName) {

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/ExposedCloudEvents.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/ExposedCloudEvents.java
@@ -65,6 +65,12 @@ public class ExposedCloudEvents {
                 .build(data);
     }
 
+    @Funq
+    @CloudEventMapping(trigger = "test-null-response")
+    public CloudEvent<String> returnNull(CloudEvent<Void> ignore) {
+        return null;
+    }
+
     public static class TestBean implements Serializable {
         private int i;
         private String s;

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/VertxRequestHandler.java
@@ -261,6 +261,12 @@ public class VertxRequestHandler implements Handler<RoutingContext> {
                             outputCloudEvent = (CloudEvent<?>) output;
                         }
 
+                        if (outputCloudEvent == null) {
+                            routingContext.response().setStatusCode(204);
+                            routingContext.response().end();
+                            return;
+                        }
+
                         String id = outputCloudEvent.id();
                         if (id == null) {
                             id = getResponseId();


### PR DESCRIPTION
Allows user to return empty response (no CloudEvent) from non-void methods.

Signed-off-by: Matej Vasek <mvasek@redhat.com>