### PR TITLE
Add a test verifying JWT signed with a secret key

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/SignSecretKeyUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/SignSecretKeyUnitTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.jwt.test;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.jwt.build.Jwt;
+
+public class SignSecretKeyUnitTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultGroupsEndpoint.class)
+                    .addAsResource("secretKey.jwk")
+                    .addAsResource("applicationSignSecretKey.properties", "application.properties"));
+
+    /**
+     * Validate a request with MP-JWT without a 'groups' claim is successful
+     * due to the default value being provided in the configuration
+     *
+     */
+    @Test
+    public void echoGroups() {
+        String token = Jwt.upn("upn").groups("User").sign();
+        RestAssured.given().auth()
+                .oauth2(token)
+                .get("/endp/echo")
+                .then().assertThat().statusCode(200)
+                .body(equalTo("User"));
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationSignSecretKey.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationSignSecretKey.properties
@@ -1,0 +1,8 @@
+smallrye.jwt.verify.key.location=/secretKey.jwk
+smallrye.jwt.sign.key.location=/secretKey.jwk
+smallrye.jwt.new-token.issuer=https://server.example.com
+mp.jwt.verify.issuer=https://server.example.com
+smallrye.jwt.verify.algorithm=HS256
+
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".min-level=TRACE
+quarkus.log.category."io.quarkus.smallrye.jwt.runtime.auth.MpJwtValidator".level=TRACE

--- a/extensions/smallrye-jwt/deployment/src/test/resources/secretKey.jwk
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/secretKey.jwk
@@ -1,0 +1,6 @@
+{
+ "keys":
+ [
+  { "kty":"oct", "k":"uWlwBLGv4EpifZ52EhTuU9L-76AF9Vf4yumSD1P-2uE", "alg":"HS256" }
+ ]
+}


### PR DESCRIPTION
Fixes #25632.

This test uses a secret key to sign a token and verify it with the same key