### PR TITLE
Improve annotation literals generation in ArC

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -256,7 +256,6 @@ public class ArcProcessor {
             additionalStereotypes.putAll(item.getStereotypes());
         }
         builder.setAdditionalStereotypes(additionalStereotypes);
-        builder.setSharedAnnotationLiterals(true);
         builder.addResourceAnnotations(
                 resourceAnnotations.stream().map(ResourceAnnotationBuildItem::getName).collect(Collectors.toList()));
         // register all annotation transformers

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/staticmethods/InterceptedStaticMethodsProcessor.java
@@ -187,7 +187,7 @@ public class InterceptedStaticMethodsProcessor {
 
             List<String> initMethods = new ArrayList<>();
             for (InterceptedStaticMethodBuildItem interceptedStaticMethod : entry.getValue()) {
-                initMethods.add(implementInit(beanArchiveIndex.getIndex(), classOutput, initializer, interceptedStaticMethod,
+                initMethods.add(implementInit(beanArchiveIndex.getIndex(), initializer, interceptedStaticMethod,
                         reflectiveMethods, phase.getBeanProcessor()));
                 implementForward(initializer, interceptedStaticMethod);
             }
@@ -255,7 +255,7 @@ public class InterceptedStaticMethodsProcessor {
         forward.returnValue(ret);
     }
 
-    private String implementInit(IndexView index, ClassOutput classOutput, ClassCreator initializer,
+    private String implementInit(IndexView index, ClassCreator initializer,
             InterceptedStaticMethodBuildItem interceptedStaticMethod,
             BuildProducer<ReflectiveMethodBuildItem> reflectiveMethods, BeanProcessor beanProcessor) {
 
@@ -312,13 +312,13 @@ public class InterceptedStaticMethodsProcessor {
         ResultHandle bindingsHandle;
         if (bindings.size() == 1) {
             bindingsHandle = init.invokeStaticMethod(MethodDescriptors.COLLECTIONS_SINGLETON,
-                    createBindingLiteral(index, classOutput, init, bindings.iterator().next(),
+                    createBindingLiteral(index, init, bindings.iterator().next(),
                             beanProcessor.getAnnotationLiteralProcessor()));
         } else {
             bindingsHandle = init.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
             for (AnnotationInstance binding : bindings) {
                 init.invokeInterfaceMethod(MethodDescriptors.SET_ADD, bindingsHandle,
-                        createBindingLiteral(index, classOutput, init, binding, beanProcessor.getAnnotationLiteralProcessor()));
+                        createBindingLiteral(index, init, binding, beanProcessor.getAnnotationLiteralProcessor()));
             }
         }
 
@@ -343,11 +343,10 @@ public class InterceptedStaticMethodsProcessor {
         return name;
     }
 
-    private ResultHandle createBindingLiteral(IndexView index, ClassOutput classOutput, BytecodeCreator init,
-            AnnotationInstance binding, AnnotationLiteralProcessor annotationLiteralProcessor) {
+    private ResultHandle createBindingLiteral(IndexView index, BytecodeCreator init,
+            AnnotationInstance binding, AnnotationLiteralProcessor annotationLiterals) {
         ClassInfo bindingClass = index.getClassByName(binding.name());
-        return annotationLiteralProcessor.process(init, classOutput, bindingClass, binding,
-                "io.quarkus.arc.runtime");
+        return annotationLiterals.create(init, bindingClass, binding);
     }
 
     private ResultHandle createInterceptorInvocation(InterceptorInfo interceptor, BytecodeCreator init,

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -159,6 +159,14 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>io.quarkus.gizmo</groupId>
+                <artifactId>gizmo</artifactId>
+                <version>${version.gizmo}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
 
     </dependencyManagement>

--- a/independent-projects/arc/processor/pom.xml
+++ b/independent-projects/arc/processor/pom.xml
@@ -56,6 +56,12 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.quarkus.gizmo</groupId>
+            <artifactId>gizmo</artifactId>
+            <type>test-jar</type>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralGenerator.java
@@ -6,10 +6,8 @@ import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
 import io.quarkus.arc.impl.ComputingCache;
-import io.quarkus.arc.processor.AnnotationLiteralProcessor.Key;
-import io.quarkus.arc.processor.AnnotationLiteralProcessor.Literal;
-import io.quarkus.arc.processor.ResourceOutput.Resource;
-import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.arc.processor.AnnotationLiteralProcessor.AnnotationLiteralClassInfo;
+import io.quarkus.arc.processor.AnnotationLiteralProcessor.CacheKey;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.gizmo.FieldCreator;
@@ -20,32 +18,18 @@ import io.quarkus.gizmo.ResultHandle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.enterprise.util.AnnotationLiteral;
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.AnnotationValue;
-import org.jboss.jandex.ArrayType;
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 /**
- * @author Martin Kouba
+ * This is an internal companion of {@link AnnotationLiteralProcessor} that handles generating
+ * annotation literal classes. See {@link #generate(ComputingCache, Set) generate()} for more info.
  */
 public class AnnotationLiteralGenerator extends AbstractGenerator {
-
-    static final String ANNOTATION_LITERAL_SUFFIX = "_AnnotationLiteral";
-
-    static final String SHARED_SUFFIX = "_Shared";
-
     private static final Logger LOGGER = Logger.getLogger(AnnotationLiteralGenerator.class);
 
     AnnotationLiteralGenerator(boolean generateSources) {
@@ -53,137 +37,130 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
     }
 
     /**
-     * @param annotationLiterals
-     * @param beanDeployment
-     * @param existingClasses
-     * @return a collection of resources
+     * Creator of an {@link AnnotationLiteralProcessor} must call this method at an appropriate point
+     * in time and write the result to an appropriate output. If not, the bytecode sequences generated
+     * using the {@code AnnotationLiteralProcessor} will refer to non-existing classes.
+     *
+     * @param existingClasses names of classes that already exist and should not be generated again
+     * @return the generated classes, never {@code null}
      */
-    Collection<Resource> generate(String name, BeanDeployment beanDeployment,
-            ComputingCache<Key, Literal> annotationLiteralsCache, Set<String> existingClasses) {
-        List<Resource> resources = new ArrayList<>();
-        annotationLiteralsCache.forEachEntry((key, literal) -> {
+    Collection<ResourceOutput.Resource> generate(ComputingCache<CacheKey, AnnotationLiteralClassInfo> cache,
+            Set<String> existingClasses) {
+        List<ResourceOutput.Resource> resources = new ArrayList<>();
+        cache.forEachExistingValue(literal -> {
             ResourceClassOutput classOutput = new ResourceClassOutput(literal.isApplicationClass, generateSources);
-            createSharedAnnotationLiteral(classOutput, key, literal, existingClasses);
+            createAnnotationLiteralClass(classOutput, literal, existingClasses);
             resources.addAll(classOutput.getResources());
         });
         return resources;
     }
 
-    void createSharedAnnotationLiteral(ClassOutput classOutput, Key key, Literal literal, Set<String> existingClasses) {
+    /**
+     * Based on given {@code literal} data, generates an annotation literal class into the given {@code classOutput}.
+     * Does nothing if {@code existingClasses} indicates that the class to be generated already exists.
+     * <p>
+     * The generated annotation literal class is supposed to have a constructor that accepts values
+     * of all annotation members.
+     *
+     * @param classOutput the output to which the class is written
+     * @param literal data about the annotation literal class to be generated
+     * @param existingClasses set of existing classes that shouldn't be generated again
+     */
+    private void createAnnotationLiteralClass(ClassOutput classOutput, AnnotationLiteralClassInfo literal,
+            Set<String> existingClasses) {
         // Ljavax/enterprise/util/AnnotationLiteral<Lcom/foo/MyQualifier;>;Lcom/foo/MyQualifier;
         String signature = String.format("L%1$s<L%2$s;>;L%2$s;",
                 AnnotationLiteral.class.getName().replace('.', '/'),
-                key.annotationName.toString().replace('.', '/'));
-        String generatedName = literal.className.replace('.', '/');
+                literal.annotationClass.toString().replace('.', '/'));
+
+        String generatedName = literal.generatedClassName.replace('.', '/');
         if (existingClasses.contains(generatedName)) {
             return;
         }
 
-        ClassCreator annotationLiteral = ClassCreator.builder().classOutput(classOutput).className(generatedName)
+        ClassCreator annotationLiteral = ClassCreator.builder()
+                .classOutput(classOutput)
+                .className(generatedName)
                 .superClass(AnnotationLiteral.class)
-                .interfaces(key.annotationName.toString()).signature(signature).build();
+                .interfaces(literal.annotationName().toString())
+                .signature(signature)
+                .build();
 
         MethodCreator constructor = annotationLiteral.getMethodCreator(Methods.INIT, "V",
-                literal.constructorParams.stream().map(m -> m.returnType().name().toString()).toArray());
+                literal.annotationMembers().stream().map(m -> m.returnType().name().toString()).toArray());
         constructor.invokeSpecialMethod(MethodDescriptor.ofConstructor(AnnotationLiteral.class), constructor.getThis());
 
-        List<MethodInfo> defaultOfClassType = new ArrayList<>();
-
-        for (ListIterator<MethodInfo> iterator = literal.constructorParams.listIterator(); iterator.hasNext();) {
-            MethodInfo param = iterator.next();
-            String returnType = param.returnType().name().toString();
+        int constructorParameterIndex = 0;
+        for (MethodInfo annotationMember : literal.annotationMembers()) {
+            String type = annotationMember.returnType().name().toString();
             // field
-            annotationLiteral.getFieldCreator(param.name(), returnType).setModifiers(ACC_PRIVATE | ACC_FINAL);
-            // constructor param
-            constructor.writeInstanceField(FieldDescriptor.of(annotationLiteral.getClassName(), param.name(), returnType),
-                    constructor.getThis(),
-                    constructor.getMethodParam(iterator.previousIndex()));
-            // value method
-            MethodCreator value = annotationLiteral.getMethodCreator(param.name(), returnType).setModifiers(ACC_PUBLIC);
-            value.returnValue(value.readInstanceField(
-                    FieldDescriptor.of(annotationLiteral.getClassName(), param.name(), returnType), value.getThis()));
+            annotationLiteral.getFieldCreator(annotationMember.name(), type).setModifiers(ACC_PRIVATE | ACC_FINAL);
 
-            if (param.defaultValue() != null && hasClassOrClassArrayReturnType(param)) {
-                defaultOfClassType.add(param);
-            }
+            // constructor: param -> field
+            constructor.writeInstanceField(
+                    FieldDescriptor.of(annotationLiteral.getClassName(), annotationMember.name(), type),
+                    constructor.getThis(), constructor.getMethodParam(constructorParameterIndex));
+
+            // annotation member method implementation
+            MethodCreator value = annotationLiteral.getMethodCreator(annotationMember.name(), type).setModifiers(ACC_PUBLIC);
+            value.returnValue(value.readInstanceField(
+                    FieldDescriptor.of(annotationLiteral.getClassName(), annotationMember.name(), type), value.getThis()));
+
+            constructorParameterIndex++;
         }
         constructor.returnValue(null);
-        generateStaticFieldsWithDefaultValues(annotationLiteral, defaultOfClassType);
+
+        generateStaticFieldsWithDefaultValues(annotationLiteral, literal.annotationMembers());
 
         annotationLiteral.close();
-
-        LOGGER.debugf("Shared annotation literal generated: %s", literal.className);
+        LOGGER.debugf("Annotation literal class generated: %s", literal.generatedClassName);
     }
 
-    static void createAnnotationLiteral(ClassOutput classOutput, ClassInfo annotationClass,
-            AnnotationInstance annotationInstance,
-            String literalName) {
+    static String defaultValueStaticFieldName(MethodInfo annotationMember) {
+        return annotationMember.name() + "_default_value";
+    }
 
-        Map<String, AnnotationValue> annotationValues = annotationInstance.values().stream()
-                .collect(Collectors.toMap(AnnotationValue::name, Function.identity()));
+    private static boolean returnsClassOrClassArray(MethodInfo annotationMember) {
+        boolean returnsClass = DotNames.CLASS.equals(annotationMember.returnType().name());
+        boolean returnsClassArray = annotationMember.returnType().kind() == Type.Kind.ARRAY
+                && DotNames.CLASS.equals(annotationMember.returnType().asArrayType().component().name());
+        return returnsClass || returnsClassArray;
+    }
 
-        // Ljavax/enterprise/util/AnnotationLiteral<Lcom/foo/MyQualifier;>;Lcom/foo/MyQualifier;
-        String signature = String.format("L%1$s<L%2$s;>;L%2$s;",
-                AnnotationLiteral.class.getName().replace('.', '/'),
-                annotationClass.name().toString().replace('.', '/'));
-        String generatedName = literalName.replace('.', '/');
-
-        ClassCreator annotationLiteral = ClassCreator.builder().classOutput(classOutput).className(generatedName)
-                .superClass(AnnotationLiteral.class)
-                .interfaces(annotationClass.name().toString()).signature(signature).build();
-
+    /**
+     * Generates {@code public static final} fields for all the annotation members
+     * that provide a default value and are of a class or class array type.
+     * Also generates a static initializer that assigns the default value of those
+     * annotation members to the generated fields.
+     *
+     * @param classCreator the class to which the fields and the static initializer should be added
+     * @param annotationMembers the full set of annotation members of an annotation type
+     */
+    private static void generateStaticFieldsWithDefaultValues(ClassCreator classCreator, List<MethodInfo> annotationMembers) {
         List<MethodInfo> defaultOfClassType = new ArrayList<>();
-
-        for (MethodInfo method : annotationClass.methods()) {
-            if (method.name().equals(Methods.CLINIT) || method.name().equals(Methods.INIT)) {
-                continue;
+        for (MethodInfo annotationMember : annotationMembers) {
+            if (annotationMember.defaultValue() != null && returnsClassOrClassArray(annotationMember)) {
+                defaultOfClassType.add(annotationMember);
             }
-            if (method.defaultValue() != null && hasClassOrClassArrayReturnType(method)) {
-                defaultOfClassType.add(method);
-            }
-            MethodCreator valueMethod = annotationLiteral.getMethodCreator(MethodDescriptor.of(method));
-            AnnotationValue value = annotationValues.get(method.name());
-            if (value == null) {
-                value = method.defaultValue();
-            }
-            if (value == null) {
-                throw new IllegalStateException(String.format(
-                        "Value is not set for %s.%s(). Most probably an older version of Jandex was used to index an application dependency. Make sure that Jandex 2.1+ is used.",
-                        method.declaringClass().name(), method.name()));
-            }
-            valueMethod.returnValue(loadValue(literalName, valueMethod, value, annotationClass, method));
         }
-        generateStaticFieldsWithDefaultValues(annotationLiteral, defaultOfClassType);
-        annotationLiteral.close();
-        LOGGER.debugf("Annotation literal generated: %s", literalName);
-    }
 
-    private static boolean hasClassOrClassArrayReturnType(MethodInfo method) {
-        return DotNames.CLASS.equals(method.returnType().name())
-                || (method.returnType().kind() == Type.Kind.ARRAY
-                        && DotNames.CLASS.equals(method.returnType().asArrayType().component().name()));
-    }
-
-    private static void generateStaticFieldsWithDefaultValues(ClassCreator annotationLiteral,
-            List<MethodInfo> defaultOfClassType) {
         if (defaultOfClassType.isEmpty()) {
             return;
         }
 
-        MethodCreator staticConstructor = annotationLiteral.getMethodCreator(Methods.CLINIT, void.class);
+        MethodCreator staticConstructor = classCreator.getMethodCreator(Methods.CLINIT, void.class);
         staticConstructor.setModifiers(ACC_STATIC);
 
-        for (MethodInfo method : defaultOfClassType) {
-            Type returnType = method.returnType();
-            String returnTypeName = returnType.name().toString();
-            AnnotationValue defaultValue = method.defaultValue();
+        for (MethodInfo annotationMember : defaultOfClassType) {
+            String type = annotationMember.returnType().name().toString();
+            AnnotationValue defaultValue = annotationMember.defaultValue();
 
-            FieldCreator fieldCreator = annotationLiteral.getFieldCreator(defaultValueStaticFieldName(method), returnTypeName);
+            FieldCreator fieldCreator = classCreator.getFieldCreator(defaultValueStaticFieldName(annotationMember), type);
             fieldCreator.setModifiers(ACC_PUBLIC | ACC_STATIC | ACC_FINAL);
 
             if (defaultValue.kind() == AnnotationValue.Kind.ARRAY) {
                 Type[] clazzArray = defaultValue.asClassArray();
-                ResultHandle array = staticConstructor.newArray(returnTypeName, clazzArray.length);
+                ResultHandle array = staticConstructor.newArray(type, clazzArray.length);
                 for (int i = 0; i < clazzArray.length; ++i) {
                     staticConstructor.writeArrayValue(array, staticConstructor.load(i),
                             staticConstructor.loadClass(clazzArray[i].name().toString()));
@@ -198,199 +175,4 @@ public class AnnotationLiteralGenerator extends AbstractGenerator {
 
         staticConstructor.returnValue(null);
     }
-
-    private static String defaultValueStaticFieldName(MethodInfo methodInfo) {
-        return methodInfo.name() + "_default_value";
-    }
-
-    static ResultHandle loadValue(String literalClassName,
-            BytecodeCreator valueMethod, AnnotationValue value, ClassInfo annotationClass,
-            MethodInfo method) {
-        ResultHandle retValue;
-        switch (value.kind()) {
-            case BOOLEAN:
-                retValue = valueMethod.load(value.asBoolean());
-                break;
-            case STRING:
-                retValue = valueMethod.load(value.asString());
-                break;
-            case BYTE:
-                retValue = valueMethod.load(value.asByte());
-                break;
-            case SHORT:
-                retValue = valueMethod.load(value.asShort());
-                break;
-            case LONG:
-                retValue = valueMethod.load(value.asLong());
-                break;
-            case INTEGER:
-                retValue = valueMethod.load(value.asInt());
-                break;
-            case FLOAT:
-                retValue = valueMethod.load(value.asFloat());
-                break;
-            case DOUBLE:
-                retValue = valueMethod.load(value.asDouble());
-                break;
-            case CHARACTER:
-                retValue = valueMethod.load(value.asChar());
-                break;
-            case CLASS:
-                if (value.equals(method.defaultValue())) {
-                    retValue = valueMethod.readStaticField(
-                            FieldDescriptor.of(literalClassName, defaultValueStaticFieldName(method),
-                                    method.returnType().name().toString()));
-                } else {
-                    retValue = valueMethod.loadClass(value.asClass().toString());
-                }
-                break;
-            case ARRAY:
-                retValue = arrayValue(literalClassName, value, valueMethod, method, annotationClass);
-                break;
-            case ENUM:
-                retValue = valueMethod
-                        .readStaticField(FieldDescriptor.of(value.asEnumType().toString(), value.asEnum(),
-                                value.asEnumType().toString()));
-                break;
-            case NESTED:
-            default:
-                throw new UnsupportedOperationException("Unsupported value: " + value);
-        }
-        return retValue;
-    }
-
-    static ResultHandle arrayValue(String literalClassName,
-            AnnotationValue value, BytecodeCreator valueMethod, MethodInfo method,
-            ClassInfo annotationClass) {
-        ResultHandle retValue;
-        switch (value.componentKind()) {
-            case CLASS:
-                if (value.equals(method.defaultValue())) {
-                    retValue = valueMethod.readStaticField(
-                            FieldDescriptor.of(literalClassName, defaultValueStaticFieldName(method),
-                                    method.returnType().name().toString()));
-                } else {
-                    Type[] classArray = value.asClassArray();
-                    retValue = valueMethod.newArray(componentType(method), valueMethod.load(classArray.length));
-                    for (int i = 0; i < classArray.length; i++) {
-                        valueMethod.writeArrayValue(retValue, i, valueMethod.loadClass(classArray[i].name()
-                                .toString()));
-                    }
-                }
-                break;
-            case STRING:
-                String[] stringArray = value.asStringArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(stringArray.length));
-                for (int i = 0; i < stringArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(stringArray[i]));
-                }
-                break;
-            case SHORT:
-                short[] shortArray = value.asShortArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(shortArray.length));
-                for (int i = 0; i < shortArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(shortArray[i]));
-                }
-                break;
-            case INTEGER:
-                int[] intArray = value.asIntArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(intArray.length));
-                for (int i = 0; i < intArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(intArray[i]));
-                }
-                break;
-            case LONG:
-                long[] longArray = value.asLongArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(longArray.length));
-                for (int i = 0; i < longArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(longArray[i]));
-                }
-                break;
-            case BYTE:
-                byte[] byteArray = value.asByteArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(byteArray.length));
-                for (int i = 0; i < byteArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(byteArray[i]));
-                }
-                break;
-            case CHARACTER:
-                char[] charArray = value.asCharArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(charArray.length));
-                for (int i = 0; i < charArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(charArray[i]));
-                }
-                break;
-            case FLOAT:
-                float[] floatArray = value.asFloatArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(floatArray.length));
-                for (int i = 0; i < floatArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(floatArray[i]));
-                }
-                break;
-            case DOUBLE:
-                double[] doubleArray = value.asDoubleArray();
-                retValue = valueMethod.newArray(componentType(method), valueMethod.load(doubleArray.length));
-                for (int i = 0; i < doubleArray.length; i++) {
-                    valueMethod.writeArrayValue(retValue, i, valueMethod.load(doubleArray[i]));
-                }
-                break;
-            default:
-                // Return empty array for empty arrays and unsupported types
-                // For an empty array the component kind is UNKNOWN
-                if (value.componentKind() != org.jboss.jandex.AnnotationValue.Kind.UNKNOWN) {
-                    // Unsupported type - check if it is @Nonbinding, @Nonbinding array members should not be a problem in CDI
-                    AnnotationInstance nonbinding = method.annotation(DotNames.NONBINDING);
-                    if (nonbinding == null || nonbinding.target()
-                            .kind() != Kind.METHOD) {
-                        LOGGER.warnf("Unsupported array component type %s on %s - literal returns an empty array", method,
-                                annotationClass);
-                    }
-                }
-                DotName componentName = componentTypeName(method);
-                // Use empty array constants for common component kinds
-                if (DotNames.CLASS.equals(componentName)) {
-                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY);
-                } else if (DotNames.STRING.equals(componentName)) {
-                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_STRING_ARRAY);
-                } else if (PrimitiveType.LONG.name().equals(componentName)) {
-                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_LONG_ARRAY);
-                } else if (PrimitiveType.INT.name().equals(componentName)) {
-                    retValue = valueMethod.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_INT_ARRAY);
-                } else {
-                    retValue = valueMethod.newArray(componentName.toString(), valueMethod.load(0));
-                }
-        }
-        return retValue;
-    }
-
-    static String componentType(MethodInfo method) {
-        return componentTypeName(method).toString();
-    }
-
-    static DotName componentTypeName(MethodInfo method) {
-        ArrayType arrayType = method.returnType().asArrayType();
-        return arrayType.component().name();
-    }
-
-    static String generatedSharedName(DotName annotationName) {
-        // when the annotation is a java.lang annotation we need to use a different package in which to generate the literal
-        // otherwise a security exception will be thrown when the literal is loaded
-        String nameToUse = isJavaLang(annotationName.toString())
-                ? AbstractGenerator.DEFAULT_PACKAGE + annotationName.withoutPackagePrefix()
-                : annotationName.toString();
-
-        // com.foo.MyQualifier -> com.foo.MyQualifier1_Shared_AnnotationLiteral
-        return nameToUse + SHARED_SUFFIX + ANNOTATION_LITERAL_SUFFIX;
-    }
-
-    private static boolean isJavaLang(String s) {
-        return s.startsWith("java.lang");
-    }
-
-    static String generatedLocalName(String targetPackage, String simpleName, String hash) {
-        // com.foo.MyQualifier -> com.bar.MyQualifier_somehashvalue_AnnotationLiteral
-        return (isJavaLang(targetPackage) ? AbstractGenerator.DEFAULT_PACKAGE : targetPackage) + "." + simpleName + hash
-                + AnnotationLiteralGenerator.ANNOTATION_LITERAL_SUFFIX;
-    }
-
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AnnotationLiteralProcessor.java
@@ -3,145 +3,415 @@ package io.quarkus.arc.processor;
 import io.quarkus.arc.impl.ComputingCache;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import javax.enterprise.util.AnnotationLiteral;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.PrimitiveType;
+import org.jboss.jandex.Type;
 
 /**
- * Generates shared annotation literal classes that can be used to represent annotation instances at runtime.
+ * Handles generating bytecode for annotation literals. The
+ * {@link #create(BytecodeCreator, ClassInfo, AnnotationInstance) create()} method can be used
+ * to generate a bytecode sequence for instantiating an annotation literal.
+ * <p>
+ * Behind the scenes, for each annotation literal, its class is also generated. This class
+ * is a subclass of {@link AnnotationLiteral} and hence can be used at runtime. The generated
+ * annotation literal classes are shared. That is, one class is generated for each annotation
+ * type and the constructor of that class accepts values of all annotation members.
  * <p>
  * This construct is thread-safe.
  */
 public class AnnotationLiteralProcessor {
+    private static final String ANNOTATION_LITERAL_SUFFIX = "_Shared_AnnotationLiteral";
 
-    private final ComputingCache<Key, Literal> cache;
+    private final ComputingCache<CacheKey, AnnotationLiteralClassInfo> cache;
+    private final IndexView beanArchiveIndex;
 
-    AnnotationLiteralProcessor(boolean shared, Predicate<DotName> applicationClassPredicate) {
-        this.cache = shared ? new ComputingCache<>(key -> {
-            return new Literal(AnnotationLiteralGenerator.generatedSharedName(key.annotationName),
-                    applicationClassPredicate.test(key.annotationName),
-                    key.annotationClass.methods()
-                            .stream()
-                            .filter(m -> !m.name().equals(Methods.CLINIT) && !m.name().equals(Methods.INIT))
-                            .collect(Collectors.toList()));
-        }) : null;
+    AnnotationLiteralProcessor(IndexView beanArchiveIndex, Predicate<DotName> applicationClassPredicate) {
+        this.cache = new ComputingCache<>(key -> new AnnotationLiteralClassInfo(
+                generateAnnotationLiteralClassName(key.annotationName()),
+                applicationClassPredicate.test(key.annotationName()),
+                key.annotationClass));
+        this.beanArchiveIndex = beanArchiveIndex;
     }
 
     boolean hasLiteralsToGenerate() {
-        return cache != null && !cache.isEmpty();
+        return !cache.isEmpty();
     }
 
-    ComputingCache<Key, Literal> getCache() {
+    ComputingCache<CacheKey, AnnotationLiteralClassInfo> getCache() {
         return cache;
     }
 
     /**
-     *
-     * @param bytecode
-     * @param classOutput
-     * @param annotationClass
-     * @param annotationInstance
-     * @param targetPackage Target package is only used if annotation literals are not shared
-     * @return an annotation literal result handle
+     * @deprecated annotation literal sharing is now always enabled, this method is superseded
+     *             by {@link #create(BytecodeCreator, ClassInfo, AnnotationInstance)} and will be removed
+     *             at some time after Quarkus 3.0
      */
+    @Deprecated
     public ResultHandle process(BytecodeCreator bytecode, ClassOutput classOutput, ClassInfo annotationClass,
-            AnnotationInstance annotationInstance,
-            String targetPackage) {
+            AnnotationInstance annotationInstance, String targetPackage) {
+        return create(bytecode, annotationClass, annotationInstance);
+    }
+
+    /**
+     * Generates a bytecode sequence to create an instance of given annotation type, such that
+     * the annotation members have the same values as the given annotation instance.
+     * An implementation of the annotation type will be generated automatically, subclassing
+     * the {@code AnnotationLiteral} class. Therefore, we also call it the annotation literal class.
+     *
+     * @param bytecode will receive the bytecode sequence for instantiating the annotation literal class
+     *        as a sequence of {@link BytecodeCreator} method calls
+     * @param annotationClass the annotation type
+     * @param annotationInstance the annotation instance; must match the {@code annotationClass}
+     * @return an annotation literal instance result handle
+     */
+    public ResultHandle create(BytecodeCreator bytecode, ClassInfo annotationClass, AnnotationInstance annotationInstance) {
         Objects.requireNonNull(annotationClass, "Annotation class not available: " + annotationInstance);
-        if (cache != null) {
-            Literal literal = cache.getValue(new Key(annotationInstance.name(), annotationClass));
+        AnnotationLiteralClassInfo literal = cache.getValue(new CacheKey(annotationClass));
 
-            Map<String, AnnotationValue> annotationValues = annotationInstance.values().stream()
-                    .collect(Collectors.toMap(AnnotationValue::name, Function.identity()));
+        ResultHandle[] constructorParameters = new ResultHandle[literal.annotationMembers().size()];
 
-            ResultHandle[] constructorParams = new ResultHandle[literal.constructorParams.size()];
-
-            for (ListIterator<MethodInfo> iterator = literal.constructorParams.listIterator(); iterator.hasNext();) {
-                MethodInfo method = iterator.next();
-                AnnotationValue value = annotationValues.get(method.name());
-                if (value == null) {
-                    value = method.defaultValue();
-                }
-                if (value == null) {
-                    throw new IllegalStateException(String.format(
-                            "Value is not set for %s.%s(). Most probably an older version of Jandex was used to index an application dependency. Make sure that Jandex 2.1+ is used.",
-                            method.declaringClass().name(), method.name()));
-                }
-                ResultHandle retValue = AnnotationLiteralGenerator.loadValue(literal.className, bytecode, value,
-                        annotationClass, method);
-                constructorParams[iterator.previousIndex()] = retValue;
+        int constructorParameterIndex = 0;
+        for (MethodInfo annotationMember : literal.annotationMembers()) {
+            AnnotationValue value = annotationInstance.value(annotationMember.name());
+            if (value == null) {
+                value = annotationMember.defaultValue();
             }
-            return bytecode
-                    .newInstance(MethodDescriptor.ofConstructor(literal.className,
-                            literal.constructorParams.stream().map(m -> m.returnType().name().toString()).toArray()),
-                            constructorParams);
-        } else {
-            Objects.requireNonNull(classOutput);
-            Objects.requireNonNull(targetPackage);
-            String literalClassName = AnnotationLiteralGenerator.generatedLocalName(targetPackage,
-                    DotNames.simpleName(annotationClass),
-                    Hashes.sha1(annotationInstance.toString()));
-            AnnotationLiteralGenerator.createAnnotationLiteral(classOutput, annotationClass, annotationInstance,
-                    literalClassName);
-            return bytecode.newInstance(MethodDescriptor.ofConstructor(literalClassName));
-        }
-    }
+            if (value == null) {
+                throw new IllegalStateException(String.format(
+                        "Value is not set for %s.%s(). Most probably an older version of Jandex was used to index an application dependency. Make sure that Jandex 2.1+ is used.",
+                        annotationMember.declaringClass().name(), annotationMember.name()));
+            }
+            ResultHandle retValue = loadValue(bytecode, literal, annotationMember, value);
+            constructorParameters[constructorParameterIndex] = retValue;
 
-    static class Literal {
-
-        final String className;
-
-        final boolean isApplicationClass;
-
-        final List<MethodInfo> constructorParams;
-
-        public Literal(String className, boolean isApplicationClass, List<MethodInfo> constructorParams) {
-            this.className = className;
-            this.isApplicationClass = isApplicationClass;
-            this.constructorParams = constructorParams;
+            constructorParameterIndex++;
         }
 
+        return bytecode.newInstance(MethodDescriptor.ofConstructor(literal.generatedClassName,
+                literal.annotationMembers().stream().map(m -> m.returnType().name().toString()).toArray()),
+                constructorParameters);
     }
 
-    static class Key {
+    /**
+     * Generates a bytecode sequence to load given annotation member value.
+     *
+     * @param bytecode will receive the bytecode sequence for loading the annotation member value
+     *        as a sequence of {@link BytecodeCreator} method calls
+     * @param literal data about the annotation literal class currently being generated
+     * @param annotationMember the annotation member whose value we're loading
+     * @param annotationMemberValue the annotation member value we're loading
+     * @return an annotation member value result handle
+     */
+    private ResultHandle loadValue(BytecodeCreator bytecode, AnnotationLiteralClassInfo literal,
+            MethodInfo annotationMember, AnnotationValue annotationMemberValue) {
+        ResultHandle retValue;
+        switch (annotationMemberValue.kind()) {
+            case BOOLEAN:
+                retValue = bytecode.load(annotationMemberValue.asBoolean());
+                break;
+            case BYTE:
+                retValue = bytecode.load(annotationMemberValue.asByte());
+                break;
+            case SHORT:
+                retValue = bytecode.load(annotationMemberValue.asShort());
+                break;
+            case INTEGER:
+                retValue = bytecode.load(annotationMemberValue.asInt());
+                break;
+            case LONG:
+                retValue = bytecode.load(annotationMemberValue.asLong());
+                break;
+            case FLOAT:
+                retValue = bytecode.load(annotationMemberValue.asFloat());
+                break;
+            case DOUBLE:
+                retValue = bytecode.load(annotationMemberValue.asDouble());
+                break;
+            case CHARACTER:
+                retValue = bytecode.load(annotationMemberValue.asChar());
+                break;
+            case STRING:
+                retValue = bytecode.load(annotationMemberValue.asString());
+                break;
+            case ENUM:
+                retValue = bytecode.readStaticField(FieldDescriptor.of(annotationMemberValue.asEnumType().toString(),
+                        annotationMemberValue.asEnum(), annotationMemberValue.asEnumType().toString()));
+                break;
+            case CLASS:
+                if (annotationMemberValue.equals(annotationMember.defaultValue())) {
+                    retValue = bytecode.readStaticField(FieldDescriptor.of(literal.generatedClassName,
+                            AnnotationLiteralGenerator.defaultValueStaticFieldName(annotationMember),
+                            annotationMember.returnType().name().toString()));
+                } else {
+                    retValue = bytecode.loadClass(annotationMemberValue.asClass().name().toString());
+                }
+                break;
+            case NESTED:
+                AnnotationInstance nestedAnnotation = annotationMemberValue.asNested();
+                DotName annotationName = nestedAnnotation.name();
+                ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotationName);
+                if (annotationClass == null) {
+                    throw new IllegalStateException("Class of nested annotation " + nestedAnnotation + " missing");
+                }
+                retValue = create(bytecode, annotationClass, nestedAnnotation);
+                break;
+            case ARRAY:
+                retValue = loadArrayValue(bytecode, literal, annotationMember, annotationMemberValue);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported value: " + annotationMemberValue);
+        }
+        return retValue;
+    }
 
-        final DotName annotationName;
+    /**
+     * Generates a bytecode sequence to load given array-typed annotation member value.
+     *
+     * @param bytecode will receive the bytecode sequence for loading the annotation member value
+     *        as a sequence of {@link BytecodeCreator} method calls
+     * @param literal data about the annotation literal class currently being generated
+     * @param annotationMember the annotation member whose value we're loading
+     * @param annotationMemberValue the annotation member value we're loading
+     * @return an annotation member value result handle
+     */
+    private ResultHandle loadArrayValue(BytecodeCreator bytecode, AnnotationLiteralClassInfo literal,
+            MethodInfo annotationMember, AnnotationValue annotationMemberValue) {
+        ResultHandle retValue;
+        AnnotationValue.Kind componentKind = annotationMemberValue.componentKind();
+        switch (componentKind) {
+            case BOOLEAN:
+                boolean[] booleanArray = annotationMemberValue.asBooleanArray();
+                retValue = bytecode.newArray(componentType(annotationMember), booleanArray.length);
+                for (int i = 0; i < booleanArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(booleanArray[i]));
+                }
+                break;
+            case BYTE:
+                byte[] byteArray = annotationMemberValue.asByteArray();
+                retValue = bytecode.newArray(componentType(annotationMember), byteArray.length);
+                for (int i = 0; i < byteArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(byteArray[i]));
+                }
+                break;
+            case SHORT:
+                short[] shortArray = annotationMemberValue.asShortArray();
+                retValue = bytecode.newArray(componentType(annotationMember), shortArray.length);
+                for (int i = 0; i < shortArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(shortArray[i]));
+                }
+                break;
+            case INTEGER:
+                int[] intArray = annotationMemberValue.asIntArray();
+                retValue = bytecode.newArray(componentType(annotationMember), intArray.length);
+                for (int i = 0; i < intArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(intArray[i]));
+                }
+                break;
+            case LONG:
+                long[] longArray = annotationMemberValue.asLongArray();
+                retValue = bytecode.newArray(componentType(annotationMember), longArray.length);
+                for (int i = 0; i < longArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(longArray[i]));
+                }
+                break;
+            case FLOAT:
+                float[] floatArray = annotationMemberValue.asFloatArray();
+                retValue = bytecode.newArray(componentType(annotationMember), floatArray.length);
+                for (int i = 0; i < floatArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(floatArray[i]));
+                }
+                break;
+            case DOUBLE:
+                double[] doubleArray = annotationMemberValue.asDoubleArray();
+                retValue = bytecode.newArray(componentType(annotationMember), doubleArray.length);
+                for (int i = 0; i < doubleArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(doubleArray[i]));
+                }
+                break;
+            case CHARACTER:
+                char[] charArray = annotationMemberValue.asCharArray();
+                retValue = bytecode.newArray(componentType(annotationMember), charArray.length);
+                for (int i = 0; i < charArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(charArray[i]));
+                }
+                break;
+            case STRING:
+                String[] stringArray = annotationMemberValue.asStringArray();
+                retValue = bytecode.newArray(componentType(annotationMember), stringArray.length);
+                for (int i = 0; i < stringArray.length; i++) {
+                    bytecode.writeArrayValue(retValue, i, bytecode.load(stringArray[i]));
+                }
+                break;
+            case ENUM:
+                String[] enumArray = annotationMemberValue.asEnumArray();
+                DotName[] enumTypeArray = annotationMemberValue.asEnumTypeArray();
+                retValue = bytecode.newArray(componentType(annotationMember), enumArray.length);
+                for (int i = 0; i < enumArray.length; i++) {
+                    ResultHandle enumValue = bytecode.readStaticField(FieldDescriptor.of(
+                            enumTypeArray[i].toString(), enumArray[i], enumTypeArray[i].toString()));
+                    bytecode.writeArrayValue(retValue, i, enumValue);
+                }
+                break;
+            case CLASS:
+                if (annotationMemberValue.equals(annotationMember.defaultValue())) {
+                    retValue = bytecode.readStaticField(FieldDescriptor.of(literal.generatedClassName,
+                            AnnotationLiteralGenerator.defaultValueStaticFieldName(annotationMember),
+                            annotationMember.returnType().name().toString()));
+                } else {
+                    Type[] classArray = annotationMemberValue.asClassArray();
+                    retValue = bytecode.newArray(componentType(annotationMember), classArray.length);
+                    for (int i = 0; i < classArray.length; i++) {
+                        bytecode.writeArrayValue(retValue, i, bytecode.loadClass(classArray[i].name().toString()));
+                    }
+                }
+                break;
+            case NESTED:
+                AnnotationInstance[] nestedArray = annotationMemberValue.asNestedArray();
+                retValue = bytecode.newArray(componentType(annotationMember), nestedArray.length);
+                for (int i = 0; i < nestedArray.length; i++) {
+                    AnnotationInstance nestedAnnotation = nestedArray[i];
+                    DotName annotationName = nestedAnnotation.name();
+                    ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotationName);
+                    if (annotationClass == null) {
+                        throw new IllegalStateException("Class of nested annotation " + nestedAnnotation + " missing");
+                    }
+                    ResultHandle nestedAnnotationValue = create(bytecode, annotationClass, nestedAnnotation);
 
+                    bytecode.writeArrayValue(retValue, i, nestedAnnotationValue);
+                }
+                break;
+            case UNKNOWN: // empty array
+                DotName componentName = componentTypeName(annotationMember);
+                // Use empty array constants for common component kinds
+                if (PrimitiveType.BOOLEAN.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_BOOLEAN_ARRAY);
+                } else if (PrimitiveType.BYTE.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_BYTE_ARRAY);
+                } else if (PrimitiveType.SHORT.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_SHORT_ARRAY);
+                } else if (PrimitiveType.INT.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_INT_ARRAY);
+                } else if (PrimitiveType.LONG.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_LONG_ARRAY);
+                } else if (PrimitiveType.FLOAT.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_FLOAT_ARRAY);
+                } else if (PrimitiveType.DOUBLE.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_DOUBLE_ARRAY);
+                } else if (PrimitiveType.CHAR.name().equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_CHAR_ARRAY);
+                } else if (DotNames.STRING.equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_STRING_ARRAY);
+                } else if (DotNames.CLASS.equals(componentName)) {
+                    retValue = bytecode.readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY);
+                } else {
+                    retValue = bytecode.newArray(componentName.toString(), bytecode.load(0));
+                }
+                break;
+            default:
+                // at this point, the only possible componend kind is "array"
+                throw new IllegalStateException("Array component kind is " + componentKind + ", this should never happen");
+        }
+        return retValue;
+    }
+
+    private static String componentType(MethodInfo method) {
+        return componentTypeName(method).toString();
+    }
+
+    private static DotName componentTypeName(MethodInfo method) {
+        ArrayType arrayType = method.returnType().asArrayType();
+        return arrayType.component().name();
+    }
+
+    private static String generateAnnotationLiteralClassName(DotName annotationName) {
+        // when the annotation is a java.lang annotation we need to use a different package in which to generate the literal
+        // otherwise a security exception will be thrown when the literal is loaded
+        boolean isJavaLang = annotationName.toString().startsWith("java.lang");
+        String nameToUse = isJavaLang
+                ? AbstractGenerator.DEFAULT_PACKAGE + annotationName.withoutPackagePrefix()
+                : annotationName.toString();
+
+        // com.foo.MyQualifier -> com.foo.MyQualifier_Shared_AnnotationLiteral
+        return nameToUse + ANNOTATION_LITERAL_SUFFIX;
+    }
+
+    static class CacheKey {
         final ClassInfo annotationClass;
 
-        public Key(DotName name, ClassInfo annotationClass) {
-            this.annotationName = name;
+        CacheKey(ClassInfo annotationClass) {
             this.annotationClass = annotationClass;
+        }
+
+        DotName annotationName() {
+            return annotationClass.name();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(annotationClass.name(), cacheKey.annotationClass.name());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(annotationName);
+            return Objects.hash(annotationClass.name());
         }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            Key other = (Key) obj;
-            return Objects.equals(annotationName, other.annotationName);
-        }
-
     }
 
