### PR TITLE
Improve virtual thread related validation in RESTEasy Reactive

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/CompiledJavaVersionBuildItem.java
@@ -30,6 +30,8 @@ public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
 
         Status isJava17OrHigher();
 
+        Status isJava19OrHigher();
+
         enum Status {
             TRUE,
             FALSE,
@@ -57,12 +59,18 @@ public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
             public Status isJava17OrHigher() {
                 return Status.UNKNOWN;
             }
+
+            @Override
+            public Status isJava19OrHigher() {
+                return Status.UNKNOWN;
+            }
         }
 
         final class Known implements JavaVersion {
 
             private static final int JAVA_11_MAJOR = 55;
             private static final int JAVA_17_MAJOR = 61;
+            private static final int JAVA_19_MAJOR = 63;
 
             private final int determinedMajor;
 
@@ -83,6 +91,11 @@ public final class CompiledJavaVersionBuildItem extends SimpleBuildItem {
             @Override
             public Status isJava17OrHigher() {
                 return higherOrEqualStatus(JAVA_17_MAJOR);
+            }
+
+            @Override
+            public Status isJava19OrHigher() {
+                return higherOrEqualStatus(JAVA_19_MAJOR);
             }
 
             private Status higherOrEqualStatus(int javaMajor) {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/CompiledJavaVersionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/CompiledJavaVersionBuildStep.java
@@ -23,6 +23,10 @@ public class CompiledJavaVersionBuildStep {
      */
     @BuildStep
     public CompiledJavaVersionBuildItem compiledJavaVersion(BuildSystemTargetBuildItem buildSystemTarget) {
+        if ((buildSystemTarget.getOutputDirectory() == null) || (!Files.exists(buildSystemTarget.getOutputDirectory()))) {
+            // needed for Arquillian TCK tests
+            return CompiledJavaVersionBuildItem.unknown();
+        }
         AtomicReference<Integer> majorVersion = new AtomicReference<>(null);
         try {
             Files.walkFileTree(buildSystemTarget.getOutputDirectory(), new SimpleFileVisitor<>() {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TargetJavaVersion.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/TargetJavaVersion.java
@@ -1,0 +1,28 @@
+package org.jboss.resteasy.reactive.common.processor;
+
+/**
+ * Used to determine the java version of the compiled Java code
+ */
+public interface TargetJavaVersion {
+
+    Status isJava19OrHigher();
+
+    enum Status {
+        TRUE,
+        FALSE,
+        UNKNOWN
+    }
+
+    final class Unknown implements TargetJavaVersion {
+
+        public static final Unknown INSTANCE = new Unknown();
+
+        Unknown() {
+        }
+
+        @Override
+        public Status isJava19OrHigher() {
+            return Status.UNKNOWN;
+        }
+    }
+}


### PR DESCRIPTION
The changes include:

* Validation is only performed on methods that are annotated with `@RunOnVirtualThread`
* Warnings about inability to use virtual threads have been converted to errors
* Additional validation is performed regarding the target version of the project