### PR TITLE
Testing: Add failure state in testing context

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/GetExceptionsInTestResourceTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/GetExceptionsInTestResourceTestCase.java
@@ -1,0 +1,74 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.junit.QuarkusTestExtension;
+
+@ExtendWith({ GetExceptionsInTestResourceTestCase.IgnoreCustomExceptions.class, QuarkusTestExtension.class })
+@QuarkusTestResource(restrictToAnnotatedClass = true, value = GetExceptionsInTestResourceTestCase.KeepContextTestResource.class)
+public class GetExceptionsInTestResourceTestCase {
+
+    public static final AtomicReference<QuarkusTestResourceLifecycleManager.Context> CONTEXT = new AtomicReference<>();
+
+    @BeforeEach
+    public void setup() {
+        throw new CustomException();
+    }
+
+    @Test
+    public void testExceptionHaveBeenCaptured() {
+        assertTrue(CONTEXT.get().getTestStatus().isTestFailed(), "Test didn't fail!");
+        assertTrue(isCustomException(CONTEXT.get().getTestStatus().getTestErrorCause()));
+    }
+
+    private static boolean isCustomException(Throwable ex) {
+        try {
+            return ex.getClass().getClassLoader().loadClass(CustomException.class.getName()).isInstance(ex);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    public static class CustomException extends RuntimeException {
+
+    }
+
+    public static class IgnoreCustomExceptions implements LifecycleMethodExecutionExceptionHandler {
+        @Override
+        public void handleBeforeEachMethodExecutionException(ExtensionContext context, Throwable throwable)
+                throws Throwable {
+            if (!isCustomException(throwable)) {
+                throw throwable;
+            }
+        }
+    }
+
+    public static class KeepContextTestResource implements QuarkusTestResourceLifecycleManager {
+        @Override
+        public void setContext(Context context) {
+            CONTEXT.set(context);
+        }
+
+        @Override
+        public Map<String, String> start() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public void stop() {
+            // do nothing
+        }
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
@@ -10,6 +10,8 @@ import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 public class TestContextCheckerBeforeEachCallback implements QuarkusTestBeforeEachCallback {
 
     public static final List<Object> OUTER_INSTANCES = new ArrayList<>();
+    public static QuarkusTestMethodContext CONTEXT;
+
     static boolean testAnnotationChecked;
 
     @Override
@@ -18,6 +20,8 @@ public class TestContextCheckerBeforeEachCallback implements QuarkusTestBeforeEa
         OUTER_INSTANCES.addAll(context.getOuterInstances());
 
         // continue only if this comes into play only for the test we care about
+        TestContextCheckerBeforeEachCallback.CONTEXT = context;
+        // make sure that this comes into play only for the test we care about
 
         Method testMethod = context.getTestMethod();
         if (!testMethod.getDeclaringClass().getName().endsWith("QuarkusTestCallbacksTestCase")) {

--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResourceLifecycleManager.java
@@ -40,6 +40,8 @@ public interface QuarkusTestResourceLifecycleManager {
     /**
      * Set the context in which this {@link QuarkusTestResourceLifecycleManager} is being used.
      * This method is executed before the {@code init} method.
+     * The Context instance is automatically populated before calling the `start` and/or `stop` methods, so for example you can
+     * check whether any test failed when stopping the resource by using `context.getTestStatus().isTestFailed()`.
      *
      * The {@code context} is never null.
      */
@@ -177,5 +179,11 @@ public interface QuarkusTestResourceLifecycleManager {
          * {@code QuarkusTestProfile}.
          */
         String testProfile();
+
+        /**
+         * @return the failure result that is thrown during either `BeforeAll`, `BeforeEach`, test method, `AfterAll` or
+         *         `AfterEach` phases.
+         */
+        TestStatus getTestStatus();
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -41,6 +41,7 @@ public class TestResourceManager implements Closeable {
     private final Map<String, String> configProperties = new ConcurrentHashMap<>();
     private boolean started = false;
     private boolean hasPerTestResources = false;
+    private TestStatus testStatus = new TestStatus(null);
 
     public TestResourceManager(Class<?> testClass) {
         this(testClass, null, Collections.emptyList(), false);
@@ -89,6 +90,10 @@ public class TestResourceManager implements Closeable {
         }
     }
 
+    public void setTestErrorCause(Throwable testErrorCause) {
+        this.testStatus = new TestStatus(testErrorCause);
+    }
+
     public void init(String testProfileName) {
         for (TestResourceEntry entry : allTestResourceEntries) {
             try {
@@ -97,6 +102,11 @@ public class TestResourceManager implements Closeable {
                     @Override
                     public String testProfile() {
                         return testProfileName;
+                    }
+
+                    @Override
+                    public TestStatus getTestStatus() {
+                        return TestResourceManager.this.testStatus;
                     }
                 });
                 if (testResource instanceof QuarkusTestResourceConfigurableLifecycleManager

--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestStatus.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestStatus.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.common;
+
+public class TestStatus {
+
+    private final Throwable testErrorCause;
+
+    public TestStatus(Throwable testErrorCause) {
+        this.testErrorCause = testErrorCause;
+    }
+
+    /**
+     * @return the error cause that was thrown during either `BeforeAll`, `BeforeEach`, test method, `AfterAll` or
+     *         `AfterEach` phases.
+     */
+    public Throwable getTestErrorCause() {
+        return testErrorCause;
+    }
+
+    /**
+     * @return whether the test has failed.
+     */
+    public boolean isTestFailed() {
+        return getTestErrorCause() != null;
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractJvmQuarkusTestExtension.java
@@ -36,7 +36,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.RestorableSystemProperties;
 import io.quarkus.test.common.TestClassIndexer;
 
-public class AbstractJvmQuarkusTestExtension {
+public class AbstractJvmQuarkusTestExtension extends AbstractQuarkusTestWithContextExtension {
 
     protected static final String TEST_LOCATION = "test-location";
     protected static final String TEST_CLASS = "test-class";

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
@@ -1,0 +1,60 @@
+package io.quarkus.test.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+public class AbstractQuarkusTestWithContextExtension implements LifecycleMethodExecutionExceptionHandler, TestWatcher {
+    @Override
+    public void handleAfterAllMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        markTestAsFailed(context, throwable);
+
+        throw throwable;
+    }
+
+    @Override
+    public void handleAfterEachMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        markTestAsFailed(context, throwable);
+
+        throw throwable;
+    }
+
+    @Override
+    public void handleBeforeAllMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        markTestAsFailed(context, throwable);
+
+        throw throwable;
+    }
+
+    @Override
+    public void handleBeforeEachMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        markTestAsFailed(context, throwable);
+
+        throw throwable;
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        markTestAsFailed(context, cause);
+    }
+
+    protected QuarkusTestExtensionState getState(ExtensionContext context) {
+        return getStoreFromContext(context).get(QuarkusTestExtensionState.class.getName(), QuarkusTestExtensionState.class);
+    }
+
+    protected void setState(ExtensionContext context, QuarkusTestExtensionState state) {
+        getStoreFromContext(context).put(QuarkusTestExtensionState.class.getName(), state);
+    }
+
+    protected ExtensionContext.Store getStoreFromContext(ExtensionContext context) {
+        ExtensionContext root = context.getRoot();
+        return root.getStore(ExtensionContext.Namespace.GLOBAL);
+    }
+
+    protected void markTestAsFailed(ExtensionContext context, Throwable throwable) {
+        QuarkusTestExtensionState state = getState(context);
+        if (state != null) {
+            state.setTestFailed(throwable);
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/IntegrationTestUtil.java
@@ -106,9 +106,9 @@ public final class IntegrationTestUtil {
         TestHTTPResourceManager.inject(testInstance);
         ExtensionContext root = context.getRoot();
         ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
-        IntegrationTestExtensionState state = store.get(IntegrationTestExtensionState.class.getName(),
-                IntegrationTestExtensionState.class);
-        state.getTestResourceManager().inject(testInstance);
+        QuarkusTestExtensionState state = store.get(QuarkusTestExtensionState.class.getName(),
+                QuarkusTestExtensionState.class);
+        ((TestResourceManager) state.testResourceManager).inject(testInstance);
     }
 
     static Map<String, String> getSysPropsToRestore() {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -37,7 +37,7 @@ import io.quarkus.test.common.TestScopeManager;
 import io.quarkus.test.junit.launcher.ConfigUtil;
 import io.quarkus.test.junit.launcher.NativeImageLauncherProvider;
 
-public class NativeTestExtension
+public class NativeTestExtension extends AbstractQuarkusTestWithContextExtension
         implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, TestInstancePostProcessor {
 
     private static boolean failedBoot;
@@ -75,14 +75,14 @@ public class NativeTestExtension
         ensureStarted(extensionContext);
     }
 
-    private IntegrationTestExtensionState ensureStarted(ExtensionContext extensionContext) {
+    private QuarkusTestExtensionState ensureStarted(ExtensionContext extensionContext) {
         Class<?> testClass = extensionContext.getRequiredTestClass();
         ensureNoInjectAnnotationIsUsed(testClass);
 
         ExtensionContext root = extensionContext.getRoot();
         ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
-        IntegrationTestExtensionState state = store.get(IntegrationTestExtensionState.class.getName(),
-                IntegrationTestExtensionState.class);
+        QuarkusTestExtensionState state = store.get(QuarkusTestExtensionState.class.getName(),
+                QuarkusTestExtensionState.class);
         Class<? extends QuarkusTestProfile> selectedProfile = IntegrationTestUtil.findProfile(testClass);
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
         // we reload the test resources if we changed test class and if we had or will have per-test test resources
@@ -100,7 +100,7 @@ public class NativeTestExtension
             }
             try {
                 state = doNativeStart(extensionContext, selectedProfile);
-                store.put(IntegrationTestExtensionState.class.getName(), state);
+                store.put(QuarkusTestExtensionState.class.getName(), state);
 
             } catch (Throwable e) {
                 failedBoot = true;
@@ -110,7 +110,7 @@ public class NativeTestExtension
         return state;
     }
 
-    private IntegrationTestExtensionState doNativeStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile)
+    private QuarkusTestExtensionState doNativeStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile)
             throws Throwable {
         Map<String, String> devServicesProps = handleDevServices(context, false).properties();
         quarkusTestProfile = profile;

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -45,7 +45,7 @@ import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.common.TestScopeManager;
 import io.quarkus.test.junit.launcher.ArtifactLauncherProvider;
 
-public class QuarkusIntegrationTestExtension
+public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithContextExtension
         implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, TestInstancePostProcessor {
 
     private static boolean failedBoot;
@@ -85,15 +85,15 @@ public class QuarkusIntegrationTestExtension
         ensureStarted(extensionContext);
     }
 
-    private IntegrationTestExtensionState ensureStarted(ExtensionContext extensionContext) {
+    private QuarkusTestExtensionState ensureStarted(ExtensionContext extensionContext) {
         Class<?> testClass = extensionContext.getRequiredTestClass();
         ensureNoInjectAnnotationIsUsed(testClass);
         Properties quarkusArtifactProperties = readQuarkusArtifactProperties(extensionContext);
 
         ExtensionContext root = extensionContext.getRoot();
         ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
-        IntegrationTestExtensionState state = store.get(IntegrationTestExtensionState.class.getName(),
-                IntegrationTestExtensionState.class);
+        QuarkusTestExtensionState state = store.get(QuarkusTestExtensionState.class.getName(),
+                QuarkusTestExtensionState.class);
         Class<? extends QuarkusTestProfile> selectedProfile = findProfile(testClass);
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
         // we reload the test resources if we changed test class and if we had or will have per-test test resources
@@ -111,7 +111,7 @@ public class QuarkusIntegrationTestExtension
             }
             try {
                 state = doProcessStart(quarkusArtifactProperties, selectedProfile, extensionContext);
-                store.put(IntegrationTestExtensionState.class.getName(), state);
+                store.put(QuarkusTestExtensionState.class.getName(), state);
             } catch (Throwable e) {
                 try {
                     Path appLogPath = PropertyTestUtil.getLogFilePath();
@@ -131,7 +131,7 @@ public class QuarkusIntegrationTestExtension
         return state;
     }
 
-    private IntegrationTestExtensionState doProcessStart(Properties quarkusArtifactProperties,
+    private QuarkusTestExtensionState doProcessStart(Properties quarkusArtifactProperties,
             Class<? extends QuarkusTestProfile> profile, ExtensionContext context)
             throws Throwable {
         String artifactType = getArtifactType(quarkusArtifactProperties);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -33,7 +33,8 @@ import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainLauncher;
 import io.quarkus.test.junit.util.CloseAdaptor;
 
-public class QuarkusMainIntegrationTestExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWithContextExtension
+        implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     public static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace
             .create("io.quarkus.test.main.integration");

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -625,9 +625,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             throw new RuntimeException("Could not find method " + originalTestMethod + " on test class");
         }
 
-        Constructor<?> constructor = quarkusTestMethodContextClass.getConstructor(Object.class, List.class, Method.class);
+        QuarkusTestExtensionState state = getState(context);
+        Constructor<?> constructor = quarkusTestMethodContextClass.getConstructor(Object.class, List.class, Method.class,
+                Throwable.class);
         return new AbstractMap.SimpleEntry<>(quarkusTestMethodContextClass,
-                constructor.newInstance(actualTestInstance, new ArrayList<>(outerInstances), actualTestMethod));
+                constructor.newInstance(actualTestInstance, new ArrayList<>(outerInstances), actualTestMethod,
+                        state.getTestErrorCause()));
     }
 
     private boolean isNativeOrIntegrationTest(Class<?> clazz) {
@@ -642,9 +645,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         return false;
     }
 
-    private ExtensionState ensureStarted(ExtensionContext extensionContext) {
-        ExtensionContext root = extensionContext.getRoot();
-        ExtensionContext.Store store = root.getStore(ExtensionContext.Namespace.GLOBAL);
+    private QuarkusTestExtensionState ensureStarted(ExtensionContext extensionContext) {
+        ExtensionContext.Store store = getStoreFromContext(extensionContext);
         Class<?> testType = store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
         if (testType != null) {
             if (testType != QuarkusTest.class) {
@@ -654,7 +656,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         } else {
             store.put(IO_QUARKUS_TESTING_TYPE, QuarkusTest.class);
         }
-        ExtensionState state = store.get(ExtensionState.class.getName(), ExtensionState.class);
+        QuarkusTestExtensionState state = getState(extensionContext);
         Class<? extends QuarkusTestProfile> selectedProfile = getQuarkusTestProfile(extensionContext);
         boolean wrongProfile = !Objects.equals(selectedProfile, quarkusTestProfile);
         // we reload the test resources if we changed test class and the new test class is not a nested class, and if we had or will have per-test test resources
@@ -667,17 +669,18 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     try {
                         state.close();
                     } catch (Throwable throwable) {
-                        throwable.printStackTrace();
+                        markTestAsFailed(extensionContext, throwable);
                     }
                 }
             }
             PropertyTestUtil.setLogFileProperty();
             try {
                 state = doJavaStart(extensionContext, selectedProfile);
-                store.put(ExtensionState.class.getName(), state);
+                setState(extensionContext, state);
 
             } catch (Throwable e) {
                 failedBoot = true;
+                markTestAsFailed(extensionContext, e);
                 firstException = e;
                 store.put(FailedCleanup.class.getName(), new FailedCleanup());
             }
@@ -701,7 +704,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         return original;
     }
 
-    private void throwBootFailureException() throws Exception {
+    private void throwBootFailureException() {
         if (firstException != null) {
             Throwable throwable = firstException;
             firstException = null;
@@ -774,7 +777,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             return invocation.proceed();
         }
         resetHangTimeout();
-        ExtensionState state = ensureStarted(extensionContext);
+        QuarkusTestExtensionState state = ensureStarted(extensionContext);
         if (failedBoot) {
             throwBootFailureException();
             return null;
@@ -833,7 +836,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         return result;
     }
 
-    private void initTestState(ExtensionContext extensionContext, ExtensionState state) {
+    private void initTestState(ExtensionContext extensionContext, QuarkusTestExtensionState state) {
         try {
             actualTestClass = Class.forName(extensionContext.getRequiredTestClass().getName(), true,
                     Thread.currentThread().getContextClassLoader());
@@ -870,7 +873,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         }
     }
 
-    private Object createActualTestInstance(Class<?> testClass, ExtensionState state)
+    private Object createActualTestInstance(Class<?> testClass, QuarkusTestExtensionState state)
             throws ClassNotFoundException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         Object testInstance = runningQuarkusApplication.instance(testClass);
 
@@ -1177,10 +1180,11 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             return;
         }
 
+        QuarkusTestExtensionState state = getState(context);
         Class<?> quarkusTestContextClass = Class.forName(QuarkusTestContext.class.getName(), true,
                 runningQuarkusApplication.getClassLoader());
-        Object quarkusTestContextInstance = quarkusTestContextClass.getConstructor(Object.class, List.class)
-                .newInstance(actualTestInstance, new ArrayList<>(outerInstances));
+        Object quarkusTestContextInstance = quarkusTestContextClass.getConstructor(Object.class, List.class, Throwable.class)
+                .newInstance(actualTestInstance, new ArrayList<>(outerInstances), state.getTestErrorCause());
 
         ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
         try {
@@ -1300,55 +1304,35 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 + "' disabled because 'quarkus.profile.test.tags' don't match the tags of '" + testProfile + "'");
     }
 
-    class ExtensionState implements ExtensionContext.Store.CloseableResource {
+    public class ExtensionState extends QuarkusTestExtensionState {
 
-        private final Closeable testResourceManager;
-        private final Closeable resource;
-        private final AtomicBoolean closed = new AtomicBoolean();
-        private final Thread shutdownHook;
-
-        ExtensionState(Closeable testResourceManager, Closeable resource) {
-            this.testResourceManager = testResourceManager;
-            this.resource = resource;
-            this.shutdownHook = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    ExtensionState.this.close();
-                }
-            }, "Quarkus Test Cleanup Shutdown task");
-            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        public ExtensionState(Closeable testResourceManager, Closeable resource) {
+            super(testResourceManager, resource);
         }
 
         @Override
-        public void close() {
-            if (closed.compareAndSet(false, true)) {
-                ClassLoader old = Thread.currentThread().getContextClassLoader();
-                if (runningQuarkusApplication != null) {
-                    Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
-                }
+        protected void doClose() throws IOException {
+            ClassLoader old = Thread.currentThread().getContextClassLoader();
+            if (runningQuarkusApplication != null) {
+                Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
+            }
+            try {
+                resource.close();
+            } catch (Throwable e) {
+                log.error("Failed to shutdown Quarkus", e);
+            } finally {
+                runningQuarkusApplication = null;
+                clonePattern = null;
                 try {
-                    resource.close();
-                } catch (Throwable e) {
-                    log.error("Failed to shutdown Quarkus", e);
-                } finally {
-                    runningQuarkusApplication = null;
-                    clonePattern = null;
-                    try {
-                        if (QuarkusTestExtension.this.originalCl != null) {
-                            setCCL(QuarkusTestExtension.this.originalCl);
-                        }
-                        testResourceManager.close();
-                    } catch (IOException e) {
-                        log.error("Failed to shutdown Quarkus test resources", e);
-                    } finally {
-                        Thread.currentThread().setContextClassLoader(old);
-                        ConfigProviderResolver.setInstance(null);
+                    if (QuarkusTestExtension.this.originalCl != null) {
+                        setCCL(QuarkusTestExtension.this.originalCl);
                     }
-                }
-                try {
-                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
-                } catch (Throwable t) {
-                    //won't work if we are already shutting down
+                    testResourceManager.close();
+                } catch (Exception e) {
+                    log.error("Failed to shutdown Quarkus test resources", e);
+                } finally {
+                    Thread.currentThread().setContextClassLoader(old);
+                    ConfigProviderResolver.setInstance(null);
                 }
             }
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtensionState.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtensionState.java
@@ -1,0 +1,72 @@
+package io.quarkus.test.junit;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.common.TestResourceManager;
+
+public class QuarkusTestExtensionState implements ExtensionContext.Store.CloseableResource {
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    protected final Closeable testResourceManager;
+    protected final Closeable resource;
+    private final Thread shutdownHook;
+    private Throwable testErrorCause;
+
+    public QuarkusTestExtensionState(Closeable testResourceManager, Closeable resource) {
+        this.testResourceManager = testResourceManager;
+        this.resource = resource;
+        this.shutdownHook = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    QuarkusTestExtensionState.this.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }, "Quarkus Test Cleanup Shutdown task");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
+
+    public Throwable getTestErrorCause() {
+        return testErrorCause;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed.compareAndSet(false, true)) {
+            doClose();
+
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (Throwable t) {
+                //won't work if we are already shutting down
+            }
+        }
+    }
+
+    protected void setTestFailed(Throwable failure) {
+        try {
+            this.testErrorCause = failure;
+            if (testResourceManager instanceof TestResourceManager) {
+                ((TestResourceManager) testResourceManager).setTestErrorCause(testErrorCause);
+            } else {
+                testResourceManager.getClass().getClassLoader().loadClass(TestResourceManager.class.getName())
+                        .getMethod("setTestErrorCause", Throwable.class)
+                        .invoke(testResourceManager, testErrorCause);
+
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void doClose() throws IOException {
+
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestContext.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestContext.java
@@ -2,6 +2,8 @@ package io.quarkus.test.junit.callback;
 
 import java.util.List;
 
+import io.quarkus.test.common.TestStatus;
+
 /**
  * Context object passed to {@link QuarkusTestAfterAllCallback}
  */
@@ -9,10 +11,12 @@ public class QuarkusTestContext {
 
     private final Object testInstance;
     private final List<Object> outerInstances;
+    private final TestStatus testStatus;
 
-    public QuarkusTestContext(Object testInstance, List<Object> outerInstances) {
+    public QuarkusTestContext(Object testInstance, List<Object> outerInstances, Throwable testErrorCause) {
         this.testInstance = testInstance;
         this.outerInstances = outerInstances;
+        this.testStatus = new TestStatus(testErrorCause);
     }
 
     public Object getTestInstance() {
@@ -21,5 +25,13 @@ public class QuarkusTestContext {
 
     public List<Object> getOuterInstances() {
         return outerInstances;
+    }
+
+    /**
+     * @return the failure result that is thrown during either `BeforeAll`, `BeforeEach`, test method, `AfterAll` or
+     *         `AfterEach` phases.
+     */
+    public TestStatus getTestStatus() {
+        return testStatus;
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestMethodContext.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestMethodContext.java
@@ -10,8 +10,9 @@ public final class QuarkusTestMethodContext extends QuarkusTestContext {
 
     private final Method testMethod;
 
-    public QuarkusTestMethodContext(Object testInstance, List<Object> outerInstances, Method testMethod) {
-        super(testInstance, outerInstances);
+    public QuarkusTestMethodContext(Object testInstance, List<Object> outerInstances, Method testMethod,
+            Throwable testErrorCause) {
+        super(testInstance, outerInstances, testErrorCause);
         this.testMethod = testMethod;
     }
 


### PR DESCRIPTION
Sometimes it's necessary to know whether the tests failed (at test case level or even in the before stages). For example: if we use one resource via the `@QuarkusTestResource` annotation that is starting a service and we don't want to stop this service when the test fails. 

At the moment, we are not propagating when a test fails. 

This pull request addresses this issue by adding this information in:
- QuarkusTestContext (for QuarkusTest*Callbacks)
- Context (for QuarkusTestResources)

To be precise, I've added the following methods in the above contexts:

```java
/**
         * Get the test failure result if the test failed. When no test have failed, it will return null.
         *
         * @return the failure result that is thrown during either `BeforeAll`, `BeforeEach`, test method, `AfterAll` or
         *         `AfterEach` phases. 
         */
        TestStatus getTestStatus();
```

In the future, we could add even more information like the number of tests that have failed and/or the test profiles.

Fix https://github.com/quarkusio/quarkus/issues/25749