### PR TITLE
Add ability to add additional hibernate dialect for third party databases. 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -897,6 +897,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-hibernate-orm-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DatabaseKind.java
+++ b/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DatabaseKind.java
@@ -84,7 +84,7 @@ public final class DatabaseKind {
         return is(value, POSTGRESQL);
     }
 
-    private static boolean is(String value, String mainName) {
+    public static boolean is(String value, String mainName) {
         if (value == null) {
             return false;
         }

--- a/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseKindBuildItem.java
+++ b/extensions/datasource/deployment-spi/src/main/java/io/quarkus/datasource/deployment/spi/DatabaseKindBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.datasource.deployment.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class DatabaseKindBuildItem extends MultiBuildItem {
+    private final String dbKind;
+    private final String dialect;
+
+    public DatabaseKindBuildItem(String dbKind, String dialect) {
+        this.dbKind = dbKind;
+        this.dialect = dialect;
+    }
+
+    public String getDbKind() {
+        return dbKind;
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+}

--- a/extensions/hibernate-orm/deployment-spi/pom.xml
+++ b/extensions/hibernate-orm/deployment-spi/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-hibernate-orm-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
+    <name>Quarkus - Hibernate ORM - Deployment - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource-common</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/extensions/hibernate-orm/deployment-spi/src/main/java/io.quarkus.hibernate.orm.deployment.spi/DatasourceDbKindHibernateOrmMetadataBuildItem.java
+++ b/extensions/hibernate-orm/deployment-spi/src/main/java/io.quarkus.hibernate.orm.deployment.spi/DatasourceDbKindHibernateOrmMetadataBuildItem.java
@@ -1,12 +1,12 @@
-package io.quarkus.datasource.deployment.spi;
+package io.quarkus.hibernate.orm.deployment.spi;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
-public final class DatabaseKindBuildItem extends MultiBuildItem {
+public final class DatasourceDbKindHibernateOrmMetadataBuildItem extends MultiBuildItem {
     private final String dbKind;
     private final String dialect;
 
-    public DatabaseKindBuildItem(String dbKind, String dialect) {
+    public DatasourceDbKindHibernateOrmMetadataBuildItem(String dbKind, String dialect) {
         this.dbKind = dbKind;
         this.dialect = dialect;
     }

--- a/extensions/hibernate-orm/deployment/pom.xml
+++ b/extensions/hibernate-orm/deployment/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-narayana-jta-deployment</artifactId>
         </dependency>
         <dependency>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -3,7 +3,7 @@ package io.quarkus.hibernate.orm.deployment;
 import java.util.List;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
-import io.quarkus.datasource.deployment.spi.DatabaseKindBuildItem;
+import io.quarkus.hibernate.orm.deployment.spi.DatasourceDbKindHibernateOrmMetadataBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 public final class Dialects {
@@ -13,7 +13,7 @@ public final class Dialects {
     }
 
     public static String guessDialect(String persistenceUnitName, String resolvedDbKind,
-            List<DatabaseKindBuildItem> databaseKindBuildItems) {
+            List<DatasourceDbKindHibernateOrmMetadataBuildItem> dbKindMetadataBuildItems) {
         // For now select the latest dialect from the driver
         // later, we can keep doing that but also avoid DCE
         // of all the dialects we want in so that people can override them
@@ -43,7 +43,7 @@ public final class Dialects {
         }
 
         // This is created for third party extentions. I think hardcode above can be refactored by owners
-        for (DatabaseKindBuildItem item : databaseKindBuildItems) {
+        for (DatasourceDbKindHibernateOrmMetadataBuildItem item : dbKindMetadataBuildItems) {
             if (item.getDbKind().equalsIgnoreCase(resolvedDbKind)) {
                 return item.getDialect();
             }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -1,6 +1,9 @@
 package io.quarkus.hibernate.orm.deployment;
 
+import java.util.List;
+
 import io.quarkus.datasource.common.runtime.DatabaseKind;
+import io.quarkus.datasource.deployment.spi.DatabaseKindBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 public final class Dialects {
@@ -9,7 +12,8 @@ public final class Dialects {
         //utility
     }
 
-    public static String guessDialect(String persistenceUnitName, String resolvedDbKind) {
+    public static String guessDialect(String persistenceUnitName, String resolvedDbKind,
+            List<DatabaseKindBuildItem> databaseKindBuildItems) {
         // For now select the latest dialect from the driver
         // later, we can keep doing that but also avoid DCE
         // of all the dialects we want in so that people can override them
@@ -36,6 +40,13 @@ public final class Dialects {
         }
         if (DatabaseKind.isMsSQL(resolvedDbKind)) {
             return "org.hibernate.dialect.SQLServer2016Dialect";
+        }
+
+        // This is created for third party extentions. I think hardcode above can be refactored by owners
+        for (DatabaseKindBuildItem item : databaseKindBuildItems) {
+            if (item.getDbKind().equalsIgnoreCase(resolvedDbKind)) {
+                return item.getDialect();
+            }
         }
 
         String error = "Hibernate extension could not guess the dialect from the database kind '" + resolvedDbKind

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -44,7 +44,7 @@ public final class Dialects {
 
         // This is created for third party extentions. I think hardcode above can be refactored by owners
         for (DatasourceDbKindHibernateOrmMetadataBuildItem item : dbKindMetadataBuildItems) {
-            if (item.getDbKind().equalsIgnoreCase(resolvedDbKind)) {
+            if (DatabaseKind.is(resolvedDbKind, item.getDbKind())) {
                 return item.getDialect();
             }
         }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/Dialects.java
@@ -14,42 +14,13 @@ public final class Dialects {
 
     public static String guessDialect(String persistenceUnitName, String resolvedDbKind,
             List<DatasourceDbKindHibernateOrmMetadataBuildItem> dbKindMetadataBuildItems) {
-        // For now select the latest dialect from the driver
-        // later, we can keep doing that but also avoid DCE
-        // of all the dialects we want in so that people can override them
-        if (DatabaseKind.isDB2(resolvedDbKind)) {
-            return "org.hibernate.dialect.DB297Dialect";
-        }
-        if (DatabaseKind.isPostgreSQL(resolvedDbKind)) {
-            return "io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect";
-        }
-        if (DatabaseKind.isH2(resolvedDbKind)) {
-            return "io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect";
-        }
-        if (DatabaseKind.isMariaDB(resolvedDbKind)) {
-            return "org.hibernate.dialect.MariaDB106Dialect";
-        }
-        if (DatabaseKind.isMySQL(resolvedDbKind)) {
-            return "org.hibernate.dialect.MySQL8Dialect";
-        }
-        if (DatabaseKind.isOracle(resolvedDbKind)) {
-            return "org.hibernate.dialect.Oracle12cDialect";
-        }
-        if (DatabaseKind.isDerby(resolvedDbKind)) {
-            return "org.hibernate.dialect.DerbyTenSevenDialect";
-        }
-        if (DatabaseKind.isMsSQL(resolvedDbKind)) {
-            return "org.hibernate.dialect.SQLServer2016Dialect";
-        }
-
-        // This is created for third party extentions. I think hardcode above can be refactored by owners
         for (DatasourceDbKindHibernateOrmMetadataBuildItem item : dbKindMetadataBuildItems) {
             if (DatabaseKind.is(resolvedDbKind, item.getDbKind())) {
                 return item.getDialect();
             }
         }
 
-        String error = "Hibernate extension could not guess the dialect from the database kind '" + resolvedDbKind
+        String error = "The Hibernate ORM extension could not guess the dialect from the database kind '" + resolvedDbKind
                 + "'. Add an explicit '" + HibernateOrmConfig.puPropertyKey(persistenceUnitName, "dialect") + "' property.";
         throw new ConfigurationException(error);
     }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -80,6 +80,7 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanTypeExclusion;
 import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
+import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
@@ -168,6 +169,27 @@ public final class HibernateOrmProcessor {
     private static final Logger LOG = Logger.getLogger(HibernateOrmProcessor.class);
 
     private static final String INTEGRATOR_SERVICE_FILE = "META-INF/services/org.hibernate.integrator.spi.Integrator";
+
+    @BuildStep
+    void registerHibernateOrmMetadataForCoreDialects(
+            BuildProducer<DatasourceDbKindHibernateOrmMetadataBuildItem> producer) {
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.DB2,
+                "org.hibernate.dialect.DB297Dialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.DERBY,
+                "org.hibernate.dialect.DerbyTenSevenDialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.H2,
+                "io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.MARIADB,
+                "org.hibernate.dialect.MariaDB106Dialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.MSSQL,
+                "org.hibernate.dialect.SQLServer2016Dialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.MYSQL,
+                "org.hibernate.dialect.MySQL8Dialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.ORACLE,
+                "org.hibernate.dialect.Oracle12cDialect"));
+        producer.produce(new DatasourceDbKindHibernateOrmMetadataBuildItem(DatabaseKind.POSTGRESQL,
+                "io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect"));
+    }
 
     @BuildStep
     void checkTransactionsSupport(Capabilities capabilities) {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
@@ -2,25 +2,11 @@ package io.quarkus.hibernate.orm.deployment;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import java.util.Collections;
 import java.util.Set;
 
-import org.hibernate.dialect.DB297Dialect;
-import org.hibernate.dialect.DerbyTenSevenDialect;
-import org.hibernate.dialect.MariaDB106Dialect;
-import org.hibernate.dialect.MySQL8Dialect;
-import org.hibernate.dialect.Oracle12cDialect;
-import org.hibernate.dialect.SQLServer2016Dialect;
 import org.jboss.jandex.DotName;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import io.quarkus.datasource.common.runtime.DatabaseKind;
-import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
-import io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect;
-import io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect;
 
 public class ConstantsTest {
     @ParameterizedTest
@@ -33,23 +19,4 @@ public class ConstantsTest {
     private static Set<DotName> provideConstantsToTest() {
         return ClassNames.CREATED_CONSTANTS;
     }
-
-    @Test
-    public void testDialectNames() {
-        assertDialectMatch(DatabaseKind.DB2, DB297Dialect.class);
-        assertDialectMatch(DatabaseKind.POSTGRESQL, QuarkusPostgreSQL10Dialect.class);
-        assertDialectMatch(DatabaseKind.H2, QuarkusH2Dialect.class);
-        assertDialectMatch(DatabaseKind.MARIADB, MariaDB106Dialect.class);
-        assertDialectMatch(DatabaseKind.MYSQL, MySQL8Dialect.class);
-        assertDialectMatch(DatabaseKind.DERBY, DerbyTenSevenDialect.class);
-        assertDialectMatch(DatabaseKind.MSSQL, SQLServer2016Dialect.class);
-        assertDialectMatch(DatabaseKind.ORACLE, Oracle12cDialect.class);
-    }
-
-    private void assertDialectMatch(String dbName, Class<?> dialectClass) {
-        final String guessDialect = Dialects
-                .guessDialect(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, dbName, Collections.emptyList());
-        Assertions.assertEquals(dialectClass.getName(), guessDialect);
-    }
-
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/deployment/ConstantsTest.java
@@ -2,6 +2,7 @@ package io.quarkus.hibernate.orm.deployment;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.dialect.DB297Dialect;
@@ -46,7 +47,8 @@ public class ConstantsTest {
     }
 
     private void assertDialectMatch(String dbName, Class<?> dialectClass) {
-        final String guessDialect = Dialects.guessDialect(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, dbName);
+        final String guessDialect = Dialects
+                .guessDialect(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, dbName, Collections.emptyList());
         Assertions.assertEquals(dialectClass.getName(), guessDialect);
     }
 

--- a/extensions/hibernate-orm/pom.xml
+++ b/extensions/hibernate-orm/pom.xml
@@ -14,6 +14,7 @@
     <name>Quarkus - Hibernate ORM</name>
     <packaging>pom</packaging>
     <modules>
+        <module>deployment-spi</module>
         <module>deployment</module>
         <module>runtime</module>
     </modules>

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
 import javax.persistence.SharedCacheMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 
+import io.quarkus.datasource.deployment.spi.DatabaseKindBuildItem;
+import io.quarkus.hibernate.orm.deployment.*;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
@@ -46,15 +48,6 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.hibernate.orm.deployment.Dialects;
-import io.quarkus.hibernate.orm.deployment.HibernateConfigUtil;
-import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
-import io.quarkus.hibernate.orm.deployment.HibernateOrmConfigPersistenceUnit;
-import io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor;
-import io.quarkus.hibernate.orm.deployment.JpaModelBuildItem;
-import io.quarkus.hibernate.orm.deployment.PersistenceProviderSetUpBuildItem;
-import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
-import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
@@ -125,7 +118,9 @@ public final class HibernateReactiveProcessor {
             BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles,
             BuildProducer<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
-            CurateOutcomeBuildItem curateOutcomeBuildItem) {
+            CurateOutcomeBuildItem curateOutcomeBuildItem,
+            List<DatabaseKindBuildItem> databaseKindBuildItems
+            ) {
 
         final boolean enableHR = hasEntities(jpaModel);
         if (!enableHR) {
@@ -157,7 +152,7 @@ public final class HibernateReactiveProcessor {
             ParsedPersistenceXmlDescriptor reactivePU = generateReactivePersistenceUnit(
                     hibernateOrmConfig, jpaModel,
                     dbKind, applicationArchivesBuildItem, launchMode.getLaunchMode(),
-                    systemProperties, nativeImageResources, hotDeploymentWatchedFiles);
+                    systemProperties, nativeImageResources, hotDeploymentWatchedFiles, databaseKindBuildItems);
 
             //Some constant arguments to the following method:
             // - this is Reactive
@@ -209,7 +204,8 @@ public final class HibernateReactiveProcessor {
             LaunchMode launchMode,
             BuildProducer<SystemPropertyBuildItem> systemProperties,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
-            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles) {
+            BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles,
+            List<DatabaseKindBuildItem> databaseKindBuildItems) {
 
         HibernateOrmConfigPersistenceUnit persistenceUnitConfig = hibernateOrmConfig.defaultPersistenceUnit;
 
@@ -221,7 +217,7 @@ public final class HibernateReactiveProcessor {
         if (explicitDialect.isPresent()) {
             dialect = explicitDialect.get();
         } else {
-            dialect = Dialects.guessDialect(persistenceUnitConfigName, dbKind);
+            dialect = Dialects.guessDialect(persistenceUnitConfigName, dbKind, databaseKindBuildItems);
         }
 
         // we found one

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 import javax.persistence.SharedCacheMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 
-import io.quarkus.datasource.deployment.spi.DatabaseKindBuildItem;
-import io.quarkus.hibernate.orm.deployment.*;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.loader.BatchFetchStyle;
@@ -48,7 +46,9 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.hibernate.orm.deployment.*;
 import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
+import io.quarkus.hibernate.orm.deployment.spi.DatasourceDbKindHibernateOrmMetadataBuildItem;
 import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.reactive.runtime.FastBootHibernateReactivePersistenceProvider;
@@ -119,8 +119,7 @@ public final class HibernateReactiveProcessor {
             BuildProducer<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
-            List<DatabaseKindBuildItem> databaseKindBuildItems
-            ) {
+            List<DatasourceDbKindHibernateOrmMetadataBuildItem> dbKindMetadataBuildItems) {
 
         final boolean enableHR = hasEntities(jpaModel);
         if (!enableHR) {
@@ -152,7 +151,7 @@ public final class HibernateReactiveProcessor {
             ParsedPersistenceXmlDescriptor reactivePU = generateReactivePersistenceUnit(
                     hibernateOrmConfig, jpaModel,
                     dbKind, applicationArchivesBuildItem, launchMode.getLaunchMode(),
-                    systemProperties, nativeImageResources, hotDeploymentWatchedFiles, databaseKindBuildItems);
+                    systemProperties, nativeImageResources, hotDeploymentWatchedFiles, dbKindMetadataBuildItems);
 
             //Some constant arguments to the following method:
             // - this is Reactive
@@ -205,7 +204,7 @@ public final class HibernateReactiveProcessor {
             BuildProducer<SystemPropertyBuildItem> systemProperties,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles,
-            List<DatabaseKindBuildItem> databaseKindBuildItems) {
+            List<DatasourceDbKindHibernateOrmMetadataBuildItem> dbKindMetadataBuildItems) {
 
         HibernateOrmConfigPersistenceUnit persistenceUnitConfig = hibernateOrmConfig.defaultPersistenceUnit;
 
@@ -217,7 +216,7 @@ public final class HibernateReactiveProcessor {
         if (explicitDialect.isPresent()) {
             dialect = explicitDialect.get();
         } else {
-            dialect = Dialects.guessDialect(persistenceUnitConfigName, dbKind, databaseKindBuildItems);
+            dialect = Dialects.guessDialect(persistenceUnitConfigName, dbKind, dbKindMetadataBuildItems);
         }
 
         // we found one


### PR DESCRIPTION
At this moment all Hibernates dialects hardcoded in io.quarkus.hibernate.orm.deployment.Dialects

This PR first step of resolving comment in this class:
        // For now select the latest dialect from the driver
        // later, we can keep doing that but also avoid DCE
        // of all the dialects we want in so that people can override them