### PR TITLE
Introduce new JPMS exports to allow running native-image on module-path

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/JPMSExportBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/JPMSExportBuildItem.java
@@ -1,5 +1,7 @@
 package io.quarkus.deployment.builditem.nativeimage;
 
+import java.util.Objects;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -21,5 +23,22 @@ public final class JPMSExportBuildItem extends MultiBuildItem {
 
     public String getModule() {
         return moduleName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JPMSExportBuildItem that = (JPMSExportBuildItem) o;
+        return moduleName.equals(that.moduleName) && packageName.equals(that.packageName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moduleName, packageName);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -75,7 +75,7 @@ public class NativeImageBuildStep {
     private static final String MOVED_TRUST_STORE_NAME = "trustStore";
     public static final String APP_SOURCES = "app-sources";
 
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuildGraal22_2OrLater.class)
     void addExportsToNativeImage(BuildProducer<JPMSExportBuildItem> exports) {
         // Needed by io.quarkus.runtime.ResourceHelper.registerResources
         exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk"));

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -12,6 +12,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.JPMSExportBuildItem;
@@ -72,6 +74,12 @@ public class NativeImageBuildStep {
     private static final String TRUST_STORE_SYSTEM_PROPERTY_MARKER = "-Djavax.net.ssl.trustStore=";
     private static final String MOVED_TRUST_STORE_NAME = "trustStore";
     public static final String APP_SOURCES = "app-sources";
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void addExportsToNativeImage(BuildProducer<JPMSExportBuildItem> exports) {
+        // Needed by io.quarkus.runtime.ResourceHelper.registerResources
+        exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk"));
+    }
 
     @BuildStep(onlyIf = NativeBuild.class)
     ArtifactResultBuildItem result(NativeImageBuildItem image) {
@@ -807,7 +815,8 @@ public class NativeImageBuildStep {
                 }
 
                 if (jpmsExports != null) {
-                    for (JPMSExportBuildItem jpmsExport : jpmsExports) {
+                    HashSet<JPMSExportBuildItem> deduplicatedJpmsExport = new HashSet<>(jpmsExports);
+                    for (JPMSExportBuildItem jpmsExport : deduplicatedJpmsExport) {
                         nativeImageArgs.add(
                                 "-J--add-exports=" + jpmsExport.getModule() + "/" + jpmsExport.getPackage() + "=ALL-UNNAMED");
                     }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeOrNativeSourcesBuild.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeOrNativeSourcesBuild.java
@@ -22,4 +22,5 @@ public class NativeOrNativeSourcesBuild implements BooleanSupplier {
         return packageConfig.type.equalsIgnoreCase(PackageConfig.NATIVE)
                 || packageConfig.type.equalsIgnoreCase(PackageConfig.NATIVE_SOURCES);
     }
+
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeOrNativeSourcesBuildGraal22_2OrLater.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeOrNativeSourcesBuildGraal22_2OrLater.java
@@ -1,0 +1,29 @@
+package io.quarkus.deployment.pkg.steps;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.home.Version;
+
+import io.quarkus.deployment.pkg.PackageConfig;
+
+/**
+ * Supplier that can be used to only run build steps in the
+ * native or native sources builds when using Graal >= 22.2.
+ * Most build steps that need to be run conditionally should use this instead of {@link NativeBuild}.
+ */
+public class NativeOrNativeSourcesBuildGraal22_2OrLater implements BooleanSupplier {
+
+    private final PackageConfig packageConfig;
+
+    NativeOrNativeSourcesBuildGraal22_2OrLater(PackageConfig packageConfig) {
+        this.packageConfig = packageConfig;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return (packageConfig.type.equalsIgnoreCase(PackageConfig.NATIVE)
+                || packageConfig.type.equalsIgnoreCase(PackageConfig.NATIVE_SOURCES))
+                && (Version.getCurrent().isSnapshot() || Version.getCurrent().compareTo(22, 2) >= 0);
+    }
+
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageAutoFeatureStep.java
@@ -41,6 +41,7 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedPackageBuil
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.UnsafeAccessedFieldBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuildGraal22_2OrLater;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.CatchBlockCreator;
 import io.quarkus.gizmo.ClassCreator;
@@ -117,13 +118,17 @@ public class NativeImageAutoFeatureStep {
                 sb.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuildGraal22_2OrLater.class)
     JPMSExportBuildItem addExportsToNativeImage(List<JniRuntimeAccessBuildItem> jniRuntimeAccessibleClasses) {
         // required in order to access com.oracle.svm.core.jni.JNIRuntimeAccess
         if (jniRuntimeAccessibleClasses != null && !jniRuntimeAccessibleClasses.isEmpty()) {
             return new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jni");
         }
         return null;
+    }
+
+    private boolean graalVM22_2OrLater() {
+        return Version.getCurrent().isSnapshot() || Version.getCurrent().compareTo(22, 2) >= 0;
     }
 
     @BuildStep
@@ -250,8 +255,10 @@ public class NativeImageAutoFeatureStep {
         }
 
         if (!proxies.isEmpty()) {
-            // Needed to access DYNAMIC_PROXY_REGISTRY
-            exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk.proxy"));
+            if (graalVM22_2OrLater()) {
+                // Needed to access DYNAMIC_PROXY_REGISTRY
+                exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk.proxy"));
+            }
 
             ResultHandle proxySupportClass = overallCatch.loadClassFromTCCL(DYNAMIC_PROXY_REGISTRY);
             ResultHandle proxySupport = overallCatch.invokeStaticMethod(
@@ -273,8 +280,10 @@ public class NativeImageAutoFeatureStep {
 
         /* Resource includes and excludes */
         if (!resourcePatterns.isEmpty()) {
-            // Needed to access LOOKUP_METHOD
-            exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.base", "com.oracle.svm.util"));
+            if (graalVM22_2OrLater()) {
+                // Needed to access LOOKUP_METHOD
+                exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.base", "com.oracle.svm.util"));
+            }
 
             ResultHandle resourcesRegistrySingleton = overallCatch.invokeStaticMethod(IMAGE_SINGLETONS_LOOKUP,
                     overallCatch.loadClassFromTCCL("com.oracle.svm.core.configure.ResourcesRegistry"));
@@ -333,8 +342,11 @@ public class NativeImageAutoFeatureStep {
         }
 
         if (!resourceBundles.isEmpty()) {
-            // Needed to access LOCALIZATION_FEATURE
-            exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk.localization"));
+            if (graalVM22_2OrLater()) {
+                // Needed to access LOCALIZATION_FEATURE
+                exports.produce(
+                        new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk.localization"));
+            }
 
             AssignableResultHandle registerMethod = overallCatch.createVariable(Method.class);
             AssignableResultHandle locClass = overallCatch.createVariable(Class.class);
@@ -494,8 +506,10 @@ public class NativeImageAutoFeatureStep {
 
             if (entry.getValue().serialization) {
                 if (registerSerializationMethod == null) {
-                    // Needed by createRegisterSerializationForClassMethod to access LOOKUP_METHOD
-                    exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.base", "com.oracle.svm.util"));
+                    if (graalVM22_2OrLater()) {
+                        // Needed by createRegisterSerializationForClassMethod to access LOOKUP_METHOD
+                        exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.base", "com.oracle.svm.util"));
+                    }
                     registerSerializationMethod = createRegisterSerializationForClassMethod(file);
                 }
 

--- a/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
+++ b/extensions/awt/deployment/src/main/java/io/quarkus/awt/deployment/AwtProcessor.java
@@ -170,7 +170,6 @@ class AwtProcessor {
                 "sun.java2d.loops.FillRect",
                 "sun.java2d.loops.FillSpans",
                 "sun.java2d.loops.GraphicsPrimitive",
-                "sun.java2d.loops.GraphicsPrimitive[]",
                 "sun.java2d.loops.GraphicsPrimitiveMgr",
                 "sun.java2d.loops.MaskBlit",
                 "sun.java2d.loops.MaskFill",


### PR DESCRIPTION
Once https://github.com/oracle/graal/pull/4468 gets merged, native-image will run on module-path requiring some additional exports to be passed to it in order to access internal APIs.

Marking as Draft till I finish testing it with https://github.com/oracle/graal/pull/4468