### PR TITLE
Fix FileTestCase.testFiles on windows with core.autocrlf input

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/providers/FileTestCase.java
@@ -22,15 +22,6 @@ import io.restassured.RestAssured;
 
 public class FileTestCase {
 
-    private final static String LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut\n"
-            +
-            "enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor\n"
-            +
-            "in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,\n"
-            +
-            " sunt in culpa qui officia deserunt mollit anim id est laborum.\n" +
-            "\n" +
-            "";
     private static final String FILE = "src/test/resources/lorem.txt";
 
     @TestHTTPResource
@@ -43,13 +34,7 @@ public class FileTestCase {
 
     @Test
     public void testFiles() throws Exception {
-        // adjusting expected file size for Windows, whose git checkout will adjust line separators
-        String content;
-        if (System.lineSeparator().length() == 2) {
-            content = LOREM.replace("\n", System.lineSeparator());
-        } else {
-            content = LOREM;
-        }
+        String content = Files.readString(Path.of(FILE));
         String contentLength = String.valueOf(content.length());
         RestAssured.get("/providers/file/file")
                 .then()
@@ -90,7 +75,7 @@ public class FileTestCase {
                 .then()
                 .statusCode(200)
                 .header(HttpHeaders.CONTENT_LENGTH, "10")
-                .body(Matchers.equalTo(LOREM.substring(20, 30)));
+                .body(Matchers.equalTo(content.substring(20, 30)));
     }
 
     @Test

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/providers/FileTestCase.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/providers/FileTestCase.java
@@ -17,15 +17,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FileTestCase {
 
-    private final static String LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut\n"
-            +
-            "enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor\n"
-            +
-            "in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,\n"
-            +
-            " sunt in culpa qui officia deserunt mollit anim id est laborum.\n" +
-            "\n" +
-            "";
     private static final String FILE = "src/test/resources/lorem.txt";
 
     @RegisterExtension
@@ -35,13 +26,8 @@ public class FileTestCase {
 
     @Test
     public void testFiles() throws Exception {
-        // adjusting expected file size for Windows, whose git checkout will adjust line separators
-        String content;
-        if (System.lineSeparator().length() == 2) {
-            content = LOREM.replace("\n", System.lineSeparator());
-        } else {
-            content = LOREM;
-        }
+
+        String content = Files.readString(Path.of(FILE));
         String contentLength = String.valueOf(content.length());
         RestAssured.get("/providers/file/file")
                 .then()
@@ -77,7 +63,7 @@ public class FileTestCase {
                 .then()
                 .statusCode(200)
                 .header(HttpHeaders.CONTENT_LENGTH, "10")
-                .body(Matchers.equalTo(LOREM.substring(20, 30)));
+                .body(Matchers.equalTo(content.substring(20, 30)));
     }
 
     @Test


### PR DESCRIPTION
File size is dependent on how the project was checked out. When git is set up with core.autocrlf input, the checkout keeps the line endings as they are commited to the repository (as LF).

On windows, the default System line seperator however is CTRLF.
Previosly, CTRLF was used to replace LF, since the assumption was that the checkout matches the System line seperator.
This is not true however if anything other than the default was choosen for core.autocrlf. On windows, this is quite easy to achieve, since git for windows even has a dialog in the installation wizard for this setting.

This commit now changes the test to simply always read the file from the FS, instead of keeping a copy of the files content as a static variable. This solution is now agnostic to line seperators.