+    static class AnnotationLiteralClassInfo {
+        /**
+         * Name of the generated annotation literal class.
+         */
+        final String generatedClassName;
+        /**
+         * Whether the generated annotation literal class is an application class.
+         * Only used when sharing is enabled.
+         */
+        final boolean isApplicationClass;
+
+        /**
+         * The annotation type. The generated annotation literal class will implement this interface
+         * (and extend {@code AnnotationLiteral<this interface>}). The process that generates
+         * the annotation literal class may consult this, for example, to know the set of annotation members.
+         */
+        final ClassInfo annotationClass;
+
+        AnnotationLiteralClassInfo(String generatedClassName, boolean isApplicationClass, ClassInfo annotationClass) {
+            this.generatedClassName = generatedClassName;
+            this.isApplicationClass = isApplicationClass;
+            this.annotationClass = annotationClass;
+        }
+
+        DotName annotationName() {
+            return annotationClass.name();
+        }
+
+        List<MethodInfo> annotationMembers() {
+            List<MethodInfo> result = new ArrayList<>();
+            for (MethodInfo method : annotationClass.methods()) {
+                if (!method.name().equals(Methods.CLINIT) && !method.name().equals(Methods.INIT)) {
+                    result.add(method);
+                }
+            }
+            return result;
+        }
+    }
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -743,8 +743,7 @@ public class BeanGenerator extends AbstractGenerator {
                     // Create the annotation literal first
                     ClassInfo qualifierClass = bean.getDeployment().getQualifier(qualifierAnnotation.name());
                     constructor.writeArrayValue(qualifiersArray, constructor.load(qualifierIndex++),
-                            annotationLiterals.process(constructor, classOutput,
-                                    qualifierClass, qualifierAnnotation, Types.getPackageName(beanCreator.getClassName())));
+                            annotationLiterals.create(constructor, qualifierClass, qualifierAnnotation));
                 }
             }
             constructor.writeInstanceField(
@@ -1405,8 +1404,7 @@ public class BeanGenerator extends AbstractGenerator {
                 // Create annotation literals first
                 ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
                 create.writeArrayValue(bindingsArray, bindingsIndex++,
-                        annotationLiterals.process(create, classOutput, bindingClass, binding,
-                                Types.getPackageName(beanCreator.getClassName())));
+                        annotationLiterals.create(create, bindingClass, binding));
             }
 
             ResultHandle invocationContextHandle = create.invokeStaticMethod(
@@ -1536,8 +1534,7 @@ public class BeanGenerator extends AbstractGenerator {
                 // Create annotation literals first
                 ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
                 create.writeArrayValue(bindingsArray, bindingsIndex++,
-                        annotationLiterals.process(create, classOutput, bindingClass, binding,
-                                Types.getPackageName(beanCreator.getClassName())));
+                        annotationLiterals.create(create, bindingClass, binding));
 
             }
 
