### PR TITLE
Log finish of code generation for proto

### DIFF
--- a/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
+++ b/extensions/grpc/codegen/src/main/java/io/quarkus/grpc/deployment/GrpcCodeGen.java
@@ -132,6 +132,7 @@ public class GrpcCodeGen implements CodeGenProvider {
                     throw new CodeGenException("Failed to generate Java classes from proto files: " + protoFiles +
                             " to " + outDir.toAbsolutePath() + " with command " + String.join(" ", command));
                 }
+                log.info("Successfully finished generating sources from proto files");
                 return true;
             }
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
The motivation for the change is that in the dev mode, on an error on generating stuff from proto, the error is printed in the console. If the compilation finished successfully nothing is printed. So a user may have an impression that the proto files weren't compiled successfully.