### PR TITLE
Fix adding of Qute Custom Template Locators

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -1176,11 +1176,10 @@ engineBuilder.addValueResolver(ValueResolver.builder()
 [[template-locator]]
 ==== Template Locator
 
-Manual registration is sometimes handy but it's also possible to register a template locator using `EngineBuilder.addLocator()`.
-This locator is used whenever the `Engine.getTemplate()` method is called and the engine has no template for a given id stored in the cache.
+A template can be either registered manually or automatically via a template locator. The locators are used whenever the `Engine.getTemplate()` method is called and the engine has no template for a given id stored in the cache.
 The locator is responsible to use the correct character encoding when reading the contents of a template.
 
-NOTE: In Quarkus, all templates from the `src/main/resources/templates` are located automatically and the encoding set via `quarkus.qute.default-charset` (UTF-8 by default) is used.
+NOTE: In Quarkus, all templates from the `src/main/resources/templates` are located automatically and the encoding set via `quarkus.qute.default-charset` (UTF-8 by default) is used. Custom locators can be <<template-locator-registration,registered>> via the `@Locate` annotation.
 
 ==== Content Filters
 
@@ -1274,6 +1273,34 @@ class MyBean {
     }
 }
 ----
+
+[[template-locator-registration]]
+=== Template Locator Registration
+
+The easiest way to register <<template-locator,template locators>> is to make them CDI beans.
+As the custom locator is not available during the build time when a template validation is done, you need to disable the validation via the `@Locate` annotation.
+
+.Custom Locator Example
+[source,java]
+----
+@Locate("bar.html") <1>
+@Locate("foo.*") <2>
+public class CustomLocator implements TemplateLocator {
+
+    @Inject <3>
+    MyLocationService myLocationService;
+
+    @Override
+    public Optional<TemplateLocation> locate(String templateId) {
+
+        return myLocationService.getTemplateLocation(templateId);
+    }
+
+}
+----
+<1> A template named `bar.html` is located by the custom locator at runtime.
+<2> A regular expression `foo.*` disables validation for templates whose name is starting with `foo`.
+<3> Injection fields are resolved as template locators annotated with `@Locate` are registered as singleton session beans.
 
 === Template Variants
 
@@ -2270,7 +2297,7 @@ You'll need to configure a new instance via `Engine.builder()`.
 
 Templates:: 
 * By default, no <<template-locator,template locators>> are registered, i.e. `Engine.getTemplate(String)` will not work. 
-* You can register a custom template locator or parse a template manually and put the reulst in the cache via `Engine.putTemplate(String, Template)`.
+* You can register a custom template locator using `EngineBuilder.addLocator()` or parse a template manually and put the result in the cache via `Engine.putTemplate(String, Template)`.
 
 Sections::
 * No section helpers are registered by default.

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CustomTemplateLocatorPatternsBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/CustomTemplateLocatorPatternsBuildItem.java
@@ -1,0 +1,24 @@
+package io.quarkus.qute.deployment;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * List of template locations in form of RegEx located by custom locators that must not be validated as custom
+ * locators are not available at build time.
+ */
+public final class CustomTemplateLocatorPatternsBuildItem extends SimpleBuildItem {
+
+    private final Collection<Pattern> locationPatterns;
+
+    public CustomTemplateLocatorPatternsBuildItem(
+            Collection<Pattern> locationPatterns) {
+        this.locationPatterns = locationPatterns;
+    }
+
+    public Collection<Pattern> getLocationPatterns() {
+        return locationPatterns;
+    }
+}

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/Names.java
@@ -9,10 +9,13 @@ import java.util.stream.Stream;
 
 import org.jboss.jandex.DotName;
 
+import io.quarkus.qute.Locate;
+import io.quarkus.qute.Locate.Locates;
 import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateEnum;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.TemplateLocator;
 import io.quarkus.qute.i18n.Localized;
 import io.quarkus.qute.i18n.Message;
 import io.quarkus.qute.i18n.MessageBundle;
