### PR TITLE
Bump kubernetes-client-bom from 5.12.2 to 6.1.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -151,8 +151,8 @@
         <kotlin.version>1.7.10</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.0</kotlin-serialization.version>
-        <kubernetes-client.version>5.12.3</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
-        <dekorate.version>2.11.2</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.1.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.0.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.0.10</jboss-logmanager.version>

--- a/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
+++ b/extensions/kubernetes-client/deployment/src/main/java/io/quarkus/kubernetes/client/deployment/KubernetesClientProcessor.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import io.fabric8.kubernetes.client.http.HttpClient;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -32,6 +33,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeReinitializedClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.jackson.deployment.IgnoreJsonDeserializeClassBuildItem;
 import io.quarkus.kubernetes.client.runtime.KubernetesClientBuildConfig;
@@ -85,7 +87,8 @@ public class KubernetesClientProcessor {
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchies,
             BuildProducer<IgnoreJsonDeserializeClassBuildItem> ignoredJsonDeserializationClasses,
-            BuildProducer<KubernetesRoleBindingBuildItem> roleBindingProducer) {
+            BuildProducer<KubernetesRoleBindingBuildItem> roleBindingProducer,
+            BuildProducer<ServiceProviderBuildItem> serviceProviderProducer) {
 
         featureProducer.produce(new FeatureBuildItem(Feature.KUBERNETES_CLIENT));
         if (kubernetesClientConfig.generateRbac) {
@@ -201,6 +204,9 @@ public class KubernetesClientProcessor {
             log.debugv("Model Classes:\n{0}", String.join("\n", modelClasses));
         }
 
+        // Register the default HttpClient implementation
+        serviceProviderProducer.produce(new ServiceProviderBuildItem(
+                HttpClient.Factory.class.getName(), "io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory"));
         // Enable SSL support by default
         sslNativeSupport.produce(new ExtensionSslNativeSupportBuildItem(Feature.KUBERNETES_CLIENT));
     }

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/CustomKubernetesTestServerTestResource.java
@@ -11,42 +11,52 @@ public class CustomKubernetesTestServerTestResource extends KubernetesServerTest
     // setup the ConfigMap objects that the application expects to lookup configuration from
     @Override
     protected void configureServer() {
-        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap1")
-                .addToData("dummy", "dummy")
-                .addToData("overridden.secret", "cm") // will be overridden since secrets have a higher priority
-                .addToData("some.prop1", "val1")
-                .addToData("some.prop2", "val2")
-                .addToData("some.prop4", "v4") // will be overridden since cmap2 has a higher priority
-                .addToData("some.prop5", "val5")
-                .addToData("application.properties", "some.prop3=val3")
-                .addToData("application.yaml", "some:\n  prop4: val4").build());
+        getClient().inNamespace("test").configMaps()
+                .resource(configMapBuilder("cmap1")
+                        .addToData("dummy", "dummy")
+                        .addToData("overridden.secret", "cm") // will be overridden since secrets have a higher priority
+                        .addToData("some.prop1", "val1")
+                        .addToData("some.prop2", "val2")
+                        .addToData("some.prop4", "v4") // will be overridden since cmap2 has a higher priority
+                        .addToData("some.prop5", "val5")
+                        .addToData("application.properties", "some.prop3=val3")
+                        .addToData("application.yaml", "some:\n  prop4: val4").build())
+                .create();
 
-        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap2")
-                .addToData("application.yaml", "some:\n  prop4: val4").build());
+        server.getClient().inNamespace("test").configMaps()
+                .resource(configMapBuilder("cmap2")
+                        .addToData("application.yaml", "some:\n  prop4: val4").build())
+                .create();
 
-        server.getClient().inNamespace("test").configMaps().create(configMapBuilder("cmap3")
-                .addToData("dummy", "dummyFromDemo")
-                .addToData("some.prop1", "val1FromDemo")
-                .addToData("some.prop2", "val2FromDemo")
-                .addToData("some.prop5", "val5FromDemo")
-                .addToData("application.properties", "some.prop3=val3FromDemo")
-                .addToData("application.yaml", "some:\n  prop4: val4FromDemo").build());
+        server.getClient().inNamespace("test").configMaps()
+                .resource(configMapBuilder("cmap3")
+                        .addToData("dummy", "dummyFromDemo")
+                        .addToData("some.prop1", "val1FromDemo")
+                        .addToData("some.prop2", "val2FromDemo")
+                        .addToData("some.prop5", "val5FromDemo")
+                        .addToData("application.properties", "some.prop3=val3FromDemo")
+                        .addToData("application.yaml", "some:\n  prop4: val4FromDemo").build())
+                .create();
 
-        server.getClient().inNamespace("test").secrets().create(secretBuilder("s1")
-                .addToData("dummysecret", encodeValue("dummysecret"))
-                .addToData("overridden.secret", encodeValue("secret"))
-                .addToData("secret.prop1", encodeValue("val1"))
-                .addToData("secret.prop2", encodeValue("val2"))
-                .addToData("application.properties", encodeValue("secret.prop3=val3"))
-                .addToData("application.yaml", encodeValue("secret:\n  prop4: val4")).build());
+        server.getClient().inNamespace("test").secrets()
+                .resource(secretBuilder("s1")
+                        .addToData("dummysecret", encodeValue("dummysecret"))
+                        .addToData("overridden.secret", encodeValue("secret"))
+                        .addToData("secret.prop1", encodeValue("val1"))
+                        .addToData("secret.prop2", encodeValue("val2"))
+                        .addToData("application.properties", encodeValue("secret.prop3=val3"))
+                        .addToData("application.yaml", encodeValue("secret:\n  prop4: val4")).build())
+                .create();
 