@@ -1910,9 +1907,7 @@ public class BeanGenerator extends AbstractGenerator {
             } else {
                 // Create annotation literal if needed
                 ClassInfo literalClass = getClassByName(beanDeployment.getBeanArchiveIndex(), annotation.name());
-                annotationHandle = annotationLiterals.process(constructor,
-                        classOutput, literalClass, annotation,
-                        beanCreator != null ? Types.getPackageName(beanCreator.getClassName()) : null);
+                annotationHandle = annotationLiterals.create(constructor, literalClass, annotation);
             }
             constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotationsHandle,
                     annotationHandle);
@@ -1942,9 +1937,8 @@ public class BeanGenerator extends AbstractGenerator {
                     qualifierHandle = qualifier.getLiteralInstance(constructor);
                 } else {
                     // Create annotation literal if needed
-                    qualifierHandle = annotationLiterals.process(constructor,
-                            classOutput, beanDeployment.getQualifier(qualifierAnnotation.name()), qualifierAnnotation,
-                            beanCreator != null ? Types.getPackageName(beanCreator.getClassName()) : null);
+                    qualifierHandle = annotationLiterals.create(constructor,
+                            beanDeployment.getQualifier(qualifierAnnotation.name()), qualifierAnnotation);
                 }
                 constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, requiredQualifiersHandle,
                         qualifierHandle);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanProcessor.java
