### PR TITLE
Leverage Gradle build cache in integration tests

### DIFF
--- a/integration-tests/gradle/.gradle/gradle.properties
+++ b/integration-tests/gradle/.gradle/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleKtsProjectTest.java
@@ -40,7 +40,7 @@ public class AddExtensionToSingleModuleKtsProjectTest extends QuarkusGradleDevTo
         final File projectDir = getProjectDir("add-remove-extension-single-module-kts");
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "build");
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
 
         final Path buildKts = projectDir.toPath().resolve("build.gradle.kts");
         assertThat(buildKts).exists();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AddExtensionToSingleModuleProjectTest.java
@@ -37,7 +37,7 @@ public class AddExtensionToSingleModuleProjectTest extends QuarkusGradleDevTools
         final File projectDir = getProjectDir("add-remove-extension-single-module");
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "build");
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
 
         final Path build = projectDir.toPath().resolve("build.gradle");
         assertThat(build).exists();

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AdditionalSourceSetsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AdditionalSourceSetsTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.gradle;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +18,6 @@ public class AdditionalSourceSetsTest extends QuarkusGradleWrapperTestBase {
     public void executeFunctionalTest() throws URISyntaxException, IOException, InterruptedException {
         final File projectDir = getProjectDir("additional-source-sets");
         BuildResult result = runGradleWrapper(projectDir, "functionalTest");
-        assertEquals(BuildResult.SUCCESS_OUTCOME, result.getTasks().get(":functionalTest"),
-                "Failed to run tests defined in an alternate test sources directory");
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":functionalTest"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorMultiModuleTest.java
@@ -14,6 +14,6 @@ public class AnnotationProcessorMultiModuleTest extends QuarkusGradleWrapperTest
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "test");
 
-        assertThat(buildResult.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":application:test"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorSimpleModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/AnnotationProcessorSimpleModuleTest.java
@@ -15,7 +15,7 @@ public class AnnotationProcessorSimpleModuleTest extends QuarkusGradleWrapperTes
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "test");
 
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
     }
 
     @Test
@@ -24,7 +24,7 @@ public class AnnotationProcessorSimpleModuleTest extends QuarkusGradleWrapperTes
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusBuild");
 
