### PR TITLE
Make sure that disabled jobs are paused in Quartz

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -166,6 +166,7 @@ public class QuartzScheduler implements Scheduler {
                         String cron = SchedulerUtils.lookUpPropertyValue(scheduled.cron());
                         if (!cron.isEmpty()) {
                             if (SchedulerUtils.isOff(cron)) {
+                                this.pause(identity);
                                 continue;
                             }
                             if (!CronType.QUARTZ.equals(cronType)) {
@@ -214,6 +215,7 @@ public class QuartzScheduler implements Scheduler {
                         } else if (!scheduled.every().isEmpty()) {
                             OptionalLong everyMillis = SchedulerUtils.parseEveryAsMillis(scheduled);
                             if (!everyMillis.isPresent()) {
+                                this.pause(identity);
                                 continue;
                             }
                             SimpleScheduleBuilder simpleScheduleBuilder = SimpleScheduleBuilder.simpleSchedule()

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/DisabledMethodResource.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/DisabledMethodResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.it.quartz;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/scheduler/disabled")
+public class DisabledMethodResource {
+
+    @Inject
+    DisabledScheduledMethods disabledScheduledMethods;
+
+    @GET
+    @Path("cron")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getCronCount() {
+        return disabledScheduledMethods.valueSetByCronScheduledMethod;
+    }
+
+    @GET
+    @Path("every")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getEveryCount() {
+        return disabledScheduledMethods.valueSetByEveryScheduledMethod;
+    }
+}

--- a/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/DisabledScheduledMethods.java
+++ b/integration-tests/quartz/src/main/java/io/quarkus/it/quartz/DisabledScheduledMethods.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.quartz;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class DisabledScheduledMethods {
+    volatile static String valueSetByCronScheduledMethod = "";
+    volatile static String valueSetByEveryScheduledMethod = "";
+
+    // This should never be called as the job is disabled
+    @Scheduled(cron = "${disabled}", identity = "disabled-cron-counter")
+    void setValueByCron() {
+        valueSetByCronScheduledMethod = "cron";
+    }
+
+    // This should never be called as the job is turned off
+    @Scheduled(every = "${off}", identity = "disabled-every-counter")
+    void setValueByEvery() {
+        valueSetByEveryScheduledMethod = "every";
+    }
+
+}

--- a/integration-tests/quartz/src/main/resources/application.properties
+++ b/integration-tests/quartz/src/main/resources/application.properties
@@ -18,3 +18,6 @@ quarkus.flyway.baseline-description=Quartz
 # Register de LoggingJobHistoryPlugin for testing
 quarkus.quartz.plugins.jobHistory.class=org.quartz.plugins.history.LoggingJobHistoryPlugin
 quarkus.quartz.plugins.jobHistory.properties.jobSuccessMessage=Job [{1}.{0}] execution complete and reports: {8}
+
+disabled=disabled
+off=off

--- a/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
+++ b/integration-tests/quartz/src/test/java/io/quarkus/it/quartz/QuartzTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.quartz;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -19,11 +20,28 @@ public class QuartzTestCase {
         assertCounter("/scheduler/count/fix-8555");
     }
 
+    @Test
+    public void testDisabledMethodsShouldNeverBeExecuted() throws InterruptedException {
+        // Wait at least 1 second
+        Thread.sleep(1000);
+        assertEmptyValueForDisabledMethod("/scheduler/disabled/cron");
+        assertEmptyValueForDisabledMethod("/scheduler/disabled/every");
+    }
+
     private void assertCounter(String counterPath) {
         Response response = given().when().get(counterPath);
         String body = response.asString();
         int count = Integer.valueOf(body);
         assertTrue(count > 0);
+        response
+                .then()
+                .statusCode(200);
+    }
+
+    private void assertEmptyValueForDisabledMethod(String path) {
+        Response response = given().when().get(path);
+        String body = response.asString();
+        assertEquals("", body);
         response
                 .then()
                 .statusCode(200);


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/25214

Disabled methods whose jobs details and triggers were already in the
database were still getting triggered because Quartz invokes all the
jobs in the database that are not in the paused State.
This is to make sure that the disabled methods are effectively not
triggered by Quartz in any way.

Furthermore, I do not believe the full scheduled method implementing the Application custom logic
was called because of the checks in the extensions which meant the
App business logic trigger was not full invoked but pausing the triggers
via Quartz we are sure that the trigger won't be invoked when it is
disabled.

Previously this was done via checks in the extension which mean that
only the Application logic of the scheduled method was not called.

- https://github.com/quarkusio/quarkus/blob/4df39b60a0b3d132713e6d60087a1054588d4a5f/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java#L215-L218
- https://github.com/quarkusio/quarkus/blob/4df39b60a0b3d132713e6d60087a1054588d4a5f/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java#L168-L170

which meant that the trigger was not stored in known business triggers
at https://github.com/quarkusio/quarkus/blob/4df39b60a0b3d132713e6d60087a1054588d4a5f/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java#L302-L303

meaning that upon the execution invocation of the method in
https://github.com/quarkusio/quarkus/blob/4df39b60a0b3d132713e6d60087a1054588d4a5f/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java#L560
the business logic wasn't triggered but a NPE (same as https://github.com/quarkusio/quarkus/issues/24931) could have been raised
with the code in main branch