### PR TITLE
Ensure that Vert.x's ConnectionBase#remoteAddress does not return null

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/test/java/io/quarkus/amazon/lambda/http/LambdaHttpHandlerTest.java
+++ b/extensions/amazon-lambda-http/runtime/src/test/java/io/quarkus/amazon/lambda/http/LambdaHttpHandlerTest.java
@@ -20,7 +20,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 
@@ -28,6 +27,9 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.quarkus.amazon.lambda.runtime.AmazonLambdaContext;
+import io.quarkus.netty.runtime.virtual.VirtualAddress;
+import io.quarkus.netty.runtime.virtual.VirtualChannel;
 import io.quarkus.netty.runtime.virtual.VirtualClientConnection;
 import io.quarkus.netty.runtime.virtual.VirtualResponseHandler;
 import io.quarkus.runtime.Application;
@@ -47,8 +49,9 @@ public class LambdaHttpHandlerTest {
     private final APIGatewayV2HTTPEvent.RequestContext requestContext = mock(APIGatewayV2HTTPEvent.RequestContext.class);
     private final APIGatewayV2HTTPEvent.RequestContext.Http requestContextMethod = mock(
             APIGatewayV2HTTPEvent.RequestContext.Http.class);
-    private final Context context = mock(Context.class);
+    private final AmazonLambdaContext context = mock(AmazonLambdaContext.class);
     private final VirtualClientConnection<?> connection = mock(VirtualClientConnection.class);
+    private final VirtualChannel peer = mock(VirtualChannel.class);
 
     @BeforeEach
     public void mockSetup() {
@@ -57,6 +60,8 @@ public class LambdaHttpHandlerTest {
         when(requestContext.getHttp()).thenReturn(requestContextMethod);
         when(requestContextMethod.getMethod()).thenReturn(METHOD);
         when(request.getHeaders()).thenReturn(Collections.singletonMap(HOST_HEADER, HOST));
+        when(connection.peer()).thenReturn(peer);
+        when(peer.remoteAddress()).thenReturn(new VirtualAddress("whatever"));
     }
 
     @SuppressWarnings({ "rawtypes", "unused" })

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaContext.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaContext.java
@@ -13,6 +13,7 @@ import static io.quarkus.amazon.lambda.runtime.AmazonLambdaApi.logStreamName;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URL;
 
 import com.amazonaws.services.lambda.runtime.ClientContext;
 import com.amazonaws.services.lambda.runtime.CognitoIdentity;
@@ -34,7 +35,7 @@ public class AmazonLambdaContext implements Context {
     private long runtimeDeadlineMs = 0;
     private final int memoryLimitInMB;
     private final LambdaLogger logger;
-
+    private final URL requestURL;
 
     public AmazonLambdaContext(HttpURLConnection request, ObjectReader cognitoReader, ObjectReader clientCtxReader)
             throws IOException {
@@ -63,6 +64,7 @@ public class AmazonLambdaContext implements Context {
             runtimeDeadlineMs = Long.valueOf(runtimeDeadline);
         }
         logger = LambdaRuntime.getLogger();
+        requestURL = request.getURL();
     }
 
     @Override
@@ -118,5 +120,9 @@ public class AmazonLambdaContext implements Context {
     @Override
     public LambdaLogger getLogger() {
         return logger;
+    }
+
+    public URL getRequestURL() {
+        return requestURL;
     }
 }

--- a/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaContext.java
+++ b/extensions/amazon-lambda/common-runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaContext.java
@@ -23,17 +23,18 @@ import com.fasterxml.jackson.databind.ObjectReader;
 
 public class AmazonLambdaContext implements Context {
 
-    private String awsRequestId;
-    private String logGroupName;
-    private String logStreamName;
-    private String functionName;
-    private String functionVersion;
-    private String invokedFunctionArn;
+    private final String awsRequestId;
+    private final String logGroupName;
+    private final String logStreamName;
+    private final String functionName;
+    private final String functionVersion;
+    private final String invokedFunctionArn;
     private CognitoIdentity cognitoIdentity;
     private ClientContext clientContext;
     private long runtimeDeadlineMs = 0;
-    private int memoryLimitInMB;
-    private LambdaLogger logger;
+    private final int memoryLimitInMB;
+    private final LambdaLogger logger;
+
 
     public AmazonLambdaContext(HttpURLConnection request, ObjectReader cognitoReader, ObjectReader clientCtxReader)
             throws IOException {

--- a/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualClientConnection.java
+++ b/extensions/netty/runtime/src/main/java/io/quarkus/netty/runtime/virtual/VirtualClientConnection.java
@@ -24,6 +24,10 @@ public class VirtualClientConnection<T> {
         return clientAddress;
     }
 
+    public VirtualChannel peer() {
+        return peer;
+    }
+
     public void close() {
         // todo more cleanup?
         connected = false;


### PR DESCRIPTION
This is done for the Amazon lambda stuff in order to ensure
that tracing works properly.
The remote address is currently set to the local Quarkus server,
which seems to make most sense.

Fixes: #25708