### PR TITLE
Use health check to detect mariadb startup and skip volume modifier on M1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -75,6 +75,9 @@
         <!-- Antlr is used by the PanacheQL parser-->
         <antlr.version>4.9.2</antlr.version>
 
+        <!-- SELinux access label, used when mounting local volumes into containers in tests -->
+        <volume.access.modifier>:Z</volume.access.modifier>
+
         <!-- Defaults for integration tests -->
         <elasticsearch-server.version>7.16.3</elasticsearch-server.version>
         <elasticsearch.image>docker.io/elastic/elasticsearch:${elasticsearch-server.version}</elasticsearch.image>
@@ -102,7 +105,7 @@
         <keycloak.version>18.0.0</keycloak.version>
         <keycloak.docker.image>quay.io/keycloak/keycloak:${keycloak.version}</keycloak.docker.image>
         <keycloak.docker.legacy.image>quay.io/keycloak/keycloak:${keycloak.version}-legacy</keycloak.docker.legacy.image>
-        
+
         <unboundid-ldap.version>6.0.5</unboundid-ldap.version>
 
         <assertj.version>3.22.0</assertj.version>
@@ -141,7 +144,7 @@
         <build-helper-plugin.version>1.9.1</build-helper-plugin.version>
         <revapi-reporter-text.version>0.14.5</revapi-reporter-text.version>
         <revapi-reporter-json.version>0.4.5</revapi-reporter-json.version>
-         <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Quarkus API. -->
+        <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Quarkus API. -->
         <revapi.oldVersion>1.6.0.Final</revapi.oldVersion>
         <revapi.newVersion>${project.version}</revapi.newVersion>
         <!-- severity Possible values: equivalent, nonBreaking, potentiallyBreaking, breaking -->
@@ -363,8 +366,8 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                       <groupId>org.apache.activemq</groupId>
-                       <artifactId>artemis-server</artifactId>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>artemis-server</artifactId>
                     </exclusion>
                     <!-- Excluding the API jar as the impl jar also contains the API -->
                     <exclusion>
@@ -673,7 +676,7 @@
                             <groupId>io.quarkus</groupId>
                             <version>${project.version}</version>
                         </dependency>
-                      </dependencies>
+                    </dependencies>
                     <configuration>
                         <!-- store outside of target to speed up formatting when mvn clean is used -->
                         <cachedir>.cache/formatter-maven-plugin-${formatter-maven-plugin.version}</cachedir>
@@ -1225,6 +1228,19 @@
             </activation>
             <properties>
                 <script.extension>bat</script.extension>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <!-- Podman compatibility. Currently, mac file systems based on Plan 9 does not support SELinux labeling z and Z should not be used. When they transition to use virtiofsd, it should support SELinux labeling, and then we can use it for better container separation on the Mac.-->
+                <volume.access.modifier></volume.access.modifier>
             </properties>
         </profile>
 

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -15,6 +15,7 @@
   ~ under the License.
   -->
 
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -153,8 +154,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <!-- Be aware when testing healthcheck scripts, caching of named images can cause apparently non-deterministic behaviour.
+                                    Change the name if making changes. -->
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--     Note that mysqladmin ping returns 0 even if the password is wrong-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost || exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <network>
                                             <mode>bridge</mode>
@@ -176,26 +193,25 @@
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
-                                            <tcp>
-                                                <mode>direct</mode>
-                                                <ports>
-                                                    <port>3306</port>
-                                                </ports>
-                                            </tcp>
+                                            <!--   good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <!-- the sqladmin check seems more reliable than a tcp check, especially with
+                                           diverse container runtimes -->
+                                            <healthy>true</healthy>
                                             <!-- Unfortunately booting MariaDB is slow, needs to set a generous timeout: -->
                                             <time>40000</time>
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
                                 </image>
                             </images>
-                            <!--Stops all mariadb images currently running, not just those we just started.
-                              Useful to stop processes still running from a previously failed integration test run -->
+                            <!--     Stops all mariadb images currently running, not just those we just started.
+                                 Useful to stop processes still running from a previously failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>
                         <executions>
