### PR TITLE
Hibernate ORM 6 preparations, batch 2

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -44,7 +44,6 @@ import javax.transaction.TransactionManager;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.boot.archive.scan.spi.ClassDescriptor;
 import org.hibernate.boot.archive.scan.spi.PackageDescriptor;
 import org.hibernate.cfg.AvailableSettings;
@@ -136,6 +135,7 @@ import io.quarkus.hibernate.orm.runtime.cdi.QuarkusArcBeanContainer;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleCreateDDLSupplier;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleIntegrator;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
 import io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator;
 import io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver;

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 
 import io.quarkus.builder.item.MultiBuildItem;
@@ -12,6 +11,7 @@ import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDefinition;
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 
 /**
  * Not to be confused with PersistenceXmlDescriptorBuildItem, which holds

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ExcludePersistenceXmlConfigTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ExcludePersistenceXmlConfigTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
+
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -43,7 +45,7 @@ public class ExcludePersistenceXmlConfigTest {
         try {
             // it is the default entity manager from application.properties, not templatePU from the persistence.xml
             Assertions.assertEquals(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME,
-                    entityManager.getEntityManagerFactory().getProperties().get("hibernate.ejb.persistenceUnitName"));
+                    entityManager.getEntityManagerFactory().getProperties().get(PERSISTENCE_UNIT_NAME));
         } finally {
             Arc.container().requestContext().deactivate();
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedDefaultValueWithPersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedDefaultValueWithPersistenceXmlTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.orm.ignore_explicit_for_joined;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
@@ -33,7 +34,7 @@ public class IgnoreExplicitForJoinedDefaultValueWithPersistenceXmlTest {
         Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
 
         // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
-        assertEquals("templatePU", properties.get("hibernate.ejb.persistenceUnitName"));
+        assertEquals("templatePU", properties.get(PERSISTENCE_UNIT_NAME));
         //If not defined in persistence.xml, internally hibernate-orm will assume false as default value
         assertEquals(null, properties.get("hibernate.discriminator.ignore_explicit_for_joined"));
     }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedFalseValueWithPersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedFalseValueWithPersistenceXmlTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.orm.ignore_explicit_for_joined;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
@@ -33,7 +34,7 @@ public class IgnoreExplicitForJoinedFalseValueWithPersistenceXmlTest {
         Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
 
         // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
-        assertEquals("templatePU", properties.get("hibernate.ejb.persistenceUnitName"));
+        assertEquals("templatePU", properties.get(PERSISTENCE_UNIT_NAME));
         assertEquals("false", properties.get("hibernate.discriminator.ignore_explicit_for_joined"));
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedTrueValueWithPersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/ignore_explicit_for_joined/IgnoreExplicitForJoinedTrueValueWithPersistenceXmlTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.hibernate.orm.ignore_explicit_for_joined;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
@@ -33,7 +34,7 @@ public class IgnoreExplicitForJoinedTrueValueWithPersistenceXmlTest {
         Map<String, Object> properties = em.getEntityManagerFactory().getProperties();
 
         // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
-        assertEquals("templatePU", properties.get("hibernate.ejb.persistenceUnitName"));
+        assertEquals("templatePU", properties.get(PERSISTENCE_UNIT_NAME));
         assertEquals("true", properties.get("hibernate.discriminator.ignore_explicit_for_joined"));
     }
 }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/ExcludePersistenceXmlConfigTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/ExcludePersistenceXmlConfigTest.java
@@ -45,7 +45,8 @@ public class ExcludePersistenceXmlConfigTest {
         try {
             // it is the default entity manager from application.properties, not templatePU from the persistence.xml
             Assertions.assertEquals(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME,
-                    entityManager.getEntityManagerFactory().getProperties().get("hibernate.ejb.persistenceUnitName"));
+                    entityManager.getEntityManagerFactory().getProperties()
+                            .get(org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME));
         } finally {
             Arc.container().requestContext().deactivate();
         }

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/xml/persistence/PersistenceXmlTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.xml.persistence;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
+
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
@@ -34,7 +36,7 @@ public class PersistenceXmlTest {
         try {
             // the PU is templatePU from the persistence.xml, not the default entity manager from application.properties
             Assertions.assertEquals("templatePU",
-                    entityManager.getEntityManagerFactory().getProperties().get("hibernate.ejb.persistenceUnitName"));
+                    entityManager.getEntityManagerFactory().getProperties().get(PERSISTENCE_UNIT_NAME));
         } finally {
             Arc.container().requestContext().deactivate();
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -11,7 +11,6 @@ import java.util.function.Supplier;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.archive.scan.spi.Scanner;
@@ -24,6 +23,7 @@ import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
 import io.quarkus.hibernate.orm.runtime.boot.QuarkusPersistenceUnitDefinition;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationRuntimeDescriptor;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
 import io.quarkus.hibernate.orm.runtime.schema.SchemaManagementIntegrator;
 import io.quarkus.hibernate.orm.runtime.tenant.DataSourceTenantConnectionResolver;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -8,6 +8,7 @@ import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceException;
 import javax.sql.DataSource;
 
+import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.SessionFactory;
@@ -20,7 +21,6 @@ import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.engine.query.spi.HQLQueryPlan;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.SessionFactoryImpl;
-import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.service.ServiceRegistry;
@@ -125,7 +125,7 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
         // will use user override value or default to false if not supplied to follow
         // JPA spec.
         final boolean jtaTransactionAccessEnabled = runtimeSettings.getBoolean(
-                AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS);
+                org.hibernate.cfg.AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS);
         if (!jtaTransactionAccessEnabled) {
             options.disableJtaTransactionAccess();
         }
@@ -136,8 +136,16 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
             options.disableRefreshDetachedEntity();
         }
 
+        //Check for use of deprecated org.hibernate.jpa.AvailableSettings.SESSION_FACTORY_OBSERVER
+        final Object legacyObserver = runtimeSettings.get("hibernate.ejb.session_factory_observer");
+        if (legacyObserver != null) {
+            throw new HibernateException("Legacy setting being used: 'hibernate.ejb.session_factory_observer' was replaced by '"
+                    + org.hibernate.cfg.AvailableSettings.SESSION_FACTORY_OBSERVER + "'. Please update your configuration.");
+        }
+
         // Locate and apply any requested SessionFactoryObserver
-        final Object sessionFactoryObserverSetting = runtimeSettings.get(AvailableSettings.SESSION_FACTORY_OBSERVER);
+        final Object sessionFactoryObserverSetting = runtimeSettings
+                .get(org.hibernate.cfg.AvailableSettings.SESSION_FACTORY_OBSERVER);
         if (sessionFactoryObserverSetting != null) {
 
             final StrategySelector strategySelector = ssr.getService(StrategySelector.class);

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import javax.persistence.PersistenceException;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.boot.CacheRegionDefinition;
 import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.MetadataSources;
@@ -75,6 +74,7 @@ import io.quarkus.hibernate.orm.runtime.IntegrationSettings;
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticInitListener;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
 import io.quarkus.hibernate.orm.runtime.proxies.ProxyDefinitions;
 import io.quarkus.hibernate.orm.runtime.recording.PrevalidatedQuarkusMetadata;

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.boot;
 
+import static org.hibernate.cfg.AvailableSettings.CLASS_CACHE_PREFIX;
+import static org.hibernate.cfg.AvailableSettings.COLLECTION_CACHE_PREFIX;
 import static org.hibernate.cfg.AvailableSettings.DRIVER;
 import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_DRIVER;
 import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_PASSWORD;
@@ -7,14 +9,12 @@ import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_URL;
 import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_USER;
 import static org.hibernate.cfg.AvailableSettings.JPA_TRANSACTION_TYPE;
 import static org.hibernate.cfg.AvailableSettings.PASS;
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
 import static org.hibernate.cfg.AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY;
 import static org.hibernate.cfg.AvailableSettings.URL;
 import static org.hibernate.cfg.AvailableSettings.USER;
 import static org.hibernate.cfg.AvailableSettings.XML_MAPPING_ENABLED;
 import static org.hibernate.internal.HEMLogging.messageLogger;
-import static org.hibernate.jpa.AvailableSettings.CLASS_CACHE_PREFIX;
-import static org.hibernate.jpa.AvailableSettings.COLLECTION_CACHE_PREFIX;
-import static org.hibernate.jpa.AvailableSettings.PERSISTENCE_UNIT_NAME;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -341,6 +341,12 @@ public class FastBootMetadataBuilder {
                     mergedSettings.addCacheRegionDefinition(
                             parseCacheRegionDefinitionEntry(keyString.substring(COLLECTION_CACHE_PREFIX.length() + 1),
                                     (String) entry.getValue(), CacheRegionDefinition.CacheRegionType.COLLECTION));
+                } else if (keyString.startsWith("hibernate.ejb.classcache")) {
+                    LOG.warn(
+                            "Deprecated configuration property prefixed by 'hibernate.ejb.classcache' is being ignored. Suggestion: change prefix to 'hibernate.classcache'");
+                } else if (keyString.startsWith("hibernate.ejb.collectioncache")) {
+                    LOG.warn(
+                            "Deprecated configuration property prefixed by 'hibernate.ejb.collectioncache' is being ignored. Suggestion: change prefix to 'hibernate.collectioncache'");
                 }
             }
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/QuarkusPersistenceUnitDefinition.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/QuarkusPersistenceUnitDefinition.java
@@ -9,11 +9,11 @@ import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
 
 import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.runtime.ObjectSubstitution;
 
 /**

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusConnectionProviderInitiator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/customized/QuarkusConnectionProviderInitiator.java
@@ -3,7 +3,6 @@ package io.quarkus.hibernate.orm.runtime.customized;
 import java.util.Map;
 
 import org.hibernate.HibernateException;
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator;
@@ -11,6 +10,7 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 import io.agroal.api.AgroalDataSource;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 
 public final class QuarkusConnectionProviderInitiator implements StandardServiceInitiator<ConnectionProvider> {
 

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleIntegrator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleIntegrator.java
@@ -5,7 +5,6 @@ import static org.hibernate.cfg.AvailableSettings.HBM2DDL_IMPORT_FILES;
 import org.hibernate.boot.Metadata;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 
 public class HibernateOrmDevConsoleIntegrator implements Integrator {
@@ -13,7 +12,8 @@ public class HibernateOrmDevConsoleIntegrator implements Integrator {
     public void integrate(Metadata metadata, SessionFactoryImplementor sessionFactoryImplementor,
             SessionFactoryServiceRegistry sessionFactoryServiceRegistry) {
         HibernateOrmDevConsoleInfoSupplier.pushPersistenceUnit(
-                (String) sessionFactoryImplementor.getProperties().get(AvailableSettings.PERSISTENCE_UNIT_NAME),
+                (String) sessionFactoryImplementor.getProperties()
+                        .get(org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME),
                 metadata, sessionFactoryServiceRegistry,
                 (String) sessionFactoryImplementor.getProperties().get(HBM2DDL_IMPORT_FILES));
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/migration/MultiTenancyStrategy.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/migration/MultiTenancyStrategy.java
@@ -1,0 +1,79 @@
+package io.quarkus.hibernate.orm.runtime.migration;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.CoreMessageLogger;
+import org.jboss.logging.Logger;
+
+/**
+ * This class is temporarily useful to facilitate the migration to Hibernate ORM 6;
+ * we should get rid of it afterwards as we adapt to the new details of configuring multi-tenancy.
+ * Copied from Hibernate ORM 5.x
+ *
+ * Describes the methods for multi-tenancy understood by Hibernate.
+ *
+ * @author Steve Ebersole
+ * @deprecated This class should be removed after we're done migrating to Jakarta APIs and Hibernate ORM v6.
+ */
+@Deprecated
+public enum MultiTenancyStrategy {
+    /**
+     * Multi-tenancy implemented by use of discriminator columns.
+     */
+    DISCRIMINATOR,
+    /**
+     * Multi-tenancy implemented as separate schemas.
+     */
+    SCHEMA,
+    /**
+     * Multi-tenancy implemented as separate databases.
+     */
+    DATABASE,
+    /**
+     * No multi-tenancy.
+     */
+    NONE;
+
+    private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+            CoreMessageLogger.class,
+            MultiTenancyStrategy.class.getName());
+
+    /**
+     * Does this strategy indicate a requirement for the specialized
+     * {@link org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider}, rather than the
+     * traditional {@link org.hibernate.engine.jdbc.connections.spi.ConnectionProvider}?
+     *
+     * @return {@code true} indicates a MultiTenantConnectionProvider is required; {@code false} indicates it is not.
+     */
+    public boolean requiresMultiTenantConnectionProvider() {
+        return this == DATABASE || this == SCHEMA;
+    }
+
+    /**
+     * Extract the MultiTenancyStrategy from the setting map.
+     *
+     * @param properties The map of settings.
+     *
+     * @return The selected strategy. {@link #NONE} is always the default.
+     */
+    public static MultiTenancyStrategy determineMultiTenancyStrategy(Map properties) {
+        final Object strategy = properties.get(Environment.MULTI_TENANT);
+        if (strategy == null) {
+            return MultiTenancyStrategy.NONE;
+        }
+
+        if (MultiTenancyStrategy.class.isInstance(strategy)) {
+            return (MultiTenancyStrategy) strategy;
+        }
+
+        final String strategyName = strategy.toString();
+        try {
+            return MultiTenancyStrategy.valueOf(strategyName.toUpperCase(Locale.ROOT));
+        } catch (RuntimeException e) {
+            LOG.warn("Unknown multi tenancy strategy [ " + strategyName + " ], using MultiTenancyStrategy.NONE.");
+            return MultiTenancyStrategy.NONE;
+        }
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/schema/SchemaManagementIntegrator.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/schema/SchemaManagementIntegrator.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.runtime.schema;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
+
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -72,7 +74,7 @@ public class SchemaManagementIntegrator implements Integrator, DatabaseSchemaPro
         if (name != null) {
             return name;
         }
-        Object persistenceUnitName = sf.getProperties().get("hibernate.ejb.persistenceUnitName");
+        Object persistenceUnitName = sf.getProperties().get(PERSISTENCE_UNIT_NAME);
         if (persistenceUnitName != null) {
             return persistenceUnitName.toString();
         }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/tenant/DataSourceTenantConnectionResolver.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 import javax.enterprise.inject.Default;
 
-import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.jboss.logging.Logger;
 
@@ -17,6 +16,7 @@ import io.quarkus.agroal.DataSource;
 import io.quarkus.arc.Arc;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.hibernate.orm.runtime.customized.QuarkusConnectionProvider;
+import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 
 /**
  * Creates a database connection based on the data sources in the configuration file.

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole;
 
+import static org.hibernate.cfg.AvailableSettings.PERSISTENCE_UNIT_NAME;
+
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -70,7 +72,7 @@ public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier
         if (name != null) {
             return name;
         }
-        Object persistenceUnitName = sessionFactory.getProperties().get("hibernate.ejb.persistenceUnitName");
+        Object persistenceUnitName = sessionFactory.getProperties().get(PERSISTENCE_UNIT_NAME);
         if (persistenceUnitName != null) {
             return persistenceUnitName.toString();
         }


### PR DESCRIPTION
Follows up on #25733 - same rationale and still should not have visible impact.

One change people might notice is that we're more noisy if use of legacy configuration properties are being detected.