### PR TITLE
Re-order plugin repository for Gradle in codestart

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/settings.tpl.qute.gradle.kts
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/settings.tpl.qute.gradle.kts
@@ -2,9 +2,9 @@ pluginManagement {
     val quarkusPluginVersion: String by settings
     val quarkusPluginId: String by settings
     repositories {
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
+        mavenLocal()
 {#if gradle.plugin-repositories}
 {#for rep in gradle.plugin-repositories}
         maven { url = uri("{rep.url}") }

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/settings.tpl.qute.gradle
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/settings.tpl.qute.gradle
@@ -1,8 +1,8 @@
 pluginManagement {
     repositories {
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
+        mavenLocal()
 {#if gradle.plugin-repositories}
 {#for rep in gradle.plugin-repositories}
         maven { url "{rep.url}" }


### PR DESCRIPTION
This change the order of repository used for plugin resolution. 
This has already be done for dependencies.

close #25787 