### PR TITLE
Better message for bad exec fmt with native test

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +95,16 @@ public final class LauncherUtil {
                     "Interrupted while waiting to determine the status of process '" + quarkusProcess.pid() + "'.");
         }
         if (!quarkusProcess.isAlive()) {
-            throw new RuntimeException("Unable to successfully launch process '" + quarkusProcess.pid() + "'. Exit code is: '"
-                    + quarkusProcess.exitValue() + "'.");
+            int exit = quarkusProcess.exitValue();
+            String message = "Unable to successfully launch process '" + quarkusProcess.pid() + "'. Exit code is: '"
+                    + exit + "'.";
+            String osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ROOT);
+            boolean isMac = osName.contains("mac") || osName.contains("darwin");
+            if (isMac && exit == 126) {
+                message += System.lineSeparator()
+                        + "This may be caused by building the native binary in a Linux container while the host is macOS.";
+            }
+            throw new RuntimeException(message);
         }
     }
 

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +25,7 @@ import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.QuarkusConfigFactory;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
+import io.quarkus.utilities.OS;
 import io.smallrye.config.SmallRyeConfig;
 
 public final class LauncherUtil {
@@ -98,9 +98,7 @@ public final class LauncherUtil {
             int exit = quarkusProcess.exitValue();
             String message = "Unable to successfully launch process '" + quarkusProcess.pid() + "'. Exit code is: '"
                     + exit + "'.";
-            String osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ROOT);
-            boolean isMac = osName.contains("mac") || osName.contains("darwin");
-            if (isMac && exit == 126) {
+            if (OS.determineOS().equals(OS.MAC) && exit == 126) {
                 message += System.lineSeparator()
                         + "This may be caused by building the native binary in a Linux container while the host is macOS.";
             }


### PR DESCRIPTION
When native executable test fails with `code==126` on `macOS` its likely caused by building Linux ELF in container.
Improving message to indicate this.

Related to: https://github.com/quarkusio/quarkus/issues/24860