### PR TITLE
Bump maven-surefire-plugin from 3.0.0-M5 to 3.0.0-M7

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -29,7 +29,7 @@
 
         <!-- version.* properties are defined in jboss-parent and are overridden/updated here: -->
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <version.exec.plugin>3.0.0</version.exec.plugin>
         <failsafe-plugin.version>${version.surefire.plugin}</failsafe-plugin.version>
 
@@ -415,8 +415,6 @@
                         <!-- limit the amount of memory surefire can use, 1500m should be plenty-->
                         <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
                         <argLine>${jacoco.agent.argLine} -Xmx1500m -XX:MaxMetaspaceSize=1500m -Djava.io.tmpdir="${project.build.directory}" ${surefire.argLine.additional}</argLine>
-                        <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
-                        <trimStackTrace>false</trimStackTrace>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>
@@ -435,8 +433,6 @@
                         </systemPropertyVariables>
                         <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
                         <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
-                        <!-- https://lists.apache.org/thread.html/r9030808273c82ac6d7b9602d34d446c7d8c4e8aa02c41bca164df1c5%40%3Cdev.maven.apache.org%3E -->
-                        <trimStackTrace>false</trimStackTrace>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
                     </configuration>
                 </plugin>

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -169,8 +169,7 @@ Your extension is a multi-module project. So let's start by checking out the par
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>{quarkus-version}</quarkus.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -616,8 +616,7 @@ As a reference, these are the full contents of the `pom.xml`:
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>{quarkus-version}</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/extensions/azure-functions-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/azure-functions-http/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
     <resources-plugin.version>3.1.0</resources-plugin.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 
     <azure.functions.maven.plugin.version>1.9.1</azure.functions.maven.plugin.version>
     <functionAppName>${appName}</functionAppName>

--- a/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/extensions/funqy/funqy-amazon-lambda/maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -51,7 +51,7 @@
         <version.gizmo>1.0.11.Final</version.gizmo>
         <version.jpa>2.2.3</version.jpa>
 
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
 

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -34,7 +34,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 
         <!-- Dependency versions -->

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jackson-bom.version>2.13.3</jackson-bom.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>

