### PR TITLE
[Guide] fix reactive-sql-clients startup method

### DIFF
--- a/docs/src/main/asciidoc/reactive-sql-clients.adoc
+++ b/docs/src/main/asciidoc/reactive-sql-clients.adoc
@@ -177,8 +177,7 @@ But for development we can simply drop and create the tables on startup, and the
 @ConfigProperty(name = "myapp.schema.create", defaultValue = "true") // <1>
 boolean schemaCreate;
 
-@PostConstruct
-void config() {
+void config(@Observes StartupEvent ev) {
     if (schemaCreate) {
         initdb();
     }


### PR DESCRIPTION
The way stated in the docs doesn't work (at least on my machine) because the `await` method blocks the thread which is not allowed apparently.

Screenshots:
![website](https://user-images.githubusercontent.com/63104422/170552236-d7da4e0d-c485-46d2-bee9-126ae7971bc2.png)
![ide](https://user-images.githubusercontent.com/63104422/170552298-14ece24a-2ee1-4c10-a788-da96f2c9538c.png)
