### PR TITLE
Keep the custom Class-Path in the manifest file

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -1342,8 +1342,11 @@ public class JarResultBuildStep {
         if (attributes.containsKey(Attributes.Name.CLASS_PATH)) {
             log.warn(
                     "A CLASS_PATH entry was already defined in your MANIFEST.MF or using the property quarkus.package.manifest.attributes.\"Class-Path\". Quarkus has overwritten this existing entry.");
+            String existingClassPath = attributes.getValue(Attributes.Name.CLASS_PATH);
+            attributes.put(Attributes.Name.CLASS_PATH, existingClassPath + " " + classPath);
+        } else {
+            attributes.put(Attributes.Name.CLASS_PATH, classPath);
         }
-        attributes.put(Attributes.Name.CLASS_PATH, classPath);
         if (attributes.containsKey(Attributes.Name.MAIN_CLASS)) {
             String existingMainClass = attributes.getValue(Attributes.Name.MAIN_CLASS);
             if (!mainClassName.equals(existingMainClass)) {

--- a/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestEntriesThinJarTest.java
+++ b/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestEntriesThinJarTest.java
@@ -40,6 +40,10 @@ public class CustomManifestEntriesThinJarTest {
                 String customAttribute = manifest.getMainAttributes().getValue("Built-By");
                 assertThat(customAttribute).isNotNull();
                 assertThat(customAttribute).isEqualTo("Quarkus Plugin");
+
+                String classPath = manifest.getMainAttributes().getValue("Class-Path");
+                assertThat(classPath).isNotNull();
+                assertThat(classPath).startsWith("resources/ libs/a.jar");
             }
         }
     }

--- a/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestEntriesUberJarTest.java
+++ b/integration-tests/packaging/src/test/java/io/quarkus/maven/CustomManifestEntriesUberJarTest.java
@@ -40,6 +40,10 @@ public class CustomManifestEntriesUberJarTest {
                 String customAttribute = manifest.getMainAttributes().getValue("Built-By");
                 assertThat(customAttribute).isNotNull();
                 assertThat(customAttribute).isEqualTo("Quarkus Plugin");
+
+                String classPath = manifest.getMainAttributes().getValue("Class-Path");
+                assertThat(classPath).isNotNull();
+                assertThat(classPath).startsWith("resources/ libs/a.jar");
             }
         }
     }

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-entries-thin.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-entries-thin.properties
@@ -1,2 +1,3 @@
 quarkus.package.type=jar
 quarkus.package.manifest.attributes."Built-By"=Quarkus Plugin
+quarkus.package.manifest.attributes."Class-Path"=resources/ libs/a.jar

--- a/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-entries-uber.properties
+++ b/integration-tests/packaging/src/test/resources/projects/custom-manifest-section/custom-entries-uber.properties
@@ -1,2 +1,3 @@
 quarkus.package.type=uber-jar
 quarkus.package.manifest.attributes."Built-By"=Quarkus Plugin
+quarkus.package.manifest.attributes."Class-Path"=resources/ libs/a.jar


### PR DESCRIPTION
Currently we can specify custom manifest entries, but we cannot keep the custom `Class-Path` because generating the manifest would overwrite this existing entry. 

By adding additional JAR files and directories to the class path, we can not only avoid specifying a long `-classpath` flag, but also load resources via relative paths.