### PR TITLE
Dev services: MSSQL reactive client does not support JDBC url format

### DIFF
--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
@@ -3,7 +3,6 @@ package io.quarkus.datasource.deployment.spi;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -56,15 +55,16 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
                     @Override
                     public Map<String, String> apply(String dsName,
                             DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevDb) {
+                        String jdbcUrl = runningDevDb.getJdbcUrl();
                         if (dsName == null) {
-                            return Collections.singletonMap("quarkus.datasource.jdbc.url", runningDevDb.getUrl());
+                            return Collections.singletonMap("quarkus.datasource.jdbc.url", jdbcUrl);
                         } else {
                             // we use quoted and unquoted versions because depending on whether a user configured other JDBC properties
                             // one of the URLs may be ignored
                             // see https://github.com/quarkusio/quarkus/issues/21387
                             return Map.of(
-                                    datasourceURLPropName(dsName), runningDevDb.getUrl(),
-                                    datasourceURLPropName("\"" + dsName + "\""), runningDevDb.getUrl());
+                                    datasourceURLPropName(dsName), jdbcUrl,
+                                    datasourceURLPropName("\"" + dsName + "\""), jdbcUrl);
                         }
                     }
 
@@ -86,31 +86,21 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
     }
 
     public static DevServicesDatasourceConfigurationHandlerBuildItem reactive(String dbKind) {
-        return reactive(dbKind, new Function<String, String>() {
-            @Override
-            public String apply(String url) {
-                return url.replaceFirst("jdbc:", "vertx-reactive:");
-            }
-        });
-    }
-
-    public static DevServicesDatasourceConfigurationHandlerBuildItem reactive(String dbKind,
-            Function<String, String> jdbcUrlTransformer) {
         return new DevServicesDatasourceConfigurationHandlerBuildItem(dbKind,
                 new BiFunction<String, DevServicesDatasourceProvider.RunningDevServicesDatasource, Map<String, String>>() {
                     @Override
                     public Map<String, String> apply(String dsName,
                             DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevDb) {
-                        String url = jdbcUrlTransformer.apply(runningDevDb.getUrl());
+                        String reactiveUrl = runningDevDb.getReactiveUrl();
                         if (dsName == null) {
-                            return Collections.singletonMap("quarkus.datasource.reactive.url", url);
+                            return Collections.singletonMap("quarkus.datasource.reactive.url", reactiveUrl);
                         } else {
                             // we use quoted and unquoted versions because depending on whether a user configured other JDBC properties
                             // one of the URLs may be ignored
                             // see https://github.com/quarkusio/quarkus/issues/21387
                             return Map.of(
-                                    datasourceReactiveURLPropName(dsName, false), url,
-                                    datasourceReactiveURLPropName(dsName, true), url);
+                                    datasourceReactiveURLPropName(dsName, false), reactiveUrl,
+                                    datasourceReactiveURLPropName(dsName, true), reactiveUrl);
                         }
                     }
                 }, new Predicate<String>() {

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceConfigurationHandlerBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkus.datasource.deployment.spi;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -85,17 +86,31 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
     }
 
     public static DevServicesDatasourceConfigurationHandlerBuildItem reactive(String dbKind) {
+        return reactive(dbKind, new Function<String, String>() {
+            @Override
+            public String apply(String url) {
+                return url.replaceFirst("jdbc:", "vertx-reactive:");
+            }
+        });
+    }
+
+    public static DevServicesDatasourceConfigurationHandlerBuildItem reactive(String dbKind,
+            Function<String, String> jdbcUrlTransformer) {
         return new DevServicesDatasourceConfigurationHandlerBuildItem(dbKind,
                 new BiFunction<String, DevServicesDatasourceProvider.RunningDevServicesDatasource, Map<String, String>>() {
                     @Override
                     public Map<String, String> apply(String dsName,
                             DevServicesDatasourceProvider.RunningDevServicesDatasource runningDevDb) {
+                        String url = jdbcUrlTransformer.apply(runningDevDb.getUrl());
                         if (dsName == null) {
-                            return Collections.singletonMap("quarkus.datasource.reactive.url",
-                                    runningDevDb.getUrl().replaceFirst("jdbc:", "vertx-reactive:"));
+                            return Collections.singletonMap("quarkus.datasource.reactive.url", url);
                         } else {
-                            return Collections.singletonMap("quarkus.datasource.\"" + dsName + "\".reactive.url",
-                                    runningDevDb.getUrl().replaceFirst("jdbc:", "vertx-reactive:"));
+                            // we use quoted and unquoted versions because depending on whether a user configured other JDBC properties
+                            // one of the URLs may be ignored
+                            // see https://github.com/quarkusio/quarkus/issues/21387
+                            return Map.of(
+                                    datasourceReactiveURLPropName(dsName, false), url,
+                                    datasourceReactiveURLPropName(dsName, true), url);
                         }
                     }
                 }, new Predicate<String>() {
@@ -104,10 +119,24 @@ public final class DevServicesDatasourceConfigurationHandlerBuildItem extends Mu
                         if (dsName == null) {
                             return ConfigUtils.isPropertyPresent("quarkus.datasource.reactive.url");
                         } else {
-                            return ConfigUtils.isPropertyPresent("quarkus.datasource.\"" + dsName + "\".reactive.url") ||
-                                    ConfigUtils.isPropertyPresent("quarkus.datasource." + dsName + ".reactive.url");
+                            return ConfigUtils.isPropertyPresent(datasourceReactiveURLPropName(dsName, false)) ||
+                                    ConfigUtils.isPropertyPresent(datasourceReactiveURLPropName(dsName, true));
                         }
                     }
                 });
+    }
+
+    private static String datasourceReactiveURLPropName(String dsName, boolean quotedName) {
+        StringBuilder key = new StringBuilder("quarkus.datasource");
+        key.append('.');
+        if (quotedName) {
+            key.append('"');
+        }
+        key.append(dsName);
+        if (quotedName) {
+            key.append('"');
+        }
+        key.append(".reactive.url");
+        return key.toString();
     }
 }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DevServicesDatasourceProvider.java
