### PR TITLE
Revert "Remove ClientBuilder service files from narayana-lra extension dependencies"

### DIFF
--- a/extensions/narayana-lra/runtime/pom.xml
+++ b/extensions/narayana-lra/runtime/pom.xml
@@ -51,12 +51,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <configuration>
-                    <removedResources>
-                        <org.jboss.narayana.rts:narayana-lra>META-INF/services/javax.ws.rs.client.ClientBuilder</org.jboss.narayana.rts:narayana-lra>
-                        <org.jboss.narayana.rts:lra-client>META-INF/services/javax.ws.rs.client.ClientBuilder</org.jboss.narayana.rts:lra-client>
-                    </removedResources>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Reverts quarkusio/quarkus#25970

I have to revert this one because otherwise I can't release:
> [ERROR] Failed to execute goal org.codehaus.mojo:versions-maven-plugin:2.8.1:set (default-cli) on project quarkus-parent: Execution default-cli of goal org.codehaus.mojo:versions-maven-plugin:2.8.1:set failed: Error parsing /data/home/gsmet/git/quarkus-release/work/quarkus/extensions/narayana-lra/runtime/pom.xml: Undeclared namespace prefix "org.jboss.narayana.rts"

You cannot use the `groupId:artifactId` syntax for an attribute as it's the syntax of XML namespaces. We need to adjust the plugin to use a more widely supported syntax.

I will merge it right away as it's blocking the release.

/cc @gastaldi @xstefank @aloubyansky 