### PR TITLE
Automatically set the default min log level for the relevant category when setting quarkus.hibernate-orm.log.bind-parameters to true

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryBuildItem.java
@@ -12,6 +12,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class LogCategoryBuildItem extends MultiBuildItem {
     private final String category;
     private final Level level;
+    private final boolean setMinLevelDefault;
 
     /**
      * Construct a new instance.
@@ -20,11 +21,22 @@ public final class LogCategoryBuildItem extends MultiBuildItem {
      * @param level the level (must not be {@code null})
      */
     public LogCategoryBuildItem(final String category, final Level level) {
+        this(category, level, false);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param category the category (must not be {@code null} or empty)
+     * @param level the level (must not be {@code null})
+     */
+    public LogCategoryBuildItem(final String category, final Level level, boolean setMinLevelDefault) {
         Assert.checkNotNullParam("category", category);
         Assert.checkNotEmptyParam("category", category);
         Assert.checkNotNullParam("level", level);
         this.category = category;
         this.level = level;
+        this.setMinLevelDefault = setMinLevelDefault;
     }
 
     /**
@@ -43,5 +55,12 @@ public final class LogCategoryBuildItem extends MultiBuildItem {
      */
     public Level getLevel() {
         return level;
+    }
+
+    /**
+     * @return {@code true} if the default min-level for the category should also be set.
+     */
+    public boolean isSetMinLevelDefault() {
+        return setMinLevelDefault;
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryMinLevelDefaultsBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/LogCategoryMinLevelDefaultsBuildItem.java
@@ -1,0 +1,17 @@
+package io.quarkus.deployment.builditem;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.runtime.logging.InheritableLevel;
+
+public final class LogCategoryMinLevelDefaultsBuildItem extends SimpleBuildItem {
+
+    public final Map<String, InheritableLevel> content;
+
+    public LogCategoryMinLevelDefaultsBuildItem(Map<String, InheritableLevel> content) {
+        this.content = Collections.unmodifiableMap(content);
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/InheritableLevel.java
@@ -6,6 +6,8 @@ import java.util.logging.Level;
 
 import org.jboss.logmanager.LogContext;
 
+import io.quarkus.runtime.ObjectSubstitution;
+
 /**
  * A level that may be inheritable.
  */
@@ -17,8 +19,12 @@ public abstract class InheritableLevel {
         if (str.equalsIgnoreCase("inherit")) {
             return Inherited.INSTANCE;
         } else {
-            return new ActualLevel(LogContext.getLogContext().getLevelForName(str.toUpperCase(Locale.ROOT)));
+            return of(LogContext.getLogContext().getLevelForName(str.toUpperCase(Locale.ROOT)));
         }
+    }
+
+    public static InheritableLevel of(Level level) {
+        return new ActualLevel(level);
     }
 
     public abstract boolean isInherited();
@@ -35,7 +41,7 @@ public abstract class InheritableLevel {
 
     public abstract int hashCode();
 
-    static final class ActualLevel extends InheritableLevel {
+    public static final class ActualLevel extends InheritableLevel {
         final Level level;
 
         ActualLevel(Level level) {
@@ -63,7 +69,7 @@ public abstract class InheritableLevel {
         }
     }
 
-    static final class Inherited extends InheritableLevel {
+    public static final class Inherited extends InheritableLevel {
         static final Inherited INSTANCE = new Inherited();
 
         private Inherited() {
@@ -87,6 +93,19 @@ public abstract class InheritableLevel {
 
         public int hashCode() {
             return 0;
+        }
+    }
+
+    public static class Substitution implements ObjectSubstitution<InheritableLevel, String> {
+
+        @Override
+        public String serialize(InheritableLevel obj) {
+            return obj.toString();
+        }
+
+        @Override
+        public InheritableLevel deserialize(String obj) {
+            return InheritableLevel.of(obj);
         }
     }
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -863,7 +863,7 @@ public final class HibernateOrmProcessor {
     public void produceLoggingCategories(HibernateOrmConfig hibernateOrmConfig,
             BuildProducer<LogCategoryBuildItem> categories) {
         if (hibernateOrmConfig.log.bindParam || hibernateOrmConfig.log.bindParameters) {
-            categories.produce(new LogCategoryBuildItem("org.hibernate.type.descriptor.sql.BasicBinder", Level.TRACE));
+            categories.produce(new LogCategoryBuildItem("org.hibernate.type.descriptor.sql.BasicBinder", Level.TRACE, true));
         }
     }
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogBindParametersDefaultValueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogBindParametersDefaultValueTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.orm.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LogBindParametersDefaultValueTest {
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class))
+            .withConfigurationResource("application.properties")
+            // Expect no trace
+            .setLogRecordPredicate(record -> record.getMessage().contains("binding parameter"))
+            .assertLogRecords(records -> assertThat(records).isEmpty());
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    @Transactional
+    public void testFormattedValue() {
+        em.persist(new MyEntity("SomeName"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogBindParametersTrueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogBindParametersTrueTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.MyEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LogBindParametersTrueTest {
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyEntity.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.log.bind-parameters", "true")
+            // Expect a trace
+            .setLogRecordPredicate(record -> record.getMessage().contains("binding parameter"))
+            .assertLogRecords(records -> assertThat(records)
+                    .hasSize(2)
+                    .anySatisfy(record -> {
+                        assertThat(record.getLevel().getName()).isEqualTo("TRACE");
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains("SomeName");
+                    }));
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    @Transactional
+    public void testFormattedValue() {
+        em.persist(new MyEntity("SomeName"));
+    }
+
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogSqlFormatSqlDefaultValueTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogSqlFormatSqlDefaultValueTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.logsql;
+package io.quarkus.hibernate.orm.log;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogSqlFormatSqlFalseTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/log/LogSqlFormatSqlFalseTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.logsql;
+package io.quarkus.hibernate.orm.log;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 


### PR DESCRIPTION
Fixes #16885

Without this patch, whenever someone sets `quarkus.hibernate-orm.log.bind-parameters` to `true` but forgets to update the min-level for the corresponding log category, they get this warning:

```
2022-06-13 18:06:00,838 WARN  [io.qua.run.log.LoggingSetupRecorder] (main) Log level TRACE for category 'org.hibernate.type.descriptor.sql.BasicBinder' set below minimum logging level DEBUG, promoting it to DEBUG
```

... and no logs at all for bound parameters, which is quite confusing.

Regarding the implementation: I chose to apply the fix anytime someone sends a `LogCategoryBuildItem`, because... why would anyone want to lower the log level for a category below the min-level, and trigger warnings on startup as a result?