### PR TITLE
Make reactive-oracle-client depend on jdbc-oracle

### DIFF
--- a/.github/native-tests.json
+++ b/.github/native-tests.json
@@ -45,7 +45,7 @@
         {
             "category": "Data7",
             "timeout": 65,
-            "test-modules": "reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql",
+            "test-modules": "reactive-oracle-client, reactive-mysql-client, reactive-db2-client, hibernate-reactive-db2, hibernate-reactive-mysql",
             "os-name": "ubuntu-latest"
         },
         {

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DefaultDataSourceDbKindBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DefaultDataSourceDbKindBuildItem.java
@@ -76,7 +76,7 @@ public final class DefaultDataSourceDbKindBuildItem extends MultiBuildItem {
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
         if (defaultDbKinds.isEmpty()) {
             return Optional.empty();
-        } else if (defaultDbKinds.size() == 1) {
+        } else if (defaultDbKinds.stream().map(DefaultDataSourceDbKindBuildItem::getDbKind).distinct().count() == 1) {
             return Optional.of(defaultDbKinds.get(0).dbKind);
         } else {
             //if we have one and only one test scoped driver we assume it is the default

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -21,6 +21,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-datasource-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/reactive-oracle-client/runtime/pom.xml
+++ b/extensions/reactive-oracle-client/runtime/pom.xml
@@ -17,6 +17,14 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-oracle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-datasource</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes #25415

Reactive Oracle Client extension does not work in native mode.
Instead of duplicating code, this PR makes the reactive client extension depend on jdbc client extension.

Also, it enables Reactive Oracle Client integration tests in native mode.