@@ -82,7 +82,7 @@ public class BeanProcessor {
         this.applicationClassPredicate = builder.applicationClassPredicate;
         this.name = builder.name;
         this.output = builder.output;
-        this.annotationLiterals = new AnnotationLiteralProcessor(builder.sharedAnnotationLiterals, applicationClassPredicate);
+        this.annotationLiterals = new AnnotationLiteralProcessor(builder.beanArchiveIndex, applicationClassPredicate);
         this.generateSources = builder.generateSources;
         this.allowMocking = builder.allowMocking;
         this.transformUnproxyableClasses = builder.transformUnproxyableClasses;
@@ -173,7 +173,6 @@ public class BeanProcessor {
         ObserverGenerator observerGenerator = new ObserverGenerator(annotationLiterals, applicationClassPredicate,
                 privateMembers, generateSources, reflectionRegistration, existingClasses, observerToGeneratedName,
                 injectionPointAnnotationsPredicate, allowMocking);
-        AnnotationLiteralGenerator annotationLiteralsGenerator = new AnnotationLiteralGenerator(generateSources);
 
         List<Resource> resources = new ArrayList<>();
 
@@ -242,8 +241,8 @@ public class BeanProcessor {
 
         // Generate AnnotationLiterals
         if (annotationLiterals.hasLiteralsToGenerate()) {
-            resources.addAll(
-                    annotationLiteralsGenerator.generate(name, beanDeployment, annotationLiterals.getCache(), existingClasses));
+            AnnotationLiteralGenerator generator = new AnnotationLiteralGenerator(generateSources);
+            resources.addAll(generator.generate(annotationLiterals.getCache(), existingClasses));
         }
 
         if (output != null) {
@@ -293,7 +292,6 @@ public class BeanProcessor {
         Collection<BeanDefiningAnnotation> additionalBeanDefiningAnnotations;
         Map<DotName, Collection<AnnotationInstance>> additionalStereotypes;
         ResourceOutput output;
-        boolean sharedAnnotationLiterals;
         ReflectionRegistration reflectionRegistration;
 
         final List<DotName> resourceAnnotations;
@@ -326,7 +324,6 @@ public class BeanProcessor {
             name = DEFAULT_NAME;
             additionalBeanDefiningAnnotations = Collections.emptySet();
             additionalStereotypes = Collections.emptyMap();
-            sharedAnnotationLiterals = true;
             reflectionRegistration = ReflectionRegistration.NOOP;
             resourceAnnotations = new ArrayList<>();
             annotationTransformers = new ArrayList<>();
@@ -412,8 +409,12 @@ public class BeanProcessor {
             return this;
         }
 
+        /**
+         * @deprecated annotation literal sharing is now always enabled, this method doesn't do anything
+         *             and will be removed at some time after Quarkus 3.0
+         */
+        @Deprecated
         public Builder setSharedAnnotationLiterals(boolean sharedAnnotationLiterals) {
-            this.sharedAnnotationLiterals = sharedAnnotationLiterals;
             return this;
         }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BuiltinBean.java
@@ -230,9 +230,7 @@ enum BuiltinBean {
                     // Create annotation literal first
                     ClassInfo qualifierClass = ctx.beanDeployment.getQualifier(qualifierAnnotation.name());
                     ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
-                            ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
-                                    qualifierClass, qualifierAnnotation,
-                                    Types.getPackageName(ctx.clazzCreator.getClassName())));
+                            ctx.annotationLiterals.create(ctx.constructor, qualifierClass, qualifierAnnotation));
                 }
             }
         }
@@ -315,9 +313,7 @@ enum BuiltinBean {
                 // Create annotation literal first
                 ClassInfo annotationClass = getClassByName(ctx.beanDeployment.getBeanArchiveIndex(), annotation.name());
                 ctx.constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, annotations,
-                        ctx.annotationLiterals.process(ctx.constructor, ctx.classOutput,
-                                annotationClass, annotation,
-                                Types.getPackageName(ctx.clazzCreator.getClassName())));
+                        ctx.annotationLiterals.create(ctx.constructor, annotationClass, annotation));
             }
         }
         ResultHandle parameterizedType = Types.getTypeHandle(ctx.constructor, ctx.injectionPoint.getType());

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -111,8 +111,7 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                 // Create annotation literals first
                 ClassInfo bindingClass = beanDeployment.getInterceptorBinding(binding.name());
                 getComponents.invokeInterfaceMethod(MethodDescriptors.SET_ADD, bindingsHandle,
-                        annotationLiterals.process(getComponents, classOutput, bindingClass, binding,
-                                SETUP_PACKAGE));
+                        annotationLiterals.create(getComponents, bindingClass, binding));
             }
             getComponents.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, transitiveBindingsHandle,
                     getComponents.loadClass(entry.getKey().toString()), bindingsHandle);
