### PR TITLE
Use Azure Edge Server rather than MS SQL on Mac M1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1237,12 +1237,17 @@
             <properties>
                 <!-- Podman compatibility. Currently, mac file systems based on Plan 9 does not support SELinux labeling z and Z should not be used. When they transition to use virtiofsd, it should support SELinux labeling, and then we can use it for better container separation on the Mac.-->
                 <volume.access.modifier></volume.access.modifier>
-                
+
                 <!-- See https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8
                 and https://www.emmanuelgautier.com/blog/mysql-docker-arm-m1
                 This hopefully should be temporary -->
                 <mysql.image>arm64v8/mysql:8-oracle</mysql.image>
 
+                <!-- See
+                https://github.com/microsoft/mssql-docker/issues/668 and https://stackoverflow.com/questions/65398641/docker-connect-sql-server-container-non-zero-code-1/66919852#66919852.
+                The MS SQL image segfaults on ARM. Azure Edge is not fully compatible, but it is better than not running the tests at all.
+                DockerHub does not list any tags so we have to use latest for the moment.-->
+                <mssql.image>mcr.microsoft.com/azure-sql-edge:latest</mssql.image>
             </properties>
         </profile>
 


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/25428. See also discussion in #25648. 

To test, 
```
mvn clean 
mvn -Dquickly 
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f  extensions/reactive-mssql-client/deployment/pom.xml
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -Dtest-containers -f extensions/jdbc/jdbc-mssql
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -Dtest-containers -f integration-tests/jpa-mssql
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -Dtest-containers -f integration-tests/reactive-mssql-client           
```

The clean and rebuild is needed to avoid issues relating to licence-non-acceptance of the changed image name. 

## What's changed?

The MS SQL image segfaults on ARM. The best option seemed to be the widely recommended workaround of using Azure Edge Server. The two products are not functionally interchangeable, but there is enough similarity to make it worth running this way.

Note: this change will also affect dev services if built locally, but not in the official releases, unless they are built on M1. I think that’s kind of weird but kind of ok, but I’m open to objections if people think that's too inconsistent.