### PR TITLE
Switch from AutomaticFeature to Feature and pass in via --feature

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageFeatureBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/NativeImageFeatureBuildItem.java
@@ -1,0 +1,28 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Objects;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Represents a GraalVM {@link Feature} to be passed to native-image through the {@code --features} options.
+ */
+public final class NativeImageFeatureBuildItem extends MultiBuildItem {
+
+    private final String qualifiedName;
+
+    public NativeImageFeatureBuildItem(Class<? extends Feature> featureClass) {
+        this.qualifiedName = Objects.requireNonNull(featureClass).getName();
+    }
+
+    public NativeImageFeatureBuildItem(String qualifiedName) {
+        this.qualifiedName = Objects.requireNonNull(qualifiedName);
+    }
+
+    public String getQualifiedName() {
+        return qualifiedName;
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -54,9 +54,9 @@ import io.quarkus.runtime.ResourceHelper;
 import io.quarkus.runtime.graal.ResourcesFeature;
 import io.quarkus.runtime.graal.WeakReflection;
 
-public class NativeImageAutoFeatureStep {
+public class NativeImageFeatureStep {
 
-    private static final String GRAAL_AUTOFEATURE = "io.quarkus.runner.AutoFeature";
+    public static final String GRAAL_FEATURE = "io.quarkus.runner.Feature";
     private static final MethodDescriptor VERSION_CURRENT = ofMethod(Version.class, "getCurrent", Version.class);
     private static final MethodDescriptor VERSION_COMPARE_TO = ofMethod(Version.class, "compareTo", int.class, int[].class);
 
@@ -153,9 +153,8 @@ public class NativeImageAutoFeatureStep {
             public void write(String s, byte[] bytes) {
                 nativeImageClass.produce(new GeneratedNativeImageClassBuildItem(s, bytes));
             }
-        }, GRAAL_AUTOFEATURE, null,
+        }, GRAAL_FEATURE, null,
                 Object.class.getName(), Feature.class.getName());
-        file.addAnnotation("com.oracle.svm.core.annotate.AutomaticFeature");
 
         MethodCreator duringSetup = file.getMethodCreator("duringSetup", "V", DURING_SETUP_ACCESS);
         // Register Lambda Capturing Types
@@ -206,7 +205,7 @@ public class NativeImageAutoFeatureStep {
                 overallCatch.load("Quarkus build time init default"));
 
         if (!runtimeInitializedClassBuildItems.isEmpty()) {
-            ResultHandle thisClass = overallCatch.loadClassFromTCCL(GRAAL_AUTOFEATURE);
+            ResultHandle thisClass = overallCatch.loadClassFromTCCL(GRAAL_FEATURE);
             ResultHandle cl = overallCatch.invokeVirtualMethod(ofMethod(Class.class, "getClassLoader", ClassLoader.class),
                     thisClass);
             ResultHandle classes = overallCatch.newArray(Class.class,
@@ -238,7 +237,7 @@ public class NativeImageAutoFeatureStep {
 
         // hack in reinitialization of process info classes
         if (!runtimeReinitializedClassBuildItems.isEmpty()) {
-            ResultHandle thisClass = overallCatch.loadClassFromTCCL(GRAAL_AUTOFEATURE);
+            ResultHandle thisClass = overallCatch.loadClassFromTCCL(GRAAL_FEATURE);
             ResultHandle cl = overallCatch.invokeVirtualMethod(ofMethod(Class.class, "getClassLoader", ClassLoader.class),
                     thisClass);
             ResultHandle quarkus = overallCatch.load("Quarkus");

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DisableLoggingFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DisableLoggingFeature.java
@@ -1,4 +1,4 @@
-package io.quarkus.websockets.client.runtime;
+package io.quarkus.runtime.graal;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -7,16 +7,13 @@ import java.util.logging.Logger;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Disables logging during the analysis phase
  */
-@AutomaticFeature
-public class DisableLoggingAutoFeature implements Feature {
+public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
-            "io.undertow.websockets",
+            "org.jboss.threads"
     };
 
     private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/ResourcesFeature.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/ResourcesFeature.java
@@ -6,11 +6,8 @@ import java.io.InputStreamReader;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 import io.quarkus.runtime.ResourceHelper;
 
-@AutomaticFeature
 public class ResourcesFeature implements Feature {
 
     public static final String META_INF_QUARKUS_NATIVE_RESOURCES_TXT = "META-INF/quarkus-native-resources.txt";

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -2,10 +2,13 @@ package io.quarkus.awt.deployment;
 
 import static io.quarkus.deployment.builditem.nativeimage.UnsupportedOSBuildItem.Os.WINDOWS;
 
+import io.quarkus.awt.runtime.graal.AwtFeature;
+import io.quarkus.awt.runtime.graal.DarwinAwtFeature;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JniRuntimeAccessBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeMinimalJavaVersionBuildItem;
@@ -19,6 +22,12 @@ class AwtProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.AWT);
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void nativeImageFeatures(BuildProducer<NativeImageFeatureBuildItem> nativeImageFeatures) {
+        nativeImageFeatures.produce(new NativeImageFeatureBuildItem(AwtFeature.class));
+        nativeImageFeatures.produce(new NativeImageFeatureBuildItem(DarwinAwtFeature.class));
     }
 
     @BuildStep(onlyIf = NativeBuild.class)

--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/AwtFeature.java
@@ -4,13 +4,10 @@ import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Note that this initialization s not enough if user wants to deserialize actual images
  * (e.g. from XML). AWT Extension must be loaded for decoding JDK supported image formats.
  */
-@AutomaticFeature
 public class AwtFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {

--- a/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/DarwinAwtFeature.java
+++ b/extensions/awt/runtime/src/main/java/io/quarkus/awt/runtime/graal/DarwinAwtFeature.java
@@ -6,11 +6,8 @@ import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 import io.quarkus.runtime.util.JavaVersionUtil;
 
-@AutomaticFeature
 @Platforms({ Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class })
 public class DarwinAwtFeature implements Feature {
     @Override

--- a/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
+++ b/extensions/caffeine/deployment/src/main/java/io/quarkus/caffeine/deployment/CaffeineProcessor.java
@@ -7,10 +7,13 @@ import java.util.List;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
+import io.quarkus.caffeine.runtime.graal.CacheConstructorsFeature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 
 public class CaffeineProcessor {
 
@@ -40,5 +43,10 @@ public class CaffeineProcessor {
                 reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, name));
             }
         }
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(CacheConstructorsFeature.class);
     }
 }

--- a/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
+++ b/extensions/caffeine/runtime/src/main/java/io/quarkus/caffeine/runtime/graal/CacheConstructorsFeature.java
@@ -6,8 +6,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * This Automatic Feature for GraalVM will register for reflection
  * the most commonly used cache implementations from Caffeine.
@@ -20,8 +18,7 @@ import com.oracle.svm.core.annotate.AutomaticFeature;
  * Caffeine is indeed being used: only if the cache builder is reachable
  * in the application code.
  */
-@AutomaticFeature
-public class CacheConstructorsAutofeature implements Feature {
+public class CacheConstructorsFeature implements Feature {
 
     private final AtomicBoolean triggered = new AtomicBoolean(false);
 

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -102,6 +102,7 @@ import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.LogCategoryBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
@@ -136,6 +137,7 @@ import io.quarkus.hibernate.orm.runtime.boot.xml.RecordableXmlMapping;
 import io.quarkus.hibernate.orm.runtime.cdi.QuarkusArcBeanContainer;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleCreateDDLSupplier;
 import io.quarkus.hibernate.orm.runtime.devconsole.HibernateOrmDevConsoleIntegrator;
+import io.quarkus.hibernate.orm.runtime.graal.DisableLoggingFeature;
 import io.quarkus.hibernate.orm.runtime.integration.HibernateOrmIntegrationStaticDescriptor;
 import io.quarkus.hibernate.orm.runtime.migration.MultiTenancyStrategy;
 import io.quarkus.hibernate.orm.runtime.proxies.PreGeneratedProxies;
@@ -169,6 +171,11 @@ public final class HibernateOrmProcessor {
     private static final Logger LOG = Logger.getLogger(HibernateOrmProcessor.class);
 
     private static final String INTEGRATOR_SERVICE_FILE = "META-INF/services/org.hibernate.integrator.spi.Integrator";
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
+    }
 
     @BuildStep
     void registerHibernateOrmMetadataForCoreDialects(

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/graal/DisableLoggingFeature.java
@@ -7,13 +7,10 @@ import java.util.logging.Logger;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Disables logging during the analysis phase
  */
-@AutomaticFeature
-public class DisableLoggingAutoFeature implements Feature {
+public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
             "org.hibernate.Version",

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -33,9 +33,11 @@ import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.elasticsearch.restclient.common.deployment.DevservicesElasticsearchBuildItem;
 import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
@@ -51,6 +53,7 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.ElasticsearchIndexBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.graal.DisableLoggingFeature;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 class HibernateSearchElasticsearchProcessor {
@@ -59,9 +62,14 @@ class HibernateSearchElasticsearchProcessor {
 
     HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
 
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
+    }
+
     @BuildStep
     void setupLogFilters(BuildProducer<LogCleanupFilterBuildItem> filters) {
-        // if the category changes, please also update DisableLoggingAutoFeature in the runtime module
+        // if the category changes, please also update DisableLoggingFeature in the runtime module
         filters.produce(new LogCleanupFilterBuildItem(
                 "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateSearchPreIntegrationService", "HSEARCH000034"));
     }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/DisableLoggingFeature.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/graal/DisableLoggingFeature.java
@@ -1,4 +1,4 @@
-package io.quarkus.runtime.graal;
+package io.quarkus.hibernate.search.orm.elasticsearch.runtime.graal;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -7,16 +7,13 @@ import java.util.logging.Logger;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Disables logging during the analysis phase
  */
-@AutomaticFeature
-public class DisableLoggingAutoFeature implements Feature {
+public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
-            "org.jboss.threads"
+            "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateSearchPreIntegrationService"
     };
 
     private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -66,13 +66,16 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ConfigClassBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveFieldBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
+import io.quarkus.hibernate.validator.runtime.DisableLoggingFeature;
 import io.quarkus.hibernate.validator.runtime.HibernateValidatorBuildTimeConfig;
 import io.quarkus.hibernate.validator.runtime.HibernateValidatorRecorder;
 import io.quarkus.hibernate.validator.runtime.ValidatorProvider;
@@ -124,6 +127,11 @@ class HibernateValidatorProcessor {
     @BuildStep
     LogCleanupFilterBuildItem logCleanup() {
         return new LogCleanupFilterBuildItem("org.hibernate.validator.internal.util.Version", "HV000001:");
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
     }
 
     @BuildStep

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/DisableLoggingFeature.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/DisableLoggingFeature.java
@@ -7,13 +7,10 @@ import java.util.logging.Logger;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Disables logging during the analysis phase
  */
-@AutomaticFeature
-public class DisableLoggingAutoFeature implements Feature {
+public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
             "org.hibernate.validator.internal.util.Version",

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/JDBCPostgreSQLProcessor.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/JDBCPostgreSQLProcessor.java
@@ -12,16 +12,24 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.jdbc.postgresql.runtime.PostgreSQLAgroalConnectionConfigurer;
 import io.quarkus.jdbc.postgresql.runtime.PostgreSQLServiceBindingConverter;
+import io.quarkus.jdbc.postgresql.runtime.graal.SQLXMLFeature;
 
 public class JDBCPostgreSQLProcessor {
 
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.JDBC_POSTGRESQL);
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(SQLXMLFeature.class);
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/graal/SQLXMLFeature.java
+++ b/extensions/jdbc/jdbc-postgresql/runtime/src/main/java/io/quarkus/jdbc/postgresql/runtime/graal/SQLXMLFeature.java
@@ -9,9 +9,6 @@ import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.postgresql.core.BaseConnection;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
-@AutomaticFeature
 public final class SQLXMLFeature implements Feature {
 
     private final AtomicBoolean triggered = new AtomicBoolean(false);

--- a/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
+++ b/extensions/websockets/client/deployment/src/main/java/io/quarkus/websockets/client/deployment/WebsocketClientProcessor.java
@@ -32,11 +32,14 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.undertow.deployment.ServletContextAttributeBuildItem;
+import io.quarkus.websockets.client.runtime.DisableLoggingFeature;
 import io.quarkus.websockets.client.runtime.WebsocketCoreRecorder;
 import io.undertow.websockets.DefaultContainerConfigurator;
 import io.undertow.websockets.ServerWebSocketContainer;
@@ -48,6 +51,11 @@ public class WebsocketClientProcessor {
     private static final DotName CLIENT_ENDPOINT = DotName.createSimple(ClientEndpoint.class.getName());
     private static final DotName SERVER_APPLICATION_CONFIG = DotName.createSimple(ServerApplicationConfig.class.getName());
     private static final DotName ENDPOINT = DotName.createSimple(Endpoint.class.getName());
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
+    }
 
     @BuildStep
     void holdConfig(BuildProducer<FeatureBuildItem> feature) {

--- a/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingFeature.java
+++ b/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/DisableLoggingFeature.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.search.orm.elasticsearch.runtime.graal;
+package io.quarkus.websockets.client.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -7,16 +7,13 @@ import java.util.logging.Logger;
 
 import org.graalvm.nativeimage.hosted.Feature;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-
 /**
  * Disables logging during the analysis phase
  */
-@AutomaticFeature
-public class DisableLoggingAutoFeature implements Feature {
+public class DisableLoggingFeature implements Feature {
 
     private static final String[] CATEGORIES = {
-            "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateSearchPreIntegrationService"
+            "io.undertow.websockets",
     };
 
     private final Map<String, Level> categoryMap = new HashMap<>(CATEGORIES.length);


### PR DESCRIPTION
While the Feature interface is API, the annotation AutomaticFeature is
not in the API. That is intentional: if a feature is necessary, then it
should be added via the --features=... option in a
native-image.properties file.

Source: https://github.com/oracle/graal/discussions/4616

Implements 1st part of https://github.com/quarkusio/quarkus/issues/25943

Marking as Draft till tested completes on my fork.