### PR TITLE
ArC - fix io.quarkus.arc.All List injection

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInjectionTest.java
@@ -61,6 +61,8 @@ public class ListInjectionTest {
         // Test constructor injection and additional qualifier
         assertEquals(1, foo.convertersMyQualifier.size());
         assertEquals("OK", foo.convertersMyQualifier.get(0).convert("OK"));
+        assertEquals(1, foo.convertersMyQualifierField.size());
+        assertEquals("OK", foo.convertersMyQualifierField.get(0).convert("OK"));
 
         // Test List<InstanceHandle<?>>
         assertEquals(1, foo.counterHandles.size());
@@ -107,6 +109,11 @@ public class ListInjectionTest {
         List<Converter> convertersDefault;
 
         final List<Converter> convertersMyQualifier;
+
+        @Inject
+        @All
+        @MyQualifier
+        List<Converter> convertersMyQualifierField;
 
         Foo(@All @MyQualifier List<Converter> convertersMyQualifier) {
             this.convertersMyQualifier = convertersMyQualifier;


### PR DESCRIPTION
- fix a case where `@All List<Foo>` and `@Inject @All List<Foo>` injection points are present
- the value of a synthetic Identified qualifier is a hash of the type
and all annotations, however, we do not add a synthetic bean if the type and
qualifiers match; as a result of the injection points is not satisfied