### PR TITLE
QuteProcessor - more concise format to report incorrect expressions

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -186,39 +186,47 @@ public class QuteProcessor {
                 errors.add(TemplateException.builder()
                         .code(Code.INCORRECT_EXPRESSION)
                         .origin(incorrectExpression.origin)
-                        .message("Incorrect expression found: \\{{}\\}\n\t- {}\n\t- at {}:{}")
-                        .arguments(incorrectExpression.expression, incorrectExpression.reason,
-                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()),
-                                incorrectExpression.origin.getLine())
+                        .message(
+                                "{templatePath.or(origin.templateId)}:{origin.line}:{origin.lineCharacterStart} - \\{{expression}\\}: {reason}")
+                        .argument("templatePath",
+                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()))
+                        .argument("expression", incorrectExpression.expression)
+                        .argument("reason", incorrectExpression.reason)
                         .build());
             } else if (incorrectExpression.clazz != null) {
                 errors.add(TemplateException.builder()
                         .code(Code.INCORRECT_EXPRESSION)
                         .origin(incorrectExpression.origin)
                         .message(
-                                "Incorrect expression found: \\{{}}\n\t- property/method [{}] not found on class [{}] nor handled by an extension method\n\t- at {}:{}")
-                        .arguments(incorrectExpression.expression, incorrectExpression.property, incorrectExpression.clazz,
-                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()),
-                                incorrectExpression.origin.getLine())
+                                "{templatePath.or(origin.templateId)}:{origin.line}:{origin.lineCharacterStart} - \\{{expression}}: Property/method [{property}] not found on class [{clazz}] nor handled by an extension method")
+                        .argument("templatePath",
+                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()))
+                        .argument("expression", incorrectExpression.expression)
+                        .argument("property", incorrectExpression.property)
+                        .argument("clazz", incorrectExpression.clazz)
                         .build());
             } else {
                 errors.add(TemplateException.builder()
                         .code(Code.INCORRECT_EXPRESSION)
                         .origin(incorrectExpression.origin)
-                        .message("Incorrect expression found: \\{{}}\n\t- @Named bean not found for [{}]\n\t- at {}:{}")
-                        .arguments(incorrectExpression.expression, incorrectExpression.property,
-                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()),
-                                incorrectExpression.origin.getLine())
+                        .message(
+                                "{templatePath.or(origin.templateId)}:{origin.line}:{origin.lineCharacterStart} - \\{{expression}}: @Named bean not found for [{property}]")
+                        .argument("templatePath",
+                                findTemplatePath(analysis, incorrectExpression.origin.getTemplateGeneratedId()))
+                        .argument("expression", incorrectExpression.expression)
+                        .argument("property", incorrectExpression.property)
                         .build());
             }
         }
 
         if (!errors.isEmpty()) {
-            StringBuilder message = new StringBuilder("Found template problems (").append(errors.size()).append("):");
+            StringBuilder message = new StringBuilder("Found incorrect expressions (").append(errors.size())
+                    .append("):");
             int idx = 1;
             for (TemplateException error : errors) {
-                message.append("\n").append("[").append(idx++).append("] ").append(error.getMessage());
+                message.append("\n\t").append("[").append(idx++).append("] ").append(error.getMessage());
             }
+            message.append("\n");
             TemplateException exception = new TemplateException(message.toString());
             for (TemplateException error : errors) {
                 exception.addSuppressed(error);
@@ -832,7 +840,7 @@ public class QuteProcessor {
             } else {
                 // No namespace extension method found - incorrect expression
                 incorrectExpressions.produce(new IncorrectExpressionBuildItem(expression.toOriginalString(),
-                        String.format("no matching namespace [%s] extension method found", namespace), expression.getOrigin()));
+                        String.format("No matching namespace [%s] extension method found", namespace), expression.getOrigin()));
                 match.clearValues();
                 return putResult(match, results, expression);
             }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TemplateDataValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/TemplateDataValidationTest.java
