### PR TITLE
Relocate the profile names of `quarkus.config.locations`

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -142,6 +142,8 @@ public final class ConfigUtils {
                 if (profileValue != null) {
                     List<String> profiles = ProfileConfigSourceInterceptor.convertProfile(profileValue.getValue());
                     for (String profile : profiles) {
+                        relocations.put("%" + profile + "." + SMALLRYE_CONFIG_LOCATIONS,
+                                "%" + profile + "." + "quarkus.config.locations");
                         relocations.put("%" + profile + "." + SMALLRYE_CONFIG_PROFILE_PARENT,
                                 "%" + profile + "." + "quarkus.config.profile.parent");
                     }


### PR DESCRIPTION
- Fixes #25186