### PR TITLE
No need to use response methods returning a Future, if not used

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -328,7 +328,7 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     @Override
     public ServerHttpResponse end() {
         if (!response.ended()) {
-            response.end();
+            response.end((Handler<AsyncResult<Void>>) null);
         }
         return this;
     }
@@ -340,13 +340,13 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
 
     @Override
     public ServerHttpResponse end(byte[] data) {
-        response.end(Buffer.buffer(data));
+        response.end(Buffer.buffer(data), null);
         return this;
     }
 
     @Override
     public ServerHttpResponse end(String data) {
-        response.end(data);
+        response.end(Buffer.buffer(data), null);
         return this;
     }
 


### PR DESCRIPTION
This is introducing a small, but noticeable performance improvement while interacting with `WriteStream', both saving few object allocations and useless work to happen.

Existing `end` methods return `Future`, that mean adding Netty listeners and creating wrapping Futures: given that are not used, we can get rid of them by passing `null`; not very elegant but it works 
