### PR TITLE
Align the version of Elasticsearch/Logstash/Kibana (7.16) across all integration tests and documentation

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -77,9 +77,9 @@
 
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>7.16.3</elasticsearch-server.version>
-        <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
-        <logstash.image>docker.elastic.co/logstash/logstash:${elasticsearch-server.version}</logstash.image>
-        <kibana.image>docker.elastic.co/kibana/kibana:${elasticsearch-server.version}</kibana.image>
+        <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
+        <logstash.image>docker.io/elastic/logstash:${elasticsearch-server.version}</logstash.image>
+        <kibana.image>docker.io/elastic/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>1.2.3</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -78,6 +78,8 @@
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>7.10.0</elasticsearch-server.version>
         <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss:${elasticsearch-server.version}</elasticsearch.image>
+        <logstash.image>docker.elastic.co/logstash/logstash-oss:${elasticsearch-server.version}</logstash.image>
+        <kibana.image>docker.elastic.co/kibana/kibana-oss:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>1.2.3</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -76,10 +76,10 @@
         <antlr.version>4.9.2</antlr.version>
 
         <!-- Defaults for integration tests -->
-        <elasticsearch-server.version>7.10.0</elasticsearch-server.version>
-        <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss:${elasticsearch-server.version}</elasticsearch.image>
-        <logstash.image>docker.elastic.co/logstash/logstash-oss:${elasticsearch-server.version}</logstash.image>
-        <kibana.image>docker.elastic.co/kibana/kibana-oss:${elasticsearch-server.version}</kibana.image>
+        <elasticsearch-server.version>7.16.3</elasticsearch-server.version>
+        <elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
+        <logstash.image>docker.elastic.co/logstash/logstash:${elasticsearch-server.version}</logstash.image>
+        <kibana.image>docker.elastic.co/kibana/kibana:${elasticsearch-server.version}</kibana.image>
         <elasticsearch.protocol>http</elasticsearch.protocol>
         <opensearch-server.version>1.2.3</opensearch-server.version>
         <opensearch.image>docker.io/opensearchproject/opensearch:${opensearch-server.version}</opensearch.image>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2824,6 +2824,9 @@
                         <restassured-version>${rest-assured.version}</restassured-version>
                         <maven-version>${proposed-maven-version}</maven-version>
                         <gradle-version>${gradle-wrapper.version}</gradle-version>
+                        <elasticsearch-image>${elasticsearch.image}</elasticsearch-image>
+                        <logstash-image>${logstash.image}</logstash-image>
+                        <kibana-image>${kibana.image}</kibana-image>
                         <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
 
                         <jandex-maven-plugin-version>${jandex-maven-plugin.version}</jandex-maven-plugin-version>

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -6,7 +6,6 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Centralized log management (Graylog, Logstash, Fluentd)
 
 include::./attributes.adoc[]
-:es-version: 7.10.0
 
 This guide explains how you can send your logs to a centralized log management system like Graylog, Logstash (inside the Elastic Stack or ELK - Elasticsearch, Logstash, Kibana) or
 Fluentd (inside EFK - Elasticsearch, Fluentd, Kibana).
@@ -103,7 +102,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:{es-version}
+    image: {elasticsearch-image}
     ports:
       - "9200:9200"
     environment:
@@ -190,7 +189,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:{es-version}
+    image: {elasticsearch-image}
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -201,7 +200,7 @@ services:
       - elk
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:{es-version}
+    image: {logstash-image}
     volumes:
       - source: $HOME/pipelines
         target: /usr/share/logstash/pipeline
@@ -216,7 +215,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:{es-version}
+    image: {kibana-image}
     ports:
       - "5601:5601"
     networks:
@@ -279,7 +278,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:{es-version}
+    image: {elasticsearch-image}
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -303,7 +302,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:{es-version}
+    image: {kibana-image}
     ports:
       - "5601:5601"
     networks:
@@ -366,7 +365,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:{es-version}
+    image: {elasticsearch-image}
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -389,7 +388,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:{es-version}
+    image: {kibana-image}
     ports:
       - "5601:5601"
     networks:

--- a/docs/src/main/asciidoc/centralized-log-management.adoc
+++ b/docs/src/main/asciidoc/centralized-log-management.adoc
@@ -6,7 +6,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Centralized log management (Graylog, Logstash, Fluentd)
 
 include::./attributes.adoc[]
-:es-version: 6.8.2
+:es-version: 7.10.0
 
 This guide explains how you can send your logs to a centralized log management system like Graylog, Logstash (inside the Elastic Stack or ELK - Elasticsearch, Logstash, Kibana) or
 Fluentd (inside EFK - Elasticsearch, Fluentd, Kibana).
@@ -108,6 +108,7 @@ services:
       - "9200:9200"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - graylog
 
@@ -117,13 +118,17 @@ services:
       - graylog
 
   graylog:
-    image: graylog/graylog:3.1
+    image: graylog/graylog:4.3.0
     ports:
       - "9000:9000"
       - "12201:12201/udp"
       - "1514:1514"
     environment:
       GRAYLOG_HTTP_EXTERNAL_URI: "http://127.0.0.1:9000/"
