### PR TITLE
Registers media type `text/xml` for RESTEasy Reactive with JAXB

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ValidatorMediaTypeUtil.java
@@ -10,8 +10,10 @@ import javax.ws.rs.core.MediaType;
  */
 public final class ValidatorMediaTypeUtil {
 
-    private static final List<MediaType> SUPPORTED_MEDIA_TYPES = Arrays.asList(MediaType.APPLICATION_JSON_TYPE,
+    private static final List<MediaType> SUPPORTED_MEDIA_TYPES = Arrays.asList(
+            MediaType.APPLICATION_JSON_TYPE,
             MediaType.APPLICATION_XML_TYPE,
+            MediaType.TEXT_XML_TYPE,
             MediaType.TEXT_PLAIN_TYPE);
 
     private ValidatorMediaTypeUtil() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/deployment/ResteasyReactiveJaxbCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/deployment/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/deployment/ResteasyReactiveJaxbCommonProcessor.java
@@ -1,6 +1,6 @@
 package io.quarkus.resteasy.reactive.jaxb.common.deployment;
 
-import java.util.Collections;
+import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
@@ -25,8 +25,8 @@ public class ResteasyReactiveJaxbCommonProcessor {
                 .setUnremovable().build());
 
         additionalReaders.produce(new MessageBodyReaderBuildItem(JaxbMessageBodyReader.class.getName(), Object.class.getName(),
-                Collections.singletonList(MediaType.APPLICATION_XML)));
+                List.of(MediaType.APPLICATION_XML, MediaType.TEXT_XML)));
         additionalWriters.produce(new MessageBodyWriterBuildItem(JaxbMessageBodyWriter.class.getName(), Object.class.getName(),
-                Collections.singletonList(MediaType.APPLICATION_XML)));
+                List.of(MediaType.APPLICATION_XML, MediaType.TEXT_XML)));
     }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/runtime/serialisers/JaxbMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jaxb-common/runtime/src/main/java/io/quarkus/resteasy/reactive/jaxb/common/runtime/serialisers/JaxbMessageBodyReader.java
@@ -47,9 +47,9 @@ public class JaxbMessageBodyReader implements ServerMessageBodyReader<Object> {
             return false;
         }
         String subtype = mediaType.getSubtype();
-        boolean isApplicationMediaType = "application".equals(mediaType.getType());
-        return (isApplicationMediaType && "xml".equalsIgnoreCase(subtype) || subtype.endsWith("+xml"))
-                || (mediaType.isWildcardSubtype() && (mediaType.isWildcardType() || isApplicationMediaType));
+        boolean isCorrectMediaType = "application".equals(mediaType.getType()) || "text".equals(mediaType.getType());
+        return (isCorrectMediaType && "xml".equalsIgnoreCase(subtype) || subtype.endsWith("+xml"))
+                || (mediaType.isWildcardSubtype() && (mediaType.isWildcardType() || isCorrectMediaType));
     }
 
     private Object doReadFrom(Class<Object> type, Type genericType, InputStream entityStream) throws IOException {

--- a/extensions/resteasy-reactive/rest-client-reactive-jaxb/deployment/src/test/java/io/quarkus/rest/client/reactive/jaxb/test/SimpleJaxbTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jaxb/deployment/src/test/java/io/quarkus/rest/client/reactive/jaxb/test/SimpleJaxbTest.java
@@ -9,6 +9,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlRootElement;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.jupiter.api.Test;
@@ -26,9 +27,16 @@ public class SimpleJaxbTest {
     URI uri;
 
     @Test
-    void shouldConsumeJsonEntity() {
+    void shouldConsumeXMLEntity() {
         var dto = RestClientBuilder.newBuilder().baseUri(uri).build(XmlClient.class)
                 .dto();
+        assertThat(dto).isEqualTo(new Dto("foo", "bar"));
+    }
+
+    @Test
+    void shouldConsumePlainXMLEntity() {
+        var dto = RestClientBuilder.newBuilder().baseUri(uri).build(XmlClient.class)
+                .plain();
         assertThat(dto).isEqualTo(new Dto("foo", "bar"));
     }
 
@@ -39,6 +47,11 @@ public class SimpleJaxbTest {
         @Path("/dto")
         @Produces(MediaType.APPLICATION_XML)
         Dto dto();
+
+        @GET
+        @Path("/plain")
+        @Produces(MediaType.TEXT_XML)
+        Dto plain();
     }
 
     @Path("/xml")
@@ -50,8 +63,16 @@ public class SimpleJaxbTest {
         public Dto dto() {
             return new Dto("foo", "bar");
         }
+
+        @GET
+        @Produces(MediaType.TEXT_XML)
+        @Path("/plain")
+        public Dto plain() {
+            return new Dto("foo", "bar");
+        }
     }
 
+    @XmlRootElement(name = "Dto")
     public static class Dto {
         public String name;
         public String value;


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/25884 by adding the JAXB message body writers and readers for `text/xml`. Will still default to `application/xml` if unspecified for the message body writer.

Let me know if I should add this somewhere else too or provide some more (integration) tests.