@@ -24,14 +24,17 @@ public interface DevServicesDatasourceProvider {
     class RunningDevServicesDatasource {
 
         private final String id;
-        private final String url;
+        private final String jdbcUrl;
+        private final String reactiveUrl;
         private final String username;
         private final String password;
         private final Closeable closeTask;
 
-        public RunningDevServicesDatasource(String id, String url, String username, String password, Closeable closeTask) {
+        public RunningDevServicesDatasource(String id, String jdbcUrl, String reactiveUrl, String username, String password,
+                Closeable closeTask) {
             this.id = id;
-            this.url = url;
+            this.jdbcUrl = jdbcUrl;
+            this.reactiveUrl = reactiveUrl;
             this.username = username;
             this.password = password;
             this.closeTask = closeTask;
@@ -41,8 +44,12 @@ public interface DevServicesDatasourceProvider {
             return id;
         }
 
-        public String getUrl() {
-            return url;
+        public String getJdbcUrl() {
+            return jdbcUrl;
+        }
+
+        public String getReactiveUrl() {
+            return reactiveUrl;
         }
 
         public Closeable getCloseTask() {

--- a/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
+++ b/extensions/devservices/db2/src/main/java/io/quarkus/devservices/db2/deployment/DB2DevServicesProcessor.java
@@ -46,6 +46,7 @@ public class DB2DevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "IBM Db2"));
@@ -96,6 +97,10 @@ public class DB2DevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
         }
     }
 }

--- a/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
+++ b/extensions/devservices/derby/src/main/java/io/quarkus/devservices/derby/deployment/DerbyDevServicesProcessor.java
@@ -69,6 +69,7 @@ public class DerbyDevServicesProcessor {
                                     + additionalArgs.toString(),
                             null,
                             null,
+                            null,
                             new Closeable() {
                                 @Override
                                 public void close() throws IOException {

--- a/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
+++ b/extensions/devservices/h2/src/main/java/io/quarkus/devservices/h2/deployment/H2DevServicesProcessor.java
@@ -53,6 +53,7 @@ public class H2DevServicesProcessor {
                             + ";DB_CLOSE_DELAY=-1" + additionalArgs.toString();
                     return new RunningDevServicesDatasource(null,
                             connectionUrl,
+                            null,
                             "sa",
                             "sa",
                             new Closeable() {

--- a/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
+++ b/extensions/devservices/mariadb/src/main/java/io/quarkus/devservices/mariadb/deployment/MariaDBDevServicesProcessor.java
@@ -54,6 +54,7 @@ public class MariaDBDevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "MariaDB"));
@@ -100,6 +101,10 @@ public class MariaDBDevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
         }
     }
 }

--- a/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
+++ b/extensions/devservices/mssql/src/main/java/io/quarkus/devservices/mssql/deployment/MSSQLDevServicesProcessor.java
@@ -44,6 +44,7 @@ public class MSSQLDevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "Microsoft SQL Server"));
@@ -93,6 +94,16 @@ public class MSSQLDevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            StringBuilder url = new StringBuilder("vertx-reactive:sqlserver://");
+            if (useSharedNetwork) {
+                url.append(hostName).append(":").append(MS_SQL_SERVER_PORT);
+            } else {
+                url.append(this.getHost()).append(":").append(this.getMappedPort(MS_SQL_SERVER_PORT));
+            }
+            return url.toString();
         }
     }
 }

