### PR TITLE
Allow setting excluded resources from Gradle extension plugin

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/QuarkusExtensionConfiguration.java
@@ -9,6 +9,8 @@ import org.gradle.api.provider.Property;
 
 import io.quarkus.extension.gradle.dsl.Capabilities;
 import io.quarkus.extension.gradle.dsl.Capability;
+import io.quarkus.extension.gradle.dsl.RemovedResource;
+import io.quarkus.extension.gradle.dsl.RemovedResources;
 
 public class QuarkusExtensionConfiguration {
 
@@ -21,6 +23,7 @@ public class QuarkusExtensionConfiguration {
     private ListProperty<String> lesserPriorityArtifacts;
     private ListProperty<String> conditionalDependencies;
     private ListProperty<String> dependencyCondition;
+    private RemovedResources removedResources = new RemovedResources();
     private Capabilities capabilities = new Capabilities();
 
     private Project project;
@@ -123,6 +126,14 @@ public class QuarkusExtensionConfiguration {
 
     public void capabilities(Action<Capabilities> capabilitiesAction) {
         capabilitiesAction.execute(this.capabilities);
+    }
+
+    public List<RemovedResource> getRemoveResources() {
+        return removedResources.getRemovedResources();
+    }
+
+    public void removedResources(Action<RemovedResources> removedResourcesAction) {
+        removedResourcesAction.execute(this.removedResources);
     }
 
     public String getDefaultDeployementArtifactName() {

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/RemovedResource.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/RemovedResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.extension.gradle.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemovedResource {
+
+    private String artifact;
+    private List<String> removedResources = new ArrayList<>(1);
+
+    public RemovedResource(String artifact) {
+        this.artifact = artifact;
+    }
+
+    public RemovedResource resource(String resource) {
+        removedResources.add(resource);
+        return this;
+    }
+
+    public String getArtifactName() {
+        return artifact;
+    }
+
+    public List<String> getRemovedResources() {
+        return removedResources;
+    }
+
+}

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/RemovedResources.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/dsl/RemovedResources.java
@@ -1,0 +1,20 @@
+package io.quarkus.extension.gradle.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemovedResources {
+
+    private List<RemovedResource> removedResources = new ArrayList<>(0);
+
+    public RemovedResource artifact(String name) {
+        RemovedResource removedResource = new RemovedResource(name);
+        removedResources.add(removedResource);
+        return removedResource;
+    }
+
+    public List<RemovedResource> getRemovedResources() {
+        return removedResources;
+    }
+
+}

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -119,6 +119,27 @@ public class ExtensionDescriptorTaskTest {
     }
 
     @Test
+    public void shouldContainsRemoveResources() throws IOException {
+        String buildFileContent = TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(),
+                "removedResources { \n" +
+                        "artifact('org.acme:acme-resources').resource('META-INF/a') \n" +
+                        "artifact('org.acme:acme-resources-two').resource('META-INF/b').resource('META-INF/c') \n" +
+                        "}\n");
+
+        TestUtils.writeFile(buildFile, buildFileContent);
+        TestUtils.runExtensionDescriptorTask(testProjectDir);
+
+        File extensionPropertiesFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.properties");
+        assertThat(extensionPropertiesFile).exists();
+
+        Properties extensionProperty = TestUtils.readPropertyFile(extensionPropertiesFile.toPath());
+        assertThat(extensionProperty).containsEntry("deployment-artifact", "org.acme:test-deployment:1.0.0");
+        assertThat(extensionProperty).containsEntry("removed-resources.org.acme:acme-resources::jar", "META-INF/a");
+        assertThat(extensionProperty).containsEntry("removed-resources.org.acme:acme-resources-two::jar",
+                "META-INF/b,META-INF/c");
+    }
+
+    @Test
     public void shouldGenerateDescriptorBasedOnExistingFile() throws IOException {
         TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
         File metaInfDir = new File(testProjectDir, "src/main/resources/META-INF");


### PR DESCRIPTION
This branch adds the ability to exclude resource from the Gradle extension plugin. This can be done using the following syntax:

````
quarkusExtension {
    removedResources {
        artifact('org.acme:acme-resources').resource('META-INF/a')
        artifact('org.acme:acme-thirdparty').resource('META-INF/b').resource('META-INF/c')
    }
}
````


I will add documentation for both maven, gradle and gradle with kotlin DSL in a next PR.
