### PR TITLE
Bump SmallRye Reactive Messaging to 3.17.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -51,7 +51,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.22.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.16.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>3.17.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.1.2</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>


### PR DESCRIPTION
This release:

- provides AMQP _selector_ support
- contains many enhancements/bug fixes for the rabbitmq connector

See https://github.com/smallrye/smallrye-reactive-messaging/releases/tag/3.17.0 for more details.