--- a/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
+++ b/extensions/devservices/mysql/src/main/java/io/quarkus/devservices/mysql/deployment/MySQLDevServicesProcessor.java
@@ -54,6 +54,7 @@ public class MySQLDevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "MySQL"));
@@ -103,6 +104,10 @@ public class MySQLDevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
         }
     }
 }

--- a/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
+++ b/extensions/devservices/oracle/src/main/java/io/quarkus/devservices/oracle/deployment/OracleDevServicesProcessor.java
@@ -60,6 +60,7 @@ public class OracleDevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "Oracle"));
@@ -109,6 +110,10 @@ public class OracleDevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
         }
     }
 }

--- a/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
+++ b/extensions/devservices/postgresql/src/main/java/io/quarkus/devservices/postgresql/deployment/PostgresqlDevServicesProcessor.java
@@ -54,6 +54,7 @@ public class PostgresqlDevServicesProcessor {
 
                 return new RunningDevServicesDatasource(container.getContainerId(),
                         container.getEffectiveJdbcUrl(),
+                        container.getReactiveUrl(),
                         container.getUsername(),
                         container.getPassword(),
                         new ContainerShutdownCloseable(container, "PostgreSQL"));
@@ -106,6 +107,10 @@ public class PostgresqlDevServicesProcessor {
             } else {
                 return super.getJdbcUrl();
             }
+        }
+
+        public String getReactiveUrl() {
+            return getEffectiveJdbcUrl().replaceFirst("jdbc:", "vertx-reactive:");
         }
     }
 }

--- a/extensions/reactive-mssql-client/deployment/pom.xml
+++ b/extensions/reactive-mssql-client/deployment/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.reactive.mssql.client.deployment;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -83,7 +84,16 @@ class ReactiveMSSQLClientProcessor {
 
     @BuildStep
     DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
-        return DevServicesDatasourceConfigurationHandlerBuildItem.reactive(DatabaseKind.MSSQL);
+        return DevServicesDatasourceConfigurationHandlerBuildItem.reactive(DatabaseKind.MSSQL, new Function<String, String>() {
+            @Override
+            public String apply(String url) {
+                url = url.replaceFirst("jdbc:", "vertx-reactive:");
+                if (url.endsWith(";encrypt=false")) {
+                    return url.substring(0, url.length() - ";encrypt=false".length());
+                }
+                return url;
+            }
+        });
     }
 
     @BuildStep

