### PR TITLE
Kubernetes docs: Replace static tables with the auto-generated tables

### DIFF
--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -44,14 +44,14 @@ For example, the presence of `src/main/jib/foo/bar` would result in  `/foo/bar` 
 
 There are cases where the built container image may need to have Java debugging conditionally enabled at runtime.
 
-When the base image has not been changed (and therefore `ubi8/openjdk-11-runtime` or `ubi8/openjdk-17-runtime` is used), then the `quarkus.jib.jvm-additional-arguments` configuration property can be used in order to
+When the base image has not been changed (and therefore `ubi8/openjdk-11-runtime` or `ubi8/openjdk-17-runtime` is used), then the `quarkus.jib.jvm-arguments` configuration property can be used in order to
 make the JVM listen on the debug port at startup.
 
 The exact configuration is:
 
 [source,properties]
 ----
-quarkus.jib.jvm-additional-arguments=-agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=n\\,address=*:5005
+quarkus.jib.jvm-arguments=-agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=n\\,address=*:5005
 ----
 
 Other base images might provide launch scripts that enable debugging when an environment variable is set, in which case you would set than environment variable when launching the container.

--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -691,54 +691,8 @@ Here are some examples:
 The table below describe all the available configuration options.
 
 .Kubernetes
-|====
-| Property                                           | Type                                      | Description | Default Value
-| quarkus.kubernetes.name                            | String                                    |             | ${quarkus.container-image.name}
-| quarkus.kubernetes.version                         | String                                    |             | ${quarkus.container-image.tag}
-| quarkus.kubernetes.deployment-kind                 | String                                    |             | Deployment
-| quarkus.kubernetes.part-of                         | String                                    |             |
-| quarkus.kubernetes.init-containers                 | Map<String, Container>                    |             |
-| quarkus.kubernetes.namespace                       | String                                    |             |
-| quarkus.kubernetes.labels                          | Map                                       |             |
-| quarkus.kubernetes.annotations                     | Map                                       |             |
-| quarkus.kubernetes.app-secret                      | String                                    |             |
-| quarkus.kubernetes.app-config-map                  | String                                    |             |
-| quarkus.kubernetes.env-vars                        | Map<String, Env>                          |             |
-| quarkus.kubernetes.working-dir                     | String                                    |             |
-| quarkus.kubernetes.command                         | String[]                                  |             |
-| quarkus.kubernetes.arguments                       | String[]                                  |             |
-| quarkus.kubernetes.replicas                        | int                                       |             | 1
-| quarkus.kubernetes.service-account                 | String                                    |             |
-| quarkus.kubernetes.ports                           | Map<String, Port>                         |             |
-| quarkus.kubernetes.service-type                    | ServiceType                               |             | ClusterIP
-| quarkus.kubernetes.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
-| quarkus.kubernetes.secret-volumes                  | Map<String, SecretVolume>                 |             |
-| quarkus.kubernetes.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
-| quarkus.kubernetes.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
-| quarkus.kubernetes.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
-| quarkus.kubernetes.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
-| quarkus.kubernetes.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
-| quarkus.kubernetes.mounts                          | Map<String, Mount>                        |             |
-| quarkus.kubernetes.image-pull-policy               | ImagePullPolicy                           |             | Always
-| quarkus.kubernetes.image-pull-secrets              | String[]                                  |             |
-| quarkus.kubernetes.liveness-probe                  | Probe                                     |             | ( see Probe )
-| quarkus.kubernetes.readiness-probe                 | Probe                                     |             | ( see Probe )
-| quarkus.kubernetes.sidecars                        | Map<String, Container>                    |             |
-| quarkus.kubernetes.ingress.expose                  | boolean                                   |             | false
-| quarkus.kubernetes.ingress.host                    | String                                    |             |
-| quarkus.kubernetes.ingress.annotations             | Map<String, String>                       |             |
-| quarkus.kubernetes.headless                        | boolean                                   |             | false
-| quarkus.kubernetes.hostaliases                     | Map<String, HostAlias>                    |             |
-| quarkus.kubernetes.resources.requests.cpu          | String                                    |             |
-| quarkus.kubernetes.resources.requests.memory       | String                                    |             |
-| quarkus.kubernetes.resources.limits.cpu            | String                                    |             |
-| quarkus.kubernetes.resources.limits.memory         | String                                    |             |
-| quarkus.kubernetes.security-context                | SecurityContext                           |             | ( see SecurityContext )
-| quarkus.kubernetes.remote-debug.enabled            | boolean                                   |             | false
-| quarkus.kubernetes.remote-debug.transport          | String                                    |             | dt_socket
-| quarkus.kubernetes.remote-debug.address-port       | int                                       |             | 5005
-| quarkus.kubernetes.remote-debug.suspend            | String                                    |             | n
-|====
+:no-duration-note: true
+include::{generated-dir}/config/quarkus-kubernetes-kubernetes-config.adoc[opts=optional, leveloffset=+1]
 
 Properties that use non-standard types, can be referenced by expanding the property.
 For example to define a `kubernetes-readiness-probe` which is of type `Probe`:
@@ -765,164 +719,8 @@ quarkus.kubernetes-client.trust-certs=true
 
 The full list of the Kubernetes client configuration properties is provided below.
 
+:no-duration-note: true
 include::{generated-dir}/config/quarkus-kubernetes-client.adoc[opts=optional, leveloffset=+1]
-
-==== Basic Types
-
-.ServiceType
-Allowed values: `cluster-ip`, `node-port`, `load-balancer`, `external-name`
-
-.Env
-|====
-| Property  | Type   | Description | Default Value
-| value     | String |             |
-| secret    | String |             |
-| configmap | String |             |
-| field     | String |             |
-|====
-
-.Probe
-|====
-| Property              | Type     | Description | Default Value
-| http-action-path      | String   |             |
-| exec-action           | String   |             |
-| tcp-socket-action     | String   |             |
-| initial-delay         | Duration |             |             0
-| period                | Duration |             |           30s
-| timeout               | Duration |             |           10s
-|====
-
-.Port
-|====
-| Property        | Type     | Description | Default Value
-| container-port  | int      |             |
-| host-port       | int      |             | 0
-| path            | String   |             | /
-| protocol        | Protocol |             | TCP
-|====
-
-.Container
-|====
-| Property          | Type                                    | Description | Default Value
-| image             | String                                  |             |
-| env-vars          | Env[]                                   |             |
-| working-dir       | String                                  |             |
-| command           | String[]                                |             |
-| arguments         | String[]                                |             |
-| ports             | Port[]                                  |             |
-| mounts            | Mount[]                                 |             |
-| image-pull-policy | ImagePullPolicy                         |             | Always
-| liveness-probe    | Probe                                   |             |
-| readiness-probe   | Probe                                   |             |
-|====
-
-.HostAlias
-|====
-| Property    | Type     | Description       | Default Value
-| hostnames   | String[] | list of hostnames |
-|====
-
-.SecurityContext
-|====
-| Property               | Type                                    | Description | Default Value
-| se-linux-options       | SeLinuxOptions                          |             |
-| windows-options        | WindowsOptions                          |             |
-| run-as-user            | long                                    |             |
-| run-as-group           | long                                    |             |
-| run-as-non-root        | boolean                                 |             |
-| supplemental-groups    | long[]                                  |             |
-| fs-group               | long                                    |             |
-| sysctls                | Map<String, String>                     |             | 
-| fs-group-change-policy | String                                  |             |
-|====
-
-.SeLinuxOptions
-|====
-| Property  | Type     | Description   | Default Value
-| level     | String   |               |
-| role      | String   |               |
-| user      | String   |               |
-| type      | String   |               |
-|====
-
-.WindowsOptions
-|====
-| Property                  | Type     | Description   | Default Value
-| gmsa-credential-spec-name | String   |               |
-| gmsa-credential-spec      | String   |               |
-| run-as-user-name          | String   |               |
-| host-process              | boolean  |               |
-|====
-
-==== Mounts and Volumes
-
-.Mount
-|====
-| Property  | Type    | Description | Default Value
-| path      | String  |             |
-| sub-path  | String  |             |
-| read-only | boolean |             | false
-|====
-
-.ConfigMapVolume
-|====
-| Property        | Type    | Description | Default Value
-| config-map-name | String  |             |
-| default-mode    | int     |             | 0600
-| optional        | boolean |             | false
-|====
-
-.SecretVolume
-|====
-| Property     | Type    | Description | Default Value
-| secret-name  | String  |             |
-| default-mode | int     |             | 0600
-| optional     | boolean |             | false
-|====
-
-
-.AzureDiskVolume
-|====
-| Property     | Type    | Description | Default Value
-| disk-name    | String  |             |
-| disk-uri     | String  |             |
-| kind         | String  |             | Managed
-| caching-mode | String  |             | ReadWrite
-| fs-type      | String  |             | ext4
-| read-only    | boolean |             | false
-|====
-
-.AwsElasticBlockStoreVolume
-|====
-| Property    | Type    | Description | Default Value
-| volume-id   | String  |             |
-| partition   | int     |             |
-| fs-type     | String  |             | ext4
-| read-only   | boolean |             | false
-|====
-
-.GitRepoVolume
-|====
-| Property    | Type   | Description | Default Value
-| repository  | String |             |
-| directory   | String |             |
-| revision    | String |             |
-|====
-
-.PersistentVolumeClaimVolume
-|====
-| Property    | Type    | Description | Default Value
-| claim-name  | String  |             |
-| read-only   | boolean |             | false
-|====
-
-.AzureFileVolume
-|====
-| Property    | Type    | Description | Default Value
-| share-name  | String  |             |
-| secret-name | String  |             |
-| read-only   | boolean |             | false
-|====
 
 [#openshift]
 === OpenShift
@@ -1016,50 +814,8 @@ relieves OpenShift users of the necessity of setting the `deployment-target` pro
 The OpenShift resources can be customized in a similar approach with Kubernetes.
 
 .OpenShift
-|====
-| Property                                          | Type                                      | Description | Default Value
-| quarkus.openshift.name                            | String                                    |             | ${quarkus.container-image.name}
-| quarkus.openshift.version                         | String                                    |             | ${quarkus.container-image.tag}
-| quarkus.openshift.deployment-kind                 | String                                    |             | DeploymentConfig
-| quarkus.openshift.part-of                         | String                                    |             |
-| quarkus.openshift.init-containers                 | Map<String, Container>                    |             |
-| quarkus.openshift.labels                          | Map                                       |             |
-| quarkus.openshift.annotations                     | Map                                       |             |
-| quarkus.openshift.app-secret                      | String                                    |             |
-| quarkus.openshift.app-config-map                  | String                                    |             |
-| quarkus.openshift.env-vars                        | Map<String, Env>                          |             |
-| quarkus.openshift.working-dir                     | String                                    |             |
-| quarkus.openshift.command                         | String[]                                  |             |
-| quarkus.openshift.arguments                       | String[]                                  |             |
-| quarkus.openshift.jvm-arguments                   | String[]                                  | The JVM arguments to pass to the JVM when starting the application            | -Dquarkus.http.host=0.0.0.0,-Djava.util.logging.manager=org.jboss.logmanager.LogManager
-| quarkus.openshift.jvm-additional-arguments        | String[]                                  | Additional JVM arguments to pass to the JVM when starting the application            |
-| quarkus.openshift.replicas                        | int                                       |             | 1
-| quarkus.openshift.service-account                 | String                                    |             |
-| quarkus.openshift.ports                           | Map<String, Port>                         |             |
-| quarkus.openshift.service-type                    | ServiceType                               |             | ClusterIP
-| quarkus.openshift.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
-| quarkus.openshift.secret-volumes                  | Map<String, SecretVolume>                 |             |
-| quarkus.openshift.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
-| quarkus.openshift.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
-| quarkus.openshift.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
-| quarkus.openshift.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
-| quarkus.openshift.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
-| quarkus.openshift.mounts                          | Map<String, Mount>                        |             |
-| quarkus.openshift.image-pull-policy               | ImagePullPolicy                           |             | Always
-| quarkus.openshift.image-pull-secrets              | String[]                                  |             |
-| quarkus.openshift.liveness-probe                  | Probe                                     |             | ( see Probe )
-| quarkus.openshift.readiness-probe                 | Probe                                     |             | ( see Probe )
-| quarkus.openshift.sidecars                        | Map<String, Container>                    |             |
-| quarkus.openshift.route.expose                    | boolean                                   |             | false
-| quarkus.openshift.route.host                      | String                                    |             |
-| quarkus.openshift.route.annotations               | Map<String, String>                       |             |
-| quarkus.openshift.headless                        | boolean                                   |             | false
-| quarkus.openshift.security-context                | SecurityContext                           |             | ( see SecurityContext )
-| quarkus.openshift.remote-debug.enabled            | boolean                                   |             | false
-| quarkus.openshift.remote-debug.transport          | String                                    |             | dt_socket
-| quarkus.openshift.remote-debug.address-port       | int                                       |             | 5005
-| quarkus.openshift.remote-debug.suspend            | String                                    |             | n
-|====
+:no-duration-note: true
+include::{generated-dir}/config/quarkus-openshift-openshift-config.adoc[opts=optional, leveloffset=+1]
 
 [#knative]
 === Knative
@@ -1123,75 +879,8 @@ kubectl apply -f target/kubernetes/knative.json
 The generated service can be customized using the following properties:
 
 .Knative
-|====
-| Property                                        | Type                                      | Description | Default Value
-| quarkus.knative.name                            | String                                    |             | ${quarkus.container-image.name}
-| quarkus.knative.version                         | String                                    |             | ${quarkus.container-image.tag}
-| quarkus.knative.part-of                         | String                                    |             |
-| quarkus.knative.init-containers                 | Map<String, Container>                    |             |
-| quarkus.knative.labels                          | Map                                       |             |
-| quarkus.knative.annotations                     | Map                                       |             |
-| quarkus.knative.app-secret                      | String                                    |             |
-| quarkus.knative.app-config-map                  | String                                    |             |
-| quarkus.knative.env-vars                        | Map<String, Env>                          |             |
-| quarkus.knative.working-dir                     | String                                    |             |
-| quarkus.knative.command                         | String[]                                  |             |
-| quarkus.knative.arguments                       | String[]                                  |             |
-| quarkus.knative.replicas                        | int                                       |             | 1
-| quarkus.knative.service-account                 | String                                    |             |
-| quarkus.knative.host                            | String                                    |             |
-| quarkus.knative.ports                           | Map<String, Port>                         |             |
-| quarkus.knative.service-type                    | ServiceType                               |             | ClusterIP
-| quarkus.knative.pvc-volumes                     | Map<String, PersistentVolumeClaimVolume>  |             |
-| quarkus.knative.secret-volumes                  | Map<String, SecretVolume>                 |             |
-| quarkus.knative.config-map-volumes              | Map<String, ConfigMapVolume>              |             |
-| quarkus.knative.git-repo-volumes                | Map<String, GitRepoVolume>                |             |
-| quarkus.knative.aws-elastic-block-store-volumes | Map<String, AwsElasticBlockStoreVolume>   |             |
-| quarkus.knative.azure-disk-volumes              | Map<String, AzureDiskVolume>              |             |
-| quarkus.knative.azure-file-volumes              | Map<String, AzureFileVolume>              |             |
-| quarkus.knative.mounts                          | Map<String, Mount>                        |             |
-| quarkus.knative.image-pull-policy               | ImagePullPolicy                           |             | Always
-| quarkus.knative.image-pull-secrets              | String[]                                  |             |
-| quarkus.knative.liveness-probe                  | Probe                                     |             | ( see Probe )
-| quarkus.knative.readiness-probe                 | Probe                                     |             | ( see Probe )
-| quarkus.knative.sidecars                        | Map<String, Container>                    |             |
-| quarkus.knative.revision-name                   | String                                    |             | 
-| quarkus.knative.traffic                         | Traffic[]                                 |             | ( see Traffic )
-| quarkus.knative.min-scale                       | int                                       | See link:https://knative.dev/docs/serving/autoscaling/scale-bounds/#lower-bound[link]  |
-| quarkus.knative.max-scale                       | int                                       | See link:https://knative.dev/docs/serving/autoscaling/scale-bounds/#upper-bound[link]  |
-| quarkus.knative.scale-to-zero-enabled           | boolean                                   | See link:https://knative.dev/docs/serving/autoscaling/scale-to-zero/#enable-scale-to-zero[link]  | true
-| quarkus.knative.revision-auto-scaling           | AutoScalingConfig                         |             | ( see AutoScalingConfig )
-| quarkus.knative.global-auto-scaling             | GlobalAutoScalingConfig                   |             | ( see GlobalAutoScalingConfig )
-| quarkus.knative.security-context                | SecurityContext                           |             | ( see SecurityContext )
-|====
-
-.Traffic
-|====
-| Property        | Type    | Description | Default Value
-| revision-name   | String  | A specific revision to which to send this portion of traffic                                    |
-| tag             | String  | Expose a dedicated url for referencing this target                                              |
-| latest-revision | Boolean | Optionally provided to indicate that the latest revision should be used for this traffic target | false 
-| percent         | Logn    | Indicates the percent of traffic that is being routed to this revision                          | 100
-|====
-
-.AutoScalingConfig
-|====
-| Property                      | Type    | Description | Default Value
-| auto-scaler-class             | String  | The auto-scaler class. Possible values: `kpa` for Knative Pod Autoscaler, `hpa` for Horizontal Pod Autoscaler | kpa
-| metric                        | String  | The autoscaling metric to use. Possible values (concurrency, rps, cpu)                    | 
-| target                        | int     | This value specifies the autoscaling target                                               |  
-| container-concurrency         | int     | The exact amount of requests allowed to the replica at a time                             | 
-| target-utilization-percentage | int     | This value specifies a percentage of the target to actually be targeted by the autoscaler |  
-|====
-
-.GlobalAutoScalingConfig
-|====
-| Property                      | Type    | Description | Default Value
-| auto-scaler-class             | String  | The auto-scaler class. Possible values: `kpa` for Knative Pod Autoscaler, `hpa` for Horizontal Pod Autoscaler | kpa
-| container-concurrency         | int     | The exact amount of requests allowed to the replica at a time                             | 
-| target-utilization-percentage | int     | This value specifies a percentage of the target to actually be targeted by the autoscaler |  
-| requests-per-second           | Logn    | The requests per second per replica                                                       | 
-|====
+:no-duration-note: true
+include::{generated-dir}/config/quarkus-knative-knative-config.adoc[opts=optional, leveloffset=+1]
 
 === Deployment targets
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftConfig.java
@@ -70,20 +70,14 @@ public class OpenshiftConfig {
     /**
      * The JVM arguments to pass to the JVM when starting the application
      */
-    @ConfigItem(defaultValue = "-Dquarkus.http.host=0.0.0.0,-Djava.util.logging.manager=org.jboss.logmanager.LogManager")
-    public List<String> jvmArguments;
-
-    /**
-     * Additional JVM arguments to pass to the JVM when starting the application
-     */
     @ConfigItem
-    public Optional<List<String>> jvmAdditionalArguments;
+    public Optional<List<String>> jvmArguments;
 
     /**
      * Additional arguments to pass when starting the native application
      */
-    @ConfigItem(defaultValue = "-Dquarkus.http.host=0.0.0.0")
-    public List<String> nativeArguments;
+    @ConfigItem
+    public Optional<List<String>> nativeArguments;
 
     /**
      * The directory where the jar is added during the assemble phase.
@@ -159,8 +153,8 @@ public class OpenshiftConfig {
      * @return the effective JVM arguments to use by getting the jvmArguments and the jvmAdditionalArguments properties.
      */
     public List<String> getEffectiveJvmArguments() {
-        List<String> effectiveJvmArguments = new ArrayList<>(jvmArguments);
-        jvmAdditionalArguments.ifPresent(effectiveJvmArguments::addAll);
+        List<String> effectiveJvmArguments = new ArrayList<>();
+        jvmArguments.ifPresent(effectiveJvmArguments::addAll);
         return effectiveJvmArguments;
     }
 

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -202,12 +202,16 @@ public class OpenshiftProcessor {
             baseImage.ifPresent(b -> {
                 envProducer.produce(
                         KubernetesEnvBuildItem.createSimpleVar(b.getHomeDirEnvVar(), nativeBinaryDirectory, OPENSHIFT));
-                envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(),
-                        String.join(" ", config.nativeArguments), OPENSHIFT));
+                config.nativeArguments.ifPresent(nativeArguments -> {
+                    envProducer.produce(KubernetesEnvBuildItem.createSimpleVar(b.getOptsEnvVar(),
+                            String.join(" ", nativeArguments), OPENSHIFT));
+                });
+
             });
 
-            if (!baseImage.isPresent()) {
-                commandProducer.produce(KubernetesCommandBuildItem.commandWithArgs(pathToNativeBinary, config.nativeArguments));
+            if (!baseImage.isPresent() && config.nativeArguments.isPresent()) {
+                commandProducer
+                        .produce(KubernetesCommandBuildItem.commandWithArgs(pathToNativeBinary, config.nativeArguments.get()));
             }
         }
     }

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftUtils.java
@@ -101,7 +101,6 @@ public class OpenshiftUtils {
         boolean hasS2iBaseJvmImage = properties.contains("quarkus.s2i.base-jvm-image");
         boolean hasS2iBaseNativeImage = properties.contains("quarkus.s2i.base-native-image");
         boolean hasS2iJvmArguments = properties.contains("quarkus.s2i.jvm-arguments");
-        boolean hasS2iJvmAdditionalArguments = properties.contains("quarkus.s2i.jvm-additional-arguments");
         boolean hasS2iNativeArguments = properties.contains("quarkus.s2i.native-arguments");
         boolean hasS2iJarDirectory = properties.contains("quarkus.s2i.jar-directory");
         boolean hasS2iJarFileName = properties.contains("quarkus.s2i.jar-file-name");
@@ -112,7 +111,6 @@ public class OpenshiftUtils {
         boolean hasOpenshiftBaseJvmImage = properties.contains("quarkus.openshift.base-jvm-image");
         boolean hasOpenshiftBaseNativeImage = properties.contains("quarkus.openshift.base-native-image");
         boolean hasOpenshiftJvmArguments = properties.contains("quarkus.openshift.jvm-arguments");
-        boolean hasOpenshiftJvmAdditionalArguments = properties.contains("quarkus.openshift.jvm-additional-arguments");
         boolean hasOpenshiftNativeArguments = properties.contains("quarkus.openshift.native-arguments");
         boolean hasOpenshiftJarDirectory = properties.contains("quarkus.openshift.jar-directory");
         boolean hasOpenshiftJarFileName = properties.contains("quarkus.openshift.jar-file-name");
@@ -126,9 +124,6 @@ public class OpenshiftUtils {
                 : openshiftConfig.baseNativeImage;
         result.jvmArguments = hasS2iJvmArguments && !hasOpenshiftJvmArguments ? s2iConfig.jvmArguments
                 : openshiftConfig.jvmArguments;
-        result.jvmAdditionalArguments = hasS2iJvmAdditionalArguments && !hasOpenshiftJvmAdditionalArguments
-                ? s2iConfig.jvmAdditionalArguments
-                : openshiftConfig.jvmAdditionalArguments;
         result.nativeArguments = hasS2iNativeArguments && !hasOpenshiftNativeArguments ? s2iConfig.nativeArguments
                 : openshiftConfig.nativeArguments;
         result.jarDirectory = hasS2iJarDirectory && !hasOpenshiftJarDirectory ? Optional.of(s2iConfig.jarDirectory)

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iConfig.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/S2iConfig.java
@@ -57,20 +57,14 @@ public class S2iConfig {
     /**
      * The JVM arguments to pass to the JVM when starting the application
      */
-    @ConfigItem(defaultValue = "-Dquarkus.http.host=0.0.0.0,-Djava.util.logging.manager=org.jboss.logmanager.LogManager")
-    public List<String> jvmArguments;
-
-    /**
-     * Additional JVM arguments to pass to the JVM when starting the application
-     */
     @ConfigItem
-    public Optional<List<String>> jvmAdditionalArguments;
+    public Optional<List<String>> jvmArguments;
 
     /**
      * Additional arguments to pass when starting the native application
      */
-    @ConfigItem(defaultValue = "-Dquarkus.http.host=0.0.0.0")
-    public List<String> nativeArguments;
+    @ConfigItem
+    public Optional<List<String>> nativeArguments;
 
     /**
      * The directory where the jar is added during the assemble phase.

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmAdditionalArgumentsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmAdditionalArgumentsTest.java
@@ -47,8 +47,6 @@ public class OpenshiftWithJvmAdditionalArgumentsTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getCommand()).containsExactly("java",
-                                    "-Dquarkus.http.host=0.0.0.0",
-                                    "-Djava.util.logging.manager=org.jboss.logmanager.LogManager",
                                     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005",
                                     "-jar",
                                     "/deployments/quarkus-run.jar");

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-jvm-additional-arguments.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-jvm-additional-arguments.properties
@@ -1,2 +1,2 @@
 quarkus.kubernetes.deployment-target=openshift
-quarkus.openshift.jvm-additional-arguments=-agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=n\\,address=*:5005
+quarkus.openshift.jvm-arguments=-agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=n\\,address=*:5005

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-s2i.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-s2i.properties
@@ -1,2 +1,3 @@
 quarkus.openshift.expose=true
 quarkus.s2i.base-jvm-image=my.registry.example/openjdk/openjdk-11-rhel7
+quarkus.s2i.jvm-arguments=-Djava.util.logging.manager=org.jboss.logmanager.LogManager


### PR DESCRIPTION
I found out that some properties were not synced between the content in the Kubernetes guide and the config-all page (which uses the auto generated table). 

Let's use the auto-generated tables also in the Kubernetes guide, so we avoid having to maintain these properties, plus also having to explain the inner basic types (as it's already part of the auto generated table).