### PR TITLE
Disable Websockets logging during native image build

### DIFF
--- a/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingAutoFeature.java
+++ b/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingAutoFeature.java
@@ -1,0 +1,43 @@
+package io.quarkus.websockets.client.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+
+/**
+ * Disables logging during the analysis phase
+ */
+@AutomaticFeature
+public class DisableLoggingAutoFeature implements Feature {
+
+    private static final String[] CATEGORIES = {
+            "io.undertow.websockets",
+    };
+
+    private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        for (String category : CATEGORIES) {
+            Logger logger = Logger.getLogger(category);
+            categoryMap.put(category, logger.getLevel());
+            logger.setLevel(Level.WARNING);
+        }
+    }
+
+    @Override
+    public void afterAnalysis(AfterAnalysisAccess access) {
+        for (String category : CATEGORIES) {
+            Level level = categoryMap.remove(category);
+            if (level != null) {
+                Logger logger = Logger.getLogger(category);
+                logger.setLevel(level);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This gets rid of the following messages when building the native image:

```
16:32:37,255 INFO  [io.und.websockets] UT026004: Adding annotated client endpoint class io.quarkus.it.websocket.CodingClient
16:32:37,260 INFO  [io.und.websockets] UT026003: Adding annotated server endpoint class io.quarkus.it.websocket.RecodingSocket for path /recoder
16:32:37,260 INFO  [io.und.websockets] UT026003: Adding annotated server endpoint class io.quarkus.it.websocket.EchoSocket for path /echo
16:32:37,260 INFO  [io.und.websockets] UT026003: Adding annotated server endpoint class io.quarkus.it.websocket.WebSocketOpenEndpoint for path /wsopen
16:32:37,367 INFO  [io.und.websockets] UT026005: Adding programmatic server endpoint class io.quarkus.it.websocket.AddWebSocketHandler$WebSocketEndpoint for path /added-dynamic
```