### PR TITLE
Introduce Vert.x route order marks

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/main/java/io/quarkus/resteasy/deployment/ResteasyStandaloneBuildStep.java
@@ -31,6 +31,8 @@ import io.vertx.ext.web.RoutingContext;
 
 public class ResteasyStandaloneBuildStep {
 
+    private static final int REST_ROUTE_ORDER_OFFSET = 100;
+
     public static final class ResteasyStandaloneBuildItem extends SimpleBuildItem {
 
         final String deploymentRootPath;
@@ -86,7 +88,9 @@ public class ResteasyStandaloneBuildStep {
                 executorBuildItem.getExecutorProxy(), resteasyVertxConfig);
         // Exact match for resources matched to the root path
         routes.produce(
-                RouteBuildItem.builder().orderedRoute(standalone.deploymentRootPath, VertxHttpRecorder.DEFAULT_ROUTE_ORDER + 1)
+                RouteBuildItem.builder()
+                        .orderedRoute(standalone.deploymentRootPath,
+                                VertxHttpRecorder.AFTER_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET)
                         .handler(handler).build());
         String matchPath = standalone.deploymentRootPath;
         if (matchPath.endsWith("/")) {
@@ -95,7 +99,8 @@ public class ResteasyStandaloneBuildStep {
             matchPath += "/*";
         }
         // Match paths that begin with the deployment path
-        routes.produce(RouteBuildItem.builder().orderedRoute(matchPath, VertxHttpRecorder.DEFAULT_ROUTE_ORDER + 1)
+        routes.produce(RouteBuildItem.builder()
+                .orderedRoute(matchPath, VertxHttpRecorder.AFTER_DEFAULT_ROUTE_ORDER_MARK + REST_ROUTE_ORDER_OFFSET)
                 .handler(handler).build());
 
         recorder.start(shutdown, requireVirtual.isPresent());

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -123,8 +123,14 @@ public class VertxHttpRecorder {
 
     public static final String MAX_REQUEST_SIZE_KEY = "io.quarkus.max-request-size";
 
-    // We do not use Integer.MAX on purpose to allow advanced users to register a route AFTER the default route
+    /** Order mark for route with priority over the default route (add an offset from this mark) **/
+    public static final int BEFORE_DEFAULT_ROUTE_ORDER_MARK = 1_000;
+
+    /** Default route order (i.e Static Resources, Servlet) **/
     public static final int DEFAULT_ROUTE_ORDER = 10_000;
+
+    /** Order mark for route without priority over the default route (add an offset from this mark) **/
+    public static final int AFTER_DEFAULT_ROUTE_ORDER_MARK = 20_000;
 
     private static final Logger LOGGER = Logger.getLogger(VertxHttpRecorder.class.getName());
 


### PR DESCRIPTION
Try to fix #25759 by introducing route order marks for consumers.

Extensions using `DEFAULT_ROUTE_ORDER + x` with `x < 10_000` to be after RESTEasy might be broken by this change.