### PR TITLE
Allow to provide custom configuration for JAXB context

### DIFF
--- a/docs/src/main/asciidoc/rest-json.adoc
+++ b/docs/src/main/asciidoc/rest-json.adoc
@@ -233,12 +233,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 
 import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 public class CustomObjectMapper {
 
     // Replaces the CDI producer for ObjectMapper built into Quarkus
     @Singleton
+    @Produces
     ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers) {
         ObjectMapper mapper = myObjectMapper(); // Custom `ObjectMapper`
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1138,6 +1138,93 @@ Importing this module will allow HTTP message bodies to be read from XML
 and serialised to XML, for <<resource-types,all the types not already registered with a more specific
 serialisation>>.
 
+==== Advanced JAXB-specific features
+
+When using the `quarkus-resteasy-reactive-jaxb` extension there are some advanced features that RESTEasy Reactive supports.
+
+===== Inject JAXB components
+
+The JAXB resteasy reactive extension will serialize and unserialize requests and responses transparently for users. However, if you need finer grain control over JAXB components, you can inject either the JAXBContext, Marshaller, or Unmarshaller components into your beans:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyService {
+
+    @Inject
+    JAXBContext jaxbContext;
+
+    @Inject
+    Marshaller marshaller;
+
+    @Inject
+    Unmarshaller unmarshaller;
+
+    // ...
+}
+----
+
+[NOTE]
+====
+Quarkus will automatically find all the classes annotated with `@XmlRootElement` and then bound them to the JAXB context.
+====
+
+===== Customize the JAXB configuration
+
+To customize the JAXB configuration for either the JAXB context, and/or the Marshaller/Unmarshaller components, the suggested approach is to define a CDI bean of type `io.quarkus.jaxb.runtime.JaxbContextCustomizer`.
+
+An example where a custom module needs to be registered would look like so:
+
+[source,java]
+----
+@Singleton
+public class RegisterCustomModuleCustomizer implements JaxbContextCustomizer {
+
+    // For JAXB context configuration
+    @Override
+    public void customizeContextProperties(Map<String, Object> properties) {
+
+    }
+
+    // For Marshaller configuration
+    @Override
+    public void customizeMarshaller(Marshaller marshaller) throws PropertyException {
+        marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+    }
+
+    // For Unmarshaller configuration
+    @Override
+    public void customizeUnmarshaller(Unmarshaller unmarshaller) throws PropertyException {
+        // ...
+    }
+}
+----
+
+[NOTE]
+====
+It's not necessary to implement all three methods, but only the want you need.
+====
+
+Alternatively, you can provide your own `JAXBContext` bean by doing:
+
+[source,java]
+----
+public class CustomJaxbContext {
+
+    // Replaces the CDI producer for JAXBContext built into Quarkus
+    @Singleton
+    @Produces
+    JAXBContext jaxbContext() {
+        // ...
+    }
+}
+----
+
+[IMPORTANT]
+====
+Note that if you provide your custom JAXB context instance, you will need to register the classes you want to use for the XML serialization. This means that Quarkus will not update your custom JAXB context instance with the auto-discovered classes. 
+====
+
 === Web Links support
 
 [[links]]

--- a/extensions/jaxb/deployment/pom.xml
+++ b/extensions/jaxb/deployment/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
+            <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -24,6 +24,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbClassesToBeBoundBuildItem.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbClassesToBeBoundBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.jaxb.deployment;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * List of classes to be bound in the JAXB context.
+ */
+public final class JaxbClassesToBeBoundBuildItem extends MultiBuildItem {
+
+    private final List<String> classes;
+
+    public JaxbClassesToBeBoundBuildItem(List<String> classes) {
+        this.classes = Objects.requireNonNull(classes);
+    }
+
+    public List<String> getClasses() {
+        return classes;
+    }
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/CustomJaxbContextCustomizer.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/CustomJaxbContextCustomizer.java
@@ -1,0 +1,15 @@
+package io.quarkus.jaxb.deployment;
+
+import javax.inject.Singleton;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.PropertyException;
+
+import io.quarkus.jaxb.runtime.JaxbContextCustomizer;
+
+@Singleton
+public class CustomJaxbContextCustomizer implements JaxbContextCustomizer {
+    @Override
+    public void customizeMarshaller(Marshaller marshaller) throws PropertyException {
+        marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+    }
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/InjectJaxbContextTest.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/InjectJaxbContextTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.jaxb.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.StringWriter;
+
+import javax.inject.Inject;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class InjectJaxbContextTest {
+
+    @Inject
+    JAXBContext jaxbContext;
+
+    @Inject
+    Marshaller marshaller;
+
+    @Inject
+    Unmarshaller unmarshaller;
+
+    @Test
+    public void shouldInjectJaxbBeans() {
+        assertNotNull(jaxbContext);
+        assertNotNull(marshaller);
+        assertNotNull(unmarshaller);
+    }
+
+    @Test
+    public void shouldPersonBeInTheJaxbContext() throws JAXBException {
+        Person person = new Person();
+        person.setFirst("first");
+        person.setLast("last");
+
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(person, sw);
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<person>\n"
+                + "    <first>first</first>\n"
+                + "    <last>last</last>\n"
+                + "</person>\n", sw.toString());
+    }
+
+}

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/Person.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/Person.java
@@ -1,0 +1,38 @@
+package io.quarkus.jaxb.deployment;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Person {
+
+    private String first;
+    private String last;
+
+    public Person() {
+
+    }
+
+    public Person(String first, String last) {
+        this.first = first;
+        this.last = last;
+    }
+
+    public String getFirst() {
+        return first;
+    }
+
+    public void setFirst(String first) {
+        this.first = first;
+    }
+
+    public String getLast() {
+        return last;
+    }
+
+    public void setLast(String last) {
+        this.last = last;
+    }
+}

--- a/extensions/jaxb/runtime/pom.xml
+++ b/extensions/jaxb/runtime/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
+            <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextConfigRecorder.java
@@ -1,0 +1,20 @@
+package io.quarkus.jaxb.runtime;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class JaxbContextConfigRecorder {
+    private volatile static Set<String> classesToBeBound = new HashSet<>();
+
+    public void addClassesToBeBound(Collection<String> additionalClassesToBeBound) {
+        this.classesToBeBound.addAll(additionalClassesToBeBound);
+    }
+
+    public static String[] getClassesToBeBound() {
+        return classesToBeBound.toArray(new String[0]);
+    }
+}

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextCustomizer.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextCustomizer.java
@@ -1,0 +1,45 @@
+package io.quarkus.jaxb.runtime;
+
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.PropertyException;
+import javax.xml.bind.Unmarshaller;
+
+/**
+ * Meant to be implemented by a CDI bean that provides arbitrary customization for the default {@link JAXBContext}.
+ * <p>
+ * All implementations (that are registered as CDI beans) are taken into account when producing the default
+ * {@link JAXBContext}.
+ * <p>
+ * See also {@link JaxbContextProducer#jaxbContext}.
+ */
+public interface JaxbContextCustomizer extends Comparable<JaxbContextCustomizer> {
+
+    int DEFAULT_PRIORITY = 0;
+
+    default void customizeContextProperties(Map<String, Object> properties) {
+
+    }
+
+    default void customizeMarshaller(Marshaller marshaller) throws PropertyException {
+
+    }
+
+    default void customizeUnmarshaller(Unmarshaller unmarshaller) throws PropertyException {
+
+    }
+
+    /**
+     * Defines the priority that the customizers are applied.
+     * A lower integer value means that the customizer will be applied after a customizer with a higher priority
+     */
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    default int compareTo(JaxbContextCustomizer o) {
+        return Integer.compare(o.priority(), priority());
+    }
+}

--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextProducer.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/JaxbContextProducer.java
@@ -1,0 +1,93 @@
+package io.quarkus.jaxb.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+import io.quarkus.arc.DefaultBean;
+
+@ApplicationScoped
+public class JaxbContextProducer {
+    @DefaultBean
+    @Singleton
+    @Produces
+    public JAXBContext jaxbContext(Instance<JaxbContextCustomizer> customizers) {
+        try {
+            Map<String, Object> properties = new HashMap<>();
+            List<JaxbContextCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
+            for (JaxbContextCustomizer customizer : sortedCustomizers) {
+                customizer.customizeContextProperties(properties);
+            }
+
+            String[] classNamesToBeBounded = JaxbContextConfigRecorder.getClassesToBeBound();
+            List<Class<?>> classes = new ArrayList<>();
+            for (int i = 0; i < classNamesToBeBounded.length; i++) {
+                Class<?> clazz = getClassByName(classNamesToBeBounded[i]);
+                if (!clazz.isPrimitive()) {
+                    classes.add(clazz);
+                }
+            }
+            return JAXBContext.newInstance(classes.toArray(new Class[0]), properties);
+        } catch (JAXBException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    public Marshaller marshaller(JAXBContext jaxbContext, Instance<JaxbContextCustomizer> customizers) {
+        try {
+            Marshaller marshaller = jaxbContext.createMarshaller();
+            List<JaxbContextCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
+            for (JaxbContextCustomizer customizer : sortedCustomizers) {
+                customizer.customizeMarshaller(marshaller);
+            }
+
+            return marshaller;
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DefaultBean
+    @Singleton
+    @Produces
+    public Unmarshaller unmarshaller(JAXBContext jaxbContext, Instance<JaxbContextCustomizer> customizers) {
+        try {
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            List<JaxbContextCustomizer> sortedCustomizers = sortCustomizersInDescendingPriorityOrder(customizers);
+            for (JaxbContextCustomizer customizer : sortedCustomizers) {
+                customizer.customizeUnmarshaller(unmarshaller);
+            }
+
+            return unmarshaller;
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<JaxbContextCustomizer> sortCustomizersInDescendingPriorityOrder(Instance<JaxbContextCustomizer> customizers) {
+        List<JaxbContextCustomizer> sortedCustomizers = new ArrayList<>();
+        for (JaxbContextCustomizer customizer : customizers) {
+            sortedCustomizers.add(customizer);
+        }
+        Collections.sort(sortedCustomizers);
+        return sortedCustomizers;
+    }
+
+    private Class<?> getClassByName(String name) throws ClassNotFoundException {
+        return Class.forName(name, false, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
+++ b/extensions/resteasy-classic/resteasy-jaxb/deployment/src/main/java/io/quarkus/resteasy/jaxb/deployment/ResteasyJaxbProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.resteasy.jaxb.deployment;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.jboss.jandex.DotName;
@@ -10,12 +11,15 @@ import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.resteasy.annotations.providers.jaxb.WrappedMap;
 import org.jboss.resteasy.api.validation.ConstraintType;
 
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.jaxb.deployment.JaxbClassesToBeBoundBuildItem;
 
 public class ResteasyJaxbProcessor {
 
@@ -40,6 +44,15 @@ public class ResteasyJaxbProcessor {
                 addReflectiveClass(reflectiveClass, true, true, "javax.xml.bind.annotation.W3CDomHandler");
                 break;
             }
+        }
+    }
+
+    @BuildStep
+    void setupJaxbContextConfigForValidator(Capabilities capabilities,
+            BuildProducer<JaxbClassesToBeBoundBuildItem> classesToBeBoundProducer) {
+        if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
+            classesToBeBoundProducer.produce(new JaxbClassesToBeBoundBuildItem(
+                    Collections.singletonList(org.jboss.resteasy.api.validation.ViolationReport.class.getName())));
         }
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/runtime/serialisers/JaxbMessageBodyWriter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/runtime/serialisers/JaxbMessageBodyWriter.java
@@ -1,16 +1,22 @@
 package io.quarkus.resteasy.reactive.jaxb.common.runtime.serialisers;
 
+import java.beans.Introspector;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Map;
 
+import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.xml.bind.JAXB;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
 
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -19,11 +25,14 @@ import io.vertx.core.MultiMap;
 
 public class JaxbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableMessageBodyWriter {
 
+    @Inject
+    Marshaller marshaller;
+
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws WebApplicationException {
         setContentTypeIfNecessary(httpHeaders);
-        JAXB.marshal(o, entityStream);
+        marshal(o, entityStream);
     }
 
     @Override
@@ -31,9 +40,25 @@ public class JaxbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteableM
             throws WebApplicationException, IOException {
         setContentTypeIfNecessary(context);
         OutputStream stream = context.getOrCreateOutputStream();
-        JAXB.marshal(o, stream);
+        marshal(o, stream);
         // we don't use try-with-resources because that results in writing to the http output without the exception mapping coming into play
         stream.close();
+    }
+
+    protected void marshal(Object o, OutputStream outputStream) {
+        try {
+            Object jaxbObject = o;
+            Class<?> clazz = o.getClass();
+            XmlRootElement jaxbElement = clazz.getAnnotation(XmlRootElement.class);
+            if (jaxbElement == null) {
+                jaxbObject = new JAXBElement(new QName(Introspector.decapitalize(clazz.getSimpleName())), clazz, o);
+            }
+
+            marshaller.marshal(jaxbObject, outputStream);
+
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void setContentTypeIfNecessary(MultivaluedMap<String, Object> httpHeaders) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/deployment/ResteasyReactiveJaxbProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/deployment/ResteasyReactiveJaxbProcessor.java
@@ -1,14 +1,171 @@
 package io.quarkus.resteasy.reactive.jaxb.deployment;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.resteasy.reactive.common.model.ResourceMethod;
+import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
+
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.jaxb.deployment.JaxbClassesToBeBoundBuildItem;
+import io.quarkus.resteasy.reactive.common.deployment.JaxRsResourceIndexBuildItem;
+import io.quarkus.resteasy.reactive.server.deployment.ResteasyReactiveResourceMethodEntriesBuildItem;
 
 public class ResteasyReactiveJaxbProcessor {
 
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> feature) {
         feature.produce(new FeatureBuildItem(Feature.RESTEASY_REACTIVE_JAXB));
+    }
+
+    @BuildStep
+    void registerClassesToBeBound(ResteasyReactiveResourceMethodEntriesBuildItem resourceMethodEntries,
+            JaxRsResourceIndexBuildItem index,
+            BuildProducer<JaxbClassesToBeBoundBuildItem> classesToBeBoundBuildItemProducer) {
+        Set<ClassInfo> classesInfo = new HashSet<>();
+
+        IndexView indexView = index.getIndexView();
+        for (ResteasyReactiveResourceMethodEntriesBuildItem.Entry entry : resourceMethodEntries.getEntries()) {
+            ResourceMethod resourceInfo = entry.getResourceMethod();
+            MethodInfo methodInfo = entry.getMethodInfo();
+            ClassInfo effectiveReturnType = getEffectiveClassInfo(methodInfo.returnType(), indexView);
+
+            if (effectiveReturnType != null) {
+                // When using "application/xml", the return type needs to be registered
+                if (producesXml(resourceInfo)) {
+                    classesInfo.add(effectiveReturnType);
+                }
+
+                // When using "multipart/form-data", the parts that use "application/xml" need to be registered
+                if (producesMultipart(resourceInfo)) {
+                    classesInfo.addAll(getEffectivePartsUsingXml(effectiveReturnType, indexView));
+                }
+            }
+
+            // If consumes "application/xml" or "multipart/form-data", we register all the classes of the parameters
+            if (consumesXml(resourceInfo) || consumesMultipart(resourceInfo)) {
+                for (Type parameter : methodInfo.parameters()) {
+                    ClassInfo effectiveParameter = getEffectiveClassInfo(parameter, indexView);
+                    if (effectiveParameter != null) {
+                        classesInfo.add(effectiveParameter);
+                    }
+                }
+            }
+        }
+
+        classesToBeBoundBuildItemProducer.produce(new JaxbClassesToBeBoundBuildItem(toClasses(classesInfo)));
+    }
+
+    @BuildStep
+    void setupJaxbContextConfigForValidator(Capabilities capabilities,
+            BuildProducer<JaxbClassesToBeBoundBuildItem> classesToBeBoundProducer) {
+        if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
+            classesToBeBoundProducer.produce(new JaxbClassesToBeBoundBuildItem(
+                    Collections.singletonList("io.quarkus.hibernate.validator.runtime.jaxrs.ViolationReport")));
+        }
+    }
+
+    private List<ClassInfo> getEffectivePartsUsingXml(ClassInfo returnType, IndexView indexView) {
+        List<ClassInfo> classInfos = new ArrayList<>();
+        for (FieldInfo field : returnType.fields()) {
+            AnnotationInstance partTypeInstance = field.annotation(ResteasyReactiveDotNames.PART_TYPE_NAME);
+            if (partTypeInstance != null) {
+                AnnotationValue partTypeValue = partTypeInstance.value();
+                if (partTypeValue != null && MediaType.APPLICATION_XML.equals(partTypeValue.asString())) {
+                    classInfos.add(getEffectiveClassInfo(field.type(), indexView));
+                }
+            }
+        }
+
+        return classInfos;
+    }
+
+    private ClassInfo getEffectiveClassInfo(Type type, IndexView indexView) {
+        if (type.kind() == Type.Kind.VOID || type.kind() == Type.Kind.PRIMITIVE) {
+            return null;
+        }
+
+        Type effectiveType = type;
+        if (effectiveType.name().equals(ResteasyReactiveDotNames.REST_RESPONSE) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.UNI) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.COMPLETABLE_FUTURE) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.COMPLETION_STAGE) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.MULTI)) {
+            if (effectiveType.kind() != Type.Kind.PARAMETERIZED_TYPE) {
+                return null;
+            }
+
+            effectiveType = type.asParameterizedType().arguments().get(0);
+        }
+        if (effectiveType.name().equals(ResteasyReactiveDotNames.SET) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.COLLECTION) ||
+                effectiveType.name().equals(ResteasyReactiveDotNames.LIST)) {
+            effectiveType = effectiveType.asParameterizedType().arguments().get(0);
+        } else if (effectiveType.name().equals(ResteasyReactiveDotNames.MAP)) {
+            effectiveType = effectiveType.asParameterizedType().arguments().get(1);
+        }
+
+        ClassInfo effectiveReturnClassInfo = indexView.getClassByName(effectiveType.name());
+        if ((effectiveReturnClassInfo == null) || effectiveReturnClassInfo.name().equals(ResteasyReactiveDotNames.OBJECT)) {
+            return null;
+        }
+
+        return effectiveReturnClassInfo;
+    }
+
+    private boolean consumesXml(ResourceMethod resourceInfo) {
+        return containsMediaType(resourceInfo.getConsumes(), MediaType.APPLICATION_XML);
+    }
+
+    private boolean consumesMultipart(ResourceMethod resourceInfo) {
+        return containsMediaType(resourceInfo.getConsumes(), MediaType.MULTIPART_FORM_DATA);
+    }
+
+    private boolean producesXml(ResourceMethod resourceInfo) {
+        return containsMediaType(resourceInfo.getProduces(), MediaType.APPLICATION_XML);
+    }
+
+    private boolean producesMultipart(ResourceMethod resourceInfo) {
+        return containsMediaType(resourceInfo.getProduces(), MediaType.MULTIPART_FORM_DATA);
+    }
+
+    private boolean containsMediaType(String[] types, String mediaType) {
+        if (types != null) {
+            for (String type : types) {
+                if (type.toLowerCase(Locale.ROOT).contains(mediaType)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private List<String> toClasses(Collection<ClassInfo> classesInfo) {
+        List<String> classes = new ArrayList<>();
+        for (ClassInfo classInfo : classesInfo) {
+            classes.add(classInfo.toString());
+        }
+
+        return classes;
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/MultipartTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/MultipartTest.java
@@ -2,11 +2,14 @@ package io.quarkus.resteasy.reactive.jaxb.deployment.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.jboss.resteasy.reactive.MultipartForm;
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -18,17 +21,21 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
-public class MultipartOutputTest {
+public class MultipartTest {
     private static final String EXPECTED_CONTENT_DISPOSITION_PART = "Content-Disposition: form-data; name=\"%s\"";
     private static final String EXPECTED_CONTENT_TYPE_PART = "Content-Type: %s";
     private static final String EXPECTED_RESPONSE_NAME = "a name";
     private static final String EXPECTED_RESPONSE_PERSON_NAME = "Michal";
     private static final int EXPECTED_RESPONSE_PERSON_AGE = 23;
-    private static final String EXPECTED_RESPONSE_PERSON = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
-            + "<person>\n"
-            + "    <age>" + EXPECTED_RESPONSE_PERSON_AGE + "</age>\n"
-            + "    <name>" + EXPECTED_RESPONSE_PERSON_NAME + "</name>\n"
+    private static final String EXPECTED_RESPONSE_PERSON = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<person>"
+            + "<age>" + EXPECTED_RESPONSE_PERSON_AGE + "</age>"
+            + "<name>" + EXPECTED_RESPONSE_PERSON_NAME + "</name>"
             + "</person>";
+    private static final String SCHOOL = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            + "<school>"
+            + "<name>Divino Pastor</name>"
+            + "</school>";
 
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest()
@@ -36,7 +43,7 @@ public class MultipartOutputTest {
                     .addClasses(MultipartOutputResource.class, MultipartOutputResponse.class, Person.class));
 
     @Test
-    public void testSimple() {
+    public void testOutput() {
         String response = RestAssured.get("/multipart/output")
                 .then()
                 .contentType(ContentType.MULTIPART)
@@ -47,6 +54,20 @@ public class MultipartOutputTest {
         assertContains(response, "person", MediaType.APPLICATION_XML, EXPECTED_RESPONSE_PERSON);
     }
 
+    @Test
+    public void testInput() {
+        String response = RestAssured
+                .given()
+                .multiPart("name", "John")
+                .multiPart("school", SCHOOL, MediaType.APPLICATION_XML)
+                .post("/multipart/input")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        assertThat(response).isEqualTo("John-Divino Pastor");
+    }
+
     private void assertContains(String response, String name, String contentType, Object value) {
         String[] lines = response.split("--");
         assertThat(lines).anyMatch(line -> line.contains(String.format(EXPECTED_CONTENT_DISPOSITION_PART, name))
@@ -54,18 +75,26 @@ public class MultipartOutputTest {
                 && line.contains(value.toString()));
     }
 
-    @Path("/multipart/output")
+    @Path("/multipart")
     private static class MultipartOutputResource {
 
         @GET
+        @Path("/output")
         @Produces(MediaType.MULTIPART_FORM_DATA)
-        public MultipartOutputResponse simple() {
+        public MultipartOutputResponse output() {
             MultipartOutputResponse response = new MultipartOutputResponse();
             response.name = EXPECTED_RESPONSE_NAME;
             response.person = new Person();
             response.person.name = EXPECTED_RESPONSE_PERSON_NAME;
             response.person.age = EXPECTED_RESPONSE_PERSON_AGE;
             return response;
+        }
+
+        @POST
+        @Path("/input")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public String input(@MultipartForm MultipartInput input) {
+            return input.name + "-" + input.school.name;
         }
 
     }
@@ -78,6 +107,16 @@ public class MultipartOutputTest {
         @RestForm
         @PartType(MediaType.APPLICATION_XML)
         Person person;
+    }
+
+    public static class MultipartInput {
+
+        @RestForm
+        String name;
+
+        @RestForm
+        @PartType(MediaType.APPLICATION_XML)
+        School school;
     }
 
     private static class Person {
@@ -98,6 +137,18 @@ public class MultipartOutputTest {
 
         public void setAge(Integer age) {
             this.age = age;
+        }
+    }
+
+    private static class School {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb/deployment/src/test/java/io/quarkus/resteasy/reactive/jaxb/deployment/test/SimpleXmlTest.java
@@ -211,6 +211,7 @@ public class SimpleXmlTest {
     public static class SimpleXmlResource {
 
         @GET
+        @Produces(MediaType.APPLICATION_XML)
         @Path("/person")
         public Person getPerson() {
             Person person = new Person();


### PR DESCRIPTION
Changes added as part of this pull request:

When using the `quarkus-resteasy-reactive-jaxb` extension there are some advanced features that RESTEasy Reactive supports.

1. Inject JAXB components

The JAXB resteasy reactive extension will serialize and deserialize requests and responses transparently for users. However, if you need finer usage of the JAXB components, you can inject either the JAXBContext, Marshaller, or Unmarshaller components into your beans:

```java
@ApplicationScoped
public class MyService {

    @Inject
    JAXBContext jaxbContext;

    @Inject
    Marshaller marshaller;

    @Inject
    Unmarshaller unmarshaller;

    // ...
}
```

Note: Quarkus will automatically register all the classes annotated with `@XmlRootElement` to the JAXB context.

2. Customize the JAXB configuration

To customize the JAXB configuration for either the JAXB context, and/or the Marshaller/Unmarshaller components, the suggested approach is to define a CDI bean of type `io.quarkus.jaxb.runtime.JaxbContextCustomizer`.

An example where a custom module needs to be registered would look like so:

```java
@Singleton
public class RegisterCustomModuleCustomizer implements JaxbContextCustomizer {

    // For JAXB context configuration
    @Override
    public void customizeContextProperties(Map<String, Object> properties) {

    }

    // For Marshaller configuration
    @Override
    public void customizeMarshaller(Marshaller marshaller) throws PropertyException {
        marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
    }

    // For Unmarshaller configuration
    @Override
    public void customizeUnmarshaller(Unmarshaller unmarshaller) throws PropertyException {
        // ...
    }
}
```

Note: It's not necessary to implement the three methods, but only the want you need.

Alternatively, you can provide your own `JAXBContext` bean by doing:

```java
public class CustomJaxbContext {

    // Replaces the CDI producer for JAXBContext built into Quarkus
    @Singleton
    JAXBContext jaxbContext() {
        // ...
    }
}
```

Note: By replacing the JAXB context, you need to bound the classes to be serialized/deserialized and also configure the JAXB context accordingly. 

Resolves https://github.com/quarkusio/quarkus/issues/25753