### PR TITLE
Improve doc for containerized native build

### DIFF
--- a/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
@@ -2,11 +2,12 @@
 .CLI
 ----
 ifdef::build-additional-parameters[]
-quarkus build --native -Dquarkus.native.container-build=true {build-additional-parameters}
+quarkus build --native --no-tests -Dquarkus.native.container-build=true {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-quarkus build --native -Dquarkus.native.container-build=true
+quarkus build --native --no-tests -Dquarkus.native.container-build=true
 endif::[]
+# The --no-tests flag is required only on Windows and macOS.
 ----
 ifndef::devtools-no-maven[]
 ifdef::devtools-wrapped[+]


### PR DESCRIPTION
Added `--no-tests` flag to the build command.

On macOS and Windows the following command fails:
`quarkus build --native -Dquarkus.native.container-build=true`.
Reason is that the Quarkus CLI runs integration tests against binary built in Linux container.
The produced binary is ELF not runnable under another OS.

related to: https://github.com/quarkusio/quarkus/issues/24860