### PR TITLE
WIP: Cache (Caffeine): Allow setting refreshAfterWrite property

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -621,6 +621,7 @@ Here's what your cache configuration could look like:
 quarkus.cache.caffeine."foo".initial-capacity=10 <1>
 quarkus.cache.caffeine."foo".maximum-size=20
 quarkus.cache.caffeine."foo".expire-after-write=60S
+quarkus.cache.caffeine."foo".refresh-after-write=30
 quarkus.cache.caffeine."bar".maximum-size=1000 <2>
 ----
 <1> The `foo` cache is being configured.

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheConfig.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheConfig.java
@@ -75,6 +75,13 @@ public class CacheConfig {
             Optional<Duration> expireAfterAccess;
 
             /**
+             * Specifies that active entries are eligible for automatic refresh once a fixed duration has
+             * elapsed after the entry's creation, or the most recent replacement of its value.
+             */
+            @ConfigItem
+            Optional<Duration> refreshAfterWrite;
+
+            /**
              * Whether or not metrics are recorded if the application depends on the Micrometer extension. Setting this
              * value to {@code true} will enable the accumulation of cache stats inside Caffeine.
              */

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CaffeineCacheInfoBuilder.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CaffeineCacheInfoBuilder.java
@@ -22,6 +22,7 @@ public class CaffeineCacheInfoBuilder {
                     namespaceConfig.maximumSize.ifPresent(size -> cacheInfo.maximumSize = size);
                     namespaceConfig.expireAfterWrite.ifPresent(delay -> cacheInfo.expireAfterWrite = delay);
                     namespaceConfig.expireAfterAccess.ifPresent(delay -> cacheInfo.expireAfterAccess = delay);
+                    namespaceConfig.refreshAfterWrite.ifPresent(delay -> cacheInfo.refreshAfterWrite = delay);
                     cacheInfo.metricsEnabled = namespaceConfig.metricsEnabled;
                 }
                 return cacheInfo;

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheConfigTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/deployment/CacheConfigTest.java
@@ -35,6 +35,7 @@ public class CacheConfigTest {
         assertEquals(100L, cache.getCacheInfo().maximumSize);
         assertEquals(Duration.ofSeconds(30L), cache.getCacheInfo().expireAfterWrite);
         assertEquals(Duration.ofDays(2L), cache.getCacheInfo().expireAfterAccess);
+        assertEquals(Duration.ofSeconds(30L), cache.getCacheInfo().refreshAfterWrite);
         assertTrue(cache.getCacheInfo().metricsEnabled);
     }
 

--- a/extensions/cache/deployment/src/test/resources/cache-config-test.properties
+++ b/extensions/cache/deployment/src/test/resources/cache-config-test.properties
@@ -2,4 +2,5 @@ quarkus.cache.caffeine."test-cache".initial-capacity=10
 quarkus.cache.caffeine."test-cache".maximum-size=100
 quarkus.cache.caffeine."test-cache".expire-after-write=30
 quarkus.cache.caffeine."test-cache".expire-after-access=P2D
+quarkus.cache.caffeine."test-cache".refresh-after-write=30
 quarkus.cache.caffeine."test-cache".metrics-enabled=true

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheBuildRecorder.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheBuildRecorder.java
@@ -35,9 +35,10 @@ public class CaffeineCacheBuildRecorder {
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debugf(
                                     "Building Caffeine cache [%s] with [initialCapacity=%s], [maximumSize=%s], [expireAfterWrite=%s], "
-                                            + "[expireAfterAccess=%s] and [metricsEnabled=%s]",
+                                            + "[expireAfterAccess=%s], [refreshAfterWrite=%s] and [metricsEnabled=%s]",
                                     cacheInfo.name, cacheInfo.initialCapacity, cacheInfo.maximumSize,
-                                    cacheInfo.expireAfterWrite, cacheInfo.expireAfterAccess, cacheInfo.metricsEnabled);
+                                    cacheInfo.expireAfterWrite, cacheInfo.expireAfterAccess, cacheInfo.refreshAfterWrite,
+                                    cacheInfo.metricsEnabled);
                         }
                         /*
                          * Metrics will be recorded for the current cache if:

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -51,6 +51,9 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
         if (cacheInfo.expireAfterAccess != null) {
             builder.expireAfterAccess(cacheInfo.expireAfterAccess);
         }
+        if (cacheInfo.refreshAfterWrite != null) {
+            builder.refreshAfterWrite(cacheInfo.refreshAfterWrite);
+        }
         if (recordStats) {
             LOGGER.tracef("Recording Caffeine stats for cache [%s]", cacheInfo.name);
             statsCounter = new ConcurrentStatsCounter();
@@ -64,7 +67,7 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
             LOGGER.tracef("Caffeine stats recording is disabled for cache [%s]", cacheInfo.name);
             statsCounter = StatsCounter.disabledStatsCounter();
         }
-        cache = builder.buildAsync();
+        cache = cacheInfo.refreshAfterWrite == null ? builder.buildAsync() : builder.buildAsync(k -> null);
     }
 
     @Override

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfo.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheInfo.java
@@ -15,6 +15,8 @@ public class CaffeineCacheInfo {
 
     public Duration expireAfterAccess;
 
+    public Duration refreshAfterWrite;
+
     public boolean metricsEnabled;
 
     @Override


### PR DESCRIPTION
Allow setting refreshAfterWrite property on caffeine - Issue #25921

I am not confident about [CacheLoader](https://github.com/ben-manes/caffeine/wiki/Population#loading) required when using refreshAfterWrite property. Also did not found good information about this.

So If someone could take a look, will be great.