@@ -493,9 +492,8 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                         if (sharedQualifier == null) {
                             // Create annotation literal first
                             ClassInfo qualifierClass = removedBean.getDeployment().getQualifier(qualifierAnnotation.name());
-                            ResultHandle qualifierHandle = annotationLiterals.process(addMethod, classOutput,
-                                    qualifierClass, qualifierAnnotation,
-                                    Types.getPackageName(componentsProvider.getClassName()));
+                            ResultHandle qualifierHandle = annotationLiterals.create(addMethod, qualifierClass,
+                                    qualifierAnnotation);
                             addMethod.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiersHandle,
                                     qualifierHandle);
                             sharedQualifers.put(new AnnotationInstanceKey(qualifierAnnotation), qualifierHandle);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
@@ -278,8 +278,7 @@ public class DecoratorGenerator extends BeanGenerator {
                 // Create annotation literal first
                 ClassInfo delegateQualifierClass = decorator.getDeployment().getQualifier(delegateQualifier.name());
                 constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, delegateQualifiersHandle,
-                        annotationLiterals.process(constructor, classOutput, delegateQualifierClass, delegateQualifier,
-                                Types.getPackageName(creator.getClassName())));
+                        annotationLiterals.create(constructor, delegateQualifierClass, delegateQualifier));
             }
             constructor.writeInstanceField(delegateQualifiers.getFieldDescriptor(), constructor.getThis(),
                     delegateQualifiersHandle);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
