### PR TITLE
Disable Oracle db tests on Mac M1 because of segfault (and updated readiness check)

### DIFF
--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -146,7 +146,7 @@
                                             <ORACLE_PASSWORD>hibernate_orm_test</ORACLE_PASSWORD>
                                         </env>
                                         <log>
-                                            <prefix>Oracle Database: </prefix>
+                                            <prefix>Oracle Database:</prefix>
                                             <date>default</date>
                                             <color>red</color>
                                         </log>
@@ -154,7 +154,8 @@
                                             <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
-                                            <log>DATABASE IS READY TO USE!</log>
+                                            <!-- leversge the healthcheck in the image we use -->
+                                            <healthy>yes</healthy>
                                         </wait>
                                     </run>
                                 </image>
@@ -196,6 +197,41 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
+         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${oracle.image}</name>
+                                    <run>
+                                        <skip>true</skip>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -255,7 +255,40 @@
                 </plugins>
             </build>
         </profile>
-
+        <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
+         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${oracle.image}</name>
+                                    <run>
+                                        <skip>true</skip>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -225,6 +225,40 @@
                 </plugins>
             </build>
         </profile>
+        <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
+   db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${oracle.image}</name>
+                                    <run>
+                                        <skip>true</skip>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/25428. See also discussion in #25648.

To test, 

```
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/reactive-oracle-client/pom.xml
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/jpa-oracle/pom.xml
TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f extensions/reactive-oracle-client/deployment/pom.xml
```

(this is now a no-op on M1 but it should be more interesting on other architectures, because I've swapped one of the log-search-based startup checks with a health check). 

## What's changed?

I hit https://github.com/fabric8io/docker-maven-plugin/issues/1369 with the log readiness check. Based on the discussion, I wonder if it’s a timing issue which my machine exposes by being fast. (I saw similar issues with `<log>` experimenting with the mariadb readiness check.)

```
ERRO[20873] accept tcp [::]:1521: use of closed network connection
[ERROR] DOCKER> IO Error while requesting logs: org.apache.http.ConnectionClosedException: Premature end of chunk coded message body: closing chunk expected Thread-6
```

The image we use has a healthcheck configured, so we can just use that with fabric8 docker-maven-plugin.

I also hit a more serious problem, which is that I could not get the database to start on M1. It seemed to be the same issue as https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1. Others there reported success with qemu, which podman is using under the covers. I tried with podman 4.0.3 and podman 4.1, without success.

Reluctantly, I disabled the tests. We should re-evaluate with later versions of the Oracle database in the future.
