### PR TITLE
Refine how resource classes with same components are merged

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -299,22 +298,24 @@ public class RuntimeDeploymentManager {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
+            if (this == o) {
                 return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (o == null) {
                 return false;
-            MappersKey that = (MappersKey) o;
-            return key.equals(that.key);
+            }
+
+            return key.equals(((MappersKey) o).key);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(key);
+            return key.hashCode();
         }
 
         @Override
         public int compareTo(MappersKey o) {
-            if (key.compareTo(o.key) == 0) {
+            if (key.equals(o.key)) {
                 return 0;
             }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -278,22 +278,35 @@ public class RuntimeDeploymentManager {
         public MappersKey(URITemplate path) {
             this.path = path;
 
-            // create a key without any names. Names of e.g. default regex components can differ, but the component still has the same meaning.
-            StringBuilder keyBuilder = new StringBuilder();
-            for (URITemplate.TemplateComponent component : path.components) {
-                keyBuilder.append(component.type);
-                keyBuilder.append(";");
-                keyBuilder.append(component.literalText);
-                keyBuilder.append(";");
-                if (component.pattern != null) {
-                    // (?<id1>[a-zA-Z]+) -> [a-zA-Z]+
-                    String pattern = component.pattern.pattern();
-                    keyBuilder.append(component.pattern.pattern(), pattern.indexOf('>') + 1, pattern.length() - 1);
+            if (path.components.length == 0) {
+                this.key = "";
+            } else {
+                // create a key without any names. Names of e.g. default regex components can differ, but the component still has the same meaning.
+                StringBuilder keyBuilder = new StringBuilder();
+                for (URITemplate.TemplateComponent component : path.components) {
+                    int standardLength = component.type.name().length() + 1
+                            + (component.literalText != null ? component.literalText.length() : 0) + 1 + 1;
+                    int additionalLength = 0;
+                    if (component.pattern != null) {
+                        additionalLength = component.pattern.pattern().length();
+                    }
+                    StringBuilder kb = new StringBuilder(standardLength + additionalLength);
+                    kb.append(component.type);
+                    kb.append(";");
+                    kb.append(component.literalText);
+                    kb.append(";");
+                    if (component.pattern != null) {
+                        // (?<id1>[a-zA-Z]+) -> [a-zA-Z]+
+                        String pattern = component.pattern.pattern();
+                        kb.append(component.pattern.pattern(), pattern.indexOf('>') + 1, pattern.length() - 1);
+                    }
+                    kb.append("|");
+                    keyBuilder.append(kb);
                 }
-                keyBuilder.append("|");
+
+                this.key = keyBuilder.toString();
             }
 
-            this.key = keyBuilder.toString();
         }
 
         @Override

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/ResourceClassMergeTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/ResourceClassMergeTest.java
@@ -1,0 +1,103 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ResourceClassMergeTest {
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(MatchDefaultRegexDifferentNameResourceA.class,
+                                    MatchDefaultRegexDifferentNameResourceB.class, MatchCustomRegexDifferentNameResourceA.class,
+                                    MatchCustomRegexDifferentNameResourceB.class);
+                }
+            });
+
+    @Test
+    public void testCallMatchDefaultRegexDifferentNameResource() {
+        given()
+                .when().get("routing-broken/abc/some/other/path")
+                .then()
+                .statusCode(200)
+                .body(is("abc"));
+
+        given()
+                .when().get("routing-broken/efg/some/path")
+                .then()
+                .statusCode(200)
+                .body(is("efg"));
+    }
+
+    @Test
+    public void testCallMatchCustomRegexDifferentNameResource() {
+        given()
+                .when().get("routing-broken-custom-regex/abc/some/other/path")
+                .then()
+                .statusCode(200)
+                .body(is("abc"));
+
+        given()
+                .when().get("routing-broken-custom-regex/efg/some/path")
+                .then()
+                .statusCode(200)
+                .body(is("efg"));
+    }
+
+    @Path("/routing-broken/{id1}")
+    public static class MatchDefaultRegexDifferentNameResourceA {
+        @GET
+        @Path("/some/other/path")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response doSomething(@PathParam("id1") String id) {
+            return Response.ok(id).build();
+        }
+    }
+
+    @Path("/routing-broken/{id}")
+    public static class MatchDefaultRegexDifferentNameResourceB {
+        @GET
+        @Path("/some/path")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response doSomething(@PathParam("id") String id) {
+            return Response.ok(id).build();
+        }
+    }
+
+    @Path("/routing-broken-custom-regex/{id1: [a-zA-Z]+}")
+    public static class MatchCustomRegexDifferentNameResourceA {
+        @GET
+        @Path("/some/other/path")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response doSomething(@PathParam("id1") String id) {
+            return Response.ok(id).build();
+        }
+    }
+
+    @Path("/routing-broken-custom-regex/{id: [a-zA-Z]+}")
+    public static class MatchCustomRegexDifferentNameResourceB {
+        @GET
+        @Path("/some/path")
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response doSomething(@PathParam("id") String id) {
+            return Response.ok(id).build();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25462 

Resources classes where merged by using all components as map key. This leads to situations where the only differing property of a component may be its name. The name is for a DEFAULT_REGEX however not enough to be considered a different path itself.

The merge is now based on a custom (String) key, build on properties which should enforce uniqueness when needed: type, literal, and pattern.