### PR TITLE
Fix container build logging

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/ExecUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/ExecUtil.java
@@ -163,7 +163,7 @@ public class ExecUtil {
             String... args) {
         try {
             Process process = startProcess(directory, command, args);
-            outputFilterFunction.apply(process.getInputStream());
+            outputFilterFunction.apply(process.getInputStream()).run();
             process.waitFor();
             return process.exitValue() == 0;
         } catch (InterruptedException e) {


### PR DESCRIPTION
In Quarkus 2.10.CR1, the container build (e.g. Docker) performed by Quarkus does not log any output anymore. This appears to be caused by the refactoring in commit 418d986f7ea21f93aef3490921f436612bcfe141, as the `Runnable#run()` method is never called in `ExecUtil#exec()` on the `Runnable` returned by `outputFilterFunction`.