### PR TITLE
Fix for OpenAPI documentation for 401 and 403 responses being overridden when using @RolesAllowed

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoRolesAllowedFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/main/java/io/quarkus/smallrye/openapi/deployment/filter/AutoRolesAllowedFilter.java
@@ -95,7 +95,9 @@ public class AutoRolesAllowedFilter implements OASFilter {
                                     operation = operation.addSecurityRequirement(securityRequirement);
                                     APIResponses responses = operation.getResponses();
                                     for (APIResponseImpl response : getSecurityResponses()) {
-                                        responses.addAPIResponse(response.getResponseCode(), response);
+                                        if (!responses.hasAPIResponse(response.getResponseCode())) {
+                                            responses.addAPIResponse(response.getResponseCode(), response);
+                                        }
                                     }
                                     operation = operation.responses(responses);
                                 } else if (hasAuthenticatedMethodReferences()
@@ -105,7 +107,9 @@ public class AutoRolesAllowedFilter implements OASFilter {
                                     operation = operation.addSecurityRequirement(securityRequirement);
                                     APIResponses responses = operation.getResponses();
                                     for (APIResponseImpl response : getSecurityResponses()) {
-                                        responses.addAPIResponse(response.getResponseCode(), response);
+                                        if (!responses.hasAPIResponse(response.getResponseCode())) {
+                                            responses.addAPIResponse(response.getResponseCode(), response);
+                                        }
                                     }
                                     operation = operation.responses(responses);
                                 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/AutoSecurityRolesAllowedTestCase.java
@@ -55,4 +55,78 @@ public class AutoSecurityRolesAllowedTestCase {
 
     }
 
+    @Test
+    public void testOpenAPIAnnotations() {
+        RestAssured.given().header("Accept", "application/json")
+                .when().get("/q/openapi")
+                .then()
+                .log().body()
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/1'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/1'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/2'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/2'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/3'.get.responses.401.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/3'.get.responses.403.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/4'.get.responses.401.description",
+                        Matchers.equalTo("Who are you?"))
+                .and()
+                .body("paths.'/resource2/test-security/classLevel/4'.get.responses.403.description",
+                        Matchers.equalTo("You cannot do that."))
+                .and()
+                .body("paths.'/resource2/test-security/naked'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/naked'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/annotated'.get.responses.401.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/annotated'.get.responses.403.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/1'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/1'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/2'.get.responses.401.description",
+                        Matchers.equalTo("Not Authorized"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/2'.get.responses.403.description",
+                        Matchers.equalTo("Not Allowed"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/public'.get.responses.401.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/public'.get.responses.403.description",
+                        Matchers.nullValue())
+                .and()
+                .body("paths.'/resource2/test-security/annotated/documented'.get.responses.401.description",
+                        Matchers.equalTo("Who are you?"))
+                .and()
+                .body("paths.'/resource2/test-security/annotated/documented'.get.responses.403.description",
+                        Matchers.equalTo("You cannot do that."))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/3'.get.responses.401.description",
+                        Matchers.equalTo("Who are you?"))
+                .and()
+                .body("paths.'/resource2/test-security/methodLevel/3'.get.responses.403.description",
+                        Matchers.equalTo("You cannot do that."));
+    }
+
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtClassLevel.java
@@ -4,6 +4,8 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -32,6 +34,16 @@ public class OpenApiResourceSecuredAtClassLevel {
     @Path("/test-security/classLevel/3")
     @SecurityRequirement(name = "MyOwnName")
     public String secureEndpoint3() {
+        return "secret";
+    }
+
+    @APIResponses({
+            @APIResponse(responseCode = "401", description = "Who are you?"),
+            @APIResponse(responseCode = "403", description = "You cannot do that.")
+    })
+    @GET
+    @Path("/test-security/classLevel/4")
+    public String secureEndpoint4() {
         return "secret";
     }
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiResourceSecuredAtMethodLevel.java
@@ -4,6 +4,8 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -48,6 +50,29 @@ public class OpenApiResourceSecuredAtMethodLevel {
     @Path("/test-security/methodLevel/public")
     public String publicEndpoint() {
         return "boo";
+    }
+
+    @APIResponses({
+            @APIResponse(responseCode = "401", description = "Who are you?"),
+            @APIResponse(responseCode = "403", description = "You cannot do that.")
+    })
+    @GET
+    @Path("/test-security/annotated/documented")
+    @RolesAllowed("admin")
+    @SecurityRequirement(name = "JWTCompanyAuthentication")
+    public String secureEndpointWithSecurityAnnotationAndDocument() {
+        return "secret";
+    }
+
+    @APIResponses({
+            @APIResponse(responseCode = "401", description = "Who are you?"),
+            @APIResponse(responseCode = "403", description = "You cannot do that.")
+    })
+    @GET
+    @Path("/test-security/methodLevel/3")
+    @RolesAllowed("admin")
+    public String secureEndpoint3() {
+        return "secret";
     }
 
 }


### PR DESCRIPTION
Fix #23534
Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>