+      # CHANGE ME (must be at least 16 characters)!
+      GRAYLOG_PASSWORD_SECRET: "forpasswordencryption"
+      # Password: admin
+      GRAYLOG_ROOT_PASSWORD_SHA2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
     networks:
       - graylog
     depends_on:
@@ -191,6 +196,7 @@ services:
       - "9300:9300"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - elk
 
@@ -279,6 +285,7 @@ services:
       - "9300:9300"
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - efk
 

--- a/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
+++ b/docs/src/main/asciidoc/elasticsearch-dev-services.adoc
@@ -50,10 +50,10 @@ Note that the Elasticsearch hosts property is automatically configured with the 
 
 Dev Services for Elasticsearch only support Elasticsearch based images, Opensearch is not supported at the moment.
 
-If you need to use a different image than the default one you can configure it via
+If you need to use a different image than the default one you can configure it via:
 [source, properties]
 ----
-quarkus.elasticsearch.devservices.image-name=docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+quarkus.elasticsearch.devservices.image-name={elasticsearch-image}
 ----
 
 == Current limitations

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -337,7 +337,7 @@ If you want to use Docker to run an Elasticsearch instance, you can use the foll
 [source,bash,subs=attributes+]
 ----
 docker run --name elasticsearch  -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m"\
-       --rm -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:{elasticsearch-version}
+       --rm -p 9200:9200 {elasticsearch-image}
 ----
 
 == Running the application

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
@@ -120,6 +120,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/pom.xml
@@ -120,6 +120,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
@@ -121,6 +121,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/pom.xml
@@ -121,6 +121,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -165,6 +165,7 @@
                   <run>
                     <env>
                       <discovery.type>single-node</discovery.type>
+                      <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                     </env>
                     <ports>
                       <port>9200:9200</port>

--- a/integration-tests/elasticsearch-rest-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-client/pom.xml
@@ -165,6 +165,7 @@
                   <run>
                     <env>
                       <discovery.type>single-node</discovery.type>
+                      <xpack.security.enabled>false</xpack.security.enabled>
                       <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                     </env>
                     <ports>

--- a/integration-tests/elasticsearch-rest-high-level-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-high-level-client/pom.xml
@@ -166,6 +166,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/integration-tests/elasticsearch-rest-high-level-client/pom.xml
+++ b/integration-tests/elasticsearch-rest-high-level-client/pom.xml
@@ -166,6 +166,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
@@ -206,6 +206,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-coordination-outbox-polling/pom.xml
@@ -206,6 +206,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -222,6 +222,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch-tenancy/pom.xml
@@ -222,6 +222,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -184,6 +184,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>
                                             <port>9200:9200</port>

--- a/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-elasticsearch/pom.xml
@@ -184,6 +184,7 @@
                                     <run>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <ports>

--- a/integration-tests/logging-gelf/README.md
+++ b/integration-tests/logging-gelf/README.md
@@ -29,7 +29,7 @@ mvn clean test -Dtest-gelf
 Additionally, you can generate a native image and run the tests for this native image by adding `-Dnative`:
 
 ```
-mvn clean integration-test -Dtest-gelf -Dnative
+mvn clean integration-test -Dtest-containers -Dnative
 ```
 
 ## Testing with ELK (Elasticsearch, Logstash, Kibana) aka the Elastic Stack
