### PR TITLE
Bump gitflow-incremental-builder to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>4.0.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.1.0</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.40</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
Dependabot slots are a bit jammed, so I'm doing it myself.

---

https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.1.0

> Most notable change is the "test scope-aware" downstream handling, resulting in fewer transitive modules to be built if test-only changes are involved: [#488](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/488)

E.g. a change to `extensions/vertx-http/deployment/pom.xml` resulted in building 325 modules with GIB 4.0.0 but now only results in 287 modules. This is due to the fact that there are a few modules that use `quarkus-vertx-http-deployment` only in test scope and therefore transitively depending modules can be pruned.