### PR TITLE
Bump mongo-client.version from 4.3.4 to 4.6.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -157,8 +157,8 @@
         <liquibase.version>4.11.0</liquibase.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <mongo-client.version>4.3.4</mongo-client.version>
-        <mongo-crypt.version>1.2.1</mongo-crypt.version>
+        <mongo-client.version>4.6.1</mongo-client.version>
+        <mongo-crypt.version>1.4.0</mongo-crypt.version>
         <proton-j.version>0.33.10</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
         <hibernate-quarkus-local-cache.version>0.1.1</hibernate-quarkus-local-cache.version>

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/graal/MongoClientSubstitutions.java
@@ -158,7 +158,7 @@ final class DefaultDnsResolverSubstitution {
      * domain equal to the domain of the srvHost.
      */
     @Substitute
-    public List<String> resolveHostFromSrvRecords(final String srvHost) {
+    public List<String> resolveHostFromSrvRecords(String srvHost, String srvServiceName) {
         Config config = ConfigProvider.getConfig();
         if (!config.getOptionalValue(DnsClientProducer.FLAG, Boolean.class).orElse(false)) {
             throw new MongoConfigurationException(
@@ -172,12 +172,12 @@ final class DefaultDnsResolverSubstitution {
         List<String> hosts = new ArrayList<>();
         Duration timeout = config.getOptionalValue(DnsClientProducer.LOOKUP_TIMEOUT, Duration.class)
                 .orElse(Duration.ofSeconds(5));
-
+        String resourceName = "_" + srvServiceName + "._tcp." + srvHost;
         try {
-            List<SrvRecord> srvRecords = dnsClient.resolveSRV("_mongodb._tcp." + srvHost).await().atMost(timeout);
+            List<SrvRecord> srvRecords = dnsClient.resolveSRV(resourceName).await().atMost(timeout);
 
             if (srvRecords.isEmpty()) {
-                throw new MongoConfigurationException("No SRV records available for host " + "_mongodb._tcp." + srvHost);
+                throw new MongoConfigurationException("No SRV records available for host " + resourceName);
             }
             for (SrvRecord srvRecord : srvRecords) {
                 String resolvedHost = srvRecord.target().endsWith(".")


### PR DESCRIPTION
Also update mongo-crypt to work with this version of Mongo and
update the substitutions to support the new API.

Bumps `mongo-client.version` from 4.3.4 to 4.6.1.

Updates `mongodb-driver-sync` from 4.3.4 to 4.6.1
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.1)

Updates `mongodb-driver-core` from 4.3.4 to 4.6.1
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.1)

Updates `mongodb-driver-legacy` from 4.3.4 to 4.6.1
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.1)

Updates `mongodb-driver-reactivestreams` from 4.3.4 to 4.6.1
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.1)

Updates `bson` from 4.3.4 to 4.6.1
- [Release notes](https://github.com/mongodb/mongo-java-driver/releases)
- [Commits](https://github.com/mongodb/mongo-java-driver/compare/r4.3.4...r4.6.1)

---
updated-dependencies:
- dependency-name: org.mongodb:mongodb-driver-sync
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-legacy
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:mongodb-driver-reactivestreams
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mongodb:bson
  dependency-type: direct:production
  update-type: version-update:semver-minor
...
