### PR TITLE
Use RecomputeFieldValue kind NewInstance for JAXB RuntimeInlineAnnotationReader packageCache field

### DIFF
--- a/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/graal/JAXBSubstitutions.java
+++ b/extensions/jaxb/runtime/src/main/java/io/quarkus/jaxb/runtime/graal/JAXBSubstitutions.java
@@ -57,8 +57,8 @@ final class Target_com_sun_xml_bind_v2_runtime_reflect_opt_AccessorInjector {
 final class Target_com_sun_xml_bind_v2_model_annotation_RuntimeInlineAnnotationReader {
 
     @Alias
-    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias)
-    private Map<Class<? extends Annotation>, Map<Package, Annotation>> packageCache = new HashMap<>();
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.NewInstance, declClass = HashMap.class)
+    private Map<Class<? extends Annotation>, Map<Package, Annotation>> packageCache;
 
     @Substitute
     public <A extends Annotation> A getFieldAnnotation(Class<A> annotation, Field field, Locatable srcPos) {


### PR DESCRIPTION
Fixes some native build failures observed on the Camel Quarkus nightly build with Quarkus `999-SNAPASHOT`.

There's some more background here https://github.com/apache/camel-quarkus/issues/3838.