### PR TITLE
Refactor configuration creation to ensure Gradle has full visibility of Configuration's contents

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -335,6 +335,11 @@ public class QuarkusPlugin implements Plugin<Project> {
                 .extendsFrom(configContainer.findByName(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME));
 
         ApplicationDeploymentClasspathBuilder.initConfigurations(project);
+
+        // Also initialize the configurations that are specific to a LaunchMode
+        for (LaunchMode launchMode : LaunchMode.values()) {
+            new ApplicationDeploymentClasspathBuilder(project, launchMode);
+        }
     }
 
     private Set<Path> getSourcesParents(SourceSet mainSourceSet) {

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/tooling/ToolingUtils.java
@@ -4,18 +4,13 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownDomainObjectException;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.initialization.IncludedBuild;
-import org.gradle.api.plugins.JavaPlugin;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.gradle.ModelParameter;
@@ -25,29 +20,15 @@ import io.quarkus.runtime.LaunchMode;
 public class ToolingUtils {
 
     private static final String DEPLOYMENT_CONFIGURATION_SUFFIX = "Deployment";
+    private static final String PLATFORM_CONFIGURATION_SUFFIX = "Platform";
     public static final String DEV_MODE_CONFIGURATION_NAME = "quarkusDev";
 
     public static String toDeploymentConfigurationName(String baseConfigurationName) {
         return baseConfigurationName + DEPLOYMENT_CONFIGURATION_SUFFIX;
     }
 
-    public static List<Dependency> getEnforcedPlatforms(Project project) {
-        return getEnforcedPlatforms(project.getConfigurations()
-                .getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
-    }
-
-    public static List<Dependency> getEnforcedPlatforms(Configuration config) {
-        final List<org.gradle.api.artifacts.Dependency> directExtension = new ArrayList<>();
-        for (Dependency d : config.getAllDependencies()) {
-            if (!(d instanceof ModuleDependency)) {
-                continue;
-            }
-            final ModuleDependency module = (ModuleDependency) d;
-            if (isEnforcedPlatform(module)) {
-                directExtension.add(d);
-            }
-        }
-        return directExtension;
+    public static String toPlatformConfigurationName(String baseConfigurationName) {
+        return baseConfigurationName + PLATFORM_CONFIGURATION_SUFFIX;
     }
 
     public static boolean isEnforcedPlatform(ModuleDependency module) {


### PR DESCRIPTION
The purpose of this PR is to demonstrate a possible way in which the creation of Configuration objects can happen during the configuration phase, and then how the population of Configurations can be delayed until they are specifically requested by the prepare/build/generate tasks later. This allows Gradle to natively access the dependency trees that Quarkus' tasks use, which means that Gradle's analysis tools should work properly when dealing with Quarkus' dependencies.

The refactor I attempted on [ApplicationDeploymentClasspathBuilder.java](https://github.com/quarkusio/quarkus/compare/main...jskillin-idt:gradle-dependency-refactor-pr?expand=1#diff-4c1c1cd991fde67d746dd1ed3b84e95a0a14f2454ca5e64ba4e98aa195418509), in which I unified all the logic concerning how the platforms and extensions are discovered, also revealed the circular dependency between the runtime and deployment configurations. The deployment configuration must reference the runtime configuration to discover which runtime extensions are present which it then uses to discover both the deployment extensions, and any conditional runtime extension dependencies. The runtime configuration must ask the deployment configuration to resolve before it is usable, because the deployment configuration may find new runtime extensions to add. I believed that this PR was already sizeable enough so I have left this for another day.

This PR does change the Gradle API in a minor way:
* `quarkusExtension { dependencyCondition = [] }` was renamed to `quarkusExtension { dependencyConditions = [] }` since the grammar is more accurate, and the internal code already used the plural form. This can be undone if desired.

This PR otherwise should not change the end user interaction with the existing plugins. It should, however, mean that "gradle dependencies" will produce accurate, up-to-date dependency trees as Quarkus' tasks will view them, which enables "dependencyInsights" (and possibly build scans; I don't have access to them) to also properly assist with dependency conflicts, if Gradle's stricter dependency features have been enabled.


**This PR is likely lacking proper testing.** I attempted to write an integration test to cover the basics of conditional dependencies, as they were the most likely to break. I am uncertain as to how to fully test these changes to ensure nothing else broke. I'm willing to write more tests once I know what I am looking for. The integration test I wrote is also possibly not of the quality or style that the Quarkus project wants. The tests themselves are simple enough, so I could rewrite them if, again, I know what I am targeting.