### PR TITLE
Improve parameters support for synthetic components

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/SyntheticBeanBuildItem.java
@@ -129,11 +129,6 @@ public final class SyntheticBeanBuildItem extends MultiBuildItem {
             return qualifiers;
         }
 
-        @Override
-        protected ExtendedBeanConfigurator self() {
-            return this;
-        }
-
         Supplier<?> getSupplier() {
             return supplier;
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -34,11 +34,6 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
         this.beanConsumer = beanConsumer;
     }
 
-    @Override
-    protected BeanConfigurator<T> self() {
-        return this;
-    }
-
     /**
      * Finish the configurator. The configurator should not be modified after this method is called.
      */

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -10,7 +10,6 @@ import io.quarkus.gizmo.ResultHandle;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +25,8 @@ import org.jboss.jandex.Type.Kind;
 /**
  * This construct is not thread-safe.
  */
-public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>, T> implements Consumer<AnnotationInstance> {
+public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THIS, T>, T> extends ConfiguratorBase<THIS>
+        implements Consumer<AnnotationInstance> {
 
     protected final DotName implClazz;
     protected final Set<Type> types;
@@ -38,7 +38,6 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
     protected Consumer<MethodCreator> destroyerConsumer;
     protected boolean defaultBean;
     protected boolean removable;
-    protected final Map<String, Object> params;
     protected Type providerType;
     protected boolean forceApplicationClass;
     protected String targetPackageName;
@@ -50,10 +49,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         this.qualifiers = new HashSet<>();
         this.scope = BuiltinScope.DEPENDENT.getInfo();
         this.removable = true;
-        this.params = new HashMap<>();
     }
-
-    protected abstract B self();
 
     /**
      * Read metadata from another configurator base.
@@ -61,7 +57,8 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
      * @param base
      * @return self
      */
-    public B read(BeanConfiguratorBase<?, ?> base) {
+    public THIS read(BeanConfiguratorBase<?, ?> base) {
+        super.read(base);
         types.clear();
         types.addAll(base.types);
         qualifiers.clear();
@@ -78,66 +75,64 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
             defaultBean();
         }
         removable = base.removable;
-        params.clear();
-        params.putAll(base.params);
         providerType(base.providerType);
         return self();
     }
 
-    public B types(Class<?>... types) {
+    public THIS types(Class<?>... types) {
         for (Class<?> type : types) {
             addType(type);
         }
         return self();
     }
 
-    public B types(Type... types) {
+    public THIS types(Type... types) {
         Collections.addAll(this.types, types);
         return self();
     }
 
-    public B addType(DotName className) {
+    public THIS addType(DotName className) {
         this.types.add(Type.create(className, Kind.CLASS));
         return self();
     }
 
-    public B addType(Type type) {
+    public THIS addType(Type type) {
         this.types.add(type);
         return self();
     }
 
-    public B addType(Class<?> type) {
+    public THIS addType(Class<?> type) {
         return addType(DotName.createSimple(type.getName()));
     }
 
-    public B addQualifier(Class<? extends Annotation> annotationClass) {
+    public THIS addQualifier(Class<? extends Annotation> annotationClass) {
         return addQualifier(DotName.createSimple(annotationClass.getName()));
     }
 
-    public B addQualifier(DotName annotationName) {
+    public THIS addQualifier(DotName annotationName) {
         return addQualifier(AnnotationInstance.create(annotationName, null, new AnnotationValue[] {}));
     }
 
-    public B addQualifier(AnnotationInstance qualifier) {
+    public THIS addQualifier(AnnotationInstance qualifier) {
         this.qualifiers.add(qualifier);
         return self();
     }
 
-    public QualifierConfigurator<B> addQualifier() {
-        return new QualifierConfigurator<B>(cast(this));
+    public QualifierConfigurator<THIS> addQualifier() {
+        return new QualifierConfigurator<>(cast(this));
     }
 
-    public B qualifiers(AnnotationInstance... qualifiers) {
+    public THIS qualifiers(AnnotationInstance... qualifiers) {
         Collections.addAll(this.qualifiers, qualifiers);
         return self();
     }
 
-    public B scope(ScopeInfo scope) {
+    public THIS scope(ScopeInfo scope) {
         this.scope = scope;
         return self();
     }
 
-    public B scope(Class<? extends Annotation> scope) {
+    public THIS scope(Class<? extends Annotation> scope) {
         DotName scopeName = DotName.createSimple(scope.getName());
         BuiltinScope builtinScope = BuiltinScope.from(scopeName);
         if (builtinScope != null) {
@@ -149,7 +144,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         return self();
     }
 
-    public B name(String name) {
+    public THIS name(String name) {
         this.name = name;
         return self();
     }
@@ -161,16 +156,16 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
      * @param name
      * @return self
      */
-    public B named(String name) {
+    public THIS named(String name) {
         return name(name).addQualifier().annotation(DotNames.NAMED).addValue("value", name).done();
     }
 
-    public B defaultBean() {
+    public THIS defaultBean() {
         this.defaultBean = true;
         return self();
     }
 
-    public B unremovable() {
+    public THIS unremovable() {
         this.removable = false;
         return self();
     }
@@ -181,54 +176,24 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
      *
      * @return self
      */
-    public B forceApplicationClass() {
+    public THIS forceApplicationClass() {
         this.forceApplicationClass = true;
         return self();
     }
 
-    public B targetPackageName(String name) {
+    public THIS targetPackageName(String name) {
         this.targetPackageName = name;
         return self();
     }
 
-    public B alternativePriority(int value) {
+    public THIS alternativePriority(int value) {
         this.alternative = true;
         this.priority = value;
         return self();
     }
 
-    public B priority(int value) {
+    public THIS priority(int value) {
         this.priority = value;
-        return self();
-    }
-
-    public B param(String name, Class<?> value) {
-        params.put(name, value);
-        return self();
-    }
-
-    public B param(String name, int value) {
-        params.put(name, value);
-        return self();
-    }
-
-    public B param(String name, long value) {
-        params.put(name, value);
-        return self();
-    }
-
-    public B param(String name, double value) {
-        params.put(name, value);
-        return self();
-    }
-
-    public B param(String name, String value) {
-        params.put(name, value);
-        return self();
-    }
-
-    public B param(String name, boolean value) {
-        params.put(name, value);
         return self();
     }
 
@@ -242,12 +207,12 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
      * @param providerType
      * @return self
      */
-    public B providerType(Type providerType) {
+    public THIS providerType(Type providerType) {
         this.providerType = providerType;
         return self();
     }
 
-    public <U extends T> B creator(Class<? extends BeanCreator<U>> creatorClazz) {
+    public <U extends T> THIS creator(Class<? extends BeanCreator<U>> creatorClazz) {
         return creator(mc -> {
             // return new FooBeanCreator().create(context, params)
             ResultHandle paramsHandle = mc.readInstanceField(
@@ -262,12 +227,12 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         });
     }
 
-    public <U extends T> B creator(Consumer<MethodCreator> methodCreatorConsumer) {
+    public THIS creator(Consumer<MethodCreator> methodCreatorConsumer) {
         this.creatorConsumer = methodCreatorConsumer;
         return cast(this);
     }
 
-    public <U extends T> B destroyer(Class<? extends BeanDestroyer<U>> destroyerClazz) {
+    public <U extends T> THIS destroyer(Class<? extends BeanDestroyer<U>> destroyerClazz) {
         return destroyer(mc -> {
             // new FooBeanDestroyer().destroy(instance, context, params)
             ResultHandle paramsHandle = mc.readInstanceField(
@@ -283,7 +248,7 @@ public abstract class BeanConfiguratorBase<B extends BeanConfiguratorBase<B, T>,
         });
     }
 
-    public <U extends T> B destroyer(Consumer<MethodCreator> methodCreatorConsumer) {
+    public THIS destroyer(Consumer<MethodCreator> methodCreatorConsumer) {
         this.destroyerConsumer = methodCreatorConsumer;
         return cast(this);
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -1194,7 +1194,7 @@ public class BeanDeployment {
                 configurator.observedQualifiers,
                 Reception.ALWAYS, configurator.transactionPhase, configurator.isAsync, configurator.priority,
                 observerTransformers, buildContext,
-                jtaCapabilities, configurator.notifyConsumer));
+                jtaCapabilities, configurator.notifyConsumer, configurator.params));
     }
 
     static void processErrors(List<Throwable> errors) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -44,7 +44,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -81,7 +80,6 @@ public class BeanGenerator extends AbstractGenerator {
     protected static final String FIELD_NAME_QUALIFIERS = "qualifiers";
     protected static final String FIELD_NAME_STEREOTYPES = "stereotypes";
     protected static final String FIELD_NAME_PROXY = "proxy";
-    protected static final String FIELD_NAME_PARAMS = "params";
 
     protected final AnnotationLiteralProcessor annotationLiterals;
     protected final Predicate<DotName> applicationClassPredicate;
@@ -182,39 +180,9 @@ public class BeanGenerator extends AbstractGenerator {
                 Collections.emptyMap(), Collections.emptyMap(),
                 annotationLiterals, reflectionRegistration);
 
-        FieldCreator params = beanCreator.getFieldCreator(FIELD_NAME_PARAMS, Map.class)
-                .setModifiers(ACC_PRIVATE | ACC_FINAL);
+        SyntheticComponentsUtil.addParamsFieldAndInit(beanCreator, constructor, bean.getParams(), annotationLiterals,
+                bean.getDeployment().getBeanArchiveIndex());
 
-        // If needed, store the synthetic bean parameters
-        ResultHandle paramsHandle;
-        if (bean.getParams().isEmpty()) {
-            paramsHandle = constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_EMPTY_MAP);
-        } else {
-            paramsHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
-            for (Entry<String, Object> entry : bean.getParams().entrySet()) {
-                ResultHandle valHandle = null;
-                if (entry.getValue() instanceof String) {
-                    valHandle = constructor.load(entry.getValue().toString());
-                } else if (entry.getValue() instanceof Integer) {
-                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Integer.class, int.class),
-                            constructor.load(((Integer) entry.getValue()).intValue()));
-                } else if (entry.getValue() instanceof Long) {
-                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Long.class, long.class),
-                            constructor.load(((Long) entry.getValue()).longValue()));
-                } else if (entry.getValue() instanceof Double) {
-                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Double.class, double.class),
-                            constructor.load(((Double) entry.getValue()).doubleValue()));
-                } else if (entry.getValue() instanceof Class) {
-                    valHandle = constructor.loadClass((Class<?>) entry.getValue());
-                } else if (entry.getValue() instanceof Boolean) {
-                    valHandle = constructor.load((Boolean) entry.getValue());
-                }
-                // TODO other param types
-                constructor.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, paramsHandle, constructor.load(entry.getKey()),
-                        valHandle);
-            }
-        }
-        constructor.writeInstanceField(params.getFieldDescriptor(), constructor.getThis(), paramsHandle);
         constructor.returnValue(null);
 
         implementGetIdentifier(bean, beanCreator);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ConfiguratorBase.java
@@ -1,0 +1,158 @@
+package io.quarkus.arc.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+
+/**
+ * Base class for configurators that accept a parameter map.
+ * <p>
+ * This construct is not thread-safe.
+ */
+public abstract class ConfiguratorBase<THIS extends ConfiguratorBase<THIS>> {
+
+    protected final Map<String, Object> params = new HashMap<>();
+
+    @SuppressWarnings("unchecked")
+    protected THIS self() {
+        return (THIS) this;
+    }
+
+    public THIS read(ConfiguratorBase<?> base) {
+        params.clear();
+        params.putAll(base.params);
+        return self();
+    }
+
+    public THIS param(String name, boolean value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, boolean[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, byte value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, byte[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, short value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, short[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, int value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, int[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, long value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, long[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, float value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, float[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, double value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, double[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, char value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, char[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, String value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, String[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, Enum<?> value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, Enum<?>[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, Class<?> value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, Class<?>[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, ClassInfo value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, ClassInfo[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, AnnotationInstance value) {
+        params.put(name, value);
+        return self();
+    }
+
+    public THIS param(String name, AnnotationInstance[] value) {
+        params.put(name, value);
+        return self();
+    }
+
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverConfigurator.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.processor;
 
 import io.quarkus.gizmo.MethodCreator;
 import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -20,7 +21,7 @@ import org.jboss.jandex.Type.Kind;
  *
  * @see ObserverRegistrar
  */
-public final class ObserverConfigurator implements Consumer<AnnotationInstance> {
+public final class ObserverConfigurator extends ConfiguratorBase<ObserverConfigurator> implements Consumer<AnnotationInstance> {
 
     final Consumer<ObserverConfigurator> consumer;
     String id;
@@ -82,6 +83,11 @@ public final class ObserverConfigurator implements Consumer<AnnotationInstance> 
 
     public QualifierConfigurator<ObserverConfigurator> addQualifier() {
         return new QualifierConfigurator<>(this);
+    }
+
+    public ObserverConfigurator qualifiers(AnnotationInstance... qualifiers) {
+        Collections.addAll(this.observedQualifiers, qualifiers);
+        return this;
     }
 
     public ObserverConfigurator priority(int priority) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverGenerator.java
@@ -485,6 +485,9 @@ public class ObserverGenerator extends AbstractGenerator {
             constructor = observerCreator.getMethodCreator(Methods.INIT, "V");
             // Invoke super()
             constructor.invokeSpecialMethod(MethodDescriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
+
+            SyntheticComponentsUtil.addParamsFieldAndInit(observerCreator, constructor, observer.getParams(),
+                    annotationLiterals, observer.getBeanDeployment().getBeanArchiveIndex());
         } else {
             // Declaring provider and injection points
             // First collect all param types

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ObserverInfo.java
@@ -68,7 +68,7 @@ public class ObserverInfo implements InjectionTargetInfo {
                 initQualifiers(declaringBean.getDeployment(), observerMethod, eventParameter),
                 initReception(isAsync, declaringBean.getDeployment(), observerMethod),
                 initTransactionPhase(isAsync, declaringBean.getDeployment(), observerMethod), isAsync, priority, transformers,
-                buildContext, jtaCapabilities, null);
+                buildContext, jtaCapabilities, null, Collections.emptyMap());
     }
 
     static ObserverInfo create(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean,
@@ -76,7 +76,7 @@ public class ObserverInfo implements InjectionTargetInfo {
             MethodParameterInfo eventParameter, Type observedType, Set<AnnotationInstance> qualifiers, Reception reception,
             TransactionPhase transactionPhase, boolean isAsync, int priority,
             List<ObserverTransformer> transformers, BuildContext buildContext, boolean jtaCapabilities,
-            Consumer<MethodCreator> notify) {
+            Consumer<MethodCreator> notify, Map<String, Object> params) {
 
         if (!transformers.isEmpty()) {
             // Transform attributes if needed
@@ -122,7 +122,7 @@ public class ObserverInfo implements InjectionTargetInfo {
                     info, transactionPhase);
         }
         return new ObserverInfo(id, beanDeployment, beanClass, declaringBean, observerMethod, injection, eventParameter,
-                isAsync, priority, reception, transactionPhase, observedType, qualifiers, notify);
+                isAsync, priority, reception, transactionPhase, observedType, qualifiers, notify, params);
     }
 
     private final String id;
@@ -157,11 +157,13 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     private final Consumer<MethodCreator> notify;
 
+    private final Map<String, Object> params;
+
     ObserverInfo(String id, BeanDeployment beanDeployment, DotName beanClass, BeanInfo declaringBean, MethodInfo observerMethod,
             Injection injection,
             MethodParameterInfo eventParameter,
             boolean isAsync, int priority, Reception reception, TransactionPhase transactionPhase,
-            Type observedType, Set<AnnotationInstance> qualifiers, Consumer<MethodCreator> notify) {
+            Type observedType, Set<AnnotationInstance> qualifiers, Consumer<MethodCreator> notify, Map<String, Object> params) {
         this.id = id;
         this.beanDeployment = beanDeployment;
         this.beanClass = beanClass;
@@ -177,6 +179,7 @@ public class ObserverInfo implements InjectionTargetInfo {
         this.observedType = observedType;
         this.qualifiers = qualifiers;
         this.notify = notify;
+        this.params = params;
     }
 
     @Override
@@ -269,6 +272,10 @@ public class ObserverInfo implements InjectionTargetInfo {
 
     Consumer<MethodCreator> getNotify() {
         return notify;
+    }
+
+    Map<String, Object> getParams() {
+        return params;
     }
 
     void init(List<Throwable> errors) {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SyntheticComponentsUtil.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/SyntheticComponentsUtil.java
@@ -1,0 +1,187 @@
+package io.quarkus.arc.processor;
+
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.IndexView;
+
+final class SyntheticComponentsUtil {
+    private static final String FIELD_NAME_PARAMS = "params";
+
+    /**
+     * Adds the {@code params} field to given class and adds constructor code to initialize the field.
+     *
+     * @param classCreator class to which the {@code params} field will be added
+     * @param constructor constructor in which the {@code params} field will be initialized
+     * @param params the parameter map, will be "copied" to the {@code params} field
+     * @param annotationLiterals to allow creating annotation literals
+     * @param beanArchiveIndex to find annotation types when generating annotation literal classes
+     */
+    static void addParamsFieldAndInit(ClassCreator classCreator, MethodCreator constructor, Map<String, Object> params,
+            AnnotationLiteralProcessor annotationLiterals, IndexView beanArchiveIndex) {
+
+        FieldCreator field = classCreator.getFieldCreator(FIELD_NAME_PARAMS, Map.class)
+                .setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+        ResultHandle paramsHandle;
+        if (params.isEmpty()) {
+            paramsHandle = constructor.invokeStaticMethod(MethodDescriptors.COLLECTIONS_EMPTY_MAP);
+        } else {
+            paramsHandle = constructor.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                ResultHandle valHandle = null;
+                if (entry.getValue() instanceof Boolean) {
+                    valHandle = constructor.load(((Boolean) entry.getValue()).booleanValue());
+                } else if (entry.getValue() instanceof boolean[]) {
+                    boolean[] array = (boolean[]) entry.getValue();
+                    valHandle = constructor.newArray(boolean.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Byte) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Byte.class, byte.class),
+                            constructor.load(((Byte) entry.getValue()).byteValue()));
+                } else if (entry.getValue() instanceof byte[]) {
+                    byte[] array = (byte[]) entry.getValue();
+                    valHandle = constructor.newArray(byte.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Short) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Short.class, short.class),
+                            constructor.load(((Short) entry.getValue()).shortValue()));
+                } else if (entry.getValue() instanceof short[]) {
+                    short[] array = (short[]) entry.getValue();
+                    valHandle = constructor.newArray(short.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Integer) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Integer.class, int.class),
+                            constructor.load(((Integer) entry.getValue()).intValue()));
+                } else if (entry.getValue() instanceof int[]) {
+                    int[] array = (int[]) entry.getValue();
+                    valHandle = constructor.newArray(int.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Long) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Long.class, long.class),
+                            constructor.load(((Long) entry.getValue()).longValue()));
+                } else if (entry.getValue() instanceof long[]) {
+                    long[] array = (long[]) entry.getValue();
+                    valHandle = constructor.newArray(long.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Float) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Float.class, float.class),
+                            constructor.load(((Float) entry.getValue()).floatValue()));
+                } else if (entry.getValue() instanceof float[]) {
+                    float[] array = (float[]) entry.getValue();
+                    valHandle = constructor.newArray(float.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Double) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Double.class, double.class),
+                            constructor.load(((Double) entry.getValue()).doubleValue()));
+                } else if (entry.getValue() instanceof double[]) {
+                    double[] array = (double[]) entry.getValue();
+                    valHandle = constructor.newArray(double.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Character) {
+                    valHandle = constructor.newInstance(MethodDescriptor.ofConstructor(Character.class, char.class),
+                            constructor.load(((Character) entry.getValue()).charValue()));
+                } else if (entry.getValue() instanceof char[]) {
+                    char[] array = (char[]) entry.getValue();
+                    valHandle = constructor.newArray(char.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof String) {
+                    valHandle = constructor.load((String) entry.getValue());
+                } else if (entry.getValue() instanceof String[]) {
+                    String[] array = (String[]) entry.getValue();
+                    valHandle = constructor.newArray(String.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Enum) {
+                    valHandle = constructor.load((Enum<?>) entry.getValue());
+                } else if (entry.getValue() instanceof Enum[]) {
+                    Enum<?>[] array = (Enum<?>[]) entry.getValue();
+                    // most commonly, all values in the array are of the same type, in which case we create an array
+                    // of that type; otherwise, we create an array of Enum, which is the least upper bound
+                    Class<?> arrayElementClass = array.length == 0 ? Enum.class : array[0].getDeclaringClass();
+                    for (Enum<?> value : array) {
+                        if (!arrayElementClass.equals(value.getDeclaringClass())) {
+                            arrayElementClass = Enum.class;
+                            break;
+                        }
+                    }
+                    valHandle = constructor.newArray(arrayElementClass, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.load(array[i]));
+                    }
+                } else if (entry.getValue() instanceof Class) {
+                    valHandle = constructor.loadClassFromTCCL((Class<?>) entry.getValue());
+                } else if (entry.getValue() instanceof Class[]) {
+                    Class<?>[] array = (Class<?>[]) entry.getValue();
+                    valHandle = constructor.newArray(Class.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.loadClassFromTCCL(array[i]));
+                    }
+                } else if (entry.getValue() instanceof ClassInfo) {
+                    valHandle = constructor.loadClassFromTCCL(((ClassInfo) entry.getValue()).name().toString());
+                } else if (entry.getValue() instanceof ClassInfo[]) {
+                    ClassInfo[] array = (ClassInfo[]) entry.getValue();
+                    valHandle = constructor.newArray(Class.class, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        constructor.writeArrayValue(valHandle, i, constructor.loadClassFromTCCL(array[i].name().toString()));
+                    }
+                } else if (entry.getValue() instanceof AnnotationInstance) {
+                    AnnotationInstance annotationInstance = (AnnotationInstance) entry.getValue();
+                    ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotationInstance.name());
+                    valHandle = annotationLiterals.create(constructor, annotationClass, annotationInstance);
+                } else if (entry.getValue() instanceof AnnotationInstance[]) {
+                    AnnotationInstance[] array = (AnnotationInstance[]) entry.getValue();
+                    // most commonly, all values in the array are of the same type, in which case we create an array
+                    // of that type; otherwise, we create an array of Annotation, which is the least upper bound
+                    String arrayElementClass = array.length == 0 ? Annotation.class.getName() : array[0].name().toString();
+                    for (AnnotationInstance value : array) {
+                        if (!arrayElementClass.equals(value.name().toString())) {
+                            arrayElementClass = Annotation.class.getName();
+                            break;
+                        }
+                    }
+                    valHandle = constructor.newArray(arrayElementClass, array.length);
+                    for (int i = 0; i < array.length; i++) {
+                        AnnotationInstance annotationInstance = array[i];
+                        ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotationInstance.name());
+                        ResultHandle elementHandle = annotationLiterals.create(constructor, annotationClass,
+                                annotationInstance);
+                        constructor.writeArrayValue(valHandle, i, elementHandle);
+                    }
+                }
+
+                constructor.invokeInterfaceMethod(MethodDescriptors.MAP_PUT, paramsHandle,
+                        constructor.load(entry.getKey()), valHandle);
+            }
+        }
+
+        constructor.writeInstanceField(field.getFieldDescriptor(), constructor.getThis(), paramsHandle);
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanParamsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanParamsTest.java
@@ -1,0 +1,189 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SyntheticBeanParamsTest {
+    public enum SimpleEnum {
+        FOO,
+        BAR,
+        BAZ,
+    }
+
+    public enum AnotherEnum {
+        INSTANCE
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface SimpleAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnotherAnnotation {
+        int value();
+    }
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .additionalClasses(SimpleEnum.class, AnotherEnum.class, SimpleAnnotation.class, AnotherAnnotation.class,
+                    Verification.class)
+            .beanRegistrars(new BeanRegistrar() {
+                @Override
+                public void register(RegistrationContext context) {
+                    ClassInfo enumClass = context.get(Key.INDEX).getClassByName(
+                            DotName.createSimple(SimpleEnum.class.getName()));
+                    ClassInfo annClass = context.get(Key.INDEX).getClassByName(
+                            DotName.createSimple(SimpleAnnotation.class.getName()));
+
+                    context.configure(Verification.class)
+                            .addType(Verification.class)
+                            .param("bool", true)
+                            .param("b", (byte) 1)
+                            .param("s", (short) 2)
+                            .param("i", 3)
+                            .param("l", 4L)
+                            .param("f", 5.0F)
+                            .param("d", 6.0)
+                            .param("ch", 'a')
+                            .param("str", "bc")
+                            .param("en", SimpleEnum.FOO)
+                            .param("cls", Object.class)
+                            .param("clsJandex", enumClass)
+                            .param("ann", simpleAnnotation("one"))
+                            .param("boolArray", new boolean[] { true, false })
+                            .param("bArray", new byte[] { (byte) 7, (byte) 8 })
+                            .param("sArray", new short[] { (short) 9, (short) 10 })
+                            .param("iArray", new int[] { 11, 12 })
+                            .param("lArray", new long[] { 13L, 14L })
+                            .param("fArray", new float[] { 15.0F, 16.0F })
+                            .param("dArray", new double[] { 17.0, 18.0 })
+                            .param("chArray", new char[] { 'd', 'e' })
+                            .param("strArray", new String[] { "fg", "hi" })
+                            .param("enArray", new SimpleEnum[] { SimpleEnum.BAR, SimpleEnum.BAZ })
+                            .param("enMixedArray", new Enum[] { SimpleEnum.FOO, AnotherEnum.INSTANCE })
+                            .param("clsArray", new Class<?>[] { String.class, Number.class })
+                            .param("clsJandexArray", new ClassInfo[] { enumClass, annClass })
+                            .param("annArray", new AnnotationInstance[] { simpleAnnotation("two"),
+                                    simpleAnnotation("three") })
+                            .param("annMixedArray", new AnnotationInstance[] { simpleAnnotation("four"),
+                                    anotherAnnotation(42) })
+                            .creator(mc -> {
+                                ResultHandle params = mc.readInstanceField(
+                                        FieldDescriptor.of(mc.getMethodDescriptor().getDeclaringClass(), "params", Map.class),
+                                        mc.getThis());
+                                mc.invokeStaticMethod(
+                                        MethodDescriptor.ofMethod(Verification.class, "invoke", void.class, Map.class),
+                                        params);
+                                ResultHandle instance = mc.newInstance(MethodDescriptor.ofConstructor(Verification.class));
+                                mc.returnValue(instance);
+                            })
+                            .done();
+                }
+            })
+            .build();
+
+    @Test
+    public void test() {
+        Verification verification = Arc.container().select(Verification.class).get();
+        assertNotNull(verification);
+        assertTrue(Verification.invoked);
+    }
+
+    static class Verification {
+        static boolean invoked = false;
+
+        static void invoke(Map<String, Object> params) {
+            assertEquals(true, (boolean) params.get("bool"));
+            assertEquals((byte) 1, (byte) params.get("b"));
+            assertEquals((short) 2, (short) params.get("s"));
+            assertEquals(3, (int) params.get("i"));
+            assertEquals(4L, (long) params.get("l"));
+            assertEquals(5.0F, (float) params.get("f"));
+            assertEquals(6.0, (double) params.get("d"));
+            assertEquals('a', (char) params.get("ch"));
+            assertEquals("bc", (String) params.get("str"));
+            assertEquals(SimpleEnum.FOO, (SimpleEnum) params.get("en"));
+            assertEquals(Object.class, (Class<?>) params.get("cls"));
+            assertEquals(SimpleEnum.class, (Class<?>) params.get("clsJandex"));
+            assertEquals("one", ((SimpleAnnotation) params.get("ann")).value());
+
+            assertEquals(2, ((boolean[]) params.get("boolArray")).length);
+            assertEquals(true, ((boolean[]) params.get("boolArray"))[0]);
+            assertEquals(false, ((boolean[]) params.get("boolArray"))[1]);
+            assertEquals(2, ((byte[]) params.get("bArray")).length);
+            assertEquals((byte) 7, ((byte[]) params.get("bArray"))[0]);
+            assertEquals((byte) 8, ((byte[]) params.get("bArray"))[1]);
+            assertEquals(2, ((short[]) params.get("sArray")).length);
+            assertEquals((short) 9, ((short[]) params.get("sArray"))[0]);
+            assertEquals((short) 10, ((short[]) params.get("sArray"))[1]);
+            assertEquals(2, ((int[]) params.get("iArray")).length);
+            assertEquals(11, ((int[]) params.get("iArray"))[0]);
+            assertEquals(12, ((int[]) params.get("iArray"))[1]);
+            assertEquals(2, ((long[]) params.get("lArray")).length);
+            assertEquals(13L, ((long[]) params.get("lArray"))[0]);
+            assertEquals(14L, ((long[]) params.get("lArray"))[1]);
+            assertEquals(2, ((float[]) params.get("fArray")).length);
+            assertEquals(15.0F, ((float[]) params.get("fArray"))[0]);
+            assertEquals(16.0F, ((float[]) params.get("fArray"))[1]);
+            assertEquals(2, ((double[]) params.get("dArray")).length);
+            assertEquals(17.0, ((double[]) params.get("dArray"))[0]);
+            assertEquals(18.0, ((double[]) params.get("dArray"))[1]);
+            assertEquals(2, ((char[]) params.get("chArray")).length);
+            assertEquals('d', ((char[]) params.get("chArray"))[0]);
+            assertEquals('e', ((char[]) params.get("chArray"))[1]);
+            assertEquals(2, ((String[]) params.get("strArray")).length);
+            assertEquals("fg", ((String[]) params.get("strArray"))[0]);
+            assertEquals("hi", ((String[]) params.get("strArray"))[1]);
+            assertEquals(2, ((SimpleEnum[]) params.get("enArray")).length);
+            assertEquals(SimpleEnum.BAR, ((SimpleEnum[]) params.get("enArray"))[0]);
+            assertEquals(SimpleEnum.BAZ, ((SimpleEnum[]) params.get("enArray"))[1]);
+            assertEquals(2, ((Enum<?>[]) params.get("enMixedArray")).length);
+            assertEquals(SimpleEnum.FOO, ((Enum<?>[]) params.get("enMixedArray"))[0]);
+            assertEquals(AnotherEnum.INSTANCE, ((Enum<?>[]) params.get("enMixedArray"))[1]);
+            assertEquals(2, ((Class<?>[]) params.get("clsArray")).length);
+            assertEquals(String.class, ((Class<?>[]) params.get("clsArray"))[0]);
+            assertEquals(Number.class, ((Class<?>[]) params.get("clsArray"))[1]);
+            assertEquals(2, ((Class<?>[]) params.get("clsJandexArray")).length);
+            assertEquals(SimpleEnum.class, ((Class<?>[]) params.get("clsJandexArray"))[0]);
+            assertEquals(SimpleAnnotation.class, ((Class<?>[]) params.get("clsJandexArray"))[1]);
+            assertEquals(2, ((SimpleAnnotation[]) params.get("annArray")).length);
+            assertEquals("two", ((SimpleAnnotation[]) params.get("annArray"))[0].value());
+            assertEquals("three", ((SimpleAnnotation[]) params.get("annArray"))[1].value());
+            assertEquals(2, ((Annotation[]) params.get("annMixedArray")).length);
+            assertEquals("four", ((SimpleAnnotation) ((Annotation[]) params.get("annMixedArray"))[0]).value());
+            assertEquals(42, ((AnotherAnnotation) ((Annotation[]) params.get("annMixedArray"))[1]).value());
+
+            invoked = true;
+        }
+    }
+
+    private static AnnotationInstance simpleAnnotation(String value) {
+        return AnnotationInstance.create(DotName.createSimple(SimpleAnnotation.class.getName()), null,
+                List.of(AnnotationValue.createStringValue("value", value)));
+    }
+
+    private static AnnotationInstance anotherAnnotation(int value) {
+        return AnnotationInstance.create(DotName.createSimple(AnotherAnnotation.class.getName()), null,
+                List.of(AnnotationValue.createIntegerValue("value", value)));
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/SyntheticObserverParamsTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/observers/SyntheticObserverParamsTest.java
@@ -1,0 +1,185 @@
+package io.quarkus.arc.test.buildextension.observers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.processor.ObserverRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SyntheticObserverParamsTest {
+    public enum SimpleEnum {
+        FOO,
+        BAR,
+        BAZ,
+    }
+
+    public enum AnotherEnum {
+        INSTANCE
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface SimpleAnnotation {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnotherAnnotation {
+        int value();
+    }
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .additionalClasses(SimpleEnum.class, AnotherEnum.class, SimpleAnnotation.class, AnotherAnnotation.class)
+            .observerRegistrars(new ObserverRegistrar() {
+                @Override
+                public void register(RegistrationContext context) {
+                    ClassInfo enumClass = context.get(Key.INDEX).getClassByName(
+                            DotName.createSimple(SimpleEnum.class.getName()));
+                    ClassInfo annClass = context.get(Key.INDEX).getClassByName(
+                            DotName.createSimple(SimpleAnnotation.class.getName()));
+
+                    context.configure()
+                            .observedType(String.class)
+                            .param("bool", true)
+                            .param("b", (byte) 1)
+                            .param("s", (short) 2)
+                            .param("i", 3)
+                            .param("l", 4L)
+                            .param("f", 5.0F)
+                            .param("d", 6.0)
+                            .param("ch", 'a')
+                            .param("str", "bc")
+                            .param("en", SimpleEnum.FOO)
+                            .param("cls", Object.class)
+                            .param("clsJandex", enumClass)
+                            .param("ann", simpleAnnotation("one"))
+                            .param("boolArray", new boolean[] { true, false })
+                            .param("bArray", new byte[] { (byte) 7, (byte) 8 })
+                            .param("sArray", new short[] { (short) 9, (short) 10 })
+                            .param("iArray", new int[] { 11, 12 })
+                            .param("lArray", new long[] { 13L, 14L })
+                            .param("fArray", new float[] { 15.0F, 16.0F })
+                            .param("dArray", new double[] { 17.0, 18.0 })
+                            .param("chArray", new char[] { 'd', 'e' })
+                            .param("strArray", new String[] { "fg", "hi" })
+                            .param("enArray", new SimpleEnum[] { SimpleEnum.BAR, SimpleEnum.BAZ })
+                            .param("enMixedArray", new Enum[] { SimpleEnum.FOO, AnotherEnum.INSTANCE })
+                            .param("clsArray", new Class<?>[] { String.class, Number.class })
+                            .param("clsJandexArray", new ClassInfo[] { enumClass, annClass })
+                            .param("annArray", new AnnotationInstance[] { simpleAnnotation("two"),
+                                    simpleAnnotation("three") })
+                            .param("annMixedArray", new AnnotationInstance[] { simpleAnnotation("four"),
+                                    anotherAnnotation(42) })
+                            .notify(mc -> {
+                                ResultHandle params = mc.readInstanceField(
+                                        FieldDescriptor.of(mc.getMethodDescriptor().getDeclaringClass(), "params", Map.class),
+                                        mc.getThis());
+                                mc.invokeStaticMethod(
+                                        MethodDescriptor.ofMethod(Verification.class, "invoke", void.class, Map.class),
+                                        params);
+                                mc.returnValue(null);
+                            })
+                            .done();
+                }
+            })
+            .build();
+
+    @Test
+    public void test() {
+        Arc.container().beanManager().getEvent().fire("ignored");
+        assertTrue(Verification.invoked);
+    }
+
+    static class Verification {
+        static boolean invoked = false;
+
+        static void invoke(Map<String, Object> params) {
+            assertEquals(true, (boolean) params.get("bool"));
+            assertEquals((byte) 1, (byte) params.get("b"));
+            assertEquals((short) 2, (short) params.get("s"));
+            assertEquals(3, (int) params.get("i"));
+            assertEquals(4L, (long) params.get("l"));
+            assertEquals(5.0F, (float) params.get("f"));
+            assertEquals(6.0, (double) params.get("d"));
+            assertEquals('a', (char) params.get("ch"));
+            assertEquals("bc", (String) params.get("str"));
+            assertEquals(SimpleEnum.FOO, (SimpleEnum) params.get("en"));
+            assertEquals(Object.class, (Class<?>) params.get("cls"));
+            assertEquals(SimpleEnum.class, (Class<?>) params.get("clsJandex"));
+            assertEquals("one", ((SimpleAnnotation) params.get("ann")).value());
+
+            assertEquals(2, ((boolean[]) params.get("boolArray")).length);
+            assertEquals(true, ((boolean[]) params.get("boolArray"))[0]);
+            assertEquals(false, ((boolean[]) params.get("boolArray"))[1]);
+            assertEquals(2, ((byte[]) params.get("bArray")).length);
+            assertEquals((byte) 7, ((byte[]) params.get("bArray"))[0]);
+            assertEquals((byte) 8, ((byte[]) params.get("bArray"))[1]);
+            assertEquals(2, ((short[]) params.get("sArray")).length);
+            assertEquals((short) 9, ((short[]) params.get("sArray"))[0]);
+            assertEquals((short) 10, ((short[]) params.get("sArray"))[1]);
+            assertEquals(2, ((int[]) params.get("iArray")).length);
+            assertEquals(11, ((int[]) params.get("iArray"))[0]);
+            assertEquals(12, ((int[]) params.get("iArray"))[1]);
+            assertEquals(2, ((long[]) params.get("lArray")).length);
+            assertEquals(13L, ((long[]) params.get("lArray"))[0]);
+            assertEquals(14L, ((long[]) params.get("lArray"))[1]);
+            assertEquals(2, ((float[]) params.get("fArray")).length);
+            assertEquals(15.0F, ((float[]) params.get("fArray"))[0]);
+            assertEquals(16.0F, ((float[]) params.get("fArray"))[1]);
+            assertEquals(2, ((double[]) params.get("dArray")).length);
+            assertEquals(17.0, ((double[]) params.get("dArray"))[0]);
+            assertEquals(18.0, ((double[]) params.get("dArray"))[1]);
+            assertEquals(2, ((char[]) params.get("chArray")).length);
+            assertEquals('d', ((char[]) params.get("chArray"))[0]);
+            assertEquals('e', ((char[]) params.get("chArray"))[1]);
+            assertEquals(2, ((String[]) params.get("strArray")).length);
+            assertEquals("fg", ((String[]) params.get("strArray"))[0]);
+            assertEquals("hi", ((String[]) params.get("strArray"))[1]);
+            assertEquals(2, ((SimpleEnum[]) params.get("enArray")).length);
+            assertEquals(SimpleEnum.BAR, ((SimpleEnum[]) params.get("enArray"))[0]);
+            assertEquals(SimpleEnum.BAZ, ((SimpleEnum[]) params.get("enArray"))[1]);
+            assertEquals(2, ((Enum<?>[]) params.get("enMixedArray")).length);
+            assertEquals(SimpleEnum.FOO, ((Enum<?>[]) params.get("enMixedArray"))[0]);
+            assertEquals(AnotherEnum.INSTANCE, ((Enum<?>[]) params.get("enMixedArray"))[1]);
+            assertEquals(2, ((Class<?>[]) params.get("clsArray")).length);
+            assertEquals(String.class, ((Class<?>[]) params.get("clsArray"))[0]);
+            assertEquals(Number.class, ((Class<?>[]) params.get("clsArray"))[1]);
+            assertEquals(2, ((Class<?>[]) params.get("clsJandexArray")).length);
+            assertEquals(SimpleEnum.class, ((Class<?>[]) params.get("clsJandexArray"))[0]);
+            assertEquals(SimpleAnnotation.class, ((Class<?>[]) params.get("clsJandexArray"))[1]);
+            assertEquals(2, ((SimpleAnnotation[]) params.get("annArray")).length);
+            assertEquals("two", ((SimpleAnnotation[]) params.get("annArray"))[0].value());
+            assertEquals("three", ((SimpleAnnotation[]) params.get("annArray"))[1].value());
+            assertEquals(2, ((Annotation[]) params.get("annMixedArray")).length);
+            assertEquals("four", ((SimpleAnnotation) ((Annotation[]) params.get("annMixedArray"))[0]).value());
+            assertEquals(42, ((AnotherAnnotation) ((Annotation[]) params.get("annMixedArray"))[1]).value());
+
+            invoked = true;
+        }
+    }
+
+    private static AnnotationInstance simpleAnnotation(String value) {
+        return AnnotationInstance.create(DotName.createSimple(SimpleAnnotation.class.getName()), null,
+                List.of(AnnotationValue.createStringValue("value", value)));
+    }
+
+    private static AnnotationInstance anotherAnnotation(int value) {
+        return AnnotationInstance.create(DotName.createSimple(AnotherAnnotation.class.getName()), null,
+                List.of(AnnotationValue.createIntegerValue("value", value)));
+    }
+}


### PR DESCRIPTION
This commit introduces support for parameters to synthetic observers
and significantly expands the set of possible parameters types
of synthetic beans. Parameters can be used in synthetic bean
creation and destruction functions, and in the synthetic observer
notification function.

Any type that can be used for annotation members can also be used
for synthetic component parameters: all primitive types, strings,
enums, classes, annotations, and arrays of previously mentioned
types. Tests for synthetic components with parameters are added, too.