--- a/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
+++ b/extensions/reactive-mssql-client/deployment/src/main/java/io/quarkus/reactive/mssql/client/deployment/ReactiveMSSQLClientProcessor.java
@@ -2,7 +2,6 @@ package io.quarkus.reactive.mssql.client.deployment;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -84,16 +83,7 @@ class ReactiveMSSQLClientProcessor {
 
     @BuildStep
     DevServicesDatasourceConfigurationHandlerBuildItem devDbHandler() {
-        return DevServicesDatasourceConfigurationHandlerBuildItem.reactive(DatabaseKind.MSSQL, new Function<String, String>() {
-            @Override
-            public String apply(String url) {
-                url = url.replaceFirst("jdbc:", "vertx-reactive:");
-                if (url.endsWith(";encrypt=false")) {
-                    return url.substring(0, url.length() - ";encrypt=false".length());
-                }
-                return url;
-            }
-        });
+        return DevServicesDatasourceConfigurationHandlerBuildItem.reactive(DatabaseKind.MSSQL);
     }
 
     @BuildStep

--- a/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevServicesMsSQLDatasourceTestCase.java
+++ b/extensions/reactive-mssql-client/deployment/src/test/java/io/quarkus/reactive/mssql/client/DevServicesMsSQLDatasourceTestCase.java
@@ -1,0 +1,40 @@
+package io.quarkus.reactive.mssql.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.mutiny.mssqlclient.MSSQLPool;
+
+public class DevServicesMsSQLDatasourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("container-license-acceptance.txt"))
+            // Expect no warnings from reactive
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    && record.getMessage().toLowerCase(Locale.ENGLISH).contains("reactive"))
+            .assertLogRecords(records -> assertThat(records)
+                    // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .extracting(LogRecord::getMessage)
+                    .isEmpty());
+
+    @Inject
+    MSSQLPool pool;
+
+    @Test
+    public void testDatasource() throws Exception {
+        pool.withConnection(conn -> conn.query("SELECT 1").execute().replaceWithVoid())
+                .await().atMost(Duration.ofMinutes(2));
+    }
+}

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevServicesMySQLDatasourceTestCase.java
+++ b/extensions/reactive-mysql-client/deployment/src/test/java/io/quarkus/reactive/mysql/client/DevServicesMySQLDatasourceTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.reactive.mysql.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.mutiny.mysqlclient.MySQLPool;
+
+public class DevServicesMySQLDatasourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withEmptyApplication()
+            // Expect no warnings from reactive
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    && record.getMessage().toLowerCase(Locale.ENGLISH).contains("reactive"))
+            .assertLogRecords(records -> assertThat(records)
+                    // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .extracting(LogRecord::getMessage)
+                    .isEmpty());
+
+    @Inject
+    MySQLPool pool;
+
+    @Test
+    public void testDatasource() throws Exception {
+        pool.withConnection(conn -> conn.query("SELECT 1").execute().replaceWithVoid())
+                .await().atMost(Duration.ofMinutes(2));
+    }
+}

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevServicesOracleDatasourceTestCase.java
+++ b/extensions/reactive-oracle-client/deployment/src/test/java/io/quarkus/reactive/oracle/client/DevServicesOracleDatasourceTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.reactive.oracle.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.mutiny.oracleclient.OraclePool;
+
+public class DevServicesOracleDatasourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withEmptyApplication()
+            // Expect no warnings from reactive
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    && record.getMessage().toLowerCase(Locale.ENGLISH).contains("reactive"))
+            .assertLogRecords(records -> assertThat(records)
+                    // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .extracting(LogRecord::getMessage)
+                    .isEmpty());
+
+    @Inject
+    OraclePool pool;
+
+    @Test
+    public void testDatasource() throws Exception {
+        pool.withConnection(conn -> conn.query("SELECT 1 FROM DUAL").execute().replaceWithVoid())
+                .await().atMost(Duration.ofMinutes(2));
+    }
+}

--- a/extensions/reactive-pg-client/deployment/pom.xml
+++ b/extensions/reactive-pg-client/deployment/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevServicesPostgresqlDatasourceTestCase.java
+++ b/extensions/reactive-pg-client/deployment/src/test/java/io/quarkus/reactive/pg/client/DevServicesPostgresqlDatasourceTestCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.reactive.pg.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.mutiny.pgclient.PgPool;
+
+public class DevServicesPostgresqlDatasourceTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withEmptyApplication()
+            // Expect no warnings from reactive
+            .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue()
+                    && record.getMessage().toLowerCase(Locale.ENGLISH).contains("reactive"))
+            .assertLogRecords(records -> assertThat(records)
+                    // This is just to get meaningful error messages, as LogRecord doesn't have a toString()
+                    .extracting(LogRecord::getMessage)
+                    .isEmpty());
+
+    @Inject
+    PgPool pool;
+
+    @Test
+    public void testDatasource() throws Exception {
+        pool.withConnection(conn -> conn.query("SELECT 1").execute().replaceWithVoid())
+                .await().atMost(Duration.ofMinutes(2));
+    }
+}


### PR DESCRIPTION
Fixes #25233

The "encrypt" property is not needed anyway, it is the default of both the JDBC and reactive clients.

https://docs.microsoft.com/en-us/sql/connect/jdbc/understanding-ssl-support?view=sql-server-ver15#remarks