### PR TITLE
Upgrade Kotlin to v1.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -144,7 +144,7 @@
         <aws-lambda-java-events.version>3.11.0</aws-lambda-java-events.version>
         <aws-xray.version>2.11.2</aws-xray.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.6.21</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <kotlin.coroutine.version>1.6.2</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.3</kotlin-serialization.version>
         <kubernetes-client.version>5.12.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.6.21</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <dokka.version>1.6.21</dokka.version>
         <scala.version>2.13.8</scala.version>
         <scala-maven-plugin.version>4.6.2</scala-maven-plugin.version>

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.6.21</version>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -43,7 +43,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.6.0</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <scala.version>2.12.13</scala.version>
         <scala-plugin.version>4.4.0</scala-plugin.version>
 


### PR DESCRIPTION
This should be one of the most impactful updates for Quarkus Kotlin users

The speedups to compile times range from 50-200% and include better incremental compilation support.