### PR TITLE
Upgrade to Hibernate Reactive 1.1.5.Beta2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.6.8.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
-        <hibernate-reactive.version>1.1.4.Final</hibernate-reactive.version>
+        <hibernate-reactive.version>1.1.5.Beta2</hibernate-reactive.version>
         <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.3.Final</hibernate-search.version>
         <narayana.version>5.12.6.Final</narayana.version>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -61,9 +61,6 @@ recipeList:
   - org.openrewrite.maven.ChangePropertyValue:
       key: jakarta.persistence-api.version
       newValue: 3.0.0
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: hibernate-reactive.version
-      newValue: 1.1.5.Beta1
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.hibernate
       oldArtifactId: hibernate-core


### PR DESCRIPTION
We'll follow up with a Final shortly - just need a couple final things verified, but that would be easier when have this Beta out already.