### PR TITLE
Podman on Windows needs one /, not two // prefix

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -40,7 +40,8 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         List<String> containerRuntimeArgs = super.getContainerRuntimeBuildArgs();
         String volumeOutputPath = outputPath;
         if (SystemUtils.IS_OS_WINDOWS) {
-            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
+            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath,
+                    containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN);
         }
 
         Collections.addAll(containerRuntimeArgs, "-v",

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -122,7 +122,8 @@ public class UpxCompressionBuildStep {
 
         String volumeOutputPath = nativeImage.getPath().toFile().getParentFile().getAbsolutePath();
         if (SystemUtils.IS_OS_WINDOWS) {
-            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
+            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath,
+                    containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN);
         } else if (SystemUtils.IS_OS_LINUX) {
             String uid = getLinuxID("-ur");
             String gid = getLinuxID("-gr");

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
@@ -78,14 +78,15 @@ public class FileUtil {
      * @param windowsStylePath A path formatted in Windows-style, e.g. "C:\foo\bar".
      * @return A translated path accepted by Docker, e.g. "//c/foo/bar".
      */
-    public static String translateToVolumePath(String windowsStylePath) {
+    public static String translateToVolumePath(String windowsStylePath, boolean isPodman) {
         String translated = windowsStylePath.replace('\\', '/');
         Pattern p = Pattern.compile("^(\\w)(?:$|:(/)?(.*))");
         Matcher m = p.matcher(translated);
         if (m.matches()) {
             String slash = Optional.ofNullable(m.group(2)).orElse("/");
             String path = Optional.ofNullable(m.group(3)).orElse("");
-            return "//" + m.group(1).toLowerCase() + slash + path;
+            // Ad `/' and `//' see https://github.com/containers/podman/issues/14414
+            return (isPodman ? "/" : "//") + m.group(1).toLowerCase() + slash + path;
         }
         return translated;
     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
@@ -10,19 +10,20 @@ public class FileUtilTest {
     @Test
     public void testTranslateToVolumePath() {
         // Windows-Style paths are formatted.
-        assertEquals("//c/", translateToVolumePath("C"));
-        assertEquals("//c/", translateToVolumePath("C:"));
-        assertEquals("//c/", translateToVolumePath("C:\\"));
-        assertEquals("//c/Users", translateToVolumePath("C:\\Users"));
+        assertEquals("/c/tmp/code-with-quarkus", translateToVolumePath("C:\\tmp\\code-with-quarkus", true));
+        assertEquals("//c/", translateToVolumePath("C", false));
+        assertEquals("//c/", translateToVolumePath("C:", false));
+        assertEquals("//c/", translateToVolumePath("C:\\", false));
+        assertEquals("//c/Users", translateToVolumePath("C:\\Users", false));
         assertEquals("//c/Users/Quarkus/lambdatest-1.0-SNAPSHOT-native-image-source-jar",
-                translateToVolumePath("C:\\Users\\Quarkus\\lambdatest-1.0-SNAPSHOT-native-image-source-jar"));
+                translateToVolumePath("C:\\Users\\Quarkus\\lambdatest-1.0-SNAPSHOT-native-image-source-jar", false));
 
         // Side effect for Unix-style path.
-        assertEquals("//c/Users/Quarkus", translateToVolumePath("c:/Users/Quarkus"));
+        assertEquals("//c/Users/Quarkus", translateToVolumePath("c:/Users/Quarkus", false));
 
         // Side effects for fancy inputs - for the sake of documentation.
-        assertEquals("something/bizarre", translateToVolumePath("something\\bizarre"));
-        assertEquals("something.bizarre", translateToVolumePath("something.bizarre"));
+        assertEquals("something/bizarre", translateToVolumePath("something\\bizarre", false));
+        assertEquals("something.bizarre", translateToVolumePath("something.bizarre", false));
     }
 
 }


### PR DESCRIPTION
fixes #25865

I can confirm it works on my system:

## Workstation

```
podman version:   4.1.0
OS Name:             Microsoft Windows 10 Enterprise
OS Version:          10.0.19044 N/A Build 19044
Hotfix(s):               7 Hotfix(s) Installed.
                                  [01]: KB5013624
                                  [02]: KB4562830
                                  [03]: KB5003791
                                  [04]: KB5007401
                                  [05]: KB5013942
                                  [06]: KB5014032
                                  [07]: KB5005699
WSL2 Kernel:        5.10.102.1
Podman machine: podman-machine-default_fedora-35-x86_64
```

## Patched change
Before:
```
podman run --env LANG=C --rm -v //c/tmp/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z
```
After:
```
podman run --env LANG=C --rm -v /c/tmp/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z 
```

## Full output

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.acme.GreetingResourceTest
2022-05-30 13:34:44,189 INFO  [org.jbo.threads] (main) JBoss Threads version 3.4.2.Final
2022-05-30 13:34:46,824 INFO  [io.quarkus] (main) code-with-quarkus 1.0.0-SNAPSHOT on JVM (powered by Quarkus 999-SNAPSHOT) started in 3.814s. Listening on: http://localhost:8081
2022-05-30 13:34:46,831 INFO  [io.quarkus] (main) Profile test activated.
2022-05-30 13:34:46,831 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.219 s - in org.acme.GreetingResourceTest
2022-05-30 13:34:49,986 INFO  [io.quarkus] (main) code-with-quarkus stopped in 0.076s
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ code-with-quarkus ---
[INFO] Building jar: C:\tmp\code-with-quarkus\target\code-with-quarkus-1.0.0-SNAPSHOT.jar
[INFO]
[INFO] --- quarkus-maven-plugin:999-SNAPSHOT:build (default) @ code-with-quarkus ---
[WARNING] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Uber JAR strategy is used for native image source JAR generation on Windows. This is done for the time being to work around a current GraalVM limitation on Windows concerning the maximum command length (see https://github.com/oracle/graal/issues/2387).
[INFO] [io.quarkus.deployment.pkg.steps.JarResultBuildStep] Building uber jar: C:\tmp\code-with-quarkus\target\code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar\code-with-quarkus-1.0.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Building native image from C:\tmp\code-with-quarkus\target\code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar\code-with-quarkus-1.0.0-SNAPSHOT-runner.jar
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildContainerRunner] Using podman to run the native image builder
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildContainerRunner] Checking image status quay.io/quarkus/ubi-quarkus-native-image:22.1-java11
Trying to pull quay.io/quarkus/ubi-quarkus-native-image:22.1-java11...
Getting image source signatures
Copying blob sha256:4f8ddd7f5a755f537dd9d5f553c8c78171dcf3018c5fc96676a07380d3e14e20
Copying blob sha256:d2e79bb19aa1ef62d9c03049a1c8524cbe7a983c33921bcc8ac912746e399cd1
Copying blob sha256:54e56e6f85721741ee7bf0336de8ad3bf138a56769a6d0097b600a0e361be58d
Copying blob sha256:d2e79bb19aa1ef62d9c03049a1c8524cbe7a983c33921bcc8ac912746e399cd1
Copying config sha256:08a0f818e1477fa6b570cefe8e90b799e95ce1b45de7fdd171f25759f29f8bfc
Writing manifest to image destination
Storing signatures
08a0f818e1477fa6b570cefe8e90b799e95ce1b45de7fdd171f25759f29f8bfc
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM 22.1.0 Java 11 CE (Java Version 11.0.15+10-jvmci-22.1-b06)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --name build-native-uGZkI quay.io/quarkus/ubi-quarkus-native-image:22.1-java11 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 -H:-ParseOnce -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -J-Djava.awt.headless=true -H:FallbackThreshold=0 --link-at-build-time -H:+ReportExceptionStackTraces -J-Xmx8g -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace code-with-quarkus-1.0.0-SNAPSHOT-runner -jar code-with-quarkus-1.0.0-SNAPSHOT-runner.jar
========================================================================================================================
GraalVM Native Image: Generating 'code-with-quarkus-1.0.0-SNAPSHOT-runner' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                   (20.2s @ 0.24GB)
 Version info: 'GraalVM 22.1.0 Java 11 CE'
 C compiler: gcc (redhat, x86_64, 8.5.0)
 Garbage collector: Serial GC
 3 user-provided feature(s)
  - io.quarkus.runner.AutoFeature
  - io.quarkus.runtime.graal.DisableLoggingAutoFeature
  - io.quarkus.runtime.graal.ResourcesFeature
[2/7] Performing analysis...  [************]                                                            (41.0s @ 1.76GB)
   9,541 (88.85%) of 10,738 classes reachable
  14,165 (59.82%) of 23,679 fields reachable
  47,410 (56.63%) of 83,715 methods reachable
     407 classes,     9 fields, and 1,297 methods registered for reflection
      68 classes,    88 fields, and    54 methods registered for JNI access
[3/7] Building universe...                                                                               (2.4s @ 2.17GB)
[4/7] Parsing methods...      [***]                                                                      (8.4s @ 1.65GB)
[5/7] Inlining methods...     [*****]                                                                    (8.7s @ 1.69GB)
[6/7] Compiling methods...    [*******]                                                                 (49.4s @ 1.08GB)
[7/7] Creating image...                                                                                 (12.7s @ 1.96GB)
  18.29MB (43.75%) for code area:   30,640 compilation units
  19.09MB (45.67%) for image heap:   6,497 classes and 232,570 objects
   4.43MB (10.59%) for other data
  41.81MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
   1.73MB sun.security.ssl                                     4.05MB byte[] for code metadata
 966.38KB java.util                                            2.38MB byte[] for general heap data
 715.53KB com.sun.crypto.provider                              2.32MB java.lang.Class
 484.63KB sun.security.x509                                    2.13MB java.lang.String
 423.51KB io.netty.buffer                                      1.74MB byte[] for java.lang.String
 414.17KB java.lang                                          894.47KB com.oracle.svm.core.hub.DynamicHubCompanion
 390.34KB java.io                                            512.77KB java.util.HashMap$Node
 388.68KB java.util.concurrent                               432.37KB java.lang.String[]
 354.27KB io.netty.handler.codec.http2                       411.01KB byte[] for reflection metadata
 298.37KB sun.security.provider                              246.23KB java.util.concurrent.ConcurrentHashMap$Node
      ... 356 additional packages                                 ... 2337 additional object types
                                           (use GraalVM Dashboard to see all)
------------------------------------------------------------------------------------------------------------------------
                        8.8s (5.8% of total time) in 33 GCs | Peak RSS: 4.01GB | CPU load: 3.17
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /project/code-with-quarkus-1.0.0-SNAPSHOT-runner (executable)
 /project/code-with-quarkus-1.0.0-SNAPSHOT-runner.build_artifacts.txt
========================================================================================================================
Finished generating 'code-with-quarkus-1.0.0-SNAPSHOT-runner' in 2m 27s.
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/code-with-quarkus/target/code-with-quarkus-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi-quarkus-native-image:22.1-java11 -c objcopy --strip-debug code-with-quarkus-1.0.0-SNAPSHOT-runner
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 232282ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:13 min
[INFO] Finished at: 2022-05-30T13:38:43-07:00
[INFO] ------------------------------------------------------------------------
```