@@ -204,6 +220,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <artifactId>quarkus-integration-test-hibernate-orm-tenancy</artifactId>
@@ -12,7 +12,10 @@
 
     <artifactId>quarkus-integration-test-hibernate-orm-tenancy-connection-resolver-legacy-qualifiers</artifactId>
     <name>Quarkus - Integration Tests - Hibernate - Tenancy - Connection</name>
-    <description>Tests for Hibernate ORM Multitenancy using a custom connection resolver and tenant resolver with legacy CDI qualifiers (@Default or @PersistenceUnit), running with the MariaDB database</description>
+    <description>Tests for Hibernate ORM Multitenancy using a custom connection resolver and tenant resolver with legacy CDI
+        qualifiers (@Default or @PersistenceUnit), running with the MariaDB
+        database
+    </description>
 
     <properties>
         <mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
@@ -198,8 +201,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <ports>
                                             <port>3308:3306</port>
@@ -217,6 +236,7 @@
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
                                             <time>20000</time>
+                                            <healthy>true</healthy>
                                             <exec>
                                                 <breakOnError>true</breakOnError>
                                                 <postStart>bash -c eval\ ${@} -- mysql -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
@@ -224,14 +244,16 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
                                 </image>
                             </images>
                             <!--Stops all mariadb images currently running, not just those
-                                we just started. Useful to stop processes still running from a previously 
+                                we just started. Useful to stop processes still running from a previously
                                 failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>
@@ -241,6 +263,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <artifactId>quarkus-integration-test-hibernate-orm-tenancy</artifactId>
@@ -12,7 +12,8 @@
 
     <artifactId>quarkus-integration-test-hibernate-orm-tenancy-connection-resolver</artifactId>
     <name>Quarkus - Integration Tests - Hibernate - Tenancy - Connection</name>
-    <description>Tests for Hibernate ORM Multitenancy usingn a custom connection resolver, running with the MariaDB database</description>
+    <description>Tests for Hibernate ORM Multitenancy usingn a custom connection resolver, running with the MariaDB database
+    </description>
 
     <properties>
         <mariadb.base_url>jdbc:mariadb://localhost:3306</mariadb.base_url>
@@ -198,8 +199,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <ports>
                                             <port>3308:3306</port>
@@ -217,6 +234,7 @@
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
                                             <time>20000</time>
+                                            <healthy>true</healthy>
                                             <exec>
                                                 <breakOnError>true</breakOnError>
                                                 <postStart>bash -c eval\ ${@} -- mysql -h localhost -uroot -psecret &lt;/etc/mysql/conf.d/init.sql</postStart>
@@ -224,14 +242,16 @@
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
                                 </image>
                             </images>
                             <!--Stops all mariadb images currently running, not just those
-                                we just started. Useful to stop processes still running from a previously 
+                                we just started. Useful to stop processes still running from a previously
                                 failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>
@@ -241,6 +261,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>

--- a/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
+++ b/integration-tests/hibernate-orm-tenancy/datasource/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <artifactId>quarkus-integration-test-hibernate-orm-tenancy</artifactId>
@@ -219,8 +219,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <ports>
                                             <port>3308:3306</port>
@@ -238,20 +254,20 @@
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
                                             <time>20000</time>
-                                            <exec>
-                                                <postStart>mysqladmin ping -h localhost -uroot -psecret</postStart>
-                                            </exec>
+                                            <healthy>true</healthy>
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
                                 </image>
                             </images>
                             <!--Stops all mariadb images currently running, not just those
-                                we just started. Useful to stop processes still running from a previously 
+                                we just started. Useful to stop processes still running from a previously
                                 failed integration test run -->
                             <allContainers>true</allContainers>
                         </configuration>
@@ -261,6 +277,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>
@@ -276,7 +293,7 @@
                 </plugins>
             </build>
         </profile>
-
+        
     </profiles>
 
 </project>

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -169,8 +169,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <network>
                                             <mode>bridge</mode>
@@ -189,21 +205,20 @@
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
-<!--                                         Speed things up a bit by not actually flushing writes to disk -->
-<!--                                         <tmpfs>/var/lib/mysql</tmpfs> -->
+                                        <!--                                         Speed things up a bit by not actually flushing writes to disk -->
+                                        <!--                                         <tmpfs>/var/lib/mysql</tmpfs> -->
                                         <wait>
                                             <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
