### PR TITLE
Include cookies from API Gateway V2 in http headers

### DIFF
--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -52,6 +52,8 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
 
     private static final Map<String, List<String>> ERROR_HEADERS = Map.of("Content-Type", List.of("application/json"));
 
+    private static final String COOKIE_HEADER = "Cookie";
+
     // comma headers for headers that have comma in value and we don't want to split it up into
     // multiple headers
     private static final Set<String> COMMA_HEADERS = Set.of("access-control-request-headers");
@@ -198,6 +200,10 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
                 }
             }
         }
+        if (request.getCookies() != null) {
+            nettyRequest.headers().add(COOKIE_HEADER, String.join("; ", request.getCookies()));
+        }
+
         if (!nettyRequest.headers().contains(HttpHeaderNames.HOST)) {
             nettyRequest.headers().add(HttpHeaderNames.HOST, "localhost");
         }

--- a/extensions/amazon-lambda-http/runtime/src/test/java/io/quarkus/amazon/lambda/http/LambdaHttpHandlerTest.java
+++ b/extensions/amazon-lambda-http/runtime/src/test/java/io/quarkus/amazon/lambda/http/LambdaHttpHandlerTest.java
@@ -9,11 +9,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -42,6 +44,11 @@ public class LambdaHttpHandlerTest {
     private static final String QUERY = "testParam1=testValue1&testParam2=testValue2";
     private static final String HOST_HEADER = "Host";
     private static final String HOST = "localhost";
+
+    private static final List<String> COOKIES = List.of("testcookie1=cvalue1", "testcookie2=cvalue2");
+    private static final String COOKIE_HEADER_KEY = "Cookie";
+    private static final String COOKIE_HEADER_VALUE = "testcookie1=cvalue1; testcookie2=cvalue2";
+
     private static final String METHOD = "GET";
 
     private final Application application = mock(Application.class);
@@ -60,6 +67,7 @@ public class LambdaHttpHandlerTest {
         when(requestContext.getHttp()).thenReturn(requestContextMethod);
         when(requestContextMethod.getMethod()).thenReturn(METHOD);
         when(request.getHeaders()).thenReturn(Collections.singletonMap(HOST_HEADER, HOST));
+        when(request.getCookies()).thenReturn(COOKIES);
         when(connection.peer()).thenReturn(peer);
         when(peer.remoteAddress()).thenReturn(new VirtualAddress("whatever"));
     }
@@ -114,6 +122,15 @@ public class LambdaHttpHandlerTest {
         APIGatewayV2HTTPResponse response = mockHttpFunction(null, status);
         verify(connection, timeout(PROCESSING_TIMEOUT).times(2)).sendMessage(any());
         assertEquals(status.code(), response.getStatusCode());
+    }
+
+    @Test
+    public void verifyCookies() throws ExecutionException, InterruptedException {
+        mockHttpFunction(null, HttpResponseStatus.OK);
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(connection, timeout(PROCESSING_TIMEOUT).times(2)).sendMessage(captor.capture());
+        DefaultHttpRequest rq = (DefaultHttpRequest) captor.getAllValues().get(0);
+        assertEquals(COOKIE_HEADER_VALUE, rq.headers().get(COOKIE_HEADER_KEY));
     }
 
 }


### PR DESCRIPTION
The event payload now includes cookies as a separate element,
so need to put in in HTTP headers

Based on https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

