### PR TITLE
Add Oidc Client and Token Propagation Quickstart

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -1,0 +1,959 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= OpenID Connect (OIDC) and OAuth2 Client and Filters Reference Guide 
+
+include::./attributes.adoc[]
+:toc:
+
+This reference guide explains how to use:
+
+ - `quarkus-oidc-client`, `quarkus-oidc-client-reactive-filter` and `quarkus-oidc-client-filter` extensions to acquire and refresh access tokens from OpenID Connect and OAuth 2.0 compliant Authorization Servers such as https://www.keycloak.org[Keycloak]
+ - `quarkus-oidc-token-propagation` and `quarkus-oidc-token-propagation-reactive` extensions to propagate the current `Bearer` or `Authorization Code Flow` access tokens
+
+The access tokens managed by these extensions can be used as HTTP Authorization Bearer tokens to access the remote services.
+
+Please also see xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart].
+
+== OidcClient
+
+Add the following dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-oidc-client</artifactId>
+</dependency>
+----
+
+`quarkus-oidc-client` extension provides a reactive `io.quarkus.oidc.client.OidcClient` which can be used to acquire and refresh tokens using SmallRye Mutiny `Uni` and `Vert.x WebClient`.
+
+`OidcClient` is initialized at the build time with the IDP token endpoint URL which can be auto-discovered or manually configured and uses this endpoint to acquire access tokens using the token grants such as `client_credentials` or `password` and refresh the tokens using a `refresh_token` grant.
+
+=== Token Endpoint Configuration
+
+By default the token endpoint address is discovered by adding a `/.well-known/openid-configuration` path to the configured `quarkus.oidc-client.auth-server-url`.
+
+For example, given this Keycloak URL:
+
+[source, properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
+----
+
+`OidcClient` will discover that the token endpoint URL is `http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens`.
+
+Alternatively, if the discovery endpoint is not available or you would like to save on the discovery endpoint roundtrip, you can disable the discovery and configure the token endpoint address with a relative path value, for example:
+
+[source, properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
+quarkus.oidc-client.discovery-enabled=false
+# Token endpoint: http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
+quarkus.oidc-client.token-path=/protocol/openid-connect/tokens
+----
+
+A more compact way to configure the token endpoint URL without the discovery is to set `quarkus.oidc-client.token-path` to an absolute URL:
+
+[source, properties]
+----
+quarkus.oidc-client.token-path=http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
+----
+
+Setting 'quarkus.oidc-client.auth-server-url' and 'quarkus.oidc-client.discovery-enabled' is not required in this case.
+
+=== Supported Token Grants
+
+The main token grants which `OidcClient` can use to acquire the tokens are the `client_credentials` (default) and `password` grants.
+
+==== Client Credentials Grant
+
+Here is how `OidcClient` can be configured to use the `client_credentials` grant:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+----
+
+The `client_credentials` grant allows to set extra parameters to the token request via `quarkus.oidc-client.grant-options.client.<param-name>=<value>`. Here is how to set the intended token recipient via the `audience` parameter:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+# 'client' is a shortcut for `client_credentials`
+quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.grant-options.client.audience=https://example.com/api
+----
+
+==== Password Grant
+
+Here is how `OidcClient` can be configured to use the `password` grant:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=password
+quarkus.oidc-client.grant-options.password.username=alice
+quarkus.oidc-client.grant-options.password.password=alice
+----
+
+It can be further customized using a `quarkus.oidc-client.grant-options.password` configuration prefix, similarly to how the client credentials grant can be customized.
+
+==== Other Grants
+
+`OidcClient` can also help with acquiring the tokens using the grants which require some extra input parameters which can not be captured in the configuration. These grants are `refresh token` (with the external refresh token), `token exchange` and `authorization code`.
+
+Using the `refresh_token` grant which uses an out of band refresh token to acquire a new set of tokens will be required if the existing refresh token has been posted to the current Quarkus endpoint for it to acquire the access token. In this case `OidcClient` needs to be configured as follows:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=refresh
+----
+
+and then you can use `OidcClient.refreshTokens` method with a provided refresh token to get the access token.
+
+Using the `token exchange` grant may be required if you are building a complex microservices application and would like to avoid the same `Bearer` token be propagated to and used by more than one service. Please see <<token-propagation,Token Propagation in MicroProfile RestClient client filter>> for more details.
+
+Using `OidcClient` to support the `authorization code` grant might be required if for some reasons you can not use the xref:security-openid-connect-web-authentication.adoc[Quarkus OpenID Connect extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=code
+----
+
+and then you can use `OidcClient.accessTokens` method accepting a Map of extra properties and pass the current `code` and `redirect_uri` parameters to exchange the authorization code for the tokens.
+
+==== Grant scopes
+
+You may need to request that a specific set of scopes is associated with an issued access token.
+Use a dedicated `quarkus.oidc-client.scopes` list property, for example: `quarkus.oidc-client.scopes=email,phone`
+
+=== Use OidcClient directly
+
+One can use `OidcClient` directly as follows:
+
+[source,java]
+----
+import javax.inject.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.Tokens;
+
+@Path("/service")
+public class OidcClientResource {
+
+    @Inject
+    OidcClient client;
+
+    volatile Tokens currentTokens;
+
+    @PostConstruct
+    public void init() {
+        currentTokens = client.getTokens().await().indefinitely();
+    }
+
+    @GET
+    public String getResponse() {
+        
+        Tokens tokens = currentTokens;
+        if (tokens.isAccessTokenExpired()) {
+            // Add @Blocking method annotation if this code is used with Reactive RestClient
+            tokens = client.refreshTokens(tokens.getRefreshToken()).await().indefinitely();
+            currentTokens = tokens;
+        } 
+        // Use tokens.getAccessToken() to configure MP RestClient Authorization header/etc
+    }
+}
+----
+
+=== Inject Tokens
+
+You can inject `Tokens` which uses `OidcClient` internally. `Tokens` can be used to acquire the access tokens and refresh them if necessary:
+
+[source,java]
+----
+import javax.inject.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+
+import io.quarkus.oidc.client.Tokens;
+
+@Path("/service")
+public class OidcClientResource {
+
+    @Inject Tokens tokens;
+
+    @GET
+    public String getResponse() {
+        //  Get the access token which may have been refreshed.
+        String accessToken = tokens.getAccessToken();
+        // Use the access token to configure MP RestClient Authorization header/etc
+    }
+}
+----
+
+=== Use OidcClients
+
+`io.quarkus.oidc.client.OidcClients` is a container of ``OidcClient``s - it includes a default `OidcClient` and named clients which can be configured like this:
+
+[source,properties]
+----
+quarkus.oidc-client.client-enabled=false
+
+quarkus.oidc-client.jwt-secret.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.jwt-secret.client-id=quarkus-app
+quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+----
+
+Note in this case the default client is disabled with a `client-enabled=false` property. The `jwt-secret` client can be accessed like this:
+
+[source,java]
+----
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    OidcClients clients;
+
+    @GET
+    public String getResponse() {
+        OidcClient client = clients.getClient("jwt-secret");
+        // use this client to get the token
+    }
+}
+----
+
+[NOTE]
+====
+If you also use xref:security-openid-connect-multitenancy.adoc[OIDC multitenancy] and each OIDC tenant has its own associated `OidcClient` then you can use a Vert.x `RoutingContext` `tenantId` attribute, for example:
+
+[source,java]
+----
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    OidcClients clients;
+    @Inject
+    RoutingContext context;
+
+    @GET
+    public String getResponse() {
+        String tenantId = context.get("tenantId");
+        // named OIDC tenant and client configurations use the same key:
+        OidcClient client = clients.getClient(tenantId);
+        // use this client to get the token
+    }
+}
+----
+====
+
+If you need you can also create new `OidcClient` programmatically like this:
+
+[source,java]
+----
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.oidc.client.OidcClient;
+import io.quarkus.oidc.client.OidcClients;
+import io.quarkus.oidc.client.OidcClientConfig;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    OidcClients clients;
+
+    @GET
+    public String getResponse() {
+        OidcClientConfig cfg = new OidcClientConfig();
+        cfg.setId("myclient");
+        cfg.setAuthServerUrl("http://localhost:8081/auth/realms/quarkus/");
+        cfg.setClientId("quarkus");
+        cfg.getCredentials().setSecret("secret");
+        Uni<OidcClient> client = clients.newClient(cfg);
+        // use this client to get the token
+    }
+}
+----
+
+[[named-oidc-clients]]
+=== Inject named OidcClient and Tokens
+
+In case of multiple configured ``OidcClient``s you can specify the `OidcClient` injection target by the extra qualifier `@NamedOidcClient` instead of working with `OidcClients`:
+
+[source,java]
+----
+package io.quarkus.oidc.client;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/clients")
+public class OidcClientResource {
+
+    @Inject
+    @NamedOidcClient("jwt-secret")
+    OidcClient client;
+
+    @GET
+    public String getResponse() {
+        // use client to get the token
+    }
+}
+----
+
+The same qualifier can be used to specify the `OidcClient` used for a `Tokens` injection:
+
+[source,java]
+----
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+@RequestScoped
+public class OidcClientRequestCustomFilter implements ClientRequestFilter {
+
+    @Inject
+    @NamedOidcClient("jwt-secret")
+    Tokens tokens;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
+    }
+}
+----
+
+[[oidc-client-reactive-filter]]
+=== Use OidcClient in RestClient Reactive ClientFilter
+
+Add the following Maven Dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
+</dependency>
+----
+
+Note it will also bring `io.quarkus:quarkus-oidc-client`.
+
+`quarkus-oidc-client-reactive-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestReactiveFilter`.
+
+It works similarly to the way `OidcClientRequestFilter` does (see <<oidc-client-filter, Use OidcClient in MicroProfile RestClient client filter>>) - it uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization` `Bearer` scheme value. The difference is that it works with xref:rest-client-reactive.adoc[Reactive RestClient] and implements a non-blocking client filter which does not block the current IO thread when acquiring or refreshing the tokens.
+
+`OidcClientRequestReactiveFilter` delays an initial token acquisition until it is executed to avoid blocking an IO thread and it currently can only be registered with `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation:
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient
+@RegisterProvider(OidcClientRequestReactiveFilter.class)
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    Uni<String> getUserName();
+}
+----
+
+`OidcClientRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-client-reactive-filter.client-name` configuration property.
+
+
+[[oidc-client-filter]]
+=== Use OidcClient in RestClient ClientFilter
+
+Add the following Maven Dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-oidc-client-filter</artifactId>
+</dependency>
+----
+
+Note it will also bring `io.quarkus:quarkus-oidc-client`.
+
+`quarkus-oidc-client-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestFilter` JAX-RS ClientRequestFilter which uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization` `Bearer` scheme value.
+
+By default, this filter will get `OidcClient` to acquire the first pair of access and refresh tokens at its initialization time. If the access tokens are short-lived and refresh tokens are not available then the token acquisition should be delayed with `quarkus.oidc-client.early-tokens-acquisition=false`.
+
+You can selectively register `OidcClientRequestFilter` by using either `io.quarkus.oidc.client.filter.OidcClientFilter` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotations:
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.client.filter.OidcClientFilter;
+
+@RegisterRestClient
+@OidcClientFilter
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+
+or
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
+
+@RegisterRestClient
+@RegisterProvider(OidcClientRequestFilter.class)
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+
+Alternatively, `OidcClientRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if `quarkus.oidc-client-filter.register-filter=true` property is set.
+
+`OidcClientRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-client-filter.client-name` configuration property.
+
+=== Use Custom RestClient ClientFilter
+
+If you prefer you can use your own custom filter and inject `Tokens`:
+
+[source,java]
+----
+import io.quarkus.oidc.client.Tokens;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class OidcClientRequestCustomFilter implements ClientRequestFilter {
+
+    @Inject
+    Tokens tokens;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
+    }
+}
+----
+
+The `Tokens` producer will acquire and refresh the tokens, and the custom filter will decide how and when to use the token.
+
+You can also inject named `Tokens`, see <<named-oidc-clients,Inject named OidcClient and Tokens>>
+
+[[refresh-access-tokens]]
+=== Refreshing Access Tokens
+
+`OidcClientRequestReactiveFilter`, `OidcClientRequestFilter` and `Tokens` producers will refresh the current expired access token if the refresh token is available.
+Additionally, `quarkus.oidc-client.refresh-token-time-skew` property can be used for a preemptive access token refreshment to avoid sending nearly expired access tokens which may cause HTTP 401 errors. For example if this property is set to `3S` and the access token will expire in less than 3 seconds then this token will be auto-refreshed.
+
+If the access token needs to be refreshed but no refresh token is available then an attempt will be made to acquire a new token using the configured grant such as `client_credentials`.
+
+Please note that some OpenID Connect Providers will not return a refresh token in a `client_credentials` grant response. For example, starting from Keycloak 12 a refresh token will not be returned by default for `client_credentials`. The providers may also restrict a number of times a refresh token can be used.
+
+[[oidc-client-authentication]]
+=== OidcClient Authentication
+
+`OidcClient` has to authenticate to the OpenID Connect Provider for the `client_credentials` and other grant requests to succeed.
+All the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[OIDC Client Authentication] options are supported, for example:
+
+`client_secret_basic`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=mysecret
+----
+
+or
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.client-secret.value=mysecret
+----
+
+or with the secret retrieved from a xref:credentials-provider.adoc[CredentialsProvider]:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+
+# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
+quarkus.oidc-client.credentials.client-secret.provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc-client.credentials.client-secret.provider.name=oidc-credentials-provider
+----
+
+`client_secret_post`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.client-secret.value=mysecret
+quarkus.oidc-client.credentials.client-secret.method=post
+----
+
+`client_secret_jwt`, signature algorithm is `HS256`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+----
+
+or with the secret retrieved from a xref:credentials-provider.adoc[CredentialsProvider], signature algorithm is `HS256`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+
+# This is a key which will be used to retrieve a secret from the map of credentials returned from CredentialsProvider
+quarkus.oidc-client.credentials.jwt.secret-provider.key=mysecret-key
+# Set it only if more than one CredentialsProvider can be registered
+quarkus.oidc-client.credentials.jwt.secret-provider.name=oidc-credentials-provider
+----
+
+`private_key_jwt` with the PEM key file, signature algorithm is `RS256`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.jwt.key-file=privateKey.pem
+----
+
+`private_key_jwt` with the key store file, signature algorithm is `RS256`:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.jwt.key-store-file=keystore.jks
+quarkus.oidc-client.credentials.jwt.key-store-password=mypassword
+quarkus.oidc-client.credentials.jwt.key-password=mykeypassword
+
+# Private key alias inside the keystore
+quarkus.oidc-client.credentials.jwt.key-id=mykeyAlias
+----
+
+Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that no client secret goes over the wire.
+
+==== Additional JWT Authentication options
+
+If either `client_secret_jwt` or `private_key_jwt` authentication methods are used then the JWT signature algorithm, key identifier, audience, subject and issuer can be customized, for example:
+
+[source,properties]
+----
+# private_key_jwt client authentication
+
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.jwt.key-file=privateKey.pem
+
+# This is a token key identifier 'kid' header - set it if your OpenID Connect provider requires it.
+# Note if the key is represented in a JSON Web Key (JWK) format with a `kid` property then
+# using 'quarkus.oidc-client.credentials.jwt.token-key-id' is not necessary.
+quarkus.oidc-client.credentials.jwt.token-key-id=mykey
+
+# Use RS512 signature algorithm instead of the default RS256
+quarkus.oidc-client.credentials.jwt.signature-algorithm=RS512
+
+# The token endpoint URL is the default audience value, use the base address URL instead:
+quarkus.oidc-client.credentials.jwt.audience=${quarkus.oidc-client.auth-server-url}
+
+# custom subject instead of the client id :
+quarkus.oidc-client.credentials.jwt.subject=custom-subject
+
+# custom issuer instead of the client id :
+quarkus.oidc-client.credentials.jwt.issuer=custom-issuer
+----
+
+==== Apple POST JWT
+
+Apple OpenID Connect Provider uses a `client_secret_post` method where a secret is a JWT produced with a `private_key_jwt` authentication method but with Apple account specific issuer and subject properties.
+
+`quarkus-oidc-client` supports a non-standard `client_secret_post_jwt` authentication method which can be configured as follows:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=${apple.url}
+quarkus.oidc-client.client-id=${apple.client-id}
+quarkus.oidc-client.credentials.client-secret.method=post-jwt
+
+quarkus.oidc-client.credentials.jwt.key-file=ecPrivateKey.pem
+quarkus.oidc-client.credentials.jwt.signature-algorithm=ES256
+quarkus.oidc-client.credentials.jwt.subject=${apple.subject}
+quarkus.oidc-client.credentials.jwt.issuer=${apple.issuer}
+----
+
+==== Mutual TLS
+
+Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`mTLS`) authentication process.
+
+`quarkus-oidc-client` can be configured as follows to support `mTLS`:
+
+[source,properties]
+----
+quarkus.oidc.tls.verification=certificate-validation
+
+# Keystore configuration
+quarkus.oidc.client.tls.key-store-file=client-keystore.jks
+quarkus.oidc.client.tls.key-store-password=${key-store-password}
+
+# Add more keystore properties if needed:
+#quarkus.oidc.client.tls.key-store-alias=keyAlias
+#quarkus.oidc.client.tls.key-store-alias-password=keyAliasPassword
+
+# Truststore configuration
+quarkus.oidc.client.tls.trust-store-file=client-truststore.jks
+quarkus.oidc.client.tls.trust-store-password=${trust-store-password}
+# Add more truststore properties if needed:
+#quarkus.oidc.client.tls.trust-store-alias=certAlias
+----
+
+[[integration-testing-oidc-client]]
+=== Testing
+
+Start by adding the following dependencies to your test project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-junit5</artifactId>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.awaitility</groupId>
+    <artifactId>awaitility</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+[[integration-testing-wiremock]]
+==== Wiremock
+
+Add the following dependencies to your test project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.github.tomakehurst</groupId>
+    <artifactId>wiremock-jre8</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+Write Wiremock based `QuarkusTestResourceLifecycleManager`, for example:
+[source, java]
+----
+package io.quarkus.it.keycloak;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.Options.ChunkedEncodingPolicy;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
+    private WireMockServer server;
+
+    @Override
+    public Map<String, String> start() {
+
+        server = new WireMockServer(wireMockConfig().dynamicPort().useChunkedTransferEncoding(ChunkedEncodingPolicy.NEVER));
+        server.start();
+
+        server.stubFor(WireMock.post("/tokens")
+                .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+        server.stubFor(WireMock.post("/tokens")
+                .withRequestBody(matching("grant_type=refresh_token&refresh_token=refresh_token_1"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put("keycloak.url", server.baseUrl());
+        return conf;
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+}
+----
+
+Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered OidcClient filter to invoke on the downstream endpoint which echoes the token back, for example, see the `integration-tests/oidc-client-wiremock` in the `main` Quarkus repository.
+
+Set `application.properties`, for example:
+
+[source, properties]
+----
+# Use 'keycloak.url' property set by the test KeycloakRealmResourceManager
+quarkus.oidc-client.auth-server-url=${keycloak.url}
+quarkus.oidc-client.discovery-enabled=false
+quarkus.oidc-client.token-path=/tokens
+quarkus.oidc-client.client-id=quarkus-service-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=password
+quarkus.oidc-client.grant-options.password.username=alice
+quarkus.oidc-client.grant-options.password.password=alice
+----
+
+and finally write the test code. Given the Wiremock-based resource above, the first test invocation should return `access_token_1` access token which will expire in 4 seconds. Use `awaitility` to wait for about 5 seconds, and now the next test invocation should return `access_token_2` access token which confirms the expired `access_token_1` access token has been refreshed.
+
+==== Keycloak
+
+If you work with Keycloak then you can use the same approach as described in the xref:security-openid-connect#integration-testing-keycloak.adoc[OpenID Connect Bearer Token Integration testing] Keycloak section.
+
+=== How to check the errors in the logs
+
+Please enable `io.quarkus.oidc.client.runtime.OidcClientImpl` `TRACE` level logging to see more details about the token acquisition and refresh errors:
+
+[source, properties]
+----
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
+----
+
+Please enable `io.quarkus.oidc.client.runtime.OidcClientRecorder` `TRACE` level logging to see more details about the OidcClient initialization errors:
+
+[source, properties]
+----
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".level=TRACE
+quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-level=TRACE
+----
+
+[[token-propagation]]
+== Token Propagation
+
+The `quarkus-oidc-token-propagation` extension provides two JAX-RS `javax.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
+`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-openid-connect.adoc[Bearer] token present in the current active request or the token acquired from the xref:security-openid-connect-web-authentication.adoc[Authorization Code Flow], as the HTTP `Authorization` header's `Bearer` scheme value.
+The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality, but in addition provides support for JWT tokens.
+
+When you need to propagate the current Authorization Code Flow access token then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
+
+However, the direct end to end Bearer token propagation should be avoided if possible. For example, `Client -> Service A -> Service B` where `Service B` receives a token sent by `Client` to `Service A`. In such cases `Service B` will not be able to distinguish if the token came from `Service A` or from `Client` directly. For `Service B` to verify the token came from `Service A` it should be able to assert a new issuer and audience claims.
+
+Additionally, a complex application may need to exchange or update the tokens before propagating them. For example, the access context might be different when `Service A` is accessing `Service B`. In this case, `Service A` might be granted a narrow or a completely different set of scopes to access `Service B`.
+
+The following sections show how `AccessTokenRequestFilter` and `JsonWebTokenRequestFilter` can help.
+
+=== RestClient AccessTokenRequestFilter
+
+`AccessTokenRequestFilter` treats all tokens as Strings and as such it can work with both JWT and opaque tokens.
+
+You can selectively register `AccessTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.token.propagation.AccessToken;
+
+@RegisterRestClient
+@AccessToken
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+or
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.token.propagation.AccessTokenRequestFilter;
+
+@RegisterRestClient
+@RegisterProvider(AccessTokenRequestFilter.class)
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+
+Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if `quarkus.oidc-token-propagation.register-filter` property is set to `true` and `quarkus.oidc-token-propagation.json-web-token` property is set to `false` (which is a default value).
+
+==== Exchange Token Before Propagation
+
+If the current access token needs to be exchanged before propagation and you work with link:https://www.keycloak.org/docs/latest/securing_apps/#_token-exchange[Keycloak] or other OpenID Connect Provider which supports a link:https://tools.ietf.org/html/rfc8693[Token Exchange] token grant then you can configure `AccessTokenRequestFilter` like this:
+
+[source,properties]
+----
+quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
+quarkus.oidc-client.client-id=quarkus-app
+quarkus.oidc-client.credentials.secret=secret
+quarkus.oidc-client.grant.type=exchange
+quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
+
+quarkus.oidc-token-propagation.exchange-token=true
+----
+
+Note `AccessTokenRequestFilter` will use `OidcClient` to exchange the current token and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect Provider.
+
+`AccessTokenRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-token-propagation.client-name` configuration property.
+
+=== RestClient JsonWebTokenRequestFilter
+
+Using `JsonWebTokenRequestFilter` is recommended if you work with Bearer JWT tokens where these tokens can have their claims such as `issuer` and `audience` modified and the updated tokens secured (for example, re-signed) again. It expects an injected `org.eclipse.microprofile.jwt.JsonWebToken` and therefore will not work with the opaque tokens. Also, if your OpenID Connect Provider supports a Token Exchange protocol then it is recommended to use `AccessTokenRequestFilter` instead - as both JWT and opaque bearer tokens can be securely exchanged with `AccessTokenRequestFilter`.
+
+`JsonWebTokenRequestFilter` makes it easy for `Service A` implementations to update the injected `org.eclipse.microprofile.jwt.JsonWebToken` with the new `issuer` and `audience` claim values and secure the updated token again with a new signature. The only difficult step is to ensure `Service A` has a signing key - it should be provisioned from a secure file system or from the remote secure storage such as Vault.
+
+You can selectively register `JsonWebTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.JsonWebToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.token.propagation.JsonWebToken;
+
+@RegisterRestClient
+@JsonWebToken
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+or
+
+[source,java]
+----
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter;
+
+@RegisterRestClient
+@RegisterProvider(JsonWebTokenRequestFilter.class)
+@Path("/")
+public interface ProtectedResourceService {
+
+    @GET
+    String getUserName();
+}
+----
+
+Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if both `quarkus.oidc-token-propagation.register-filter` and `quarkus.oidc-token-propagation.json-web-token` properties are set to `true`.
+
+==== Update Token Before Propagation
+
+If the injected token needs to have its `iss` (issuer) and/or `aud` (audience) claims updated and secured again with a new signature then you can configure `JsonWebTokenRequestFilter` like this:
+
+[source,properties]
+----
+quarkus.oidc-token-propagation.secure-json-web-token=true
+smallrye.jwt.sign.key.location=/privateKey.pem
+# Set a new issuer
+smallrye.jwt.new-token.issuer=http://frontend-resource
+# Set a new audience
+smallrye.jwt.new-token.audience=http://downstream-resource
+# Override the existing token issuer and audience claims if they are already set
+smallrye.jwt.new-token.override-matching-claims=true
+----
+
+As already noted above, please use `AccessTokenRequestFilter` if you work with Keycloak or OpenID Connect Provider which supports a Token Exchange protocol.
+
+[[integration-testing-token-propagation]]
+=== Testing
+
+You can generate the tokens as described in xref:security-openid-connect.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
+Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered token propagation filter to invoke on the downstream endpoint, for example, see the `integration-tests/oidc-token-propagation` in the `main` Quarkus repository.
+
+[[reactive-token-propagation]]
+== Token Propagation Reactive
+
+Add the following Maven Dependency:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
+</dependency>
+----
+
+The `quarkus-oidc-token-propagation-reactive` extension provides `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` which can be used to propagate the current `Bearer` or `Authorization Code Flow` access tokens.
+
+The `quarkus-oidc-token-propagation-reactive` extension (as opposed to the non-reactive `quarkus-oidc-token-propagation` extension) does not currently support the exchanging or resigning the tokens before the propagation.
+However these features may be added in the future.
+
+== References
+
+* xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
+* xref:security-openid-connect.adoc[Quarkus - Using OpenID Connect to Protect Service Applications using Bearer Token Authorization]
+* xref:security-openid-connect-web-authentication.adoc[Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow]
+* xref:security.adoc[Quarkus Security]

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -3,954 +3,504 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Using OpenID Connect (OIDC) and OAuth2 Client and Filters to manage access tokens
+= OpenID Connect Client and Token Propagation Quickstart
 
 include::./attributes.adoc[]
 :toc:
 
-This guide explains how to use:
+This quickstart demonstrates how to use `OpenID Connect Client Reactive Filter` to acquire and propagate access tokens as `HTTP Authorization Bearer` access tokens, alongside `OpenID Token Propagation Reactive Filter` which propagates the incoming `HTTP Authorization Bearer` access tokens.
 
- - `quarkus-oidc-client`, `quarkus-oidc-client-reactive-filter` and `quarkus-oidc-client-filter` extensions to acquire and refresh access tokens from OpenID Connect and OAuth 2.0 compliant Authorization Servers such as https://www.keycloak.org[Keycloak]
- - `quarkus-oidc-token-propagation` and `quarkus-oidc-token-propagation-reactive` extensions to propagate the current `Bearer` or `Authorization Code Flow` access tokens
+Please check xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Reference Guide] for all the information related to `Oidc Client` and `Token Propagation` support in Quarkus.
 
-The access tokens managed by these extensions can be used as HTTP Authorization Bearer tokens to access the remote services.
+Please also read xref:security-openid-connect.adoc[Using OpenID Connect to Protect Service Applications] guide if you need to protect your applications using Bearer Token Authorization.
 
-== OidcClient
+== Prerequisites
 
-Add the following dependency:
+:prerequisites-docker:
+include::includes/devtools/prerequisites.adoc[]
+* https://stedolan.github.io/jq/[jq tool]
 
-[source,xml]
+== Architecture
+
+In this example, we will build an application which consists of two JAX-RS resources, `FrontendResource` and `ProtectedResource`. `FrontendResource` propagates access tokens to `ProtectedResource` and uses either `OpenID Connect Client Reactive Filter` to acquire a token first before propagating it or `OpenID Token Propagation Reactive Filter` to propagate the incoming, already existing access token.
+
+`FrontendResource` has 4 endpoints:
+
+* `/frontend/user-name-with-oidc-client`
+* `/frontend/admin-name-with-oidc-client`
+* `/frontend/user-name-with-propagated-token`
+* `/frontend/admin-name-with-propagated-token`
+
+`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client` or `/frontend/admin-name-with-oidc-client` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
+
+`ProtecedResource` has 2 endpoints:
+
+* `/protected/user-name`
+* `/protected/admin-name`
+
+Both of these endpoints return the user name extracted from the incoming access token which was propagated to `ProtectedResource` from `FrontendResource`. The only difference between these endpoints is that calling `/protected/user-name` is only allowed if the current access token has a `user` role and calling `/protected/admin-name` is only allowed if the current access token has an `admin` role.
+
+== Solution
+
+We recommend that you follow the instructions in the next sections and create the application step by step.
+However, you can go right to the completed example.
+
+Clone the Git repository: `git clone {quickstarts-clone-url}`, or download an {quickstarts-archive-url}[archive].
+
+The solution is located in the `security-openid-connect-quickstart` {quickstarts-tree-url}/security-openid-connect-client-quickstart[directory].
+
+== Creating the Maven Project
+
+First, we need a new project. Create a new project with the following command:
+
+:create-app-artifact-id: security-openid-connect-client-quickstart
+:create-app-extensions: oidc,oidc-client-reactive-filter,oidc-token-propagation-reactive,resteasy-reactive
+include::includes/devtools/create-app.adoc[]
+
+This command generates a Maven project, importing the `oidc`, `oidc-client-reactive-filter`, `oidc-client-reactive-filter` and `resteasy-reactive` extensions.
+
+If you already have your Quarkus project configured, you can add these extensions to your project by running the following command in your project base directory:
+
+:add-extension-extensions: oidc,oidc-client-reactive-filter,oidc-token-propagation-reactive,resteasy-reactive
+include::includes/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
 ----
 <dependency>
     <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc-client</artifactId>
+    <artifactId>quarkus-oidc</artifactId>
 </dependency>
-----
-
-`quarkus-oidc-client` extension provides a reactive `io.quarkus.oidc.client.OidcClient` which can be used to acquire and refresh tokens using SmallRye Mutiny `Uni` and `Vert.x WebClient`.
-
-`OidcClient` is initialized at the build time with the IDP token endpoint URL which can be auto-discovered or manually configured and uses this endpoint to acquire access tokens using the token grants such as `client_credentials` or `password` and refresh the tokens using a `refresh_token` grant.
-
-=== Token Endpoint Configuration
-
-By default the token endpoint address is discovered by adding a `/.well-known/openid-configuration` path to the configured `quarkus.oidc-client.auth-server-url`.
-
-For example, given this Keycloak URL:
-
-[source, properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
-----
-
-`OidcClient` will discover that the token endpoint URL is `http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens`.
-
-Alternatively, if the discovery endpoint is not available or you would like to save on the discovery endpoint roundtrip, you can disable the discovery and configure the token endpoint address with a relative path value, for example:
-
-[source, properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
-quarkus.oidc-client.discovery-enabled=false
-# Token endpoint: http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
-quarkus.oidc-client.token-path=/protocol/openid-connect/tokens
-----
-
-A more compact way to configure the token endpoint URL without the discovery is to set `quarkus.oidc-client.token-path` to an absolute URL:
-
-[source, properties]
-----
-quarkus.oidc-client.token-path=http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/tokens
-----
-
-Setting 'quarkus.oidc-client.auth-server-url' and 'quarkus.oidc-client.discovery-enabled' is not required in this case.
-
-=== Supported Token Grants
-
-The main token grants which `OidcClient` can use to acquire the tokens are the `client_credentials` (default) and `password` grants.
-
-==== Client Credentials Grant
-
-Here is how `OidcClient` can be configured to use the `client_credentials` grant:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-----
-
-The `client_credentials` grant allows to set extra parameters to the token request via `quarkus.oidc-client.grant-options.client.<param-name>=<value>`. Here is how to set the intended token recipient via the `audience` parameter:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-# 'client' is a shortcut for `client_credentials`
-quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.grant-options.client.audience=https://example.com/api
-----
-
-==== Password Grant
-
-Here is how `OidcClient` can be configured to use the `password` grant:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-quarkus.oidc-client.grant.type=password
-quarkus.oidc-client.grant-options.password.username=alice
-quarkus.oidc-client.grant-options.password.password=alice
-----
-
-It can be further customized using a `quarkus.oidc-client.grant-options.password` configuration prefix, similarly to how the client credentials grant can be customized.
-
-==== Other Grants
-
-`OidcClient` can also help with acquiring the tokens using the grants which require some extra input parameters which can not be captured in the configuration. These grants are `refresh token` (with the external refresh token), `token exchange` and `authorization code`.
-
-Using the `refresh_token` grant which uses an out of band refresh token to acquire a new set of tokens will be required if the existing refresh token has been posted to the current Quarkus endpoint for it to acquire the access token. In this case `OidcClient` needs to be configured as follows:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-quarkus.oidc-client.grant.type=refresh
-----
-
-and then you can use `OidcClient.refreshTokens` method with a provided refresh token to get the access token.
-
-Using the `token exchange` grant may be required if you are building a complex microservices application and would like to avoid the same `Bearer` token be propagated to and used by more than one service. Please see <<token-propagation,Token Propagation in MicroProfile RestClient client filter>> for more details.
-
-Using `OidcClient` to support the `authorization code` grant might be required if for some reasons you can not use the xref:security-openid-connect-web-authentication.adoc[Quarkus OpenID Connect extension] to support Authorization Code Flow. If there is a very good reason for you to implement Authorization Code Flow then you can configure `OidcClient` as follows:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-quarkus.oidc-client.grant.type=code
-----
-
-and then you can use `OidcClient.accessTokens` method accepting a Map of extra properties and pass the current `code` and `redirect_uri` parameters to exchange the authorization code for the tokens.
-
-==== Grant scopes
-
-You may need to request that a specific set of scopes is associated with an issued access token.
-Use a dedicated `quarkus.oidc-client.scopes` list property, for example: `quarkus.oidc-client.scopes=email,phone`
-
-=== Use OidcClient directly
-
-One can use `OidcClient` directly as follows:
-
-[source,java]
-----
-import javax.inject.PostConstruct;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-
-import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.Tokens;
-
-@Path("/service")
-public class OidcClientResource {
-
-    @Inject
-    OidcClient client;
-
-    volatile Tokens currentTokens;
-
-    @PostConstruct
-    public void init() {
-        currentTokens = client.getTokens().await().indefinitely();
-    }
-
-    @GET
-    public String getResponse() {
-        
-        Tokens tokens = currentTokens;
-        if (tokens.isAccessTokenExpired()) {
-            // Add @Blocking method annotation if this code is used with Reactive RestClient
-            tokens = client.refreshTokens(tokens.getRefreshToken()).await().indefinitely();
-            currentTokens = tokens;
-        } 
-        // Use tokens.getAccessToken() to configure MP RestClient Authorization header/etc
-    }
-}
-----
-
-=== Inject Tokens
-
-You can inject `Tokens` which uses `OidcClient` internally. `Tokens` can be used to acquire the access tokens and refresh them if necessary:
-
-[source,java]
-----
-import javax.inject.PostConstruct;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-
-import io.quarkus.oidc.client.Tokens;
-
-@Path("/service")
-public class OidcClientResource {
-
-    @Inject Tokens tokens;
-
-    @GET
-    public String getResponse() {
-        //  Get the access token which may have been refreshed.
-        String accessToken = tokens.getAccessToken();
-        // Use the access token to configure MP RestClient Authorization header/etc
-    }
-}
-----
-
-=== Use OidcClients
-
-`io.quarkus.oidc.client.OidcClients` is a container of ``OidcClient``s - it includes a default `OidcClient` and named clients which can be configured like this:
-
-[source,properties]
-----
-quarkus.oidc-client.client-enabled=false
-
-quarkus.oidc-client.jwt-secret.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.jwt-secret.client-id=quarkus-app
-quarkus.oidc-client.jwt-secret.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
-----
-
-Note in this case the default client is disabled with a `client-enabled=false` property. The `jwt-secret` client can be accessed like this:
-
-[source,java]
-----
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-
-import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClients;
-
-@Path("/clients")
-public class OidcClientResource {
-
-    @Inject
-    OidcClients clients;
-
-    @GET
-    public String getResponse() {
-        OidcClient client = clients.getClient("jwt-secret");
-        // use this client to get the token
-    }
-}
-----
-
-[NOTE]
-====
-If you also use xref:security-openid-connect-multitenancy.adoc[OIDC multitenancy] and each OIDC tenant has its own associated `OidcClient` then you can use a Vert.x `RoutingContext` `tenantId` attribute, for example:
-
-[source,java]
-----
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-
-import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClients;
-import io.vertx.ext.web.RoutingContext;
-
-@Path("/clients")
-public class OidcClientResource {
-
-    @Inject
-    OidcClients clients;
-    @Inject
-    RoutingContext context;
-
-    @GET
-    public String getResponse() {
-        String tenantId = context.get("tenantId");
-        // named OIDC tenant and client configurations use the same key:
-        OidcClient client = clients.getClient(tenantId);
-        // use this client to get the token
-    }
-}
-----
-====
-
-If you need you can also create new `OidcClient` programmatically like this:
-
-[source,java]
-----
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-
-import io.quarkus.oidc.client.OidcClient;
-import io.quarkus.oidc.client.OidcClients;
-import io.quarkus.oidc.client.OidcClientConfig;
-
-import io.smallrye.mutiny.Uni;
-
-@Path("/clients")
-public class OidcClientResource {
-
-    @Inject
-    OidcClients clients;
-
-    @GET
-    public String getResponse() {
-        OidcClientConfig cfg = new OidcClientConfig();
-        cfg.setId("myclient");
-        cfg.setAuthServerUrl("http://localhost:8081/auth/realms/quarkus/");
-        cfg.setClientId("quarkus");
-        cfg.getCredentials().setSecret("secret");
-        Uni<OidcClient> client = clients.newClient(cfg);
-        // use this client to get the token
-    }
-}
-----
-
-[[named-oidc-clients]]
-=== Inject named OidcClient and Tokens
-
-In case of multiple configured ``OidcClient``s you can specify the `OidcClient` injection target by the extra qualifier `@NamedOidcClient` instead of working with `OidcClients`:
-
-[source,java]
-----
-package io.quarkus.oidc.client;
-
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-
-@Path("/clients")
-public class OidcClientResource {
-
-    @Inject
-    @NamedOidcClient("jwt-secret")
-    OidcClient client;
-
-    @GET
-    public String getResponse() {
-        // use client to get the token
-    }
-}
-----
-
-The same qualifier can be used to specify the `OidcClient` used for a `Tokens` injection:
-
-[source,java]
-----
-@Provider
-@Priority(Priorities.AUTHENTICATION)
-@RequestScoped
-public class OidcClientRequestCustomFilter implements ClientRequestFilter {
-
-    @Inject
-    @NamedOidcClient("jwt-secret")
-    Tokens tokens;
-
-    @Override
-    public void filter(ClientRequestContext requestContext) throws IOException {
-        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
-    }
-}
-----
-
-[[oidc-client-reactive-filter]]
-=== Use OidcClient in RestClient Reactive ClientFilter
-
-Add the following Maven Dependency:
-
-[source,xml]
-----
 <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
 </dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-reactive</artifactId>
+</dependency>
 ----
 
-Note it will also bring `io.quarkus:quarkus-oidc-client`.
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-oidc,oidc-client-reactive-filter,oidc-token-propagation-reactive,resteasy-reactive")
+----
 
-`quarkus-oidc-client-reactive-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestReactiveFilter`.
+== Writing the application
 
-It works similarly to the way `OidcClientRequestFilter` does (see <<oidc-client-filter, Use OidcClient in MicroProfile RestClient client filter>>) - it uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization` `Bearer` scheme value. The difference is that it works with xref:rest-client-reactive.adoc[Reactive RestClient] and implements a non-blocking client filter which does not block the current IO thread when acquiring or refreshing the tokens.
-
-`OidcClientRequestReactiveFilter` delays an initial token acquisition until it is executed to avoid blocking an IO thread and it currently can only be registered with `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotation:
+Let's start by implementing `ProtectedResource`:
 
 [source,java]
 ----
+package org.acme.security.openid.connect.client;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.quarkus.security.Authenticated;
+import io.smallrye.mutiny.Uni;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+@Path("/protected")
+@Authenticated
+public class ProtectedResource {
+
+    @Inject
+    JsonWebToken principal;
+
+    @GET
+    @RolesAllowed("user")
+    @Produces("text/plain")
+    @Path("userName")
+    public Uni<String> userName() {
+        return Uni.createFrom().item(principal.getName());
+    }
+
+    @GET
+    @RolesAllowed("admin")
+    @Produces("text/plain")
+    @Path("adminName")
+    public Uni<String> adminName() {
+        return Uni.createFrom().item(principal.getName());
+    }
+}
+----
+
+As you can see `ProtectedResource` returns a name from both `userName()` and `adminName()` methods. The name is extracted from the current `JsonWebToken`.
+
+Next lets add REST Client with `OpenID Connect Client Reactive Filter` and another REST Client with `OpenID Connect Token Propagation Filter`, `FrontendResource` will use these two clients to call `ProtectedResource`:
+
+[source,java]
+----
+package org.acme.security.openid.connect.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
 import io.smallrye.mutiny.Uni;
 
 @RegisterRestClient
 @RegisterProvider(OidcClientRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceService {
+public interface ProtectedResourceOidcClientFilter {
 
     @GET
+    @Produces("text/plain")
+    @Path("userName")
     Uni<String> getUserName();
-}
-----
-
-`OidcClientRequestReactiveFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-client-reactive-filter.client-name` configuration property.
-
-
-[[oidc-client-filter]]
-=== Use OidcClient in RestClient ClientFilter
-
-Add the following Maven Dependency:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc-client-filter</artifactId>
-</dependency>
-----
-
-Note it will also bring `io.quarkus:quarkus-oidc-client`.
-
-`quarkus-oidc-client-filter` extension provides `io.quarkus.oidc.client.filter.OidcClientRequestFilter` JAX-RS ClientRequestFilter which uses `OidcClient` to acquire the access token, refresh it if needed, and set it as an HTTP `Authorization` `Bearer` scheme value.
-
-By default, this filter will get `OidcClient` to acquire the first pair of access and refresh tokens at its initialization time. If the access tokens are short-lived and refresh tokens are not available then the token acquisition should be delayed with `quarkus.oidc-client.early-tokens-acquisition=false`.
-
-You can selectively register `OidcClientRequestFilter` by using either `io.quarkus.oidc.client.filter.OidcClientFilter` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider` annotations:
-
-[source,java]
-----
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.client.filter.OidcClientFilter;
-
-@RegisterRestClient
-@OidcClientFilter
-@Path("/")
-public interface ProtectedResourceService {
 
     @GET
-    String getUserName();
+    @Produces("text/plain")
+    @Path("adminName")
+    Uni<String> getAdminName();
 }
 ----
 
-or
+where `ProtectedResourceOidcClientFilter` will depend on `OidcClientRequestReactiveFilter` to acquire and propagate the tokens and
 
 [source,java]
 ----
+package org.acme.security.openid.connect.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.client.filter.OidcClientRequestFilter;
+
+import io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter;
+import io.smallrye.mutiny.Uni;
 
 @RegisterRestClient
-@RegisterProvider(OidcClientRequestFilter.class)
+@RegisterProvider(AccessTokenRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceService {
+public interface ProtectedResourceTokenPropagationFilter {
 
     @GET
-    String getUserName();
+    @Produces("text/plain")
+    @Path("userName")
+    Uni<String> getUserName();
+
+    @GET
+    @Produces("text/plain")
+    @Path("adminName")
+    Uni<String> getAdminName();
 }
 ----
 
-Alternatively, `OidcClientRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if `quarkus.oidc-client-filter.register-filter=true` property is set.
+where `ProtectedResourceTokenPropagationFilter` will depend on `AccessTokenRequestReactiveFilter` to propagate the incoming, already existing tokens.
 
-`OidcClientRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-client-filter.client-name` configuration property.
+Note that both `ProtectedResourceOidcClientFilter` and `ProtectedResourceTokenPropagationFilter` interfaces are identical - the reason behind it is that combining `OidcClientRequestReactiveFilter` and `AccessTokenRequestReactiveFilter` on the same REST Client will cause side-effects as both filters can interfere with other, for example, `OidcClientRequestReactiveFilter` may override the token propagated by `AccessTokenRequestReactiveFilter` or `AccessTokenRequestReactiveFilter` can fail if it is called when no token is available to propagate and `OidcClientRequestReactiveFilter` is expected to acquire a new token instead.
 
-=== Use Custom RestClient ClientFilter
-
-If you prefer you can use your own custom filter and inject `Tokens`:
+Now lets complete creating the application with adding `FrontendResource`:
 
 [source,java]
 ----
-import io.quarkus.oidc.client.Tokens;
+package org.acme.security.openid.connect.client;
 
-@Provider
-@Priority(Priorities.AUTHENTICATION)
-public class OidcClientRequestCustomFilter implements ClientRequestFilter {
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@Path("/frontend")
+public class FrontendResource {
+    @Inject
+    @RestClient
+    ProtectedResourceOidcClientFilter protectedResourceOidcClientFilter;
 
     @Inject
-    Tokens tokens;
+    @RestClient
+    ProtectedResourceTokenPropagationFilter protectedResourceTokenPropagationFilter;
 
-    @Override
-    public void filter(ClientRequestContext requestContext) throws IOException {
-        requestContext.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getAccessToken());
+    @GET
+    @Path("user-name-with-oidc-client-token")
+    @Produces("text/plain")
+    public Uni<String> getUserNameWithOidcClientToken() {
+        return protectedResourceOidcClientFilter.getUserName();
+    }
+
+    @GET
+    @Path("admin-name-with-oidc-client-token")
+    @Produces("text/plain")
+    public Uni<String> getAdminNameWithOidcClientToken() {
+	    return protectedResourceOidcClientFilter.getAdminName();
+    }
+
+    @GET
+    @Path("user-name-with-propagated-token")
+    @Produces("text/plain")
+    public Uni<String> getUserNameWithPropagatedToken() {
+        return protectedResourceTokenPropagationFilter.getUserName();
+    }
+
+    @GET
+    @Path("admin-name-with-propagated-token")
+    @Produces("text/plain")
+    public Uni<String> getAdminNameWithPropagatedToken() {
+        return protectedResourceTokenPropagationFilter.getAdminName();
     }
 }
 ----
 
-The `Tokens` producer will acquire and refresh the tokens, and the custom filter will decide how and when to use the token.
+`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client` or `/frontend/admin-name-with-oidc-client` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
 
-You can also inject named `Tokens`, see <<named-oidc-clients,Inject named OidcClient and Tokens>>
+Finally, lets add a JAX-RS `ExceptionMapper`:
 
-[[refresh-access-tokens]]
-=== Refreshing Access Tokens
-
-`OidcClientRequestReactiveFilter`, `OidcClientRequestFilter` and `Tokens` producers will refresh the current expired access token if the refresh token is available.
-Additionally, `quarkus.oidc-client.refresh-token-time-skew` property can be used for a preemptive access token refreshment to avoid sending nearly expired access tokens which may cause HTTP 401 errors. For example if this property is set to `3S` and the access token will expire in less than 3 seconds then this token will be auto-refreshed.
-
-If the access token needs to be refreshed but no refresh token is available then an attempt will be made to acquire a new token using the configured grant such as `client_credentials`.
-
-Please note that some OpenID Connect Providers will not return a refresh token in a `client_credentials` grant response. For example, starting from Keycloak 12 a refresh token will not be returned by default for `client_credentials`. The providers may also restrict a number of times a refresh token can be used.
-
-[[oidc-client-authentication]]
-=== OidcClient Authentication
-
-`OidcClient` has to authenticate to the OpenID Connect Provider for the `client_credentials` and other grant requests to succeed.
-All the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[OIDC Client Authentication] options are supported, for example:
-
-`client_secret_basic`:
-
-[source,properties]
+[source,java]
 ----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=mysecret
-----
+package org.acme.security.openid.connect.client;
 
-or
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.client-secret.value=mysecret
-----
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
-or with the secret retrieved from a xref:credentials-provider.adoc[CredentialsProvider]:
+@Provider
+public class FrontendExceptionMapper implements ExceptionMapper<ClientWebApplicationException> {
 
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
+	@Override
+	public Response toResponse(ClientWebApplicationException t) {
+		return Response.status(t.getResponse().getStatus()).build();
+	}
 
-# This is a key which will be used to retrieve a secret from the map of credentails returned from CredentialsProvider
-quarkus.oidc-client.credentials.client-secret.provider.key=mysecret-key
-# Set it only if more than one CredentialsProvider can be registered
-quarkus.oidc-client.credentials.client-secret.provider.name=oidc-credentials-provider
-----
-
-`client_secret_post`:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.client-secret.value=mysecret
-quarkus.oidc-client.credentials.client-secret.method=post
-----
-
-`client_secret_jwt`, signature algorithm is `HS256`:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.secret=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
-----
-
-or with the secret retrieved from a xref:credentials-provider.adoc[CredentialsProvider], signature algorithm is `HS256`:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-
-# This is a key which will be used to retrieve a secret from the map of credentials returned from CredentialsProvider
-quarkus.oidc-client.credentials.jwt.secret-provider.key=mysecret-key
-# Set it only if more than one CredentialsProvider can be registered
-quarkus.oidc-client.credentials.jwt.secret-provider.name=oidc-credentials-provider
-----
-
-`private_key_jwt` with the PEM key file, signature algorithm is `RS256`:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.key-file=privateKey.pem
-----
-
-`private_key_jwt` with the key store file, signature algorithm is `RS256`:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.key-store-file=keystore.jks
-quarkus.oidc-client.credentials.jwt.key-store-password=mypassword
-quarkus.oidc-client.credentials.jwt.key-password=mykeypassword
-
-# Private key alias inside the keystore
-quarkus.oidc-client.credentials.jwt.key-id=mykeyAlias
-----
-
-Using `client_secret_jwt` or `private_key_jwt` authentication methods ensures that no client secret goes over the wire.
-
-==== Additional JWT Authentication options
-
-If either `client_secret_jwt` or `private_key_jwt` authentication methods are used then the JWT signature algorithm, key identifier, audience, subject and issuer can be customized, for example:
-
-[source,properties]
-----
-# private_key_jwt client authentication
-
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus/
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.jwt.key-file=privateKey.pem
-
-# This is a token key identifier 'kid' header - set it if your OpenID Connect provider requires it.
-# Note if the key is represented in a JSON Web Key (JWK) format with a `kid` property then
-# using 'quarkus.oidc-client.credentials.jwt.token-key-id' is not necessary.
-quarkus.oidc-client.credentials.jwt.token-key-id=mykey
-
-# Use RS512 signature algorithm instead of the default RS256
-quarkus.oidc-client.credentials.jwt.signature-algorithm=RS512
-
-# The token endpoint URL is the default audience value, use the base address URL instead:
-quarkus.oidc-client.credentials.jwt.audience=${quarkus.oidc-client.auth-server-url}
-
-# custom subject instead of the client id :
-quarkus.oidc-client.credentials.jwt.subject=custom-subject
-
-# custom issuer instead of the client id :
-quarkus.oidc-client.credentials.jwt.issuer=custom-issuer
-----
-
-==== Apple POST JWT
-
-Apple OpenID Connect Provider uses a `client_secret_post` method where a secret is a JWT produced with a `private_key_jwt` authentication method but with Apple account specific issuer and subject properties.
-
-`quarkus-oidc-client` supports a non-standard `client_secret_post_jwt` authentication method which can be configured as follows:
-
-[source,properties]
-----
-quarkus.oidc-client.auth-server-url=${apple.url}
-quarkus.oidc-client.client-id=${apple.client-id}
-quarkus.oidc-client.credentials.client-secret.method=post-jwt
-
-quarkus.oidc-client.credentials.jwt.key-file=ecPrivateKey.pem
-quarkus.oidc-client.credentials.jwt.signature-algorithm=ES256
-quarkus.oidc-client.credentials.jwt.subject=${apple.subject}
-quarkus.oidc-client.credentials.jwt.issuer=${apple.issuer}
-----
-
-==== Mutual TLS
-
-Some OpenID Connect Providers may require that a client is authenticated as part of the `Mutual TLS` (`mTLS`) authentication process.
-
-`quarkus-oidc-client` can be configured as follows to support `mTLS`:
-
-[source,properties]
-----
-quarkus.oidc.tls.verification=certificate-validation
-
-# Keystore configuration
-quarkus.oidc.client.tls.key-store-file=client-keystore.jks
-quarkus.oidc.client.tls.key-store-password=${key-store-password}
-
-# Add more keystore properties if needed:
-#quarkus.oidc.client.tls.key-store-alias=keyAlias
-#quarkus.oidc.client.tls.key-store-alias-password=keyAliasPassword
-
-# Truststore configuration
-quarkus.oidc.client.tls.trust-store-file=client-truststore.jks
-quarkus.oidc.client.tls.trust-store-password=${trust-store-password}
-# Add more truststore properties if needed:
-#quarkus.oidc.client.tls.trust-store-alias=certAlias
-----
-
-[[integration-testing-oidc-client]]
-=== Testing
-
-Start by adding the following dependencies to your test project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-junit5</artifactId>
-    <scope>test</scope>
-</dependency>
-<dependency>
-    <groupId>org.awaitility</groupId>
-    <artifactId>awaitility</artifactId>
-    <scope>test</scope>
-</dependency>
-----
-
-[[integration-testing-wiremock]]
-==== Wiremock
-
-Add the following dependencies to your test project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock-jre8</artifactId>
-    <scope>test</scope>
-</dependency>
-----
-
-Write Wiremock based `QuarkusTestResourceLifecycleManager`, for example:
-[source, java]
-----
-package io.quarkus.it.keycloak;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.matching;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.Options.ChunkedEncodingPolicy;
-
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-
-public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycleManager {
-    private WireMockServer server;
-
-    @Override
-    public Map<String, String> start() {
-
-        server = new WireMockServer(wireMockConfig().dynamicPort().useChunkedTransferEncoding(ChunkedEncodingPolicy.NEVER));
-        server.start();
-
-        server.stubFor(WireMock.post("/tokens")
-                .withRequestBody(matching("grant_type=password&username=alice&password=alice"))
-                .willReturn(WireMock
-                        .aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
-        server.stubFor(WireMock.post("/tokens")
-                .withRequestBody(matching("grant_type=refresh_token&refresh_token=refresh_token_1"))
-                .willReturn(WireMock
-                        .aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(
-                                "{\"access_token\":\"access_token_2\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
-
-
-        Map<String, String> conf = new HashMap<>();
-        conf.put("keycloak.url", server.baseUrl());
-        return conf;
-    }
-
-    @Override
-    public synchronized void stop() {
-        if (server != null) {
-            server.stop();
-            server = null;
-        }
-    }
 }
 ----
 
-Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered OidcClient filter to invoke on the downstream endpoint which echoes the token back, for example, see the `integration-tests/oidc-client-wiremock` in the `main` Quarkus repository.
+This exception mapper is only added to verify during the tests that `ProtectedResource` returns `403` when the token has no expected role. Without this mapper `RESTEasy Reactive` will correctly convert the exceptions which will escape from REST Client calls to `500` to avoid leaking the information from the downstream resources such as `ProtectedResource` but in the tests it will not be possible to assert that `500` is in fact caused by an authorization exception as opposed to some internal error.
 
-Set `application.properties`, for example:
+== Configuring the application
 
-[source, properties]
+We have prepared the code, and now lets configure the application:
+
+[source,properties]
 ----
-# Use 'keycloak.url' property set by the test KeycloakRealmResourceManager
-quarkus.oidc-client.auth-server-url=${keycloak.url}
-quarkus.oidc-client.discovery-enabled=false
-quarkus.oidc-client.token-path=/tokens
-quarkus.oidc-client.client-id=quarkus-service-app
-quarkus.oidc-client.credentials.secret=secret
+# Configure OIDC
+
+%prod.quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.client-id=backend-service
+quarkus.oidc.credentials.secret=secret
+
+# Tell Dev Services for Keycloak to import the realm file
+# This property is not effective when running the application in JVM or Native modes but only in dev and test modes.
+
+quarkus.keycloak.devservices.realm-path=quarkus-realm.json
+
+# Configure OIDC Client
+
+quarkus.oidc-client.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc-client.client-id=${quarkus.oidc.client-id}
+quarkus.oidc-client.credentials.secret=${quarkus.oidc.credentials.secret}
 quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
+
+# Configure REST Clients
+
+%prod.port=8080
+%dev.port=8080
+%test.port=8081
+
+org.acme.security.openid.connect.client.ProtectedResourceOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.ProtectedResourceTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
 ----
 
-and finally write the test code. Given the Wiremock-based resource above, the first test invocation should return `access_token_1` access token which will expire in 4 seconds. Use `awaitility` to wait for about 5 seconds, and now the next test invocation should return `access_token_2` access token which confirms the expired `access_token_1` access token has been refreshed.
+This configuration references Keycloak which will be used by `ProtectedResource` to verify the incoming access tokens and by `OidcClient` to get the tokens for a user `alice` using a `password` grant. Both RESTClients point to `ProtectedResource`'s HTTP address.
 
-==== Keycloak
+NOTE: Adding a `%prod.` profile prefix to `quarkus.oidc.auth-server-url` ensures that `Dev Services for Keycloak` will launch a container for you when the application is run in dev or test modes. See <<keycloak-dev-mode, Running the Application in Dev mode>> section below for more information.
 
-If you work with Keycloak then you can use the same approach as described in the xref:security-openid-connect#integration-testing-keycloak.adoc[OpenID Connect Bearer Token Integration testing] Keycloak section.
+== Starting and Configuring the Keycloak Server
 
-=== How to check the errors in the logs
+NOTE: Do not start the Keycloak server when you run the application in dev mode or test modes - `Dev Services for Keycloak` will launch a container. See <<keycloak-dev-mode, Running the Application in Dev mode>> section below for more information. Make sure to put the {quickstarts-tree-url}/security-openid-connect-client-quickstart/config/quarkus-realm.json[realm configuration file] on the classpath (`target/classes` directory) so that it gets imported automatically when running in dev mode - unless you have already built a {quickstarts-tree-url}/security-openid-connect-quickstart[complete solution] in which case this realm file will be added to the classpath during the build.
 
-Please enable `io.quarkus.oidc.client.runtime.OidcClientImpl` `TRACE` level logging to see more details about the token acquisition and refresh errors:
+To start a Keycloak Server you can use Docker and just run the following command:
 
-[source, properties]
+[source,bash,subs=attributes+]
 ----
-quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".level=TRACE
-quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientImpl".min-level=TRACE
-----
-
-Please enable `io.quarkus.oidc.client.runtime.OidcClientRecorder` `TRACE` level logging to see more details about the OidcClient initialization errors:
-
-[source, properties]
-----
-quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".level=TRACE
-quarkus.log.category."io.quarkus.oidc.client.runtime.OidcClientRecorder".min-level=TRACE
+docker run --name keycloak -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -p 8180:8080 quay.io/keycloak/keycloak:{keycloak.version} start-dev
 ----
 
-[[token-propagation]]
-== Token Propagation
+where `keycloak.version` should be set to `17.0.0` or higher.
 
-The `quarkus-oidc-token-propagation` extension provides two JAX-RS `javax.ws.rs.client.ClientRequestFilter` class implementations that simplify the propagation of authentication information.
-`io.quarkus.oidc.token.propagation.AccessTokenRequestFilter` propagates the xref:security-openid-connect.adoc[Bearer] token present in the current active request or the token acquired from the xref:security-openid-connect-web-authentication.adoc[Authorization Code Flow], as the HTTP `Authorization` header's `Bearer` scheme value.
-The `io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter` provides the same functionality, but in addition provides support for JWT tokens.
+You should be able to access your Keycloak Server at http://localhost:8180[localhost:8180].
 
-When you need to propagate the current Authorization Code Flow access token then the immediate token propagation will work well - as the code flow access tokens (as opposed to ID tokens) are meant to be propagated for the current Quarkus endpoint to access the remote services on behalf of the currently authenticated user.
+Log in as the `admin` user to access the Keycloak Administration Console. Username should be `admin` and password `admin`.
 
-However, the direct end to end Bearer token propagation should be avoided if possible. For example, `Client -> Service A -> Service B` where `Service B` receives a token sent by `Client` to `Service A`. In such cases `Service B` will not be able to distinguish if the token came from `Service A` or from `Client` directly. For `Service B` to verify the token came from `Service A` it should be able to assert a new issuer and audience claims.
+Import the {quickstarts-tree-url}/security-openid-connect-client-quickstart/config/quarkus-realm.json[realm configuration file] to create a new realm. For more details, see the Keycloak documentation about how to https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm[create a new realm].
 
-Additionally, a complex application may need to exchange or update the tokens before propagating them. For example, the access context might be different when `Service A` is accessing `Service B`. In this case, `Service A` might be granted a narrow or a completely different set of scopes to access `Service B`.
+This `quarkus` realm file will add a `frontend` client, and `alice` and `admin` users. `alice` has a `user` role, `admin` - both `user` and `admin` roles.
 
-The following sections show how `AccessTokenRequestFilter` and `JsonWebTokenRequestFilter` can help.
+[[keycloak-dev-mode]]
+== Running the Application in Dev mode
 
-=== RestClient AccessTokenRequestFilter
+To run the application in a dev mode, use:
 
-`AccessTokenRequestFilter` treats all tokens as Strings and as such it can work with both JWT and opaque tokens.
+include::includes/devtools/dev.adoc[]
 
-You can selectively register `AccessTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.AccessToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
+xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak] will launch a Keycloak container and import a `quarkus-realm.json`.
 
-[source,java]
+Open a xref:dev-ui.adoc[Dev UI] available at http://localhost:8080/q/dev[/q/dev] and click on a `Provider: Keycloak` link in an `OpenID Connect` `Dev UI` card.
+
+You will be asked to login into a `Single Page Application` provided by `OpenID Connect Dev UI`:
+
+ * Login as `alice` (password: `alice`) who has a `user` role
+ ** accessing `/frontend/user-name-with-propagated-token` will return `200`
+ ** accessing `/frontend/admin-name-with-propagated-token` will return `403`
+ * Logout and login as `admin` (password: `admin`) who has both `admin` and `user` roles
+ ** accessing `/frontend/user-name-with-propagated-token` will return `200`
+ ** accessing `/frontend/admin-name-with-propagated-token` will return `200`
+
+In this case you are testing that `FrontendResource` can propagate the access tokens acquired by `OpenID Connect Dev UI`.
+
+== Running the Application in JVM mode
+
+When you're done playing with the `dev` mode" you can run it as a standard Java application.
+
+First compile it:
+
+include::includes/devtools/build.adoc[]
+
+Then run it:
+
+[source,bash]
 ----
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.token.propagation.AccessToken;
-
-@RegisterRestClient
-@AccessToken
-@Path("/")
-public interface ProtectedResourceService {
-
-    @GET
-    String getUserName();
-}
-----
-or
-
-[source,java]
-----
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.token.propagation.AccessTokenRequestFilter;
-
-@RegisterRestClient
-@RegisterProvider(AccessTokenRequestFilter.class)
-@Path("/")
-public interface ProtectedResourceService {
-
-    @GET
-    String getUserName();
-}
+java -jar target/quarkus-app/quarkus-run.jar
 ----
 
-Alternatively, `AccessTokenRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if `quarkus.oidc-token-propagation.register-filter` property is set to `true` and `quarkus.oidc-token-propagation.json-web-token` property is set to `false` (which is a default value).
+== Running the Application in Native Mode
 
-==== Exchange Token Before Propagation
+This same demo can be compiled into native code: no modifications required.
 
-If the current access token needs to be exchanged before propagation and you work with link:https://www.keycloak.org/docs/latest/securing_apps/#_token-exchange[Keycloak] or other OpenID Connect Provider which supports a link:https://tools.ietf.org/html/rfc8693[Token Exchange] token grant then you can configure `AccessTokenRequestFilter` like this:
+This implies that you no longer need to install a JVM on your
+production environment, as the runtime technology is included in
+the produced binary, and optimized to run with minimal resource overhead.
 
-[source,properties]
+Compilation will take a bit longer, so this step is disabled by default;
+let's build again by enabling the `native` profile:
+
+include::includes/devtools/build-native.adoc[]
+
+After getting a cup of coffee, you'll be able to run this binary directly:
+
+[source,bash]
 ----
-quarkus.oidc-client.auth-server-url=http://localhost:8180/auth/realms/quarkus
-quarkus.oidc-client.client-id=quarkus-app
-quarkus.oidc-client.credentials.secret=secret
-quarkus.oidc-client.grant.type=exchange
-quarkus.oidc-client.grant-options.exchange.audience=quarkus-app-exchange
-
-quarkus.oidc-token-propagation.exchange-token=true
-----
-
-Note `AccessTokenRequestFilter` will use `OidcClient` to exchange the current token and you can use `quarkus.oidc-client.grant-options.exchange` to set the additional exchange properties expected by your OpenID Connect Provider.
-
-`AccessTokenRequestFilter` uses a default `OidcClient` by default. A named `OidcClient` can be selected with a `quarkus.oidc-token-propagation.client-name` configuration property.
-
-=== RestClient JsonWebTokenRequestFilter
-
-Using `JsonWebTokenRequestFilter` is recommended if you work with Bearer JWT tokens where these tokens can have their claims such as `issuer` and `audience` modified and the updated tokens secured (for example, re-signed) again. It expects an injected `org.eclipse.microprofile.jwt.JsonWebToken` and therefore will not work with the opaque tokens. Also, if your OpenID Connect Provider supports a Token Exchange protocol then it is recommended to use `AccessTokenRequestFilter` instead - as both JWT and opaque bearer tokens can be securely exchanged with `AccessTokenRequestFilter`.
-
-`JsonWebTokenRequestFilter` makes it easy for `Service A` implementations to update the injected `org.eclipse.microprofile.jwt.JsonWebToken` with the new `issuer` and `audience` claim values and secure the updated token again with a new signature. The only difficult step is to ensure `Service A` has a signing key - it should be provisioned from a secure file system or from the remote secure storage such as Vault.
-
-You can selectively register `JsonWebTokenRequestFilter` by using either `io.quarkus.oidc.token.propagation.JsonWebToken` or `org.eclipse.microprofile.rest.client.annotation.RegisterProvider`, for example:
-
-[source,java]
-----
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.token.propagation.JsonWebToken;
-
-@RegisterRestClient
-@JsonWebToken
-@Path("/")
-public interface ProtectedResourceService {
-
-    @GET
-    String getUserName();
-}
-----
-or
-
-[source,java]
-----
-import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import io.quarkus.oidc.token.propagation.JsonWebTokenRequestFilter;
-
-@RegisterRestClient
-@RegisterProvider(JsonWebTokenRequestFilter.class)
-@Path("/")
-public interface ProtectedResourceService {
-
-    @GET
-    String getUserName();
-}
+./target/security-openid-connect-quickstart-1.0.0-SNAPSHOT-runner
 ----
 
-Alternatively, `JsonWebTokenRequestFilter` can be registered automatically with all MP Rest or JAX-RS clients if both `quarkus.oidc-token-propagation.register-filter` and `quarkus.oidc-token-propagation.json-web-token` properties are set to `true`.
+== Testing the Application
 
-==== Update Token Before Propagation
+See <<keycloak-dev-mode, Running the Application in Dev mode>> section above about testing your application in dev mode.
 
-If the injected token needs to have its `iss` (issuer) and/or `aud` (audience) claims updated and secured again with a new signature then you can configure `JsonWebTokenRequestFilter` like this:
+You can test the application launched in JVM or Native modes with `curl`.
 
-[source,properties]
+Obtain an access token for `alice`:
+
+[source,bash]
 ----
-quarkus.oidc-token-propagation.secure-json-web-token=true
-smallrye.jwt.sign.key.location=/privateKey.pem
-# Set a new issuer
-smallrye.jwt.new-token.issuer=http://frontend-resource
-# Set a new audience
-smallrye.jwt.new-token.audience=http://downstream-resource
-# Override the existing token issuer and audience claims if they are already set
-smallrye.jwt.new-token.override-matching-claims=true
-----
-
-As already noted above, please use `AccessTokenRequestFilter` if you work with Keycloak or OpenID Connect Provider which supports a Token Exchange protocol.
-
-[[integration-testing-token-propagation]]
-=== Testing
-
-You can generate the tokens as described in xref:security-openid-connect.adoc#integration-testing[OpenID Connect Bearer Token Integration testing] section.
-Prepare the REST test endpoints, you can have the test frontend endpoint which uses the injected MP REST client with a registered token propagation filter to invoke on the downstream endpoint, for example, see the `integration-tests/oidc-token-propagation` in the `main` Quarkus repository.
-
-[[reactive-token-propagation]]
-== Token Propagation Reactive
-
-Add the following Maven Dependency:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
-</dependency>
+export access_token=$(\
+    curl --insecure -X POST http://localhost:8180/realms/quarkus/protocol/openid-connect/token \
+    --user backend-service:secret \
+    -H 'content-type: application/x-www-form-urlencoded' \
+    -d 'username=alice&password=alice&grant_type=password' | jq --raw-output '.access_token' \
+ )
 ----
 
-The `quarkus-oidc-token-propagation-reactive` extension provides `io.quarkus.oidc.token.propagation.reactive.AccessTokenRequestReactiveFilter` which can be used to propagate the current `Bearer` or `Authorization Code Flow` access tokens.
+Now use this token to call `/frontend/user-name-with-propagated-token` and `/frontend/admin-name-with-propagated-token`:
 
-The `quarkus-oidc-token-propagation-reactive` extension (as opposed to the non-reactive `quarkus-oidc-token-propagation` extension) does not currently support the exchanging or resigning the tokens before the propagation.
-However these features may be added in the future.
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/user-name-with-propagated-token` \
+  -H "Authorization: Bearer "$access_token
+----
+
+will return `200` status code and the name `alice` while
+
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/admin-name-with-propagated-token` \
+  -H "Authorization: Bearer "$access_token
+----
+
+will return `403` - recall that `alice` only has a `user` role.
+
+Next obtain an access token for `admin`:
+
+[source,bash]
+----
+export access_token=$(\
+    curl --insecure -X POST http://localhost:8180/realms/quarkus/protocol/openid-connect/token \
+    --user backend-service:secret \
+    -H 'content-type: application/x-www-form-urlencoded' \
+    -d 'username=admin&password=admin&grant_type=password' | jq --raw-output '.access_token' \
+ )
+----
+
+and use this token to call `/frontend/user-name-with-propagated-token` and `/frontend/admin-name-with-propagated-token`:
+
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/user-name-with-propagated-token` \
+  -H "Authorization: Bearer "$access_token
+----
+
+will return `200` status code and the name `admin`, and
+
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/admin-name-with-propagated-token` \
+  -H "Authorization: Bearer "$access_token
+----
+
+will also return `200` status code and the name `admin`, as `admin` has both `user` and `admin` roles.
+
+
+Now lets check `FrontendResource` methods which do not propagate the existing tokens but use `OidcClient` to acquire and propagate the tokens. You have seen that `OidcClient` is configured to acquire teh tokens for the `alice` user, so:
+
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/user-name-with-oidc-client`
+----
+
+will return `200` status code and the name `alice`, but
+
+[source,bash]
+----
+curl -v -X GET \
+  http://localhost:8080/frontend/admin-name-with-oidc-client`
+----
+
+will return `403` status code.
 
 == References
 
+* xref:security-openid-connect-client-reference.adoc[OpenID Connect Client and Token Propagation Reference Guide]
+* xref:security-openid-connect.adoc[Using OpenID Connect to Protect Service Applications]
 * xref:security.adoc[Quarkus Security]
-* xref:security-openid-connect.adoc[Quarkus - Using OpenID Connect to Protect Service Applications using Bearer Token Authorization]
-* xref:security-openid-connect-web-authentication.adoc[Quarkus - Using OpenID Connect to Protect Web Applications using Authorization Code Flow]

--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -915,7 +915,7 @@ quarkus.oidc.end-session-path=/protocol/openid-connect/logout
 ----
 
 === Token Propagation
-Please see xref:security-openid-connect-client.adoc#token-propagation[Token Propagation] section about the Authorization Code Flow access token propagation to the downstream services.
+Please see xref:security-openid-connect-client-reference.adoc#token-propagation[Token Propagation] section about the Authorization Code Flow access token propagation to the downstream services.
 
 [[oidc-provider-client-authentication]]
 === Oidc Provider Client Authentication
@@ -1389,7 +1389,7 @@ include::{generated-dir}/config/quarkus-oidc.adoc[opts=optional]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
 * xref:security-openid-connect-providers.adoc[Well Known OpenID Connect providers].
-* xref:security-openid-connect-client.adoc[Quarkus - Using OpenID Connect and OAuth2 Client and Filters to manage access tokens]
+* xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security.adoc#oidc-jwt-oauth2-comparison[Summary of Quarkus OIDC, JWT and OAuth2 features]
 * xref:security.adoc[Quarkus Security]

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -566,7 +566,7 @@ quarkus.oidc.introspection-path=/protocol/openid-connect/tokens/introspect
 
 === Token Propagation
 
-Please see xref:security-openid-connect-client.adoc#token-propagation[Token Propagation] section about the Bearer access token propagation to the downstream services.
+Please see xref:security-openid-connect-client-reference.adoc#token-propagation[Token Propagation] section about the Bearer access token propagation to the downstream services.
 
 [[oidc-provider-authentication]]
 === Oidc Provider Client Authentication
@@ -1146,7 +1146,7 @@ Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` prop
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
-* xref:security-openid-connect-client.adoc[Quarkus - Using OpenID Connect and OAuth2 Client and Filters to manage access tokens]
+* xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client and Filters Reference Guide]
 * xref:security-openid-connect-dev-services.adoc[Dev Services for Keycloak]
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
 * xref:security.adoc#oidc-jwt-oauth2-comparison[Summary of Quarkus OIDC, JWT and OAuth2 features]

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -91,7 +91,7 @@ If you need to configure Keycloak programmatically then consider using https://w
 
 `quarkus-oidc-token-propagation` extension depends on the `quarkus-oidc` extension and provides JAX-RS `TokenCredentialRequestFilter` which sets the OpenID Connect Bearer or Authorization Code Flow access token as an HTTP `Authorization` header's  `Bearer` scheme value. This filter can be registered with MP RestClient implementations injected into the current Quarkus endpoint and the Quarkus endpoint must be protected itself with the Quarkus OpenID Connect adapter. This filter can be used to propagate the access token to the downstream services.
 
-See the xref:security-openid-connect-client.adoc[Using OpenID Connect and OAuth2 Client] guide for more information.
+See the xref:security-openid-connect-client.adoc[OpenID Connect and Token Propagation Quickstart] and xref:security-openid-connect-client-reference.adoc[OpenID Connect and OAuth2 Client Reference] guides for more information.
 
 [[smallrye-jwt]]
 === SmallRye JWT


### PR DESCRIPTION
This PR creates a `security-openid-connect-client-quickstart.adoc` which is separate from `security-openid-connect-client.adoc` which is effectively a reference guide. These 2 docs link to each other, from the quickstart a user can move to a reference guide and vice versa