@@ -61,7 +61,7 @@ Then you can use the following commands to run an ELK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-elk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to ELK. You can use Kibana on http://localhost:5601/ to access those logs.
 
 
@@ -99,5 +99,5 @@ Then you can use the following commands to run an EFK cluster using the provided
 docker-compose -f src/test/resources/docker-compose-efk.yml up
 ```
 
-Finally, run the test via `mvn clean install -Dtest-gelf -Dmaven.test.failure.ignore` and manually verify that the log
+Finally, run the test via `mvn clean install -Dtest-containers -Dmaven.test.failure.ignore` and manually verify that the log
 events has been pushed to EFK. You can use Kibana on http://localhost:5601/ to access those logs.

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -157,6 +157,7 @@
                                         </ports>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <xpack.security.enabled>false</xpack.security.enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <log>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -142,7 +142,7 @@
                             <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                             <images>
                                 <image>
-                                    <name>docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0</name>
+                                    <name>${elasticsearch.image}</name>
                                     <alias>elasticsearch</alias>
                                     <run>
                                         <network>
@@ -174,7 +174,7 @@
                                     </run>
                                 </image>
                                 <image>
-                                    <name>docker.elastic.co/logstash/logstash-oss:7.10.0</name>
+                                    <name>${logstash.image}</name>
                                     <alias>logstash</alias>
                                     <run>
                                         <network>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -157,6 +157,7 @@
                                         </ports>
                                         <env>
                                             <discovery.type>single-node</discovery.type>
+                                            <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <log>
                                             <prefix>Elasticsearch: </prefix>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -196,7 +196,7 @@
                                         </log>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/src/test/resources/pipeline:/usr/share/logstash/pipeline</volume>
+                                                <volume>${project.basedir}/src/test/resources/pipeline:/usr/share/logstash/pipeline:Z</volume>
                                             </bind>
                                         </volumes>
                                         <wait>

--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -142,7 +142,7 @@
                             <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                             <images>
                                 <image>
-                                    <name>docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3</name>
+                                    <name>docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0</name>
                                     <alias>elasticsearch</alias>
                                     <run>
                                         <network>
@@ -174,7 +174,7 @@
                                     </run>
                                 </image>
                                 <image>
-                                    <name>docker.elastic.co/logstash/logstash-oss:7.9.3</name>
+                                    <name>docker.elastic.co/logstash/logstash-oss:7.10.0</name>
                                     <alias>logstash</alias>
                                     <run>
                                         <network>

--- a/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
+++ b/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
@@ -28,7 +28,7 @@ public class GelfLogHandlerTest {
         //we need to await for a certain time as logstash needs to create the index template,
         // then elasticsearch create the index
         // then some logs being indexed.
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(20, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             RestAssured.given().when().get("/gelf-log-handler").then().statusCode(204);

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -6,6 +6,7 @@ services:
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
+      xpack.security.enabled: "false"
     networks:
       - efk
 

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
@@ -23,7 +23,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.10.0
+    image: docker.elastic.co/kibana/kibana:7.16.3
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -2,9 +2,10 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - efk
 
@@ -22,7 +23,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.8.2
+    image: docker.elastic.co/kibana/kibana-oss:7.10.0
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-efk.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    image: docker.io/elastic/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
@@ -23,7 +23,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.16.3
+    image: docker.io/elastic/kibana:7.16.3
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -2,15 +2,15 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
-      - "discovery.type=single-node"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - elk
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.9.3
+    image: docker.elastic.co/logstash/logstash-oss:7.10.0
     volumes:
       - source: $HOME/pipelines
         target: /usr/share/logstash/pipeline
@@ -25,7 +25,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.9.3
+    image: docker.elastic.co/kibana/kibana-oss:7.10.0
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
@@ -10,7 +10,7 @@ services:
       - elk
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.10.0
+    image: docker.elastic.co/logstash/logstash:7.16.3
     volumes:
       - source: $HOME/pipelines
         target: /usr/share/logstash/pipeline
@@ -25,7 +25,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.10.0
+    image: docker.elastic.co/kibana/kibana:7.16.3
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    image: docker.io/elastic/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
@@ -10,7 +10,7 @@ services:
       - elk
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.16.3
+    image: docker.io/elastic/logstash:7.16.3
     volumes:
       - source: $HOME/pipelines
         target: /usr/share/logstash/pipeline
@@ -25,7 +25,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.16.3
+    image: docker.io/elastic/kibana:7.16.3
     ports:
       - "5601:5601"
     networks:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-elk.yml
@@ -6,6 +6,7 @@ services:
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
+      xpack.security.enabled: "false"
     networks:
       - elk
 

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -2,10 +2,10 @@ version: '3.2'
 
 services:
   elasticsearch:
-    # Graylog 3 only works with Elasticsearch 6
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
     networks:
       - graylog
 
@@ -15,13 +15,16 @@ services:
       - graylog
 
   graylog:
-    image: graylog/graylog:3.3.8
+    image: graylog/graylog:4.3.0
     ports:
       - "9000:9000"
       - "12201:12201/udp"
       - "1514:1514"
     environment:
-      GRAYLOG_HTTP_EXTERNAL_URI: "http://127.0.0.1:9000/"
+      # CHANGE ME (must be at least 16 characters)!
+      GRAYLOG_PASSWORD_SECRET: "forpasswordencryptionEXAMPLE"
+      # Password: admin
+      GRAYLOG_ROOT_PASSWORD_SHA2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
     networks:
       - graylog
     depends_on:

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -6,6 +6,7 @@ services:
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"
+      xpack.security.enabled: "false"
     networks:
       - graylog
 

--- a/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
+++ b/integration-tests/logging-gelf/src/test/resources/docker-compose-graylog.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    image: docker.io/elastic/elasticsearch:7.16.3
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       discovery.type: "single-node"


### PR DESCRIPTION
Context: https://github.com/quarkusio/quarkus/pull/25648#issuecomment-1130004170

In short, we need at least Elasticsearch 7.11 to run on Apple M1, and the heterogeneous configuration made upgrading the Elasticsearch version difficult.

This makes the Elasticsearch container configuration consistent across all integration tests and bumps the Elasticsearch server version used for tests to 7.16 (also Logstash and Kibana, so technically we're upgrading the whole ELK stack).

I didn't change the version of the client, in particular the High Level REST client, which cannot be upgraded beyond 7.10 because 7.11+ is no longer open-source. However, that's no big deal as the High Level REST client is [forward-compatible with Elasticsearch (server) 7.16](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.10/java-rest-high-compatibility.html). We will have a problem when we want to upgrade to Elasticsearch 8.x, but that's a problem for another day.