### PR TITLE
Clean up directory-related properties

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/QuarkusPlugin.java
@@ -101,12 +101,15 @@ public class QuarkusPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         verifyGradleVersion();
+
+        // Apply the `java` plugin
+        project.getPluginManager().apply(JavaPlugin.class);
+
         registerModel();
+
         // register extension
         final QuarkusPluginExtension quarkusExt = project.getExtensions().create(EXTENSION_NAME, QuarkusPluginExtension.class,
                 project);
-        // register plugin
-        project.getPluginManager().apply(JavaPlugin.class);
 
         registerTasks(project, quarkusExt);
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -52,10 +52,9 @@ public class QuarkusPluginExtension {
     public QuarkusPluginExtension(Project project) {
         this.project = project;
 
-        finalName = project.getObjects().property( String.class );
-        finalName.convention( project.provider(
-                () -> String.format("%s-%s", project.getName(), project.getVersion() )
-        ) );
+        finalName = project.getObjects().property(String.class);
+        finalName.convention(project.provider(
+                () -> String.format("%s-%s", project.getName(), project.getVersion())));
 
         final SourceSet mainSourceSet = getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
@@ -63,7 +62,8 @@ public class QuarkusPluginExtension {
         outputDirectory.convention(mainSourceSet.getJava().getDestinationDirectory());
 
         sourceDirectory = project.getObjects().directoryProperty();
-        sourceDirectory.convention(mainSourceSet.getJava().getSourceDirectories().getElements().map(QuarkusPluginExtension::lastDirectory));
+        sourceDirectory.convention(
+                mainSourceSet.getJava().getSourceDirectories().getElements().map(QuarkusPluginExtension::lastDirectory));
 
         workingDirectory = project.getObjects().directoryProperty();
         workingDirectory.convention(outputDirectory);
@@ -198,7 +198,7 @@ public class QuarkusPluginExtension {
      * @see #getFinalName()
      */
     public String finalName() {
-		return finalName.get();
+        return finalName.get();
     }
 
     /**
@@ -206,7 +206,7 @@ public class QuarkusPluginExtension {
      */
     @Deprecated
     public void setFinalName(String value) {
-        finalName.set( value );
+        finalName.set(value);
     }
 
     public void sourceSets(Action<? super SourceSetExtension> action) {
@@ -263,14 +263,14 @@ public class QuarkusPluginExtension {
      * Needed for the Scala plugin.
      */
     public static Provider<Directory> lastDirectoryProvider(FileCollection fileCollection) {
-        return fileCollection.getElements().map( QuarkusPluginExtension::lastDirectory );
+        return fileCollection.getElements().map(QuarkusPluginExtension::lastDirectory);
     }
 
     public static Directory lastDirectory(Set<FileSystemLocation> locations) {
         Directory result = null;
 
-        for ( FileSystemLocation fileSystemLocation : locations ) {
-            if ( fileSystemLocation instanceof Directory ) {
+        for (FileSystemLocation fileSystemLocation : locations) {
+            if (fileSystemLocation instanceof Directory) {
                 result = (Directory) fileSystemLocation;
             }
         }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.RegularFile;
@@ -37,15 +36,7 @@ public class QuarkusPluginExtension {
 
     private final Project project;
 
-    private final DirectoryProperty outputDirectory;
-
     private final Property<String> finalName;
-
-    private final DirectoryProperty sourceDirectory;
-
-    private final DirectoryProperty workingDirectory;
-
-    private final DirectoryProperty outputConfigDirectory;
 
     private final SourceSetExtension sourceSetExtension;
 
@@ -57,19 +48,6 @@ public class QuarkusPluginExtension {
                 () -> String.format("%s-%s", project.getName(), project.getVersion())));
 
         final SourceSet mainSourceSet = getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-
-        outputDirectory = project.getObjects().directoryProperty();
-        outputDirectory.convention(mainSourceSet.getJava().getDestinationDirectory());
-
-        sourceDirectory = project.getObjects().directoryProperty();
-        sourceDirectory.convention(
-                mainSourceSet.getJava().getSourceDirectories().getElements().map(QuarkusPluginExtension::lastDirectory));
-
-        workingDirectory = project.getObjects().directoryProperty();
-        workingDirectory.convention(outputDirectory);
-
-        outputConfigDirectory = project.getObjects().directoryProperty();
-        outputConfigDirectory.convention(mainSourceSet.getResources().getDestinationDirectory());
 
         this.sourceSetExtension = new SourceSetExtension();
     }
@@ -139,52 +117,85 @@ public class QuarkusPluginExtension {
         return classesDir;
     }
 
-    public DirectoryProperty getOutputDirectory() {
-        return outputDirectory;
-    }
-
-    public File outputDirectory() {
-        return getOutputDirectory().get().getAsFile();
-    }
-
-    public void setOutputDirectory(String outputDirectory) {
-        this.outputDirectory.set(new File(outputDirectory));
-    }
-
-    public DirectoryProperty getOutputConfigDirectory() {
-        return outputConfigDirectory;
-    }
-
-    public File outputConfigDirectory() {
-        return getOutputConfigDirectory().get().getAsFile();
-    }
-
-    public void setOutputConfigDirectory(String outputConfigDirectory) {
-        this.outputConfigDirectory.set(new File(outputConfigDirectory));
-    }
-
-    public DirectoryProperty getSourceDirectory() {
-        return sourceDirectory;
-    }
-
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
     public File sourceDir() {
-        return getSourceDirectory().get().getAsFile();
+        project.getLogger().warn("Unsupported property `{}#sourceDir`", getClass().getName());
+        return getLastFile(getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getAllJava());
     }
 
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
     public void setSourceDir(String sourceDir) {
-        this.sourceDirectory.set(new File(sourceDir));
+        project.getLogger().warn("Unsupported property `{}#sourceDir`", getClass().getName());
     }
 
-    public DirectoryProperty getWorkingDirectory() {
-        return workingDirectory;
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
+    public File outputDirectory() {
+        project.getLogger().warn("Unsupported property `{}#outputDirectory`", getClass().getName());
+
+        return getSourceSets()
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                .getAllJava()
+                .getDestinationDirectory()
+                .get()
+                .getAsFile();
     }
 
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
+    public void setOutputDirectory(String outputDirectory) {
+        project.getLogger().warn("Unsupported property `{}#outputDirectory`", getClass().getName());
+    }
+
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
+    public File outputConfigDirectory() {
+        project.getLogger().warn("Unsupported property `{}#outputConfigDirectory`", getClass().getName());
+
+        return getSourceSets()
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                .getResources()
+                .getDestinationDirectory()
+                .get()
+                .getAsFile();
+    }
+
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
+    public void setOutputConfigDirectory(String outputConfigDirectory) {
+        project.getLogger().warn("Unsupported property `{}#outputConfigDirectory`", getClass().getName());
+    }
+
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
     public File workingDir() {
-        return getWorkingDirectory().get().getAsFile();
+        project.getLogger().warn("Unsupported property `{}#workingDir`", getClass().getName());
+        return outputDirectory();
     }
 
+    /**
+     * @deprecated Unsupported
+     */
+    @Deprecated
     public void setWorkingDir(String workingDir) {
-        this.workingDirectory.set(new File(workingDir));
+        project.getLogger().warn("Unsupported property `{}#workingDir`", getClass().getName());
+        setOutputDirectory(workingDir);
     }
 
     /**

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -51,17 +51,17 @@ public class QuarkusBuild extends QuarkusTask {
 
         ignoredEntries = getProject().getObjects().listProperty(String.class);
 
-        runnerJar = getProject().getLayout().getBuildDirectory().file( runnerJarName() );
-        nativeRunner = getProject().getLayout().getBuildDirectory().file( nativeRunnerName() );
-        fastJar = getProject().getLayout().getBuildDirectory().file( "quarkus-app" );
+        runnerJar = getProject().getLayout().getBuildDirectory().file(runnerJarName());
+        nativeRunner = getProject().getLayout().getBuildDirectory().file(nativeRunnerName());
+        fastJar = getProject().getLayout().getBuildDirectory().file("quarkus-app");
     }
 
     private Provider<String> runnerJarName() {
-        return extension().getFinalName().map( (finalName) -> finalName + "-runner.jar" );
+        return extension().getFinalName().map((finalName) -> finalName + "-runner.jar");
     }
 
     private Provider<String> nativeRunnerName() {
-        return extension().getFinalName().map( (finalName) -> finalName + "-runner" );
+        return extension().getFinalName().map((finalName) -> finalName + "-runner");
     }
 
     public QuarkusBuild nativeArgs(Action<Map<String, ?>> action) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusBuild.java
@@ -138,7 +138,7 @@ public class QuarkusBuild extends QuarkusTask {
 
     /**
      * Same as {@link #getRunnerJarFile()}, except this method resolves the value.
-     * <p/>
+     * <p>
      * Prefer {@link #getRunnerJarFile()} for delayed configuration
      */
     @Internal
@@ -153,7 +153,7 @@ public class QuarkusBuild extends QuarkusTask {
 
     /**
      * Same as {@link #getNativeRunnerFile()}, except this method resolves the value.
-     * <p/>
+     * <p>
      * Prefer {@link #getNativeRunnerFile()} for delayed configuration
      */
     @Internal
@@ -168,7 +168,7 @@ public class QuarkusBuild extends QuarkusTask {
 
     /**
      * Same as {@link #getFastJarFile()}, except this method resolves the value.
-     * <p/>
+     * <p>
      * Prefer {@link #getFastJarFile()} for delayed configuration
      */
     @Internal

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -243,6 +243,7 @@ public class QuarkusDev extends QuarkusTask {
         return compilerArgs;
     }
 
+    @Internal
     public List<String> getCompilerArgs() {
         return getCompilerArguments().get();
     }

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -15,8 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
 import javax.inject.Inject;
 
+import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -67,7 +69,6 @@ import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
-import org.apache.tools.ant.types.Commandline;
 
 public class QuarkusDev extends QuarkusTask {
 

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRemoteDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusRemoteDev.java
@@ -1,9 +1,15 @@
 package io.quarkus.gradle.tasks;
 
+import javax.inject.Inject;
+
+import org.gradle.api.artifacts.Configuration;
+
 public class QuarkusRemoteDev extends QuarkusDev {
 
-    public QuarkusRemoteDev() {
-        super("Remote development mode: enables hot deployment on remote JVM with background compilation");
+    @Inject
+    public QuarkusRemoteDev(Configuration quarkusDevDependencies) {
+        super("Remote development mode: enables hot deployment on remote JVM with background compilation",
+                quarkusDevDependencies);
     }
 
     protected void modifyDevModeContext(GradleDevModeLauncher.Builder builder) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusTest.java
@@ -2,13 +2,18 @@ package io.quarkus.gradle.tasks;
 
 import java.util.function.Consumer;
 
+import javax.inject.Inject;
+
+import org.gradle.api.artifacts.Configuration;
+
 import io.quarkus.deployment.dev.DevModeContext;
 import io.quarkus.deployment.dev.IsolatedTestModeMain;
 
 public class QuarkusTest extends QuarkusDev {
 
-    public QuarkusTest() {
-        super("Continuous testing mode: enables continuous testing without starting dev mode");
+    @Inject
+    public QuarkusTest(Configuration quarkusDevDependencies) {
+        super("Continuous testing mode: enables continuous testing without starting dev mode", quarkusDevDependencies);
     }
 
     protected void modifyDevModeContext(GradleDevModeLauncher.Builder builder) {


### PR DESCRIPTION
Builds on top of https://github.com/quarkusio/quarkus/pull/25633

I marked the accessors as deprecated and logged a warning when they are accessed.

The setters do nothing.  The getters return what they used to when possible.

For now, I also left `@Option` in places.  If someone did happen to be using it it would get caught up in this same processing.  See https://github.com/quarkusio/quarkus/pull/25615#issuecomment-1129001108