### PR TITLE
Allow access to dev services props

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -132,9 +132,10 @@ public class NativeTestExtension
             hasPerTestResources = testResourceManager.hasPerTestResources();
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
-            additionalProperties.putAll(devServicesProps);
-            Map<String, String> resourceManagerProps = testResourceManager.start();
+            Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
+            resourceManagerProps.putAll(devServicesProps);
             Map<String, String> old = new HashMap<>();
+            //we also make the dev services config accessible from the test itself
             for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
                 old.put(i.getKey(), System.getProperty(i.getKey()));
                 if (i.getValue() == null) {
@@ -157,6 +158,7 @@ public class NativeTestExtension
                             }
                         }
                     });
+            //this includes dev services props
             additionalProperties.putAll(resourceManagerProps);
 
             NativeImageLauncher launcher = createLauncher(requiredTestClass);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -163,8 +163,9 @@ public class QuarkusIntegrationTestExtension
             hasPerTestResources = testResourceManager.hasPerTestResources();
 
             Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
-            additionalProperties.putAll(QuarkusIntegrationTestExtension.devServicesProps);
-            Map<String, String> resourceManagerProps = testResourceManager.start();
+            Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
+            //we also make the dev services config accessible from the test itself
+            resourceManagerProps.putAll(QuarkusIntegrationTestExtension.devServicesProps);
             Map<String, String> old = new HashMap<>();
             for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
                 old.put(i.getKey(), System.getProperty(i.getKey()));

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -123,8 +123,9 @@ public class QuarkusMainIntegrationTestExtension implements BeforeEachCallback, 
                         testProfileAndProperties.testProfile != null ? testProfileAndProperties.testProfile.getClass().getName()
                                 : null);
                 Map<String, String> additionalProperties = new HashMap<>(testProfileAndProperties.properties);
-                additionalProperties.putAll(QuarkusMainIntegrationTestExtension.devServicesProps);
-                Map<String, String> resourceManagerProps = testResourceManager.start();
+                Map<String, String> resourceManagerProps = new HashMap<>(testResourceManager.start());
+                //also make the dev services props accessible from the test
+                resourceManagerProps.putAll(QuarkusMainIntegrationTestExtension.devServicesProps);
                 for (Map.Entry<String, String> i : resourceManagerProps.entrySet()) {
                     old.put(i.getKey(), System.getProperty(i.getKey()));
                     if (i.getValue() == null) {


### PR DESCRIPTION
This allows integration tests to access dev services config in the same
way you would with a TestResourceManager.

Fixes #25730