@@ -33,9 +36,12 @@ final class Names {
     static final DotName MAP_ENTRY = DotName.createSimple(Entry.class.getName());
     static final DotName COLLECTION = DotName.createSimple(Collection.class.getName());
     static final DotName TEMPLATE_INSTANCE = DotName.createSimple(TemplateInstance.class.getName());
+    static final DotName TEMPLATE_LOCATOR = DotName.createSimple(TemplateLocator.class.getName());
     static final DotName COMPLETION_STAGE = DotName.createSimple(CompletionStage.class.getName());
     static final DotName UNI = DotName.createSimple(Uni.class.getName());
     static final DotName LOCATION = DotName.createSimple(Location.class.getName());
+    static final DotName LOCATE = DotName.createSimple(Locate.class.getName());
+    static final DotName LOCATES = DotName.createSimple(Locates.class.getName());
     static final DotName CHECKED_TEMPLATE = DotName.createSimple(io.quarkus.qute.CheckedTemplate.class.getName());
     static final DotName TEMPLATE_ENUM = DotName.createSimple(TemplateEnum.class.getName());
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/BlankLocateValueTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/BlankLocateValueTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.qute.deployment.templatelocator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Locate;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateLocator;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class BlankLocateValueTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(CustomLocator.class))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof TemplateException) {
+                    assertTrue(rootCause.getMessage().contains(
+                            "'io.quarkus.qute.Locate#value()' must not be blank"));
+                } else {
+                    fail("No TemplateException thrown: " + t);
+                }
+            });
+
+    @Test
+    void failValidation() {
+        fail();
+    }
+
+    @Locate("  ")
+    public static class CustomLocator implements TemplateLocator {
+
+        @Override
+        public Optional<TemplateLocation> locate(String s) {
+
+            return Optional.empty();
+        }
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/CustomTemplateLocatorTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/CustomTemplateLocatorTest.java
@@ -1,0 +1,241 @@
+package io.quarkus.qute.deployment.templatelocator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.All;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.Locate;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.TemplateLocator;
+import io.quarkus.qute.Variant;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CustomTemplateLocatorTest {
+
+    private static final String TEMPLATE_LOCATION_1 = "/path/to/my/custom/template/basic.html";
+    private static final String TEMPLATE_LOCATION_2 = "/second/path/to/my/custom/template/regular.html";
+    private static final String TEMPLATE_LOCATION_3 = "/third/path/to/my/custom/template/custom.html";
+    private static final String TEMPLATE_LOCATION_4 = "/fourth/path/to/my/custom/template/custom.html";
+    private static final String TEMPLATE_LOCATION_5 = "/fifth/path/to/my/custom/template/custom.html";
+    private static final String CHECKED_TEMPLATE_LOCATION = "my_checked_template_base/myCheckedTemplate";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(CustomLocator1.class, CustomLocator2.class, CustomLocator3.class,
+                            TemplateValueProvider.class));
+
+    @Location(TEMPLATE_LOCATION_1)
+    Template template1;
+
+    @Location(TEMPLATE_LOCATION_2)
+    Template template2;
+
+    @Location(TEMPLATE_LOCATION_3)
+    Template template3;
+
+    @Location(TEMPLATE_LOCATION_4)
+    Template template4;
+
+    @Location(TEMPLATE_LOCATION_5)
+    Template template5;
+
+    @All
+    @Inject
+    List<TemplateLocator> locatorList;
+
+    @Test
+    public void testCustomLocatorRegistration1() {
+        assertEquals("Basic Qute Template!", template1.data("name", "Qute Template").render());
+    }
+
+    @Test
+    public void testCustomLocatorRegistration2() {
+        assertEquals("Regular test template data!", template2.data("name", "test template data").render());
+    }
+
+    @Test
+    public void testCustomLocatorRegistration3() {
+        assertEquals("Custom name!", template3.data("name", "name").render());
+    }
+
+    @Test
+    public void testCustomLocatorRegistration4() {
+        assertEquals("Custom template 4 customName!", template4.data("name", "customName").render());
+    }
+
+    @Test
+    public void testCustomLocatorRegistration5() {
+        assertEquals("Custom template 5 customName!", template5.data("name", "customName").render());
+    }
+
+    @Test
+    public void testCheckedTemplate() {
+        assertEquals("My Checked Template Number: 3", Templates.myCheckedTemplate(3).render());
+    }
+
+    @Test
+    public void testLocatorsAreRegisteredAsSingletons() {
+        assertEquals(4, locatorList.size());
+    }
+
+    @Singleton
+    public static class TemplateValueProvider {
+
+        public String getTemplateValue() {
+            return "Basic {name}!";
+        }
+    }
+
+    @Locate(TEMPLATE_LOCATION_1)
+    @Locate(TEMPLATE_LOCATION_4)
+    @Locate(TEMPLATE_LOCATION_5)
+    public static class CustomLocator1 implements TemplateLocator {
+
+        @Inject
+        TemplateValueProvider templateValueProvider;
+
+        @Override
+        public Optional<TemplateLocation> locate(String s) {
+
+            if (s.equals(TEMPLATE_LOCATION_1) || s.equals(TEMPLATE_LOCATION_4) || s.equals(TEMPLATE_LOCATION_5)) {
+                return Optional.of(new TemplateLocation() {
+
+                    @Override
+                    public Reader read() {
+                        final String value;
+                        switch (s) {
+                            case TEMPLATE_LOCATION_1:
+                                value = templateValueProvider.getTemplateValue();
+                                break;
+                            case TEMPLATE_LOCATION_4:
+                                value = "Custom template 4 {name}!";
+                                break;
+                            case TEMPLATE_LOCATION_5:
+                                value = "Custom template 5 {name}!";
+                                break;
+                            default:
+                                value = "";
+                                break;
+                        }
+                        return new StringReader(value);
+                    }
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+                });
+            }
+            return Optional.empty();
+        }
+
+    }
+
+    @Locate(TEMPLATE_LOCATION_2)
+    public static class CustomLocator2 implements TemplateLocator {
+
+        @Override
+        public Optional<TemplateLocation> locate(String s) {
+
+            if (s.equals(TEMPLATE_LOCATION_2)) {
+                return Optional.of(new TemplateLocation() {
+
+                    @Override
+                    public Reader read() {
+                        return new StringReader("Regular {name}!");
+                    }
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+                });
+            }
+            return Optional.empty();
+        }
+
+    }
+
+    @Singleton
+    public static class TemplateValueProvider2 {
+
+        public String getTemplateValue() {
+            return "Custom {name}!";
+        }
+    }
+
+    @Locate(TEMPLATE_LOCATION_3)
+    public static class CustomLocator3 implements TemplateLocator {
+
+        @Inject
+        TemplateValueProvider2 templateValueProvider2;
+
+        @Override
+        public Optional<TemplateLocation> locate(String s) {
+
+            if (s.equals(TEMPLATE_LOCATION_3)) {
+                return Optional.of(new TemplateLocation() {
+
+                    @Override
+                    public Reader read() {
+                        return new StringReader(templateValueProvider2.getTemplateValue());
+                    }
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+                });
+            }
+            return Optional.empty();
+        }
+
+    }
+
+    @Locate(CHECKED_TEMPLATE_LOCATION)
+    public static class CheckedTemplateLocator implements TemplateLocator {
+
+        @Override
+        public Optional<TemplateLocation> locate(String s) {
+
+            if (s.equals(CHECKED_TEMPLATE_LOCATION)) {
+                return Optional.of(new TemplateLocation() {
+
+                    @Override
+                    public Reader read() {
+                        return new StringReader("My Checked Template Number: {templateNumber}");
+                    }
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+                });
+            }
+            return Optional.empty();
+        }
+
+    }
+
+    @CheckedTemplate(basePath = "my_checked_template_base")
+    static class Templates {
+
+        static native TemplateInstance myCheckedTemplate(int templateNumber);
+
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/WrongLocationClassTargetTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/templatelocator/WrongLocationClassTargetTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.qute.deployment.templatelocator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Locate;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateLocator.TemplateLocation;
+import io.quarkus.qute.Variant;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WrongLocationClassTargetTest {
+
+    private static final String TEMPLATE_LOCATION = "/path/to/my/custom/template/basic.html";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(CustomLocator.class))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof TemplateException) {
+                    assertTrue(rootCause.getMessage().contains(
+                            "Classes annotated with 'io.quarkus.qute.Locate' must implement 'io.quarkus.qute.TemplateLocator'"));
+                } else {
+                    fail("No TemplateException thrown: " + t);
+                }
+            });
+
+    @Test
+    void failValidation() {
+        fail();
+    }
+
+    @Locate(TEMPLATE_LOCATION)
+    public static class CustomLocator {
+
+        public Optional<TemplateLocation> locate(String s) {
+
+            if (s.equals(TEMPLATE_LOCATION)) {
+                return Optional.of(new TemplateLocation() {
+
+                    @Override
+                    public Reader read() {
+                        return new StringReader("Basic {name}!");
+                    }
+
+                    @Override
+                    public Optional<Variant> getVariant() {
+                        return Optional.empty();
+                    }
+                });
+            }
+            return Optional.empty();
+        }
+
+    }
+
+}

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/EngineProducer.java
@@ -28,6 +28,7 @@ import javax.interceptor.Interceptor;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.All;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InjectableBean;
@@ -45,6 +46,7 @@ import io.quarkus.qute.Results;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.TemplateInstance.Initializer;
+import io.quarkus.qute.TemplateLocator;
 import io.quarkus.qute.TemplateLocator.TemplateLocation;
 import io.quarkus.qute.UserTagSectionHelper;
 import io.quarkus.qute.ValueResolver;
