### PR TITLE
Document the need of request context for using Hibernate inside a security identity augmenter

### DIFF
--- a/docs/src/main/asciidoc/security-authorization.adoc
+++ b/docs/src/main/asciidoc/security-authorization.adoc
@@ -17,6 +17,10 @@ been blocked using `quarkus.http.auth.` configuration. If you are using JAX-RS y
 requirements instead of HTTP path level matching, as these properties can be overridden by annotations on an individual
 endpoint.
 
+Authorization is based on user roles that are provided by the security provider.
+To customize these roles, a `SecurityIdentityAugmentor` can be created, see
+xref:security-customization.adoc#security-identity-customization[Security Identity Customization].
+
 == Authorization using Configuration
 
 The default implementation allows you to define permissions using config in `application.properties`. An example

--- a/docs/src/main/asciidoc/security-customization.adoc
+++ b/docs/src/main/asciidoc/security-customization.adoc
@@ -224,6 +224,49 @@ If more than one custom `SecurityIdentityAugmentor` is registered then they will
 You can enforce the order by implementing a default `SecurityIdentityAugmentor#priority` method. Augmentors with higher priorities will be invoked first.
 ====
 
+By default, the request context is not activated when augmenting the security identity, this means that if you want to use for example Hibernate
+that mandates a request context, you will have a `javax.enterprise.context.ContextNotActiveException`.
+
+The solution is to activate the request context, the following example shows how to get the roles from an Hibernate with Panache `UserRoleEntity`.
+
+[source,java]
+----
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
+import java.util.function.Supplier;
+
+@ApplicationScoped
+public class RolesAugmentor implements SecurityIdentityAugmentor {
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        if(identity.isAnonymous()) {
+            return Uni.createFrom().item(identity);
+        }
+
+        // Hibernate ORM is blocking
+        return context.runBlocking(build(identity));
+    }
+
+    @ActivateRequestContext // Will activate the request context
+    Supplier<SecurityIdentity> build(SecurityIdentity identity) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+        String user = identity.getPrincipal().getName();
+
+        UserRoleEntity.<userRoleEntity>streamAll()
+                .filter(role -> user.equals(role.user))
+                .forEach(role -> builder.addRole(role.role));
+
+        return builder::build;
+    }
+}
+----
+
 [[jaxrs-security-context]]
 == Custom JAX-RS SecurityContext
 


### PR DESCRIPTION
…urity identity augmenter

/cc @sberyozkin I took the liberty to add a small sentence at the begining of the authorization guide with a pointer with the security identity augmentor as it's the authorization guide that talks about roles and I search on this one how to customize these so it will be easier to find.