### PR TITLE
Make RESTEasy Reactive path matching more spec compliant

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/stork/StorkResponseTimeLoadBalancerTest.java
@@ -34,7 +34,7 @@ public class StorkResponseTimeLoadBalancerTest {
     @BeforeAll
     public static void setUp() {
         server = new WireMockServer(options().port(8766));
-        server.stubFor(WireMock.post("/hello/")
+        server.stubFor(WireMock.post("/hello")
                 .willReturn(aResponse().withFixedDelay(1000)
                         .withBody(SLOW_RESPONSE).withStatus(200)));
         server.start();

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/EndpointIndexer.java
@@ -391,6 +391,9 @@ public abstract class EndpointIndexer<T extends EndpointIndexer<T, PARAM, METHOD
                         if (!methodPath.startsWith("/")) {
                             methodPath = "/" + methodPath;
                         }
+                        if (methodPath.endsWith("/")) {
+                            methodPath = methodPath.substring(0, methodPath.length() - 1);
+                        }
                     } else {
                         methodPath = "";
                     }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/EndingSlashTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/EndingSlashTest.java
@@ -1,0 +1,52 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class EndingSlashTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestResource.class);
+                }
+            });
+
+    @Test
+    public void test() {
+        get("/hello/world")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World!"));
+
+        get("/hello/world/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello World!"));
+    }
+
+    @Path("/hello")
+    public static class TestResource {
+
+        @GET
+        @Path("/world/")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String test() {
+            return "Hello World!";
+        }
+    }
+}


### PR DESCRIPTION
RESTEasy Classic already behaves properly, so we should follow this patterns

Fixes: #26016