### PR TITLE
Fix DevMode test outputTarget directory with Maven

### DIFF
--- a/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
+++ b/test-framework/junit5-internal/src/main/java/io/quarkus/test/QuarkusDevModeTest.java
@@ -1,6 +1,5 @@
 package io.quarkus.test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -526,9 +525,12 @@ public class QuarkusDevModeTest
                             if (manifestFilePath.startsWith("file:")) {
                                 // manifest file path will be of the form jar:file:....!META-INF/MANIFEST.MF
                                 final String jarFilePath = manifestFilePath.substring(5, manifestFilePath.lastIndexOf('!'));
-                                final File surefirebooterJar = new File(
+                                final Path surefirebooterJar = Path.of(
                                         URLDecoder.decode(jarFilePath, StandardCharsets.UTF_8.name()));
-                                context.setDevModeRunnerJarFile(surefirebooterJar);
+                                final Path targetJar = Path.of(context.getApplicationRoot().getTargetDir())
+                                        .resolve(surefirebooterJar.getFileName());
+                                Files.copy(surefirebooterJar, targetJar);
+                                context.setDevModeRunnerJarFile(targetJar.toFile());
                             }
                             return true;
                         }


### PR DESCRIPTION
The output directory used in dev mode test was not working (with maven):
When using `QuarkusDevModeTest`, the output directory from `OutputTargetBuildItem` is: `/Users/ia3andy/workspace/redhat/quarkiverse/quarkus-quinoa/deployment/target/surefire`
While in devmode test it should be in `/var/folders/j8/sj85tl7d2pq_vnhbpj4t5lwm0000gn/T/quarkus-dev-mode-test9228356049861283982/target`

This is due to a specific handling for maven surefire, my fix is to copy the jar file for the devmode test project target directory which seems more sensible.
