### PR TITLE
Fix DevService for Keycloak logout with Keycloak 18

### DIFF
--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -187,7 +187,8 @@ var port = {config:property('quarkus.http.port')};
         localStorage.removeItem('authorized');
     
         window.location.assign('{info:logoutUrl??}'
-          + "?" + '{info:postLogoutUriParam??}' + "=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider");
+          + "?" + '{info:postLogoutUriParam??}' + "=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
+          + "&" + "id_token_hint" + "=" + idToken);
     }
         
     function exchangeCodeForTokens(code){


### PR DESCRIPTION
I've noticed it while testing OIDC Client quickstart that Keycloak 18 now enforces that the logout request includes an `id_token_hint` query parameter (`quarkus-oidc` logout tests on `main` pass because `id_token_hint` is included by `CodeAuthenticationMechanism` when dealing with RP initiated logouts).

So this PR updates a `provider.html` to fix it.

CC @pedroigor 