### PR TITLE
Resteasy Reactive: Fix support of media types with suffixes

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypesWithSuffixHandlingTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/resource/basic/MediaTypesWithSuffixHandlingTest.java
@@ -1,0 +1,216 @@
+package io.quarkus.resteasy.reactive.server.test.resource.basic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class MediaTypesWithSuffixHandlingTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest testExtension = new QuarkusUnitTest()
+            .setArchiveProducer(() -> {
+                JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+                archive.addClasses(TestResource.class, NoSuffixMessageBodyWriter.class, SuffixMessageBodyWriter.class);
+                return archive;
+            });
+
+    @Test
+    public void testWriterWithoutSuffix() {
+        RestAssured.get("/test/writer/with-no-suffix")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("result - no suffix writer"));
+    }
+
+    @Test
+    public void testReaderWithoutSuffix() {
+        RestAssured.get("/test/reader/with-no-suffix")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("from reader - result"));
+    }
+
+    @Test
+    public void testWriterWithSuffix() {
+        RestAssured.get("/test/writer/with-suffix")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("result - suffix writer"));
+    }
+
+    @Test
+    public void testReaderWithSuffix() {
+        RestAssured.get("/test/reader/with-suffix")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("from reader suffix - result"));
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @Path("/writer/with-no-suffix")
+        @Produces("text/test")
+        public String writerSimple() {
+            return "result";
+        }
+
+        @GET
+        @Path("/writer/with-suffix")
+        @Produces("text/test+suffix")
+        public String writerSuffix() {
+            return "result";
+        }
+
+        @GET
+        @Path("/reader/with-no-suffix")
+        @Consumes("text/test")
+        public String readerSimple(Object fromReader) {
+            return fromReader + " - result";
+        }
+
+        @GET
+        @Path("/reader/with-suffix")
+        @Consumes("text/test+suffix")
+        public String readerSuffix(Object fromReader) {
+            return fromReader + " - result";
+        }
+    }
+
+    @Provider
+    @Consumes("text/test")
+    @Produces("text/test")
+    public static class NoSuffixMessageBodyWriter implements ServerMessageBodyWriter<Object>, ServerMessageBodyReader<Object> {
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            String response = (String) o;
+            response += " - no suffix writer";
+            context.getOrCreateOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod,
+                MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public Object readFrom(Class<Object> type, Type genericType, MediaType mediaType,
+                ServerRequestContext context) throws WebApplicationException {
+            return "from reader";
+        }
+
+        @Override
+        public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public Object readFrom(Class<Object> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, String> multivaluedMap, InputStream inputStream)
+                throws WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+    }
+
+    @Provider
+    @Consumes("text/test+suffix")
+    @Produces("text/test+suffix")
+    public static class SuffixMessageBodyWriter implements ServerMessageBodyWriter<Object>, ServerMessageBodyReader<Object> {
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            String response = (String) o;
+            response += " - suffix writer";
+            context.getOrCreateOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod,
+                MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public Object readFrom(Class<Object> type, Type genericType, MediaType mediaType,
+                ServerRequestContext context) throws WebApplicationException {
+            return "from reader suffix";
+        }
+
+        @Override
+        public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+            throw new IllegalStateException("should never have been called");
+        }
+
+        @Override
+        public Object readFrom(Class<Object> aClass, Type type, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, String> multivaluedMap, InputStream inputStream)
+                throws WebApplicationException {
+            throw new IllegalStateException("should never have been called");
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientReaderInterceptorContextImpl.java
@@ -17,7 +17,6 @@ import javax.ws.rs.ext.ReaderInterceptorContext;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
 import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
-import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 
 public class ClientReaderInterceptorContextImpl extends AbstractClientInterceptorContextImpl
         implements ReaderInterceptorContext {
@@ -35,7 +34,7 @@ public class ClientReaderInterceptorContextImpl extends AbstractClientIntercepto
             Map<String, Object> properties, MultivaluedMap<String, String> headers,
             ConfigurationImpl configuration, Serialisers serialisers, InputStream inputStream,
             ReaderInterceptor[] interceptors) {
-        super(annotations, entityClass, entityType, MediaTypeHelper.withSuffixAsSubtype(mediaType), properties);
+        super(annotations, entityClass, entityType, mediaType, properties);
         this.configuration = configuration;
         this.serialisers = serialisers;
         this.inputStream = inputStream;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceReader.java
@@ -114,7 +114,11 @@ public class ResourceReader {
      */
     public static class ResourceReaderComparator implements Comparator<ResourceReader> {
 
-        public static final ResourceReaderComparator INSTANCE = new ResourceReaderComparator();
+        private final List<MediaType> produces;
+
+        public ResourceReaderComparator(List<MediaType> produces) {
+            this.produces = produces;
+        }
 
         @Override
         public int compare(ResourceReader o1, ResourceReader o2) {
@@ -142,6 +146,14 @@ public class ResourceReader {
             int mediaTypeCompare = MediaTypeHelper.compareWeight(mediaTypes1.get(0), mediaTypes2.get(0));
             if (mediaTypeCompare != 0) {
                 return mediaTypeCompare;
+            }
+
+            // try to compare using the number of matching produces media types
+            if (!produces.isEmpty()) {
+                mediaTypeCompare = MediaTypeHelper.compareMatchingMediaTypes(produces, mediaTypes1, mediaTypes2);
+                if (mediaTypeCompare != 0) {
+                    return mediaTypeCompare;
+                }
             }
 
             // done to make the sorting result deterministic

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
@@ -2,9 +2,11 @@ package org.jboss.resteasy.reactive.common.util;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -16,6 +18,7 @@ import javax.ws.rs.core.Response;
 public class MediaTypeHelper {
     public static final MediaTypeComparator Q_COMPARATOR = new MediaTypeComparator("q");
     public static final MediaTypeComparator QS_COMPARATOR = new MediaTypeComparator("qs");
+    private static final String MEDIA_TYPE_SUFFIX_DELIM = "+";
 
     private static float getQTypeWithParamInfo(MediaType type, String parameterName) {
         if (type.getParameters() != null) {
@@ -136,6 +139,13 @@ public class MediaTypeHelper {
 
     public static int compareWeight(MediaType one, MediaType two) {
         return Q_COMPARATOR.compare(one, two);
+    }
+
+    public static int compareMatchingMediaTypes(List<MediaType> produces, List<MediaType> mediaTypes1,
+            List<MediaType> mediaTypes2) {
+        int countMediaTypes1 = countMatchingMediaTypes(produces, mediaTypes1);
+        int countMediaTypes2 = countMatchingMediaTypes(produces, mediaTypes2);
+        return (countMediaTypes1 < countMediaTypes2) ? 1 : ((countMediaTypes1 == countMediaTypes2) ? 0 : -1);
     }
 
     public static void sortByWeight(List<MediaType> types) {
@@ -267,20 +277,77 @@ public class MediaTypeHelper {
         return false;
     }
 
+    public static List<MediaType> toListOfMediaType(String[] mediaTypes) {
+        if (mediaTypes == null || mediaTypes.length == 0) {
+            return Collections.emptyList();
+        }
+
+        List<MediaType> list = new ArrayList<>(mediaTypes.length);
+        for (String mediaType : mediaTypes) {
+            list.add(MediaType.valueOf(mediaType));
+        }
+
+        return Collections.unmodifiableList(list);
+    }
+
     /**
-     * If the supplied media type contains a suffix in the subtype, then this returns a new media type
-     * that uses the suffix as the subtype
+     * This method ungroups the media types with suffix in separated media types. For example, having the media type
+     * "application/one+two" will return a list containing ["application/one+two", "application/one", "application/two"].
+     * The Media Types without suffix remain as one media type.
+     *
+     * @param mediaTypes the list of media types to separate.
+     * @return the list of ungrouped media types.
      */
-    public static MediaType withSuffixAsSubtype(MediaType mediaType) {
+    public static List<MediaType> getUngroupedMediaTypes(List<MediaType> mediaTypes) {
+        List<MediaType> effectiveMediaTypes = new ArrayList<>();
+        for (MediaType mediaType : mediaTypes) {
+            effectiveMediaTypes.addAll(getUngroupedMediaTypes(mediaType));
+        }
+
+        return Collections.unmodifiableList(effectiveMediaTypes);
+    }
+
+    /**
+     * This method ungroups the media type with suffix in separated media types. For example, having the media type
+     * "application/one+two" will return a list containing ["application/one+two", "application/one", "application/two"].
+     * If the Media Type does not have a suffix, then it's not modified.
+     *
+     * @param mediaType the media type to separate.
+     * @return the list of ungrouped media types.
+     */
+    public static List<MediaType> getUngroupedMediaTypes(MediaType mediaType) {
         if (mediaType == null) {
-            return null;
+            return Collections.emptyList();
         }
-        int plusIndex = mediaType.getSubtype().indexOf('+');
-        if ((plusIndex > -1) && (plusIndex < mediaType.getSubtype().length() - 1)) {
-            mediaType = new MediaType(mediaType.getType(),
-                    mediaType.getSubtype().substring(plusIndex + 1),
-                    mediaType.getParameters());
+
+        if (mediaType.getSubtype() == null || !mediaType.getSubtype().contains(MEDIA_TYPE_SUFFIX_DELIM)) {
+            return Collections.singletonList(mediaType);
         }
-        return mediaType;
+
+        String[] subTypes = mediaType.getSubtype().split(Pattern.quote(MEDIA_TYPE_SUFFIX_DELIM));
+
+        List<MediaType> effectiveMediaTypes = new ArrayList<>(1 + subTypes.length);
+        effectiveMediaTypes.add(mediaType);
+        for (String subType : subTypes) {
+            effectiveMediaTypes.add(new MediaType(mediaType.getType(), subType, mediaType.getParameters()));
+        }
+
+        return Collections.unmodifiableList(effectiveMediaTypes);
+    }
+
+    private static int countMatchingMediaTypes(List<MediaType> produces, List<MediaType> mediaTypes) {
+        int count = 0;
+        for (int i = 0; i < mediaTypes.size(); i++) {
+            MediaType mediaType = mediaTypes.get(i);
+            for (int j = 0; j < produces.size(); j++) {
+                MediaType produce = produces.get(j);
+                if (mediaType.isCompatible(produce)) {
+                    count++;
+                    break;
+                }
+            }
+        }
+
+        return count;
     }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ServerMediaType.java
@@ -30,14 +30,11 @@ public class ServerMediaType {
     }
 
     /**
-     *
      * @param mediaTypes The original media types
      * @param charset charset to use
      * @param deprioritizeWildcards whether or not wildcard types should be carry less weight when sorting is performed
-     * @param useSuffix whether or not a media type whose subtype contains a suffix should swap the entire subtype with the
-     *        suffix
      */
-    public ServerMediaType(List<MediaType> mediaTypes, String charset, boolean deprioritizeWildcards, boolean useSuffix) {
+    public ServerMediaType(List<MediaType> mediaTypes, String charset, boolean deprioritizeWildcards) {
         if (mediaTypes.isEmpty()) {
             this.sortedOriginalMediaTypes = new MediaType[] { MediaType.WILDCARD_TYPE };
         } else {
@@ -86,12 +83,6 @@ public class ServerMediaType {
             MediaType existing = sortedOriginalMediaTypes[i];
             MediaType m = new MediaType(existing.getType(), existing.getSubtype(), charset);
             sortedMediaTypes[i] = m;
-        }
-        // use the suffix type if it exists when negotiating the type
-        if (useSuffix) {
-            for (int i = 0; i < sortedMediaTypes.length; i++) {
-                sortedMediaTypes[i] = MediaTypeHelper.withSuffixAsSubtype(sortedMediaTypes[i]);
-            }
         }
         // if there is only one media type, use it
         if (sortedMediaTypes.length == 1

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/serialization/DynamicEntityWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/serialization/DynamicEntityWriter.java
@@ -97,8 +97,7 @@ public class DynamicEntityWriter implements EntityWriter {
             }
         } else {
             writers = serialisers
-                    .findWriters(null, entity.getClass(), MediaTypeHelper.withSuffixAsSubtype(producesMediaType.getMediaType()),
-                            RuntimeType.SERVER)
+                    .findWriters(null, entity.getClass(), producesMediaType.getMediaType(), RuntimeType.SERVER)
                     .toArray(ServerSerialisers.NO_WRITER);
         }
         for (MessageBodyWriter<?> w : writers) {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -363,7 +363,7 @@ public class RuntimeResourceDeployment {
             // when negotiating a media type, we want to use the proper subtype to locate a ResourceWriter,
             // hence the 'true' for 'useSuffix'
             serverMediaType = new ServerMediaType(ServerMediaType.mediaTypesFromArray(method.getProduces()),
-                    StandardCharsets.UTF_8.name(), false, true);
+                    StandardCharsets.UTF_8.name(), false);
         }
         if (method.getHttpMethod() == null) {
             //this is a resource locator method
@@ -383,8 +383,7 @@ public class RuntimeResourceDeployment {
                     } else if (rawEffectiveReturnType != Void.class
                             && rawEffectiveReturnType != void.class) {
                         List<MessageBodyWriter<?>> buildTimeWriters = serialisers.findBuildTimeWriters(rawEffectiveReturnType,
-                                RuntimeType.SERVER, Collections.singletonList(
-                                        MediaTypeHelper.withSuffixAsSubtype(MediaType.valueOf(method.getProduces()[0]))));
+                                RuntimeType.SERVER, MediaTypeHelper.toListOfMediaType(method.getProduces()));
                         if (buildTimeWriters == null) {
                             //if this is null this means that the type cannot be resolved at build time
                             //this happens when the method returns a generic type (e.g. Object), so there

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/MediaTypeMapper.java
@@ -131,8 +131,9 @@ public class MediaTypeMapper implements ServerRestHandler {
         }
 
         public void setupServerMediaType() {
-            MediaTypeHelper.sortByQSWeight(mtsWithParams); // TODO: this isn't completely correct as we are supposed to take q and then qs into account...
-            serverMediaType = new ServerMediaType(mtsWithParams, StandardCharsets.UTF_8.name(), true, false);
+            // TODO: this isn't completely correct as we are supposed to take q and then qs into account...
+            MediaTypeHelper.sortByQSWeight(mtsWithParams);
+            serverMediaType = new ServerMediaType(mtsWithParams, StandardCharsets.UTF_8.name(), true);
         }
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RequestDeserializeHandler.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.ReaderInterceptor;
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
 import org.jboss.resteasy.reactive.server.jaxrs.ReaderInterceptorContextImpl;
@@ -47,7 +46,7 @@ public class RequestDeserializeHandler implements ServerRestHandler {
         String requestTypeString = requestContext.serverRequest().getRequestHeader(HttpHeaders.CONTENT_TYPE);
         if (requestTypeString != null) {
             try {
-                effectiveRequestType = MediaTypeHelper.withSuffixAsSubtype(MediaType.valueOf(requestTypeString));
+                effectiveRequestType = MediaType.valueOf(requestTypeString);
             } catch (Exception e) {
                 throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).build());
             }


### PR DESCRIPTION
Given a media type with suffix, for example: "application/test+json".

Before these changes, Resteasy Reactive was trying to find the writer/reader using only the suffix. For example, with a media type "application/test+json", it would only use "json" to locate the right writer/reader. 

Spite of this has been working well so far, if users provide a custom writer/reader for a concrete media type with suffix:

```java
@Provider
    @Produces("text/test+suffix")
    public static class SuffixMessageBodyWriter implements ServerMessageBodyWriter<Object> {

        @Override
        public boolean isWriteable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo target, MediaType mediaType) {
           // ...
        }

        @Override
        public void writeResponse(Object o, Type genericType, ServerRequestContext context) {
            // ...
        }

        // ...
    }
```

The above writer will never be used. 

After these changes, we will use the media type with suffix, plus the split parts of the suffix. For example, if the media type with suffix is: "application/test+json", it will try to find the best writer/reader for "application/test+json", "application/test" and then "application/json" (In this order).

Fix https://github.com/quarkusio/quarkus/issues/15982