### PR TITLE
Update postgres, mssql and mongo images for tests and devservices

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -89,13 +89,13 @@
         <opensearch.protocol>http</opensearch.protocol>
 
         <!-- Database images for JDBC/Reactive/Hibernate tests and devservices -->
-        <postgres.image>docker.io/postgres:14.2</postgres.image>
-        <mariadb.image>docker.io/mariadb:10.7</mariadb.image>
+        <postgres.image>docker.io/postgres:14</postgres.image>
+        <mariadb.image>docker.io/mariadb:10.6</mariadb.image>
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
-        <mssql.image>mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04</mssql.image>
+        <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
         <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
-        <mongo.image>docker.io/mongo:4.4.13</mongo.image>
+        <mongo.image>docker.io/mongo:4.4</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
Also "downgrades" mariadb to 10.6 because that will actually be supported much longer than 10.7: https://mariadb.com/kb/en/mariadb-server-release-dates/

Will effectively update:
- postgres from 14.2 to 14.3 (and if there is a 14.4+ it will be picked up automatically)
- mssql from 2019-CU15-ubuntu-20.04 to 2019-CU16-ubuntu-20.04 (and if there is a CU17+ it will be picked up automatically)
- mongo from 4.4.13 to 4.4.14 (and if there is a 4.4.15+ it will be picked up automatically)