-        assertThat(buildResult.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusBuild"))).isTrue();
         File buildDir = new File(projectDir, "build");
 
         Path metaInfDir = buildDir.toPath().resolve("classes").resolve("java").resolve("main").resolve("META-INF");

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/ApplicationConfigurationTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/ApplicationConfigurationTest.java
@@ -14,7 +14,7 @@ public class ApplicationConfigurationTest extends QuarkusGradleWrapperTestBase {
 
         BuildResult testResult = runGradleWrapper(projectDir, "clean", ":application:test");
 
-        assertThat(testResult.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(testResult.getTasks().get(":application:test"))).isTrue();
     }
 
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BeanInTestSourcesTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BeanInTestSourcesTest.java
@@ -12,6 +12,6 @@ public class BeanInTestSourcesTest extends QuarkusGradleWrapperTestBase {
     public void testBasicMultiModuleBuild() throws Exception {
         final File projectDir = getProjectDir("bean-in-testsources-project");
         final BuildResult build = runGradleWrapper(projectDir, "clean", "test");
-        assertThat(build.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":test"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildResult.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/BuildResult.java
@@ -12,6 +12,7 @@ public class BuildResult {
 
     public static final String SUCCESS_OUTCOME = "SUCCESS";
     public static final String UPTODATE_OUTCOME = "UP-TO-DATE";
+    public static final String FROM_CACHE = "FROM-CACHE";
     private static final String TASK_RESULT_PREFIX = "> Task";
 
     private Map<String, String> tasks;
@@ -53,5 +54,9 @@ public class BuildResult {
 
     public String getOutput() {
         return output;
+    }
+
+    public static boolean isSuccessful(String result) {
+        return SUCCESS_OUTCOME.equals(result) || FROM_CACHE.equals(result);
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/CustomFileSystemProviderTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/CustomFileSystemProviderTest.java
@@ -14,6 +14,6 @@ public class CustomFileSystemProviderTest extends QuarkusGradleWrapperTestBase {
         final File projectDir = getProjectDir("custom-filesystem-provider");
 
         BuildResult build = runGradleWrapper(projectDir, "clean", ":application:test");
-        assertThat(build.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":application:test"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyConstraintsTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyConstraintsTest.java
@@ -15,7 +15,7 @@ public class DependencyConstraintsTest extends QuarkusGradleWrapperTestBase {
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusBuild", "-Dquarkus.package.type=mutable-jar");
 
-        assertThat(buildResult.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusBuild"))).isTrue();
 
         final File buildDir = new File(projectDir, "build");
         final Path mainLib = buildDir.toPath().resolve("quarkus-app").resolve("lib").resolve("main");

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyResolutionTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/DependencyResolutionTest.java
@@ -16,6 +16,6 @@ public class DependencyResolutionTest extends QuarkusGradleWrapperTestBase {
 
         final BuildResult result = runGradleWrapper(projectDir, "clean", "quarkusBuild");
 
-        assertThat(result.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":quarkusBuild"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/InjectBeanFromTestConfigTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/InjectBeanFromTestConfigTest.java
@@ -14,6 +14,6 @@ public class InjectBeanFromTestConfigTest extends QuarkusGradleWrapperTestBase {
         final File projectDir = getProjectDir("inject-bean-from-test-config");
 
         BuildResult build = runGradleWrapper(projectDir, "clean", ":application:test");
-        assertThat(build.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":application:test"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/IntegrationTestBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/IntegrationTestBuildTest.java
@@ -14,8 +14,8 @@ public class IntegrationTestBuildTest extends QuarkusGradleWrapperTestBase {
 
         BuildResult buildResult = runGradleWrapper(projectDir, "clean", "quarkusIntTest");
 
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
-        assertThat(buildResult.getTasks().get(":quarkusIntTest")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":quarkusIntTest"))).isTrue();
     }
 
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/JandexMultiModuleTest.java
@@ -14,8 +14,8 @@ public class JandexMultiModuleTest extends QuarkusGradleWrapperTestBase {
         final File projectDir = getProjectDir("jandex-basic-multi-module-project");
 
         BuildResult build = runGradleWrapper(projectDir, "clean", ":application:quarkusBuild");
-        assertThat(build.getTasks().get(":common:jandex")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
-        assertThat(build.getTasks().get(":application:quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":common:jandex"))).isTrue();
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":application:quarkusBuild"))).isTrue();
     }
 
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinGRPCProjectBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/KotlinGRPCProjectBuildTest.java
@@ -12,7 +12,7 @@ public class KotlinGRPCProjectBuildTest extends QuarkusGradleWrapperTestBase {
     public void testBasicMultiModuleBuild() throws Exception {
         final File projectDir = getProjectDir("kotlin-grpc-project");
         final BuildResult build = runGradleWrapper(projectDir, "clean", "build");
-        assertThat(build.getTasks().get(":quarkusGenerateCode")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
-        assertThat(build.getTasks().get(":compileKotlin")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":quarkusGenerateCode"))).isTrue();
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":compileKotlin"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleKotlinProjectBuildTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiModuleKotlinProjectBuildTest.java
@@ -12,7 +12,7 @@ public class MultiModuleKotlinProjectBuildTest extends QuarkusGradleWrapperTestB
     public void testBasicMultiModuleBuild() throws Exception {
         final File projectDir = getProjectDir("multi-module-kotlin-project");
         final BuildResult build = runGradleWrapper(projectDir, "clean", "build");
-        assertThat(build.getTasks().get(":quarkusGenerateCode")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
-        assertThat(build.getTasks().get(":compileKotlin")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":quarkusGenerateCode"))).isTrue();
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":compileKotlin"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiSourceProjectTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/MultiSourceProjectTest.java
@@ -13,7 +13,7 @@ public class MultiSourceProjectTest extends QuarkusGradleWrapperTestBase {
         final File projectDir = getProjectDir("multi-source-project");
         final BuildResult buildResult = runGradleWrapper(projectDir, ":clean", ":test");
 
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
     }
 
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/QuarkusPluginFunctionalTest.java
@@ -38,7 +38,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
 
         BuildResult build = runGradleWrapper(projectRoot, "build", "--stacktrace");
 
-        assertThat(build.getTasks().get(":build")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(build.getTasks().get(":build"))).isTrue();
         // gradle build should not build the native image
         assertThat(build.getTasks().get(":buildNative")).isNull();
         Path buildDir = projectRoot.toPath().resolve("build");
@@ -51,7 +51,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         createProject(SourceType.JAVA);
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
         assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.UPTODATE_OUTCOME);
@@ -62,13 +62,13 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         createProject(SourceType.JAVA);
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
 
         final File applicationProperties = projectRoot.toPath().resolve("src/main/resources/application.properties").toFile();
         Files.write(applicationProperties.toPath(), "quarkus.http.port=8888".getBytes());
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(secondBuild.getTasks().get(":quarkusBuild"))).isTrue();
     }
 
     @Test
@@ -76,14 +76,14 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         createProject(SourceType.JAVA);
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
 
         final File greetingResourceFile = projectRoot.toPath().resolve("src/main/java/org/acme/foo/GreetingResource.java")
                 .toFile();
         DevModeTestUtils.filter(greetingResourceFile, ImmutableMap.of("\"/greeting\"", "\"/test/hello\""));
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(secondBuild.getTasks().get(":quarkusBuild"))).isTrue();
     }
 
     @Test
@@ -91,11 +91,11 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         createProject(SourceType.JAVA);
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
 
         runGradleWrapper(projectRoot, "addExtension", "--extensions=hibernate-orm");
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
-        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(secondBuild.getTasks().get(":quarkusBuild"))).isTrue();
     }
 
     @Test
@@ -104,13 +104,13 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
 
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
         Path runnerJar = projectRoot.toPath().resolve("build").resolve("quarkus-app").resolve("quarkus-run.jar");
         Files.delete(runnerJar);
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
 
-        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(secondBuild.getTasks().get(":quarkusBuild"))).isTrue();
         assertThat(runnerJar).exists();
     }
 
@@ -120,7 +120,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "test");
 
-        assertThat(firstBuild.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":test"))).isTrue();
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "test");
 
@@ -133,12 +133,12 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
 
         BuildResult firstBuild = runGradleWrapper(projectRoot, "quarkusBuild", "--stacktrace");
 
-        assertThat(firstBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":quarkusBuild"))).isTrue();
         assertThat(projectRoot.toPath().resolve("build").resolve("quarkus-app").resolve("quarkus-run.jar")).exists();
 
         BuildResult secondBuild = runGradleWrapper(projectRoot, "quarkusBuild", "-Dquarkus.package.type=fast-jar");
 