@@ -32,7 +32,7 @@ public class TemplateDataValidationTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (1)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("foo_My:BAZ"), te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/enums/TemplateEnumValidationFailureTest.java
@@ -32,7 +32,7 @@ public class TemplateEnumValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (1)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("TransactionType:BAR.scores"), te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/NamespaceTemplateExtensionValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/extensions/NamespaceTemplateExtensionValidationFailureTest.java
@@ -33,9 +33,9 @@ public class NamespaceTemplateExtensionValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (2)"), te.getMessage());
-                assertTrue(te.getMessage().contains("no matching namespace [bro] extension method found"), te.getMessage());
-                assertTrue(te.getMessage().contains("property/method [bubu] not found on class [java.lang.String]"),
+                assertTrue(te.getMessage().contains("Found incorrect expressions (2)"), te.getMessage());
+                assertTrue(te.getMessage().contains("No matching namespace [bro] extension method found"), te.getMessage());
+                assertTrue(te.getMessage().contains("Property/method [bubu] not found on class [java.lang.String]"),
                         te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/globals/TemplateGlobalValidationFailureTest.java
@@ -33,11 +33,10 @@ public class TemplateGlobalValidationFailureTest {
                 }
                 assertNotNull(te);
                 assertTrue(
-                        te.getMessage().contains("Incorrect expression found: {user.name}"),
-                        te.getMessage());
+                        te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(
                         te.getMessage().contains(
-                                "property/method [name] not found on class [java.lang.String] nor handled by an extension method"),
+                                "Property/method [name] not found on class [java.lang.String] nor handled by an extension method"),
                         te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleExpressionValidationTest.java
@@ -36,7 +36,7 @@ public class MessageBundleExpressionValidationTest {
                 if (te == null) {
                     fail("No template exception thrown: " + t);
                 }
-                assertTrue(te.getMessage().contains("Found template problems (5)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (5)"), te.getMessage());
                 assertTrue(te.getMessage().contains("item.foo"), te.getMessage());
                 assertTrue(te.getMessage().contains("bar"), te.getMessage());
                 assertTrue(te.getMessage().contains("foo"), te.getMessage());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/i18n/MessageBundleTemplateExpressionValidationTest.java
@@ -34,7 +34,7 @@ public class MessageBundleTemplateExpressionValidationTest {
                 if (te == null) {
                     fail("No template exception thrown: " + t);
                 }
-                assertTrue(te.getMessage().contains("Found template problems (4)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (4)"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello('foo')"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello_and_bye"), te.getMessage());
                 assertTrue(te.getMessage().contains("msg:hello(1,2)"), te.getMessage());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/NamedBeanValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/inject/NamedBeanValidationFailureTest.java
@@ -35,7 +35,7 @@ public class NamedBeanValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (2)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (2)"), te.getMessage());
                 assertTrue(te.getMessage().contains("it.ping"), te.getMessage());
                 assertTrue(te.getMessage().contains("cdi:foo.bar"), te.getMessage());
             });

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/CheckedTemplateRequireTypeSafeTest.java
@@ -46,7 +46,7 @@ public class CheckedTemplateRequireTypeSafeTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (3)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (3)"), te.getMessage());
                 assertTrue(te.getMessage().contains("any"), te.getMessage());
                 assertTrue(te.getMessage().contains("identifier"), te.getMessage());
                 assertTrue(te.getMessage().contains("index"), te.getMessage());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/InterfaceValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/InterfaceValidationFailureTest.java
@@ -33,7 +33,7 @@ public class InterfaceValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (1)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("{metrics.responses.values}"), te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/TypeSafeLoopFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/TypeSafeLoopFailureTest.java
@@ -33,7 +33,7 @@ public class TypeSafeLoopFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (1)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("foo.ages"), te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ValidationFailuresTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ValidationFailuresTest.java
@@ -48,7 +48,7 @@ public class ValidationFailuresTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (10)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (10)"), te.getMessage());
                 assertTrue(te.getMessage().contains("movie.foo"), te.getMessage());
                 assertTrue(te.getMessage().contains("movie.getName('foo')"), te.getMessage());
                 assertTrue(te.getMessage().contains("movie.findService(age)"), te.getMessage());

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/WhenValidationFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/WhenValidationFailureTest.java
@@ -34,7 +34,7 @@ public class WhenValidationFailureTest {
                     e = e.getCause();
                 }
                 assertNotNull(te);
-                assertTrue(te.getMessage().contains("Found template problems (1)"), te.getMessage());
+                assertTrue(te.getMessage().contains("Found incorrect expressions (1)"), te.getMessage());
                 assertTrue(te.getMessage().contains("{WRONG}"), te.getMessage());
             });
 

--- a/extensions/resteasy-classic/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest.java
+++ b/extensions/resteasy-classic/resteasy-qute/deployment/src/test/java/io/quarkus/qute/resteasy/deployment/TypeErrorTest.java
@@ -20,7 +20,7 @@ public class TypeErrorTest {
                     .addAsResource("templates/HelloResource/typedTemplatePrimitives.txt")
                     .addAsResource(new StringAsset("Hello {name}!"), "templates/hello.txt"))
             .assertException(t -> {
-                assertTrue(t.getMessage().contains("Incorrect expression"));
+                assertTrue(t.getMessage().contains("Found incorrect expressions"));
                 assertTrue(t.getMessage().contains("name.foo()"));
             });
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/TypeErrorTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-qute/deployment/src/test/java/io/quarkus/resteasy/reactive/qute/deployment/TypeErrorTest.java
@@ -20,7 +20,7 @@ public class TypeErrorTest {
                     .addAsResource("templates/HelloResource/typedTemplatePrimitives.txt")
                     .addAsResource(new StringAsset("Hello {name}!"), "templates/hello.txt"))
             .assertException(t -> {
-                assertTrue(t.getMessage().contains("Incorrect expression"));
+                assertTrue(t.getMessage().contains("Found incorrect expressions"));
                 assertTrue(t.getMessage().contains("name.foo()"));
             });
 

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/qute/QuteErrorPageTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/qute/QuteErrorPageTest.java
@@ -22,7 +22,7 @@ public class QuteErrorPageTest {
     public void testErrorPage() {
         config.modifyResourceFile("templates/hello.txt", file -> "{@java.lang.String hello}{hello.foo}");
         RestAssured.when().get("/hello").then()
-                .body(containsString("Incorrect expression found: {hello.foo}"))
+                .body(containsString("hello.txt:1"), containsString("{hello.foo}"))
                 .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
 


### PR DESCRIPTION
- resolves #25724

```
[ERROR] 	[error]: Build step io.quarkus.qute.deployment.QuteProcessor#processTemplateErrors threw an exception: io.quarkus.qute.TemplateException: Found incorrect expressions (2):
[ERROR] 	[1] ItemResource/items.html:13 - {item.prices}: Property/method [prices] not found on class [org.acme.qute.Item] nor handled by an extension method
[ERROR] 	[2] ItemResource/items.html:20 - {cdi:foo}: @Named bean not found for [foo]
```