### PR TITLE
MySQL on M1: use architecture-specific image, and health check for readiness detection

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1241,6 +1241,12 @@
             <properties>
                 <!-- Podman compatibility. Currently, mac file systems based on Plan 9 does not support SELinux labeling z and Z should not be used. When they transition to use virtiofsd, it should support SELinux labeling, and then we can use it for better container separation on the Mac.-->
                 <volume.access.modifier></volume.access.modifier>
+                
+                <!-- See https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8
+                and https://www.emmanuelgautier.com/blog/mysql-docker-arm-m1
+                This hopefully should be temporary -->
+                <mysql.image>arm64v8/mysql:8-oracle</mysql.image>
+
             </properties>
         </profile>
 

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -154,7 +154,7 @@
                                             <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
-                                            <!-- leversge the healthcheck in the image we use -->
+                                            <!-- leverage the healthcheck in the image we use -->
                                             <healthy>yes</healthy>
                                         </wait>
                                     </run>

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -163,8 +163,24 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>${mysql.image}</name>
+                                    <name>healthcheck-${mysql.image}</name>
                                     <alias>quarkus-test-mysql</alias>
+                                    <build>
+                                        <from>${mysql.image}</from>
+                                        <healthCheck>
+                                            <!-- The exact values for these aren't very important, but it is important they are there -->
+                                            <interval>5s</interval>
+                                            <timeout>3s</timeout>
+                                            <startPeriod>5s</startPeriod>
+                                            <retries>5</retries>
+                                            <!--  We could also use /usr/local/bin/healthcheck.sh but it seemed complicated to get the right level.
+                                            Note that mysqladmin ping returns 0 even if the password is wrong so we don't need to pass in a password, but it makes the logs cleaner-->
+                                            <cmd>
+                                                <shell>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test || exit 1
+                                                </shell>
+                                            </cmd>
+                                        </healthCheck>
+                                    </build>
                                     <run>
                                         <ports>
                                             <port>3306:3306</port>
@@ -182,13 +198,10 @@
                                         </log>
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
+                                        <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
-                                            <!-- wait until MySQL is actually up by checking if mysqladmin can ping the server with specified username/password -->
-                                            <exec>
-                                                <postStart>mysqladmin ping -h localhost -u hibernate_orm_test -phibernate_orm_test</postStart>
-                                            </exec>
+                                            <healthy>true</healthy>
                                         </wait>
                                     </run>
                                 </image>
@@ -203,6 +216,7 @@
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>stop</goal>
+                                    <goal>build</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>


### PR DESCRIPTION
Partial resolution of https://github.com/quarkusio/quarkus/issues/25428. See also discussion in https://github.com/quarkusio/quarkus/pull/25648. This PR makes modules with docker-maven-plugin tests which use mysql able to run cleanly when `-Dstart-containers` is set on M1 with podman. There are other modules with ‘mysql’ in the name, but they use mariadb under the covers, so were dealt with in another commit.


Like with https://github.com/quarkusio/quarkus/pull/25830, this will change the default dev services image, but only when quarkus is built on M1. That’s not ideal in either direction - in the unlikely event that we built on M1 and then released to all platforms, the mysql name would be wrong. For normal releases, the dev services image still won’t work out of the box on M1. However, I think that’s ok for the moment, since the alternative is some very complex architecture-detecting system for default dev services images, which kind of defeats the point of what containers are supposed to help with.

To test 

```

TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -f integration-tests/jpa-mysql
```

With `-dtest-containers` I still see failures, but they’re outside the scope of this PR.
## What’s changed

Like for DB2, I got a 404 if I tried to pull the image without explicitly specifying the architecture. However, just specifying the architecture wasn’t enough for the container to start. It would work on the command line with podman, but not in fabric8 with podman.

Following https://www.emmanuelgautier.com/blog/mysql-docker-arm-m1 and https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8 I instead changed the image name to one with better behaviour on arm. Hopefully this tuning can be removed as M1 support matures.

I also switched to a health check for startup detection.