-        assertThat(secondBuild.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(secondBuild.getTasks().get(":quarkusBuild"))).isTrue();
         assertThat(projectRoot.toPath().resolve("build").resolve("quarkus-app")).exists();
     }
 
@@ -148,7 +148,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
 
         BuildResult buildResult = runGradleWrapper(projectRoot, "test", "--stacktrace");
 
-        assertThat(buildResult.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(buildResult.getTasks().get(":test"))).isTrue();
     }
 
     @Test
@@ -158,7 +158,7 @@ public class QuarkusPluginFunctionalTest extends QuarkusGradleDevToolsTestBase {
         BuildResult firstBuild = runGradleWrapper(projectRoot, "test", "--stacktrace");
         assertThat(firstBuild.getOutput()).contains("Task :quarkusGenerateCode");
         assertThat(firstBuild.getOutput()).contains("Task :quarkusGenerateCodeTests");
-        assertThat(firstBuild.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(firstBuild.getTasks().get(":test"))).isTrue();
     }
 
     private void createProject(SourceType sourceType) throws Exception {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/SpringDependencyManagementTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/SpringDependencyManagementTest.java
@@ -17,6 +17,6 @@ public class SpringDependencyManagementTest extends QuarkusGradleWrapperTestBase
 
         final BuildResult result = runGradleWrapper(projectDir, "clean", "quarkusBuild");
 
-        assertThat(result.getTasks().get(":quarkusBuild")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":quarkusBuild"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureModuleTest.java
@@ -16,6 +16,6 @@ public class TestFixtureModuleTest extends QuarkusGradleWrapperTestBase {
 
         final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
 
-        assertThat(result.getTasks().get(":test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":test"))).isTrue();
     }
 }

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/TestFixtureMultiModuleTest.java
@@ -14,6 +14,6 @@ public class TestFixtureMultiModuleTest extends QuarkusGradleWrapperTestBase {
     public void testTaskShouldUseTestFixtures() throws IOException, URISyntaxException, InterruptedException {
         final File projectDir = getProjectDir("test-fixtures-multi-module");
         final BuildResult result = runGradleWrapper(projectDir, "clean", "test");
-        assertThat(result.getTasks().get(":application:test")).isEqualTo(BuildResult.SUCCESS_OUTCOME);
+        assertThat(BuildResult.isSuccessful(result.getTasks().get(":application:test"))).isTrue();
     }
 }


### PR DESCRIPTION
This branch enable gradle build output caching in `integration-tests/gradle` module. 
If a task has been run with success, new run of the task will leverage the cache. This can change task output result. 

close #25693 