### PR TITLE
Ensure that ParamConverter classes can access request scoped beans

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RequestScopedParamConverterTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RequestScopedParamConverterTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class RequestScopedParamConverterTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestResource.class, Model.class);
+                }
+            });
+
+    @Test
+    public void testNoAnnotation() {
+        given().header("foo", "bar").when().get("/test/test")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("test/bar"));
+    }
+
+    @Path("test")
+    public static class TestResource {
+        @GET
+        @Path("{value}")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String hello(@PathParam("value") Model model) {
+            return model.value + "/" + model.fooHeader;
+        }
+    }
+
+    public static class Model {
+
+        public final String value;
+        public final String fooHeader;
+
+        public Model(String value, String fooHeader) {
+            this.value = value;
+            this.fooHeader = fooHeader;
+        }
+
+        // called automatically by RR based on the JAX-RS convention
+        public static Model valueOf(String value) {
+            return new Model(value, (String) CurrentRequestManager.get().getHeader("foo", true));
+        }
+
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ParameterHandler.java
@@ -37,6 +37,8 @@ public class ParameterHandler implements ServerRestHandler {
 
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) {
+        // needed because user provided ParamConverter classes could use request scoped CDI beans
+        requestContext.requireCDIRequestScope();
         try {
             Object result = extractor.extractParameter(requestContext);
             if (result instanceof ParameterExtractor.ParameterCallback) {


### PR DESCRIPTION
Originally reported [here](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/RESTEasy.20Reactive.2FPanache.2FvalueOf)