### PR TITLE
Add RestEasy Reactive and OidcSecurity test

### DIFF
--- a/integration-tests/oidc-token-propagation-reactive/pom.xml
+++ b/integration-tests/oidc-token-propagation-reactive/pom.xml
@@ -17,6 +17,15 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-oidc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -33,6 +42,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/oidc-token-propagation-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
+++ b/integration-tests/oidc-token-propagation-reactive/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Path("/web-app")
+@Authenticated
+public class ProtectedJwtResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    JsonWebToken accessToken;
+
+    @Context
+    SecurityContext securityContext;
+
+    @GET
+    @Path("test-security")
+    @RolesAllowed("viewer")
+    public String testSecurity() {
+        return securityContext.getUserPrincipal().getName();
+    }
+
+    @POST
+    @Path("test-security")
+    @Consumes("application/json")
+    @RolesAllowed("viewer")
+    public String testSecurityJson(User user) {
+        return user.getName() + ":" + securityContext.getUserPrincipal().getName();
+    }
+
+    @GET
+    @Path("test-security-jwt")
+    @RolesAllowed("viewer")
+    public String testSecurityJwt() {
+        return accessToken.getName() + ":" + accessToken.getGroups().iterator().next()
+                + ":" + accessToken.getClaim("email");
+    }
+}

--- a/integration-tests/oidc-token-propagation-reactive/src/main/java/io/quarkus/it/keycloak/User.java
+++ b/integration-tests/oidc-token-propagation-reactive/src/main/java/io/quarkus/it/keycloak/User.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.keycloak;
+
+public class User {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.it.keycloak;
+
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@TestHTTPEndpoint(ProtectedJwtResource.class)
+public class TestSecurityLazyAuthTest {
+
+    @Test
+    @TestSecurity(user = "user1", roles = "viewer")
+    public void testWithDummyUser() {
+        RestAssured.when().get("test-security").then()
+                .body(is("user1"));
+    }
+
+    @Test
+    @TestSecurity(user = "user1", roles = "tester")
+    public void testWithDummyUserForbidden() {
+        RestAssured.when().get("test-security").then().statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "user1", roles = "viewer")
+    public void testPostWithDummyUser() {
+        RestAssured.given().contentType(ContentType.JSON).when().body("{\"name\":\"user1\"}").post("test-security").then()
+                .body(is("user1:user1"));
+    }
+
+    @Test
+    @TestSecurity(user = "user1", roles = "tester")
+    public void testPostWithDummyUserForbidden() {
+        RestAssured.given().contentType(ContentType.JSON).when().body("{\"name\":\"user1\"}").post("test-security").then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt", roles = "viewer")
+    @OidcSecurity(claims = {
+            @Claim(key = "email", value = "user@gmail.com")
+    })
+    public void testJwtGetWithDummyUser() {
+        RestAssured.when().get("test-security-jwt").then()
+                .body(is("userJwt:viewer:user@gmail.com"));
+    }
+
+}


### PR DESCRIPTION
Fixes #25722.

@geoand FYI, see `TestSecurityLazyAuthTest`. The RestEasy Classic based test runs here: https://github.com/quarkusio/quarkus/blob/main/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java,

I've just copied that test and `ProtectedJwtResource` to `integration-tests/oidc-token-propagation-reactive`. 

`JwtSecurity` extends `TestSecurity` and offers one option for supporting testing the endpoints which have an injected `JsonWebtoken`.
It is processed here: https://github.com/quarkusio/quarkus/blob/main/test-framework/security-jwt/src/main/java/io/quarkus/test/security/jwt/JwtTestSecurityIdentityAugmentorProducer.java

and this test augmentor is initiated from here:

https://github.com/quarkusio/quarkus/blob/main/test-framework/security/src/main/java/io/quarkus/test/security/QuarkusSecurityTestExtension.java#L88.

So this `JwtTestSecurityIdentityAugmentorProducer` adds a `JsonWebToken` instance to the current `SecurityIdentity` and this producer, https://github.com/quarkusio/quarkus/blob/main/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcJsonWebTokenProducer.java#L40, is expected to support the injection of `JsonWebToken` using this emulated token.

this test gives NPE, `ProtectedJwtResource` throws it because `JsonWebToken` remains null and is not injected.

Have a look please when you can get a chance