### PR TITLE
Kubernetes Client: Allow to disable the RBAC resources generation

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -613,6 +613,11 @@ To access the API server from within a Kubernetes cluster, some RBAC related res
 So, when the `kubernetes-client` extension is present, the `kubernetes` extension is going to create those resources automatically, so that application will be granted the `view` role.
 If more roles are required, they will have to be added manually.
 
+[NOTE]
+====
+You can disable the RBAC resources generation using the property `quarkus.kubernetes-client.generate-rbac=false`.
+====
+
 === Deploying to Minikube
 
 https://github.com/kubernetes/minikube[Minikube] is quite popular when a Kubernetes cluster is needed for development purposes. To make the deployment to Minikube

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -27,6 +27,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.jackson.deployment.IgnoreJsonDeserializeClassBuildItem;
+import io.quarkus.kubernetes.client.runtime.KubernetesClientBuildConfig;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientProducer;
 import io.quarkus.kubernetes.client.runtime.KubernetesConfigProducer;
 import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
@@ -64,6 +65,7 @@ public class KubernetesClientProcessor {
 
     @BuildStep
     public void process(ApplicationIndexBuildItem applicationIndex, CombinedIndexBuildItem combinedIndexBuildItem,
+            KubernetesClientBuildConfig kubernetesClientConfig,
             BuildProducer<ExtensionSslNativeSupportBuildItem> sslNativeSupport,
             BuildProducer<FeatureBuildItem> featureProducer,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
@@ -72,7 +74,9 @@ public class KubernetesClientProcessor {
             BuildProducer<KubernetesRoleBindingBuildItem> roleBindingProducer) {
 
         featureProducer.produce(new FeatureBuildItem(Feature.KUBERNETES_CLIENT));
-        roleBindingProducer.produce(new KubernetesRoleBindingBuildItem("view", true));
+        if (kubernetesClientConfig.generateRbac) {
+            roleBindingProducer.produce(new KubernetesRoleBindingBuildItem("view", true));
+        }
 
         // register fully (and not weakly) for reflection watchers, informers and custom resources
         final Set<DotName> watchedClasses = new HashSet<>();

--- a/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java
+++ b/extensions/kubernetes-client/runtime-internal/src/main/java/io/quarkus/kubernetes/client/runtime/KubernetesClientBuildConfig.java
@@ -155,4 +155,10 @@ public class KubernetesClientBuildConfig {
     @ConfigItem
     public Optional<String[]> noProxy;
 
+    /**
+     * Enable the generation of the RBAC manifests.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean generateRbac;
+
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndRbacDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndRbacDisabledTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.test.LogFile;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class WithKubernetesClientAndRbacDisabledTest {
+
+    private static final String APPLICATION_NAME = "kubernetes-with-client-and-rbac-disabled";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APPLICATION_NAME + ".properties")
+            .setRun(true)
+            .setForcedDependencies(
+                    Collections.singletonList(
+                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @LogFile
+    private Path logfile;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+
+        assertThat(kubernetesList).filteredOn(h -> "ServiceAccount".equals(h.getKind())).noneSatisfy(h -> {
+            assertThat(h.getMetadata().getName()).isEqualTo(APPLICATION_NAME);
+        });
+
+        assertThat(kubernetesList).filteredOn(h -> "RoleBinding".equals(h.getKind())).noneSatisfy(h -> {
+            assertThat(h.getMetadata().getName()).isEqualTo(APPLICATION_NAME + "-view");
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-client-and-rbac-disabled.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-client-and-rbac-disabled.properties
@@ -1,0 +1,1 @@
+quarkus.kubernetes-client.generate-rbac=false


### PR DESCRIPTION
To access the API server from within a Kubernetes cluster, some RBAC related resources are required (e.g. a ServiceAccount, a RoleBinding etc.).
So, when the `kubernetes-client` extension is present, the `kubernetes` extension is going to create those resources automatically, so that application will be granted the `view` role.

With these changes, we can disable the generation using the property `quarkus.kubernetes-client.generate-rbac=false`.