### PR TITLE
Warning in doc for using Kotlin with older versions of Mandrel

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -18,6 +18,12 @@ include::./status-include.adoc[]
 
 include::includes/devtools/prerequisites.adoc[]
 
+[WARNING]
+====
+If building with Mandrel, make sure to use version Mandrel 22.1 or above, for example `ubi-quarkus-mandrel:22.1-java17`.
+With older versions, you might encounter errors when trying to deserialize JSON documents that have null or missing fields, similar to the errors mentioned in the <<kotlin-jackson>> section.
+====
+
 NB: For Gradle project setup please see below, and for further reference consult the guide in the xref:gradle-tooling.adoc[Gradle setup page].
 
 == Creating the Maven project
@@ -333,6 +339,7 @@ You can also build the native executable using:
 
 include::includes/devtools/build-native.adoc[]
 
+[[kotlin-jackson]]
 == Kotlin and Jackson
 
 If the `com.fasterxml.jackson.module:jackson-module-kotlin` dependency and the `quarkus-jackson` extension (or one of the `quarkus-resteasy-jackson` or `quarkus-resteasy-reactive-jackson` extensions) have been added to the project,


### PR DESCRIPTION
To avoid crashes like the one described in #25460, I've added a small warning label right at the start of the guide.