@@ -13,21 +13,27 @@ final class FieldDescriptors {
     static final FieldDescriptor QUALIFIERS_IP_QUALIFIERS = FieldDescriptor.of(Qualifiers.class, "IP_DEFAULT_QUALIFIERS",
             Set.class);
 
-    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
-            "EMPTY_CLASS_ARRAY",
-            Class[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_BOOLEAN_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_BOOLEAN_ARRAY", boolean[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_BYTE_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_BYTE_ARRAY", byte[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_SHORT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_SHORT_ARRAY", short[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_INT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_INT_ARRAY", int[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_LONG_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_LONG_ARRAY", long[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_FLOAT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_FLOAT_ARRAY", float[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_DOUBLE_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_DOUBLE_ARRAY", double[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_CHAR_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_CHAR_ARRAY", char[].class);
 
     static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_STRING_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
-            "EMPTY_STRING_ARRAY",
-            String[].class);
-
-    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_LONG_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
-            "EMPTY_LONG_ARRAY",
-            long[].class);
-
-    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_INT_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
-            "EMPTY_INT_ARRAY",
-            int[].class);
+            "EMPTY_STRING_ARRAY", String[].class);
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_CLASS_ARRAY", Class[].class);
 
     private FieldDescriptors() {
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -136,8 +136,7 @@ public class InterceptorGenerator extends BeanGenerator {
             // Create annotation literal first
             ClassInfo bindingClass = interceptor.getDeployment().getInterceptorBinding(bindingAnnotation.name());
             constructor.invokeInterfaceMethod(MethodDescriptors.SET_ADD, bindingsHandle,
-                    annotationLiterals.process(constructor, classOutput, bindingClass, bindingAnnotation,
-                            Types.getPackageName(creator.getClassName())));
+                    annotationLiterals.create(constructor, bindingClass, bindingAnnotation));
         }
         constructor.writeInstanceField(bindings, constructor.getThis(), bindingsHandle);
         constructor.returnValue(null);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -587,8 +587,7 @@ public class ObserverGenerator extends AbstractGenerator {
                     ClassInfo qualifierClass = observer.getBeanDeployment()
                             .getQualifier(qualifierAnnotation.name());
                     constructor.writeArrayValue(qualifiersArray, constructor.load(qualifiersIndex++),
-                            annotationLiterals.process(constructor, classOutput,
-                                    qualifierClass, qualifierAnnotation, Types.getPackageName(observerCreator.getClassName())));
+                            annotationLiterals.create(constructor, qualifierClass, qualifierAnnotation));
                 }
             }
             constructor.writeInstanceField(

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SubclassGenerator.java
@@ -239,10 +239,8 @@ public class SubclassGenerator extends AbstractGenerator {
             @Override
             public ResultHandle apply(BindingKey key) {
                 // Create annotation literal if needed
-                ClassInfo bindingClass = bean.getDeployment()
-                        .getInterceptorBinding(key.annotation.name());
-                return annotationLiterals.process(constructor, classOutput, bindingClass, key.annotation,
-                        Types.getPackageName(subclass.getClassName()));
+                ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(key.annotation.name());
+                return annotationLiterals.create(constructor, bindingClass, key.annotation);
             }
         };
         // Shared lists of interceptor bindings literals
@@ -812,8 +810,7 @@ public class SubclassGenerator extends AbstractGenerator {
                 // Create annotation literals first
                 ClassInfo bindingClass = bean.getDeployment().getInterceptorBinding(binding.name());
                 destroy.writeArrayValue(bindingsArray, bindingsIndex++,
-                        annotationLiterals.process(destroy, classOutput, bindingClass, binding,
-                                Types.getPackageName(subclass.getClassName())));
+                        annotationLiterals.create(destroy, bindingClass, binding));
             }
 
             // try

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/AnnotationLiteralProcessorTest.java
@@ -1,0 +1,245 @@
+package io.quarkus.arc.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.gizmo.TestClassLoader;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+
+public class AnnotationLiteralProcessorTest {
+    public enum SimpleEnum {
+        FOO,
+        BAR,
+        BAZ,
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface SimpleAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ComplexAnnotation {
+        boolean bool();
+
+        byte b();
+
+        short s();
+
+        int i();
+
+        long l();
+
+        float f();
+
+        double d();
+
+        char ch();
+
+        String str();
+
+        SimpleEnum en();
+
+        Class<?> cls();
+
+        SimpleAnnotation nested();
+
+        boolean[] boolArray();
+
+        byte[] bArray();
+
+        short[] sArray();
+
+        int[] iArray();
+
+        long[] lArray();
+
+        float[] fArray();
+
+        double[] dArray();
+
+        char[] chArray();
+
+        String[] strArray();
+
+        SimpleEnum[] enArray();
+
+        Class<?>[] clsArray();
+
+        SimpleAnnotation[] nestedArray();
+    }
+
+    private final String generatedClass = "io.quarkus.arc.processor.test.GeneratedClass";
+    private final IndexView index;
+
+    public AnnotationLiteralProcessorTest() throws IOException {
+        index = Index.of(SimpleEnum.class, SimpleAnnotation.class, ComplexAnnotation.class);
+    }
+
+    @Test
+    public void test() throws ReflectiveOperationException {
+        AnnotationLiteralProcessor literals = new AnnotationLiteralProcessor(index, ignored -> true);
+
+        TestClassLoader cl = new TestClassLoader(getClass().getClassLoader());
+        try (ClassCreator creator = ClassCreator.builder().classOutput(cl).className(generatedClass).build()) {
+            MethodCreator method = creator.getMethodCreator("get", ComplexAnnotation.class)
+                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC);
+            ResultHandle annotation = literals.create(method,
+                    index.getClassByName(DotName.createSimple(ComplexAnnotation.class.getName())), complexAnnotation());
+            method.returnValue(annotation);
+        }
+
+        Collection<ResourceOutput.Resource> resources = new AnnotationLiteralGenerator(false)
+                .generate(literals.getCache(), Collections.emptySet());
+        for (ResourceOutput.Resource resource : resources) {
+            if (resource.getType() == ResourceOutput.Resource.Type.JAVA_CLASS) {
+                cl.write(resource.getName(), resource.getData());
+            } else {
+                throw new IllegalStateException("Unexpected " + resource.getType() + " " + resource.getName());
+            }
+        }
+
+        Class<?> clazz = cl.loadClass(generatedClass);
+        ComplexAnnotation annotation = (ComplexAnnotation) clazz.getMethod("get").invoke(null);
+        verify(annotation);
+    }
+
+    private static void verify(ComplexAnnotation ann) {
+        assertEquals(true, ann.bool());
+        assertEquals((byte) 1, ann.b());
+        assertEquals((short) 2, ann.s());
+        assertEquals(3, ann.i());
+        assertEquals(4L, ann.l());
+        assertEquals(5.0F, ann.f());
+        assertEquals(6.0, ann.d());
+        assertEquals('a', ann.ch());
+        assertEquals("bc", ann.str());
+        assertEquals(SimpleEnum.FOO, ann.en());
+        assertEquals(Object.class, ann.cls());
+        assertEquals("one", ann.nested().value());
+
+        assertEquals(2, ann.boolArray().length);
+        assertEquals(true, ann.boolArray()[0]);
+        assertEquals(false, ann.boolArray()[1]);
+        assertEquals(2, ann.bArray().length);
+        assertEquals((byte) 7, ann.bArray()[0]);
+        assertEquals((byte) 8, ann.bArray()[1]);
+        assertEquals(2, ann.sArray().length);
+        assertEquals((short) 9, ann.sArray()[0]);
+        assertEquals((short) 10, ann.sArray()[1]);
+        assertEquals(2, ann.iArray().length);
+        assertEquals(11, ann.iArray()[0]);
+        assertEquals(12, ann.iArray()[1]);
+        assertEquals(2, ann.lArray().length);
+        assertEquals(13L, ann.lArray()[0]);
+        assertEquals(14L, ann.lArray()[1]);
+        assertEquals(2, ann.fArray().length);
+        assertEquals(15.0F, ann.fArray()[0]);
+        assertEquals(16.0F, ann.fArray()[1]);
+        assertEquals(2, ann.dArray().length);
+        assertEquals(17.0, ann.dArray()[0]);
+        assertEquals(18.0, ann.dArray()[1]);
+        assertEquals(2, ann.chArray().length);
+        assertEquals('d', ann.chArray()[0]);
+        assertEquals('e', ann.chArray()[1]);
+        assertEquals(2, ann.strArray().length);
+        assertEquals("fg", ann.strArray()[0]);
+        assertEquals("hi", ann.strArray()[1]);
+        assertEquals(2, ann.enArray().length);
+        assertEquals(SimpleEnum.BAR, ann.enArray()[0]);
+        assertEquals(SimpleEnum.BAZ, ann.enArray()[1]);
+        assertEquals(2, ann.clsArray().length);
+        assertEquals(String.class, ann.clsArray()[0]);
+        assertEquals(Number.class, ann.clsArray()[1]);
+        assertEquals(2, ann.nestedArray().length);
+        assertEquals("two", ann.nestedArray()[0].value());
+        assertEquals("three", ann.nestedArray()[1].value());
+    }
+
+    private static AnnotationInstance complexAnnotation() {
+        return AnnotationInstance.create(DotName.createSimple(ComplexAnnotation.class.getName()), null, List.of(
+                AnnotationValue.createBooleanValue("bool", true),
+                AnnotationValue.createByteValue("b", (byte) 1),
+                AnnotationValue.createShortValue("s", (short) 2),
+                AnnotationValue.createIntegerValue("i", 3),
+                AnnotationValue.createLongValue("l", 4L),
+                AnnotationValue.createFloatValue("f", 5.0F),
+                AnnotationValue.createDoubleValue("d", 6.0),
+                AnnotationValue.createCharacterValue("ch", 'a'),
+                AnnotationValue.createStringValue("str", "bc"),
+                AnnotationValue.createEnumValue("en", DotName.createSimple(SimpleEnum.class.getName()), "FOO"),
+                AnnotationValue.createClassValue("cls", Type.create(DotName.createSimple("java.lang.Object"), Type.Kind.CLASS)),
+                AnnotationValue.createNestedAnnotationValue("nested", simpleAnnotation("one")),
+
+                AnnotationValue.createArrayValue("boolArray", new AnnotationValue[] {
+                        AnnotationValue.createBooleanValue("", true),
+                        AnnotationValue.createBooleanValue("", false),
+                }),
+                AnnotationValue.createArrayValue("bArray", new AnnotationValue[] {
+                        AnnotationValue.createByteValue("", (byte) 7),
+                        AnnotationValue.createByteValue("", (byte) 8),
+                }),
+                AnnotationValue.createArrayValue("sArray", new AnnotationValue[] {
+                        AnnotationValue.createShortValue("", (short) 9),
+                        AnnotationValue.createShortValue("", (short) 10),
+                }),
+                AnnotationValue.createArrayValue("iArray", new AnnotationValue[] {
+                        AnnotationValue.createIntegerValue("", 11),
+                        AnnotationValue.createIntegerValue("", 12),
+                }),
+                AnnotationValue.createArrayValue("lArray", new AnnotationValue[] {
+                        AnnotationValue.createLongValue("", 13L),
+                        AnnotationValue.createLongValue("", 14L),
+                }),
+                AnnotationValue.createArrayValue("fArray", new AnnotationValue[] {
+                        AnnotationValue.createFloatValue("", 15.0F),
+                        AnnotationValue.createFloatValue("", 16.0F),
+                }),
+                AnnotationValue.createArrayValue("dArray", new AnnotationValue[] {
+                        AnnotationValue.createDoubleValue("", 17.0),
+                        AnnotationValue.createDoubleValue("", 18.0),
+                }),
+                AnnotationValue.createArrayValue("chArray", new AnnotationValue[] {
+                        AnnotationValue.createCharacterValue("", 'd'),
+                        AnnotationValue.createCharacterValue("", 'e'),
+                }),
+                AnnotationValue.createArrayValue("strArray", new AnnotationValue[] {
+                        AnnotationValue.createStringValue("", "fg"),
+                        AnnotationValue.createStringValue("", "hi"),
+                }),
+                AnnotationValue.createArrayValue("enArray", new AnnotationValue[] {
+                        AnnotationValue.createEnumValue("", DotName.createSimple(SimpleEnum.class.getName()), "BAR"),
+                        AnnotationValue.createEnumValue("", DotName.createSimple(SimpleEnum.class.getName()), "BAZ"),
+                }),
+                AnnotationValue.createArrayValue("clsArray", new AnnotationValue[] {
+                        AnnotationValue.createClassValue("",
+                                Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS)),
+                        AnnotationValue.createClassValue("",
+                                Type.create(DotName.createSimple("java.lang.Number"), Type.Kind.CLASS)),
+                }),
+                AnnotationValue.createArrayValue("nestedArray", new AnnotationValue[] {
+                        AnnotationValue.createNestedAnnotationValue("", simpleAnnotation("two")),
+                        AnnotationValue.createNestedAnnotationValue("", simpleAnnotation("three")),
+                })));
+    }
+
+    private static AnnotationInstance simpleAnnotation(String value) {
+        return AnnotationInstance.create(DotName.createSimple(SimpleAnnotation.class.getName()), null,
+                List.of(AnnotationValue.createStringValue("value", value)));
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
@@ -2,10 +2,17 @@ package io.quarkus.arc.impl;
 
 public final class AnnotationLiterals {
 
-    public static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
-    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+    public static final boolean[] EMPTY_BOOLEAN_ARRAY = new boolean[0];
+    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    public static final short[] EMPTY_SHORT_ARRAY = new short[0];
     public static final int[] EMPTY_INT_ARRAY = new int[0];
     public static final long[] EMPTY_LONG_ARRAY = new long[0];
+    public static final float[] EMPTY_FLOAT_ARRAY = new float[0];
+    public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
+    public static final char[] EMPTY_CHAR_ARRAY = new char[0];
+
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+    public static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
 
     private AnnotationLiterals() {
     }


### PR DESCRIPTION
This commit adds support for emitting annotation literal classes with all
possible annotation member types: all primitive types, strings, enums,
classes, nested annotations, and arrays of previously mentioned types.
A test for the annotation literal class generator is added, too.

Additionally, this commit removes the ability to generate "one-off" annotation
literal classes. They are now always shared. This allows simplification of
the `AnnotationLiteralProcessor` and `AnnotationLiteralGenerator` classes.
These classes now maintain separation between generating an annotation
literal class and generating a bytecode sequence to instantiate it.

The previous user-visible APIs that dealed with "one-off" annotation literals
are now deprecated.