### PR TITLE
Expose management UI in RabbitMQ Dev Service

### DIFF
--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -37,6 +37,7 @@ The default service name is `rabbitmq`.
 Sharing is enabled by default in dev mode, but disabled in test mode.
 You can disable the sharing with `quarkus.rabbitmq.devservices.shared=false`.
 
+[[setting_port]]
 == Setting the port
 
 By default, Dev Services for RabbitMQ picks a random port and configures the application.
@@ -51,6 +52,10 @@ You can configure the image and version using the `quarkus.rabbitmq.devservices.
 ----
 quarkus.rabbitmq.devservices.image-name=rabbitmq:latest
 ----
+
+== Access the management UI
+
+By default, Dev Services for RabbitMQ uses the official image with the `management` tag. This means you have the https://github.com/docker-library/docs/tree/master/rabbitmq#management-plugin[management plugin] available. You can use the xref:dev-ui.adoc[Dev UI] to find the random http port or configure a static one via `quarkus.rabbitmq.devservices.http-port`.
 
 == Predefined Topology
 

--- a/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-dev-services.adoc
@@ -55,7 +55,8 @@ quarkus.rabbitmq.devservices.image-name=rabbitmq:latest
 
 == Access the management UI
 
-By default, Dev Services for RabbitMQ uses the official image with the `management` tag. This means you have the https://github.com/docker-library/docs/tree/master/rabbitmq#management-plugin[management plugin] available. You can use the xref:dev-ui.adoc[Dev UI] to find the random http port or configure a static one via `quarkus.rabbitmq.devservices.http-port`.
+By default, Dev Services for RabbitMQ use the official image with the `management` tag. This means you have the https://github.com/docker-library/docs/tree/master/rabbitmq#management-plugin[management plugin] available. You can use the xref:dev-ui.adoc[Dev UI] to find the HTTP port randomly affected
+or configure a static one via `quarkus.rabbitmq.devservices.http-port`.
 
 == Predefined Topology
 

--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ContainerLocator.java
@@ -60,4 +60,14 @@ public class ContainerLocator {
             return Optional.empty();
         }
     }
+
+    public Optional<Integer> locatePublicPort(String serviceName, boolean shared, LaunchMode launchMode, int privatePort) {
+        if (shared && launchMode == LaunchMode.DEVELOPMENT) {
+            return lookup(serviceName)
+                    .flatMap(container -> getMappedPort(container, privatePort))
+                    .map(ContainerPort::getPublicPort);
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -109,7 +110,15 @@ public class RabbitMQDevServicesBuildTimeConfig {
      * If not defined, the port will be chosen randomly.
      */
     @ConfigItem
-    public Optional<Integer> port;
+    public OptionalInt port;
+
+    /**
+     * Optional fixed port for the RabbitMQ management plugin.
+     * <p>
+     * If not defined, the port will be chosen randomly.
+     */
+    @ConfigItem
+    public OptionalInt httpPort;
 
     /**
      * The image to use.

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devconsole/RabbitDevConsoleProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/devconsole/RabbitDevConsoleProcessor.java
@@ -1,0 +1,23 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.deployment.devconsole;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
+import io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devconsole.DevRabbitMqHttpPortSupplier;
+import io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devconsole.RabbitHttpPortFinder;
+
+public class RabbitDevConsoleProcessor {
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public DevConsoleRuntimeTemplateInfoBuildItem collectInfos(CurateOutcomeBuildItem curateOutcomeBuildItem) {
+        return new DevConsoleRuntimeTemplateInfoBuildItem("rabbitHttpPort",
+                new DevRabbitMqHttpPortSupplier(), this.getClass(), curateOutcomeBuildItem);
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    AdditionalBeanBuildItem beans() {
+        return AdditionalBeanBuildItem.unremovableOf(RabbitHttpPortFinder.class);
+    }
+}

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="localhost:{info:rabbitHttpPort.httpPort}" class="badge badge-light">
+  <i class="fa fa-external-link-alt fa-fw"></i>
+  Rabbit UI <span class="badge badge-light">{info:rabbitHttpPort.httpPort}</span></a>
+<br>

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/dev-templates/embedded.html
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,4 +1,4 @@
 <a href="localhost:{info:rabbitHttpPort.httpPort}" class="badge badge-light">
   <i class="fa fa-external-link-alt fa-fw"></i>
-  Rabbit UI <span class="badge badge-light">{info:rabbitHttpPort.httpPort}</span></a>
+  RabbitMQ management UI <span class="badge badge-light">{info:rabbitHttpPort.httpPort}</span></a>
 <br>

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/DevRabbitMqHttpPort.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/DevRabbitMqHttpPort.java
@@ -1,0 +1,29 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devconsole;
+
+import java.util.function.Supplier;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.impl.LazyValue;
+
+public class DevRabbitMqHttpPort {
+
+    private final LazyValue<String> httpPort;
+
+    public DevRabbitMqHttpPort() {
+        this.httpPort = new LazyValue<>(new Supplier<String>() {
+
+            @Override
+            public String get() {
+                ArcContainer arcContainer = Arc.container();
+                RabbitHttpPortFinder rabbitHttpPortFinder = arcContainer.instance(RabbitHttpPortFinder.class).get();
+
+                return rabbitHttpPortFinder.httpPort;
+            }
+        });
+    }
+
+    public String getHttpPort() {
+        return httpPort.get();
+    }
+}

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/DevRabbitMqHttpPortSupplier.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/DevRabbitMqHttpPortSupplier.java
@@ -1,0 +1,11 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devconsole;
+
+import java.util.function.Supplier;
+
+public class DevRabbitMqHttpPortSupplier implements Supplier<DevRabbitMqHttpPort> {
+
+    @Override
+    public DevRabbitMqHttpPort get() {
+        return new DevRabbitMqHttpPort();
+    }
+}

--- a/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/RabbitHttpPortFinder.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/runtime/devconsole/RabbitHttpPortFinder.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.reactivemessaging.rabbitmq.runtime.devconsole;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.config.Config;
+
+import io.quarkus.runtime.StartupEvent;
+
+@Singleton
+public class RabbitHttpPortFinder {
+
+    String httpPort;
+
+    void collect(@Observes StartupEvent event, Config config) {
+        httpPort = config.getValue("rabbitmq-http-port", String.class);
+    }
+}


### PR DESCRIPTION
Since the RabbitMQ dev service uses the `management` tag, the image contains the UI. At the moment this is not accessible from the host, even so it is running. 