-        server.getClient().inNamespace("test").secrets().createOrReplace(secretBuilder("s1")
-                .addToData("dummysecret", encodeValue("dummysecretFromDemo"))
-                .addToData("overridden.secret", encodeValue("secretFromDemo"))
-                .addToData("secret.prop1", encodeValue("val1FromDemo"))
-                .addToData("secret.prop2", encodeValue("val2FromDemo"))
-                .addToData("application.properties", encodeValue("secret.prop3=val3FromDemo"))
-                .addToData("application.yaml", encodeValue("secret:\n  prop4: val4FromDemo")).build());
+        server.getClient().inNamespace("test").secrets()
+                .resource(secretBuilder("s1")
+                        .addToData("dummysecret", encodeValue("dummysecretFromDemo"))
+                        .addToData("overridden.secret", encodeValue("secretFromDemo"))
+                        .addToData("secret.prop1", encodeValue("val1FromDemo"))
+                        .addToData("secret.prop2", encodeValue("val2FromDemo"))
+                        .addToData("application.properties", encodeValue("secret.prop3=val3FromDemo"))
+                        .addToData("application.yaml", encodeValue("secret:\n  prop4: val4FromDemo")).build())
+                .createOrReplace();
     }
 
     private ConfigMapBuilder configMapBuilder(String name) {

--- a/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
+++ b/integration-tests/kubernetes-client/src/test/java/io/quarkus/it/kubernetes/client/KubernetesClientTest.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.interfaces.ECPrivateKey;
+import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
@@ -96,7 +97,8 @@ public class KubernetesClientTest {
                 .times(2);
 
         mockServer.expect().delete().withPath("/api/v1/namespaces/test/pods/pod1")
-                .andReturn(200, "{}")
+                .andReturn(200, new PodBuilder(pod1)
+                        .editMetadata().withDeletionTimestamp(Instant.now().toString()).endMetadata().build())
                 .once();
 
         // PUT on /pod/test will createOrReplace, which attempts a POST first, then a PUT if receiving a 409

--- a/test-framework/kubernetes-client/pom.xml
+++ b/test-framework/kubernetes-client/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-server-mock</artifactId>
+            <artifactId>kubernetes-client-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>javax.annotation</groupId>
@@ -38,10 +38,14 @@
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
                 <exclusion>
-                  <groupId>io.sundr</groupId>
-                  <artifactId>*</artifactId>
+                    <groupId>io.sundr</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/AbstractKubernetesTestResource.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -26,9 +25,7 @@ public abstract class AbstractKubernetesTestResource<T, C extends KubernetesClie
         server = createServer();
         initServer();
 
-        try (GenericKubernetesClient<?> client = getClient()) {
-            systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, client.getConfiguration().getMasterUrl());
-        }
+        systemProps.put(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, getClient().getConfiguration().getMasterUrl());
 
         configureServer();
         //these actually need to be system properties
@@ -40,7 +37,7 @@ public abstract class AbstractKubernetesTestResource<T, C extends KubernetesClie
         return systemProps;
     }
 
-    protected abstract GenericKubernetesClient<C> getClient();
+    protected abstract C getClient();
 
     /**
      * Can be used by subclasses in order to

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesMockServerTestResource.java
@@ -2,7 +2,6 @@ package io.quarkus.test.kubernetes.client;
 
 import java.lang.annotation.Annotation;
 
-import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 
@@ -14,7 +13,7 @@ public class KubernetesMockServerTestResource
         extends AbstractKubernetesTestResource<KubernetesMockServer, NamespacedKubernetesClient> {
 
     @Override
-    protected GenericKubernetesClient<NamespacedKubernetesClient> getClient() {
+    protected NamespacedKubernetesClient getClient() {
         return server.createClient();
     }
 

--- a/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
+++ b/test-framework/kubernetes-client/src/main/java/io/quarkus/test/kubernetes/client/KubernetesServerTestResource.java
@@ -6,7 +6,6 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.function.Consumer;
 
-import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
@@ -32,7 +31,7 @@ public class KubernetesServerTestResource extends AbstractKubernetesTestResource
     }
 
     @Override
-    protected GenericKubernetesClient<NamespacedKubernetesClient> getClient() {
+    protected NamespacedKubernetesClient getClient() {
         return server.getClient();
     }
 

--- a/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftServerTestResource.java
+++ b/test-framework/openshift-client/src/main/java/io/quarkus/test/kubernetes/client/OpenShiftServerTestResource.java
@@ -3,7 +3,6 @@ package io.quarkus.test.kubernetes.client;
 import java.lang.annotation.Annotation;
 import java.util.function.Consumer;
 
-import io.fabric8.kubernetes.client.GenericKubernetesClient;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
@@ -27,7 +26,7 @@ public class OpenShiftServerTestResource extends AbstractKubernetesTestResource<
     }
 
     @Override
-    protected GenericKubernetesClient<NamespacedOpenShiftClient> getClient() {
+    protected NamespacedOpenShiftClient getClient() {
         return server.getOpenshiftClient();
     }
 


### PR DESCRIPTION
Kubernetes Client 6.1.1 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.1.1

Major versions of the Client (transitive dependencies) must be aligned, in consequence, this PR also updates Dekorate dependency to [`3.0.0`](https://github.com/dekorateio/dekorate/releases/tag/3.0.0).


/cc @metacosm
