### PR TITLE
Fix compilation error in vertx doc

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -227,7 +227,7 @@ public Multi<String> readLargeFile() {                                          
                     new OpenOptions().setRead(true)
             )
             .onItem().transformToMulti(file -> file.toMulti())                       // <3>
-            .onItem().transform(content -> content.toString(StandardCharsets.UTF_8)) // <4>
+            .onItem().transform(content -> content.toString(StandardCharsets.UTF_8) // <4>
                     + "\n------------\n");                                           // <5>
 }
 ----


### PR DESCRIPTION
Fixed according to the quarkus-quickstarts project:
https://github.com/quarkusio/quarkus-quickstarts/blob/main/vertx-quickstart/src/main/java/org/acme/VertxResource.java#L45