### PR TITLE
Use the same default for accept backlog as Vert.x uses

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/HttpConfiguration.java
@@ -188,7 +188,7 @@ public class HttpConfiguration {
     /**
      * The accept backlog, this is how many connections can be waiting to be accepted before connections start being rejected
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "-1")
     public int acceptBacklog;
 
     /**


### PR DESCRIPTION
See https://github.com/eclipse-vertx/vert.x/blob/4.2.7/src/main/java/io/vertx/core/net/NetServerOptions.java#L46