### PR TITLE
Fix reuse of instances in Quarkus tests with nested test classes

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedPerClassLifecycleTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedPerClassLifecycleTestCase.java
@@ -1,0 +1,42 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Tests {@link Nested} support of {@link QuarkusTest}. Notes:
+ * <ul>
+ * <li>to avoid unexpected execution order, don't use surefire's {@code -Dtest=...}, use {@code -Dgroups=nested} instead</li>
+ * <li>order of nested test classes is reversed by JUnit (and there's no way to enforce a specific order)</li>
+ * </ul>
+ */
+@QuarkusTest
+@Tag("nested")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class QuarkusTestNestedPerClassLifecycleTestCase {
+
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @BeforeAll
+    public void increment() {
+        counter.incrementAndGet();
+    }
+
+    @Nested
+    class NestedTest {
+
+        @Test
+        public void verifyCounter() {
+            assertEquals(2, counter.incrementAndGet());
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -765,7 +765,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 Class<?> outerClass = actualTestClass.getEnclosingClass();
                 Constructor<?> declaredConstructor = actualTestClass.getDeclaredConstructor(outerClass);
                 declaredConstructor.setAccessible(true);
-                if (outerClass.getEnclosingClass() != null) {
+                if (outerClass.isInstance(actualTestInstance)) {
                     outerInstances.add(actualTestInstance);
                     actualTestInstance = declaredConstructor.newInstance(actualTestInstance);
                 } else {


### PR DESCRIPTION
Before these changes, we were creating instances regardless even though the parent classes were already created. 

This pull request fixes this issue and adds a test coverage when running nested classes with lifecycle test instance.

Fix https://github.com/quarkusio/quarkus/issues/25812