### PR TITLE
OpenAPI: Make sure auto security also works for `@Authenticated`

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/OpenApiConfigMapping.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/OpenApiConfigMapping.java
@@ -18,6 +18,7 @@ import io.smallrye.openapi.api.OpenApiConfig;
  */
 public class OpenApiConfigMapping extends RelocateConfigSourceInterceptor {
     private static final Map<String, String> RELOCATIONS = relocations();
+    @SuppressWarnings("unchecked")
     private final HyphenateEnumConverter enumConverter = new HyphenateEnumConverter(OpenApiConfig.OperationIdStrategy.class);
 
     public OpenApiConfigMapping() {

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityAuthenticateTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityAuthenticateTestCase.java
@@ -1,0 +1,58 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class AutoSecurityAuthenticateTestCase {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(ResourceBean2.class, OpenApiResourceAuthenticatedAtClassLevel.class,
+                            OpenApiResourceAuthenticatedAtMethodLevel.class, OpenApiResourceAuthenticatedAtMethodLevel2.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.smallrye-openapi.security-scheme=jwt\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-name=JWTCompanyAuthentication\n"
+                                    + "quarkus.smallrye-openapi.security-scheme-description=JWT Authentication"),
+
+                            "application.properties"));
+
+    @Test
+    public void testAutoSecurityRequirement() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("type", "http"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication",
+                        Matchers.hasEntry("description", "JWT Authentication"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("scheme", "bearer"))
+                .and()
+                .body("components.securitySchemes.JWTCompanyAuthentication", Matchers.hasEntry("bearerFormat", "JWT"))
+                .and()
+                .body("paths.'/resource2/test-security/annotated'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/naked'.get.security.JWTCompanyAuthentication", Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/1'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/2'.get.security.JWTCompanyAuthentication",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/3'.get.security.MyOwnName",
+                        Matchers.notNullValue())
+                .and()
+                .body("paths.'/resource3/test-security/annotated'.get.security.AtClassLevel", Matchers.notNullValue());
+
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class AutoSecurityRequirementTestCase {
+public class AutoSecurityRolesAllowedTestCase {
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtClassLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtClassLevel.java
@@ -1,0 +1,39 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/resource2")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+@Authenticated
+public class OpenApiResourceAuthenticatedAtClassLevel {
+
+    private ResourceBean2 resourceBean;
+
+    @GET
+    @Path("/test-security/classLevel/1")
+    public String secureEndpoint1() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/classLevel/2")
+    public String secureEndpoint2() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/classLevel/3")
+    @SecurityRequirement(name = "MyOwnName")
+    public String secureEndpoint3() {
+        return "secret";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtMethodLevel.java
@@ -1,0 +1,54 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/resource2")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+public class OpenApiResourceAuthenticatedAtMethodLevel {
+
+    private ResourceBean2 resourceBean;
+
+    @GET
+    @Path("/test-security/naked")
+    @Authenticated
+    public String secureEndpointWithoutSecurityAnnotation() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/annotated")
+    @Authenticated
+    @SecurityRequirement(name = "JWTCompanyAuthentication")
+    public String secureEndpointWithSecurityAnnotation() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/1")
+    @Authenticated
+    public String secureEndpoint1() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/2")
+    @Authenticated
+    public String secureEndpoint2() {
+        return "secret";
+    }
+
+    @GET
+    @Path("/test-security/methodLevel/public")
+    public String publicEndpoint() {
+        return "boo";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtMethodLevel2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceAuthenticatedAtMethodLevel2.java
@@ -1,0 +1,27 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.servers.Server;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.security.Authenticated;
+
+@Path("/resource3")
+@Tag(name = "test")
+@Server(url = "serverUrl")
+@SecurityRequirement(name = "AtClassLevel")
+public class OpenApiResourceAuthenticatedAtMethodLevel2 {
+
+    private ResourceBean2 resourceBean;
+
+    @GET
+    @Path("/test-security/annotated")
+    @Authenticated
+    public String secureEndpointWithSecurityAnnotation() {
+        return "secret";
+    }
+
+}

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean2.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/ResourceBean2.java
@@ -1,0 +1,19 @@
+package io.quarkus.smallrye.openapi.test.jaxrs;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.security.Authenticated;
+
+@ApplicationScoped
+public class ResourceBean2 {
+    @Override
+    public String toString() {
+        return "resource";
+    }
+
+    @Authenticated
+    public String anotherMethod() {
+        return "bla";
+    }
+
+}


### PR DESCRIPTION
fix #24504

This PR adds support for the `Authenticated` annotation to also create auto security information in the OpenAPI generated doc.

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>