--- a/independent-projects/ide-config/pom.xml
+++ b/independent-projects/ide-config/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     </properties>
 

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -44,7 +44,7 @@
         <version.assertj>3.23.1</version.assertj>
         <version.gizmo>1.0.11.Final</version.gizmo>
         <version.jboss-logging>3.5.0.Final</version.jboss-logging>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
         <version.smallrye-mutiny>1.5.0</version.smallrye-mutiny>
     </properties>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -50,7 +50,7 @@
         <gizmo.version>1.0.11.Final</gizmo.version>
         <jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
 
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/extension-base/java/pom.tpl.qute.xml
@@ -38,7 +38,6 @@
         {#if maven.surefire-plugin.version}
         <surefire-plugin.version>{maven.surefire-plugin.version}</surefire-plugin.version>
         <failsafe-plugin.version>$\{surefire-plugin.version}</failsafe-plugin.version>
-        <failsafe.useModulePath>false</failsafe.useModulePath>
         {/if}
     </properties>
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/base/pom.tpl.qute.xml
@@ -19,7 +19,6 @@
         <compiler-plugin.version>{maven-compiler-plugin.version}</compiler-plugin.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>{maven-surefire-plugin.version}</surefire-plugin.version>
-        <failsafe.useModulePath>false</failsafe.useModulePath>
         {#if uberjar}
         <quarkus.package.type>uber-jar</quarkus.package.type>
         {/if}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateExtension.java
@@ -53,7 +53,7 @@ public class CreateExtension {
     public static final String DEFAULT_QUARKIVERSE_PARENT_VERSION = "9";
     public static final String DEFAULT_QUARKIVERSE_NAMESPACE_ID = "quarkus-";
 
-    private static final String DEFAULT_SUREFIRE_PLUGIN_VERSION = "3.0.0-M5";
+    private static final String DEFAULT_SUREFIRE_PLUGIN_VERSION = "3.0.0-M7";
     private static final String DEFAULT_COMPILER_PLUGIN_VERSION = "3.8.1";
 
     private final QuarkusExtensionCodestartProjectInputBuilder builder = QuarkusExtensionCodestartProjectInput.builder();

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -604,7 +604,7 @@ public class TestRegistryClientBuilder {
             metadata.put("maven-plugin-artifactId", "quarkus-maven-plugin");
             metadata.put("maven-plugin-version", quarkusBom.extensions.getBom().getVersion());
             metadata.put("compiler-plugin-version", "3.8.1");
-            metadata.put("surefire-plugin-version", "3.0.0-M5");
+            metadata.put("surefire-plugin-version", "3.0.0-M7");
             return quarkusBom;
         }
 

--- a/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
+++ b/independent-projects/tools/devtools-testing/src/main/resources/fake-catalog.json
@@ -357,7 +357,7 @@
         "doc-root": "https://quarkus.io",
         "rest-assured-version": "4.3.2",
         "compiler-plugin-version": "3.8.1",
-        "surefire-plugin-version": "3.0.0-M5",
+        "surefire-plugin-version": "3.0.0-M7",
         "kotlin-version": "1.4.31",
         "scala-version": "2.12.13",
         "scala-plugin-version": "4.4.0",

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/pom.xml
@@ -7,7 +7,6 @@
   <version>1.0.0-codestart</version>
   <properties>
     <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateMavenWithCustomDep/pom.xml
@@ -7,7 +7,6 @@
   <version>1.0.0-codestart</version>
   <properties>
     <compiler-plugin.version>3.8.1-MOCK</compiler-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -56,7 +56,7 @@
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <maven-core.version>3.8.4</maven-core.version>
         <mockito.version>4.6.0</mockito.version>
-        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <quarkus.version>999-SNAPSHOT</quarkus.version>
         <maven-model-helper.version>20</maven-model-helper.version>

--- a/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-bom-quarkus-platform-descriptor-999-SNAPSHOT-999-SNAPSHOT.json
+++ b/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-bom-quarkus-platform-descriptor-999-SNAPSHOT-999-SNAPSHOT.json
@@ -3086,7 +3086,7 @@
         "doc-root" : "https://quarkus.io",
         "rest-assured-version" : "${rest-assured.version}",
         "compiler-plugin-version" : "3.8.1",
-        "surefire-plugin-version" : "3.0.0-M5",
+        "surefire-plugin-version" : "3.0.0-M7",
         "kotlin-version" : "1.5.31",
         "scala-version" : "2.12.13",
         "scala-plugin-version" : "4.4.0",

--- a/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
+++ b/independent-projects/tools/registry-client/src/test/resources/catalog-config/quarkus-universe-bom-quarkus-platform-descriptor-2.0.3.Final-2.0.3.Final.json
@@ -7329,7 +7329,7 @@
         "doc-root" : "https://quarkus.io",
         "rest-assured-version" : "4.3.2",
         "compiler-plugin-version" : "3.8.1",
-        "surefire-plugin-version" : "3.0.0-M5",
+        "surefire-plugin-version" : "3.0.0-M7",
         "kotlin-version" : "1.4.32",
         "scala-version" : "2.12.13",
         "scala-plugin-version" : "4.4.0",

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-docker/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-appcds/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-db2/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-kafka/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-kafka/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mariadb/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mariadb/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mssql/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mysql/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mysql/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-postgresql/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-postgresql/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-docker/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-multiple-tags-jib/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-with-keycloak-default-realm/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-with-keycloak-default-realm/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-with-keycloak/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-with-keycloak/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-jib-with-redis/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-jib-with-redis/pom.xml
@@ -7,7 +7,7 @@
     <version>0.1-SNAPSHOT</version>
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/pom.xml
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-push/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-deployment/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-docker-build-and-deploy-statefulset/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-jib-build-and-deploy/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/kubernetes-with-existing-selectorless-manifest/pom.xml
@@ -8,7 +8,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/minikube-with-existing-manifest/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-docker-build-and-deploy/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/maven-invoker-way/src/it/openshift-s2i-build-and-deploy/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/kubernetes/src/it/openshift-s2i-build-and-deploy/pom.xml
+++ b/integration-tests/kubernetes/src/it/openshift-s2i-build-and-deploy/pom.xml
@@ -7,7 +7,7 @@
   <version>0.1-SNAPSHOT</version>
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/arc-exclude-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/arc-exclude-dependencies/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-conflict/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/capabilities-missing/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/conditional-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/conditional-dependencies/pom.xml
@@ -19,7 +19,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>
     <modules>
         <module>quarkus-ext-a</module>

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/pom.xml
@@ -8,14 +8,13 @@
   <version>1.0.0-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/modules-in-profiles/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode-parallel/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multi-build-mode/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <commons.collections.version>4.4</commons.collections.version>
     <commons.io.version>1.3.2</commons.io.version>
   </properties>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multijar-module/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/pom.xml
@@ -12,7 +12,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/pom.xml
@@ -13,7 +13,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>${project.version}</quarkus.platform.version>
         <quarkus-plugin.version>${project.version}</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/pom.xml
@@ -12,7 +12,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
     <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus-index-dependencies/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/reactive-routes/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/pom.xml
@@ -12,7 +12,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>@project.version@</quarkus.platform.version>
         <quarkus-plugin.version>@project.version@</quarkus-plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-plugin-classpath-config/pom.xml
@@ -8,14 +8,13 @@
   <packaging>pom</packaging>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-source-sets/pom.xml
@@ -10,7 +10,6 @@
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <dependency-plugin.version>3.2.0</dependency-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
 
     <!-- General project setup -->
@@ -40,7 +39,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>@project.version@</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -216,7 +215,6 @@
               <includes>
                 <include>**/*.java</include>
               </includes>
-              <trimStackTrace>false</trimStackTrace>
               <systemPropertyVariables>
                 <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
+++ b/integration-tests/maven/src/test/resources/__snapshots__/CreateExtensionMojoIT/testCreateStandaloneExtension/my-org-my-own-ext_pom.xml
@@ -14,12 +14,11 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>1.10.5.Final</quarkus.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
M7 is a comparably quick and smaller scoped bugfix release, mainly fixing severe regressions in M6 (which we skipped because of those).

[M7 release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12351502&styleName=Text&projectId=12317927&Create=Create&atl_token=A5KQ-2QAV-T4JA-FDED_1949fe90764fadf67ad5b65e27803196acf28fa1_lout)
[M6 release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12344613&styleName=Text&projectId=12317927&Create=Create&atl_token=A5KQ-2QAV-T4JA-FDED_1949fe90764fadf67ad5b65e27803196acf28fa1_lout)

See also: https://github.com/quarkusio/quarkus/discussions/24681