-                                            <!-- wait until MySQL is actually up by checking if mysqladmin can ping the server with specified username/password -->
-                                            <exec>
-                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
-                                            </exec>
+                                            <healthy>true</healthy>
                                         </wait>
-<!--                                         <volumes> -->
-<!--                                             <bind> -->
-<!--                                                 <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume> -->
-<!--                                             </bind> -->
-<!--                                         </volumes> -->
+                                        <volumes>
+                                            <bind>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
+                                            </bind>
+                                        </volumes>
                                     </run>
                                 </image>
                             </images>
@@ -217,6 +232,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>

--- a/integration-tests/jpa-mariadb/pom.xml
+++ b/integration-tests/jpa-mariadb/pom.xml
@@ -163,8 +163,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <ports>
                                             <port>3308:3306</port>
@@ -184,13 +200,13 @@
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
                                             <time>20000</time>
-                                            <exec>
-                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
-                                            </exec>
+                                            <healthy>true</healthy>
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
@@ -206,6 +222,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -179,8 +179,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mariadb.image}</name>
+                                    <name>healthcheck-${mariadb.image}</name>
                                     <alias>quarkus-test-mariadb</alias>
+                                    <build>
+                                        <from>${mariadb.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u root -psecret|| exit 1</shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <network>
                                             <mode>bridge</mode>
@@ -204,14 +220,13 @@
                                         <wait>
                                             <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
-                                            <!-- wait until MySQL is actually up by checking if mysqladmin can ping the server with specified username/password -->
-                                            <exec>
-                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
-                                            </exec>
+                                            <healthy>true</healthy>
                                         </wait>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d:Z</volume>
+                                                <volume>
+                                                    ${project.basedir}/custom-mariadbconfig:/etc/mysql/conf.d${volume.access.modifier}
+                                                </volume>
                                             </bind>
                                         </volumes>
                                     </run>
@@ -227,6 +242,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/25428. See also discussion in #25648. This PR gets modules which use mariadb running clean with `-Dstart-containers` on M1 with podman as the container implementation. I know some of the files in this change have mysql-* names, but they’re actually using mariadb, so I included them.

To test these changes, this sequence should be sufficient. It runs clean for me on my M1 after `podman machine start`: 

```
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f extensions/reactive-mysql-client/deployment/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/hibernate-orm-tenancy/connection-resolver/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/hibernate-orm-tenancy/datasource/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/hibernate-reactive-mysql/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/jpa-mariadb/pom.xml 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/reactive-mysql-client/pom.xml
```

(and it should run much faster than before the changes, on all platforms).

Note that I do still see some errors in quarkus-integration-test-hibernate-orm-tenancy-connection-resolver-legacy-qualifiers with `-Dstart-containers -Dtest-containers`. Fixing those is outside the scope of this changeset, which is only looking at getting `-Dstart-containers` going.

There is some whitespace in the diffs, but I think most of the changes are ‘correct’. Ideally, those changes wouldn’t be contaminating this changeset, but see https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/IntelliJ.20formatting.20setup/near/283912797. Getting our xml formatting consistent will need a bigger effort.

## What’s changed?

### Readiness checks
I had a problem with tcp-ping based readiness checks for mariadb. Only one test used it, so we can switch to using an sqladmin ping check. Several tests do a ping inside a <postStart> in the <wait>. However, a <postStart> inside a <wait> isn’t a true readiness check. The plugin will always wait for the <time>and then run the`. A better (but more verbose) option is to use a container health check.

This was only strictly necessary where the tests were using a tcp ping to check for readiness (which did not work on podman), but I think it’s an improvement elsewhere.

This sped up the tests quite a bit for me since it will cut the <time> wait short if the database is ready before the timeout pops. I saw a factor of two improvement on tests which used mariadb, but on slower hardware the effect may not be so noticeable.

Be aware when testing healthcheck scripts, caching of named images can cause apparently non-deterministic behaviour. Change the name if making changes.

I also found that trying to extract common code to parent poms caused tests not to be able to connect to the containers. I don’t understand the reason - perhaps some crucial fabric8 state ends up in a target directory at the parent level?



### Volume mounts access modifier



The ':Z' SELinux access label seems to cause problems on M1. I think this is related to https://github.com/containers/podman/issues/13631. We mount config files to speed up mariadb, so I’ve parameterised the access modifier so that the mount works on M1.