### PR TITLE
Bump grpc.version from 1.46.0 to 1.47.0 and adapt substitutions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Dependency versions -->
 
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
-        <grpc.version>1.46.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <grpc.version>1.47.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
         <protoc.version>3.19.3</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>


### PR DESCRIPTION
In addition to the update (see below for details), this commit adds a
new substitution. This version of gRPC ships a new NameResolver using
Unix Domain Socket (UDS). The native compilation cannot work without
a substitution preventing accessing the UDS classes, which are not
necessarily on the classpath.

Updates `grpc-bom` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

Updates `protoc-gen-grpc-java` from 1.46.0 to 1.47.0
- [Release notes](https://github.com/grpc/grpc-java/releases)
- [Commits](https://github.com/grpc/grpc-java/compare/v1.46.0...v1.47.0)

---
updated-dependencies:
- dependency-name: io.grpc:grpc-bom
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:linux-aarch_64
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:linux-x86_32
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:linux-x86_64
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:osx-x86_64
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:osx-aarch_64
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:windows-x86_32
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: io.grpc:protoc-gen-grpc-java:windows-x86_64
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Superseed https://github.com/quarkusio/quarkus/pull/25917.