### PR TITLE
Resteasy Reactive Links: Improve "rel" deduction rules

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksContainerFactory.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksContainerFactory.java
@@ -1,14 +1,26 @@
 package io.quarkus.resteasy.reactive.links.deployment;
 
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COMPLETABLE_FUTURE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.COMPLETION_STAGE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.MULTI;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.REST_RESPONSE;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.UNI;
+
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriBuilder;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.common.util.URLUtils;
@@ -20,10 +32,16 @@ import io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveResourceMe
 
 final class LinksContainerFactory {
 
+    private static final String LIST = "list";
+    private static final String SELF = "self";
+    private static final String REMOVE = "remove";
+    private static final String UPDATE = "update";
+    private static final String ADD = "add";
+
     /**
      * Find the resource methods that are marked with a {@link RestLink} annotations and add them to a links container.
      */
-    LinksContainer getLinksContainer(List<ResteasyReactiveResourceMethodEntriesBuildItem.Entry> entries) {
+    LinksContainer getLinksContainer(List<ResteasyReactiveResourceMethodEntriesBuildItem.Entry> entries, IndexView index) {
         LinksContainer linksContainer = new LinksContainer();
 
         for (ResteasyReactiveResourceMethodEntriesBuildItem.Entry entry : entries) {
@@ -31,7 +49,7 @@ final class LinksContainerFactory {
             AnnotationInstance restLinkAnnotation = resourceMethodInfo.annotation(DotNames.REST_LINK_ANNOTATION);
             if (restLinkAnnotation != null) {
                 LinkInfo linkInfo = getLinkInfo(entry.getResourceMethod(), resourceMethodInfo,
-                        restLinkAnnotation, entry.getBasicResourceClassInfo().getPath());
+                        restLinkAnnotation, entry.getBasicResourceClassInfo().getPath(), index);
                 linksContainer.put(linkInfo);
             }
         }
@@ -39,10 +57,11 @@ final class LinksContainerFactory {
         return linksContainer;
     }
 
-    private LinkInfo getLinkInfo(ResourceMethod resourceMethod,
-            MethodInfo resourceMethodInfo, AnnotationInstance restLinkAnnotation, String resourceClassPath) {
-        String rel = getAnnotationValue(restLinkAnnotation, "rel", resourceMethod.getName());
-        String entityType = getAnnotationValue(restLinkAnnotation, "entityType", deductEntityType(resourceMethodInfo));
+    private LinkInfo getLinkInfo(ResourceMethod resourceMethod, MethodInfo resourceMethodInfo,
+            AnnotationInstance restLinkAnnotation, String resourceClassPath, IndexView index) {
+        Type returnType = getNonAsyncReturnType(resourceMethodInfo.returnType());
+        String rel = getAnnotationValue(restLinkAnnotation, "rel", deductRel(resourceMethod, returnType, index));
+        String entityType = getAnnotationValue(restLinkAnnotation, "entityType", deductEntityType(returnType));
         String path = UriBuilder.fromPath(resourceClassPath).path(resourceMethod.getPath()).toTemplate();
         while (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);
@@ -53,16 +72,47 @@ final class LinksContainerFactory {
     }
 
     /**
+     * When the "rel" property is not set, it will be resolved as follows:
+     * - "list" for GET methods returning a Collection.
+     * - "self" for GET methods returning a non-Collection.
+     * - "remove" for DELETE methods.
+     * - "update" for PUT methods.
+     * - "add" for POST methods.
+     * <p>
+     * Otherwise, it will return the method name.
+     *
+     * @param resourceMethod the resource method definition.
+     * @return the deducted rel property.
+     */
+    private String deductRel(ResourceMethod resourceMethod, Type returnType, IndexView index) {
+        String httpMethod = resourceMethod.getHttpMethod();
+        boolean isCollection = isCollection(returnType, index);
+        if (HttpMethod.GET.equals(httpMethod) && isCollection) {
+            return LIST;
+        } else if (HttpMethod.GET.equals(httpMethod)) {
+            return SELF;
+        } else if (HttpMethod.DELETE.equals(httpMethod)) {
+            return REMOVE;
+        } else if (HttpMethod.PUT.equals(httpMethod)) {
+            return UPDATE;
+        } else if (HttpMethod.POST.equals(httpMethod)) {
+            return ADD;
+        }
+
+        return resourceMethod.getName();
+    }
+
+    /**
      * If a method return type is parameterized and has a single argument (e.g. List), then use that argument as an
      * entity type. Otherwise, use the return type.
      */
-    private String deductEntityType(MethodInfo methodInfo) {
-        if (methodInfo.returnType().kind() == Type.Kind.PARAMETERIZED_TYPE) {
-            if (methodInfo.returnType().asParameterizedType().arguments().size() == 1) {
-                return methodInfo.returnType().asParameterizedType().arguments().get(0).name().toString();
+    private String deductEntityType(Type returnType) {
+        if (returnType.kind() == Type.Kind.PARAMETERIZED_TYPE) {
+            if (returnType.asParameterizedType().arguments().size() == 1) {
+                return returnType.asParameterizedType().arguments().get(0).name().toString();
             }
         }
-        return methodInfo.returnType().name().toString();
+        return returnType.name().toString();
     }
 
     /**
@@ -84,5 +134,39 @@ final class LinksContainerFactory {
             return defaultValue;
         }
         return value.asString();
+    }
+
+    private boolean isCollection(Type type, IndexView index) {
+        if (type.kind() == Type.Kind.PRIMITIVE) {
+            return false;
+        }
+        ClassInfo classInfo = index.getClassByName(type.name());
+        if (classInfo == null) {
+            return false;
+        }
+        return classInfo.interfaceNames().stream().anyMatch(DotName.createSimple(Collection.class.getName())::equals);
+    }
+
+    private Type getNonAsyncReturnType(Type returnType) {
+        switch (returnType.kind()) {
+            case ARRAY:
+            case CLASS:
+            case PRIMITIVE:
+            case VOID:
+                return returnType;
+            case PARAMETERIZED_TYPE:
+                // NOTE: same code in RuntimeResourceDeployment.getNonAsyncReturnType
+                ParameterizedType parameterizedType = returnType.asParameterizedType();
+                if (COMPLETION_STAGE.equals(parameterizedType.name())
+                        || COMPLETABLE_FUTURE.equals(parameterizedType.name())
+                        || UNI.equals(parameterizedType.name())
+                        || MULTI.equals(parameterizedType.name())
+                        || REST_RESPONSE.equals(parameterizedType.name())) {
+                    return parameterizedType.arguments().get(0);
+                }
+                return returnType;
+            default:
+        }
+        return returnType;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
@@ -33,7 +33,6 @@ import io.quarkus.resteasy.reactive.links.runtime.LinksProviderRecorder;
 import io.quarkus.resteasy.reactive.links.runtime.RestLinksProviderProducer;
 import io.quarkus.resteasy.reactive.links.runtime.hal.HalServerResponseFilter;
 import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService;
-import io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveDeploymentInfoBuildItem;
 import io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveResourceMethodEntriesBuildItem;
 import io.quarkus.resteasy.reactive.server.spi.MethodScannerBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomContainerResponseFilterBuildItem;
@@ -56,7 +55,6 @@ final class LinksProcessor {
     @BuildStep
     @Record(STATIC_INIT)
     void initializeLinksProvider(JaxRsResourceIndexBuildItem indexBuildItem,
-            ResteasyReactiveDeploymentInfoBuildItem deploymentInfoBuildItem,
             ResteasyReactiveResourceMethodEntriesBuildItem resourceMethodEntriesBuildItem,
             BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformersProducer,
             BuildProducer<GeneratedClassBuildItem> generatedClassesProducer,
@@ -66,7 +64,7 @@ final class LinksProcessor {
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClassesProducer, true);
 
         // Initialize links container
-        LinksContainer linksContainer = getLinksContainer(deploymentInfoBuildItem, resourceMethodEntriesBuildItem);
+        LinksContainer linksContainer = getLinksContainer(resourceMethodEntriesBuildItem, index);
         // Implement getters to access link path parameter values
         RuntimeValue<GetterAccessorsContainer> getterAccessorsContainer = implementPathParameterValueGetters(
                 index, classOutput, linksContainer, getterAccessorsContainerRecorder, bytecodeTransformersProducer);
@@ -98,11 +96,10 @@ final class LinksProcessor {
         }
     }
 
-    private LinksContainer getLinksContainer(ResteasyReactiveDeploymentInfoBuildItem deploymentInfoBuildItem,
-            ResteasyReactiveResourceMethodEntriesBuildItem resourceMethodEntriesBuildItem) {
+    private LinksContainer getLinksContainer(ResteasyReactiveResourceMethodEntriesBuildItem resourceMethodEntriesBuildItem,
+            IndexView index) {
         LinksContainerFactory linksContainerFactory = new LinksContainerFactory();
-        return linksContainerFactory.getLinksContainer(
-                resourceMethodEntriesBuildItem.getEntries());
+        return linksContainerFactory.getLinksContainer(resourceMethodEntriesBuildItem.getEntries(), index);
     }
 
     /**

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
@@ -35,9 +35,9 @@ public class RestLinksInjectionTest {
                 .getValues("Link");
         assertThat(firstRecordLinks).containsOnly(
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
-                Link.fromUri(recordsWithoutLinksUrl).rel("getAllWithoutLinks").build().toString(),
+                Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/1")).rel("self").build().toString(),
-                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("getBySlug").build().toString());
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString());
 
         List<String> secondRecordLinks = when().get(recordsUrl + "/2")
                 .thenReturn()
@@ -45,10 +45,10 @@ public class RestLinksInjectionTest {
                 .getValues("Link");
         assertThat(secondRecordLinks).containsOnly(
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
-                Link.fromUri(recordsWithoutLinksUrl).rel("getAllWithoutLinks").build().toString(),
+                Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/2")).rel("self").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/second"))
-                        .rel("getBySlug")
+                        .rel("get-by-slug")
                         .build()
                         .toString());
     }
@@ -61,9 +61,9 @@ public class RestLinksInjectionTest {
                 .getValues("Link");
         assertThat(firstRecordLinks).containsOnly(
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
-                Link.fromUri(recordsWithoutLinksUrl).rel("getAllWithoutLinks").build().toString(),
+                Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/1")).rel("self").build().toString(),
-                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("getBySlug").build().toString());
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString());
 
         List<String> secondRecordLinks = when().get(recordsUrl + "/second")
                 .thenReturn()
@@ -71,10 +71,10 @@ public class RestLinksInjectionTest {
                 .getValues("Link");
         assertThat(secondRecordLinks).containsOnly(
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
-                Link.fromUri(recordsWithoutLinksUrl).rel("getAllWithoutLinks").build().toString(),
+                Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/2")).rel("self").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/second"))
-                        .rel("getBySlug")
+                        .rel("get-by-slug")
                         .build()
                         .toString());
     }
@@ -87,7 +87,7 @@ public class RestLinksInjectionTest {
                 .getValues("Link");
         assertThat(links).containsOnly(
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
-                Link.fromUri(recordsWithoutLinksUrl).rel("getAllWithoutLinks").build().toString());
+                Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString());
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
@@ -31,7 +31,7 @@ public class TestResource {
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
-    @RestLink(entityType = TestRecord.class, rel = "list")
+    @RestLink(entityType = TestRecord.class)
     @InjectRestLinks
     public Uni<List<TestRecord>> getAll() {
         return Uni.createFrom().item(RECORDS).onItem().delayIt().by(Duration.ofMillis(100));
@@ -40,7 +40,7 @@ public class TestResource {
     @GET
     @Path("/without-links")
     @Produces(MediaType.APPLICATION_JSON)
-    @RestLink
+    @RestLink(rel = "list-without-links")
     public List<TestRecord> getAllWithoutLinks() {
         return RECORDS;
     }
@@ -48,7 +48,7 @@ public class TestResource {
     @GET
     @Path("/{id: \\d+}")
     @Produces({ MediaType.APPLICATION_JSON, RestMediaType.APPLICATION_HAL_JSON })
-    @RestLink(entityType = TestRecord.class, rel = "self")
+    @RestLink(entityType = TestRecord.class)
     @InjectRestLinks(RestLinkType.INSTANCE)
     public TestRecord getById(@PathParam("id") int id) {
         return RECORDS.stream()
@@ -60,7 +60,7 @@ public class TestResource {
     @GET
     @Path("/{slug: [a-zA-Z-]+}")
     @Produces(MediaType.APPLICATION_JSON)
-    @RestLink
+    @RestLink(rel = "get-by-slug")
     @InjectRestLinks(RestLinkType.INSTANCE)
     public TestRecord getBySlug(@PathParam("slug") String slug) {
         return RECORDS.stream()

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -1,14 +1,12 @@
 package org.jboss.resteasy.reactive.server.core.startup;
 
 import static org.jboss.resteasy.reactive.common.util.DeploymentUtils.loadClass;
+import static org.jboss.resteasy.reactive.common.util.types.Types.getEffectiveReturnType;
+import static org.jboss.resteasy.reactive.common.util.types.Types.getRawType;
 
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.lang.reflect.WildcardType;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import javax.ws.rs.RuntimeType;
@@ -28,7 +25,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyWriter;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.RestResponse;
 import org.jboss.resteasy.reactive.common.ResteasyReactiveConfig;
 import org.jboss.resteasy.reactive.common.model.MethodParameter;
 import org.jboss.resteasy.reactive.common.model.ParameterType;
@@ -615,45 +611,6 @@ public class RuntimeResourceDeployment {
             }
         }
         return pathParameterIndexes;
-    }
-
-    private Class<?> getRawType(Type type) {
-        if (type instanceof Class)
-            return (Class<?>) type;
-        if (type instanceof ParameterizedType) {
-            ParameterizedType ptype = (ParameterizedType) type;
-            return (Class<?>) ptype.getRawType();
-        }
-        throw new UnsupportedOperationException("Endpoint return type not supported yet: " + type);
-    }
-
-    private Type getEffectiveReturnType(Type returnType) {
-        if (returnType instanceof Class)
-            return returnType;
-        if (returnType instanceof ParameterizedType) {
-            ParameterizedType type = (ParameterizedType) returnType;
-            Type firstTypeArgument = type.getActualTypeArguments()[0];
-            if (type.getRawType() == CompletionStage.class) {
-                return getEffectiveReturnType(firstTypeArgument);
-            }
-            if (type.getRawType() == Uni.class) {
-                return getEffectiveReturnType(firstTypeArgument);
-            }
-            if (type.getRawType() == Multi.class) {
-                return getEffectiveReturnType(firstTypeArgument);
-            }
-            if (type.getRawType() == RestResponse.class) {
-                return getEffectiveReturnType(firstTypeArgument);
-            }
-            return returnType;
-        }
-        if (returnType instanceof WildcardType) {
-            Type[] bounds = ((WildcardType) returnType).getLowerBounds();
-            if (bounds.length > 0)
-                return getRawType(bounds[0]);
-            return getRawType(((WildcardType) returnType).getUpperBounds()[0]);
-        }
-        throw new UnsupportedOperationException("Endpoint return type not supported yet: " + returnType);
     }
 
 }


### PR DESCRIPTION
- The new deduction logic is based on what [Resteasy Classic](https://docs.jboss.org/resteasy/docs/2.0.0.GA/userguide/html/LinkHeader.html) (see table in section 8.2.4) is doing:
     * - `list` for GET methods returning a Collection.
     * - `self` for GET methods returning a non-Collection.
     * - `remove` for DELETE methods.
     * - `update` for PUT methods.
     * - `add` for POST methods.
     * - Otherwise, the rest method name.

This is a follow-up action from this comment: https://github.com/quarkusio/quarkus/pull/25217#issuecomment-1112005083