### PR TITLE
Add local project dependencies to a different layer for jib

### DIFF
--- a/docs/src/main/asciidoc/container-image.adoc
+++ b/docs/src/main/asciidoc/container-image.adoc
@@ -58,6 +58,17 @@ Other base images might provide launch scripts that enable debugging when an env
 
 Finally, the `quarkus.jib.jvm-entrypoint` configuration property can be used to completely override the container entry point and can thus be used to either hard code the JVM debug configuration or point to a script that handles the details.
 
+==== Multi-module projects and layering
+
+When building a multi-module project containing a Quarkus application as one module and various supporting project dependencies as other modules,
+Quarkus supports placing these supporting modules in a separate container image layer from the rest of the application dependencies, with the expectation
+that these supporting modules will change more frequently than the regular application dependencies - thus making a rebuild faster if the
+application dependencies have not changed.
+
+To enable this feature, the property `quarkus.bootstrap.workspace-discovery` needs to be set to `true` either as a system property
+when invoking the build tool, either as a build tool property. Setting this property in `application.properties` will **not** work because
+this property needs to be known very early on in the build process.
+
 [#docker]
 === Docker
 


### PR DESCRIPTION
By leveraging the fact that Quarkus can do workspace discovery
during the build, we are able to place dependencies in the
workspace in a separate layer above the normal dependencies.
The expectation is that the workspace dependencies will change
faster than the normal dependencies.

Closes: #9818