### PR TITLE
Fix hibernate-reactive-rest-data-panache when adding smallrye openapi

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractEntity;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractItem;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.Collection;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.CollectionsRepository;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.CollectionsResource;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItem;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItemsRepository;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItemsResource;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.Item;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsRepository;
+import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsResource;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+
+class OpenApiIntegrationTest {
+
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Collection.class, CollectionsResource.class, CollectionsRepository.class,
+                            AbstractEntity.class, AbstractItem.class, Item.class, ItemsResource.class,
+                            ItemsRepository.class, EmptyListItem.class, EmptyListItemsRepository.class,
+                            EmptyListItemsResource.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql"))
+            .setForcedDependencies(List.of(
+                    new AppArtifact("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion())))
+            .setRun(true);
+
+    @Test
+    public void testOpenApiForGeneratedResources() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.title", Matchers.equalTo("quarkus-hibernate-orm-rest-data-panache-deployment API"))
+                .body("paths.'/collections'", Matchers.hasKey("get"))
+                .body("paths.'/collections'", Matchers.hasKey("post"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
+                .body("paths.'/empty-list-items'", Matchers.hasKey("post"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/items'", Matchers.hasKey("get"))
+                .body("paths.'/items'", Matchers.hasKey("post"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("delete"));
+    }
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.openapi;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.AbstractEntity;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.AbstractItem;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.Collection;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.CollectionsRepository;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.CollectionsResource;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.EmptyListItem;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.EmptyListItemsRepository;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.EmptyListItemsResource;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.Item;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.ItemsRepository;
+import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.ItemsResource;
+import io.quarkus.test.QuarkusProdModeTest;
+import io.restassured.RestAssured;
+
+class OpenApiIntegrationTest {
+
+    private static final String OPEN_API_PATH = "/q/openapi";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Collection.class, CollectionsResource.class, CollectionsRepository.class,
+                            AbstractEntity.class, AbstractItem.class, Item.class, ItemsResource.class,
+                            ItemsRepository.class, EmptyListItem.class, EmptyListItemsRepository.class,
+                            EmptyListItemsResource.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql"))
+            .setForcedDependencies(List.of(
+                    new AppArtifact("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-reactive-pg-client-deployment", Version.getVersion()),
+                    new AppArtifact("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion())))
+            .setRun(true);
+
+    @Test
+    public void testOpenApiForGeneratedResources() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get(OPEN_API_PATH)
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("info.title", Matchers.equalTo("quarkus-hibernate-reactive-rest-data-panache-deployment API"))
+                .body("paths.'/collections'", Matchers.hasKey("get"))
+                .body("paths.'/collections'", Matchers.hasKey("post"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
+                .body("paths.'/empty-list-items'", Matchers.hasKey("post"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/empty-list-items/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/items'", Matchers.hasKey("get"))
+                .body("paths.'/items'", Matchers.hasKey("post"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/items/{id}'", Matchers.hasKey("delete"));
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/pom.xml
+++ b/extensions/panache/rest-data-panache/deployment/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -32,15 +32,17 @@ class JaxRsResourceImplementor {
 
     private final List<MethodImplementor> methodImplementors;
 
-    JaxRsResourceImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        this.methodImplementors = Arrays.asList(new GetMethodImplementor(isResteasyClassic, isReactivePanache),
-                new ListMethodImplementor(isResteasyClassic, isReactivePanache),
-                new AddMethodImplementor(withValidation, isResteasyClassic, isReactivePanache),
-                new UpdateMethodImplementor(withValidation, isResteasyClassic, isReactivePanache),
-                new DeleteMethodImplementor(isResteasyClassic, isReactivePanache),
+    JaxRsResourceImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache,
+            boolean isOpenApiEnabled) {
+        this.methodImplementors = Arrays.asList(
+                new GetMethodImplementor(isResteasyClassic, isReactivePanache, isOpenApiEnabled),
+                new ListMethodImplementor(isResteasyClassic, isReactivePanache, isOpenApiEnabled),
+                new AddMethodImplementor(withValidation, isResteasyClassic, isReactivePanache, isOpenApiEnabled),
+                new UpdateMethodImplementor(withValidation, isResteasyClassic, isReactivePanache, isOpenApiEnabled),
+                new DeleteMethodImplementor(isResteasyClassic, isReactivePanache, isOpenApiEnabled),
                 // The list hal endpoint needs to be added for both resteasy classic and resteasy reactive
                 // because the pagination links are programmatically added.
-                new ListHalMethodImplementor(isResteasyClassic, isReactivePanache));
+                new ListHalMethodImplementor(isResteasyClassic, isReactivePanache, isOpenApiEnabled));
     }
 
     /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
@@ -57,6 +57,7 @@ public class RestDataProcessor {
 
         boolean isReactivePanache = capabilities.isPresent(Capability.HIBERNATE_REACTIVE);
         boolean isResteasyClassic = capabilities.isPresent(Capability.RESTEASY);
+        boolean isOpenApiEnabled = capabilities.isPresent(Capability.SMALLRYE_OPENAPI);
 
         if (isReactivePanache && isResteasyClassic) {
             throw new IllegalStateException(
@@ -66,7 +67,7 @@ public class RestDataProcessor {
         ClassOutput classOutput = isResteasyClassic ? new GeneratedBeanGizmoAdaptor(resteasyClassicImplementationsProducer)
                 : new GeneratedJaxRsResourceGizmoAdaptor(resteasyReactiveImplementationsProducer);
         JaxRsResourceImplementor jaxRsResourceImplementor = new JaxRsResourceImplementor(hasValidatorCapability(capabilities),
-                isResteasyClassic, isReactivePanache);
+                isResteasyClassic, isReactivePanache, isOpenApiEnabled);
         ResourcePropertiesProvider resourcePropertiesProvider = new ResourcePropertiesProvider(index.getIndex());
 
         for (RestDataResourceBuildItem resourceBuildItem : resourceBuildItems) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -28,8 +28,9 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
 
     private final boolean withValidation;
 
-    public AddMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public AddMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache,
+            boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
         this.withValidation = withValidation;
     }
 
@@ -110,6 +111,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.CREATED);
         // Add parameter annotations
         if (withValidation) {
             methodCreator.getParameterAnnotations(0).addAnnotation(Valid.class);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -26,8 +26,8 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "remove";
 
-    public DeleteMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public DeleteMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache, boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
     }
 
     /**
@@ -92,6 +92,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addDeleteAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.NO_CONTENT);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -26,8 +26,8 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "self";
 
-    public GetMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public GetMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache, boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
     }
 
     /**
@@ -93,6 +93,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));
         addGetAnnotation(methodCreator);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.OK);
 
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -39,8 +39,8 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
-    public ListMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public ListMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache, boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
 
         this.paginationImplementor = new PaginationImplementor();
     }
@@ -140,6 +140,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.OK);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(1), "page");
@@ -205,6 +206,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.OK);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 
         ResultHandle sortQuery = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -41,8 +41,9 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
 
     private final boolean withValidation;
 
-    public UpdateMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public UpdateMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache,
+            boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
         this.withValidation = withValidation;
     }
 
@@ -143,6 +144,7 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.CREATED);
         // Add parameter annotations
         if (withValidation) {
             methodCreator.getParameterAnnotations(1).addAnnotation(Valid.class);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
@@ -26,8 +26,8 @@ import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService
  */
 abstract class HalMethodImplementor extends StandardMethodImplementor {
 
-    HalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    HalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache, boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
     }
 
     /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -40,8 +40,8 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
-    public ListHalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public ListHalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache, boolean isOpenApiEnabled) {
+        super(isResteasyClassic, isReactivePanache, isOpenApiEnabled);
         this.paginationImplementor = new PaginationImplementor();
     }
 
@@ -131,6 +131,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.OK);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(1), "page");
@@ -205,6 +206,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addOpenApiAnnotations(methodCreator, resourceMetadata.getEntityType(), Response.Status.OK);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 
         ResultHandle sortQuery = methodCreator.getMethodParam(0);


### PR DESCRIPTION
As generating a parameterized type is too complex to do with gizmo (it will be addressed in https://github.com/quarkusio/gizmo/pull/70), these changes implement a workaround so the extension hibernate-reactive-rest-data-panache does not fail when adding the smallrye openapi extension.

The ultimate solution should be:
- to generate parameterized types (`Uni<Entity>` instead of only `Uni`). 
- to make smallrye openapi more robust (see related comment [here](https://github.com/quarkusio/quarkus/issues/25990#issuecomment-1152265262) and [here](https://github.com/quarkusio/quarkus/issues/25990#issuecomment-1152291810)).

Fix https://github.com/quarkusio/quarkus/issues/25990