@@ -80,8 +82,8 @@ public class EngineProducer {
     private final ArcContainer container;
 
     public EngineProducer(QuteContext context, QuteConfig config, QuteRuntimeConfig runtimeConfig,
-            Event<EngineBuilder> builderReady, Event<Engine> engineReady, ContentTypes contentTypes, LaunchMode launchMode,
-            LocalesBuildTimeConfig locales) {
+            Event<EngineBuilder> builderReady, Event<Engine> engineReady, ContentTypes contentTypes,
+            LaunchMode launchMode, LocalesBuildTimeConfig locales, @All List<TemplateLocator> locators) {
         this.contentTypes = contentTypes;
         this.suffixes = config.suffixes;
         this.basePath = "templates/";
@@ -183,6 +185,7 @@ public class EngineProducer {
         }
         // Add locator
         builder.addLocator(this::locate);
+        registerCustomLocators(builder, locators);
 
         // Add a special parserk hook for Qute.fmt() methods
         builder.addParserHook(new Qute.IndexedArgumentsParserHook());
@@ -260,6 +263,15 @@ public class EngineProducer {
 
         // Set the engine instance
         Qute.setEngine(engine);
+    }
+
+    private void registerCustomLocators(EngineBuilder builder,
+            List<TemplateLocator> locators) {
+        if (locators != null && !locators.isEmpty()) {
+            for (TemplateLocator locator : locators) {
+                builder.addLocator(locator);
+            }
+        }
     }
 
     @Produces

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Locate.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Locate.java
@@ -1,0 +1,51 @@
+package io.quarkus.qute;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import io.quarkus.qute.Locate.Locates;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * A custom {@link TemplateLocator}s are not available during the build time, therefore {@link Template} located by
+ * the locator must disable its validation by annotating the {@link TemplateLocator} with this annotation. If
+ * {@link TemplateLocator} locates {@link Template} and fails to declare the fact this way, an exception is thrown and the build
+ * fails.
+ *
+ * An example:
+ *
+ * <pre>
+ * &#64;Locate("/my/custom/location")
+ * public class MyCustomLocator implements TemplateLocator {
+ *
+ *     &#64;Override
+ *     public Optional<TemplateLocation> locate(String s) {
+ *         return Optional.empty();
+ *     }
+ *
+ * }
+ * </pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RUNTIME)
+@Repeatable(Locates.class)
+public @interface Locate {
+
+    /**
+     * @return regex pattern matching all the {@link Template#getId()}s located by the {@link TemplateLocator}
+     */
+    String value();
+
+    /**
+     * Enables repeating of {@link Locate}.
+     */
+    @Target(ElementType.TYPE)
+    @Retention(RUNTIME)
+    @interface Locates {
+
+        Locate[] value();
+
+    }
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateLocator.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 /**
  * Locates template sources. The locator with higher priority takes precedence.
+ * Quarkus automatically register all CDI beans that implement this interface
+ * with {@link EngineBuilder#addLocator(TemplateLocator)}.
  *
  * @see Engine#getTemplate(String)
  */


### PR DESCRIPTION
Fixes: #10376

This PR disables build time validation of templates located by a custom locator. Custom Template Locators are not available during the build time when validation happens, thus adding of locator as describe in `qute-reference` fails in validation error (template not found). User can use new annotation `io.quarkus.qute.Locate` to disable this validation for templates located by custom template locators.

cc @mkouba