### PR TITLE
Revert "Bump mongodb-crypt from 1.2.1 to 1.4.0"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -159,7 +159,7 @@
         <snakeyaml.version>1.30</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>4.3.4</mongo-client.version>
-        <mongo-crypt.version>1.4.0</mongo-crypt.version>
+        <mongo-crypt.version>1.2.1</mongo-crypt.version>
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.1</hibernate-quarkus-local-cache.version>


### PR DESCRIPTION
Reverts quarkusio/quarkus#25114

Fixes: #25711