### PR TITLE
Fix failure to handle non-JWT refresh tokens

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -21,6 +21,7 @@ import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.MultiMap;
 import io.vertx.mutiny.core.buffer.Buffer;
@@ -181,6 +182,8 @@ public class OidcClientImpl implements OidcClient {
                 return new JsonObject(new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
             } catch (IllegalArgumentException ex) {
                 LOG.debug("JWT token can not be decoded using the Base64Url encoding scheme");
+            } catch (DecodeException ex) {
+                LOG.debug("JWT token can not be decoded");
             }
         } else {
             LOG.debug("Access token is not formatted as the encoded JWT token");


### PR DESCRIPTION
The OIDC client is failing to handle valid responses from:

quarkus.oidc-client.token-path=https://login.microsoftonline.com/${TENANT}/oauth2/token

Due to the assumption that a "refresh_token" must be a JWT token if it is base64 encoded.

This patch ensures that a decode JWT token failure is handled the same as a base64 decode failure ie. expiry time set to null.

```posh
io.vertx.core.json.DecodeException: 
Failed to decode:Illegal character ((CTRL-CHAR, code 1)): only regular white space (\r, \n, \t) is allowed between tokens
 at [Source: (String)"\u0001_\u0000���\u0006���N��%��X�;�\u0014�Q�\u0012�J���Y\u001FE�}_\u0000u"; line: 1, column: 2]
        at io.quarkus.vertx.runtime.jackson.QuarkusJacksonJsonCodec.fromParser(QuarkusJacksonJsonCodec.java:128)
        at io.quarkus.vertx.runtime.jackson.QuarkusJacksonJsonCodec.fromString(QuarkusJacksonJsonCodec.java:95)
        at io.vertx.core.json.JsonObject.fromJson(JsonObject.java:944)
        at io.vertx.core.json.JsonObject.<init>(JsonObject.java:51)
        at io.quarkus.oidc.client.runtime.OidcClientImpl.decodeJwtToken(OidcClientImpl.java:181)
        at io.quarkus.oidc.client.runtime.OidcClientImpl.getExpiresJwtClaim(OidcClientImpl.java:166)
        at io.quarkus.oidc.client.runtime.OidcClientImpl.getExpiresAtValue(OidcClientImpl.java:161)
        at io.quarkus.oidc.client.runtime.OidcClientImpl.emitGrantTokens(OidcClientImpl.java:140)
        at io.quarkus.oidc.client.runtime.OidcClientImpl$1.lambda$get$1(OidcClientImpl.java:126)
        at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
        at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:36)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:46)
        at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:46)
        at io.smallrye.mutiny.vertx.AsyncResultUni.lambda$subscribe$1(AsyncResultUni.java:35)
        at io.vertx.mutiny.ext.web.client.HttpRequest$4.handle(HttpRequest.java:437)
        at io.vertx.mutiny.ext.web.client.HttpRequest$4.handle(HttpRequest.java:434)
        at io.vertx.ext.web.client.impl.HttpContext.handleDispatchResponse(HttpContext.java:400)
        at io.vertx.ext.web.client.impl.HttpContext.execute(HttpContext.java:387)
        at io.vertx.ext.web.client.impl.HttpContext.next(HttpContext.java:365)
        at io.vertx.ext.web.client.impl.HttpContext.fire(HttpContext.java:332)
        at io.vertx.ext.web.client.impl.HttpContext.dispatchResponse(HttpContext.java:294)
        at io.vertx.ext.web.client.impl.HttpContext.lambda$null$8(HttpContext.java:550)
        at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
        at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:63)
        at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:38)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)
```