### PR TITLE
Add kotlin-bom to quarkus-bom and document Kotlin version

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -388,6 +388,15 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- Kotlin BOM -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Kotlin Coroutines BOM -->
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
@@ -5071,36 +5080,6 @@
                 <version>${smallrye-reactive-types-converter.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-compiler</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk7</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-reflect</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-serialization-json</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2860,6 +2860,7 @@
                         <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
 
                         <jandex-maven-plugin-version>${jandex-maven-plugin.version}</jandex-maven-plugin-version>
+                        <kotlin-version>${kotlin.version}</kotlin-version>
 
                         <grpc-version>${grpc.version}</grpc-version>
                         <protoc-version>${protoc.version}</protoc-version>

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -36,12 +36,13 @@ First, we need a new Kotlin project. This can be done using the following comman
 include::{includes}/devtools/create-app.adoc[]
 
 When adding `kotlin` to the extensions list, the Maven plugin will generate a project that is properly
-configured to work with Kotlin. Furthermore,  the `org.acme.ReactiveGreetingResource` class is implemented as Kotlin source code (as is the case with the generated tests).
+configured to work with Kotlin. Furthermore, the `org.acme.ReactiveGreetingResource` class is implemented as Kotlin source code (as is the case with the generated tests).
 The addition of `resteasy-reactive-jackson` in the extension list results in importing the RESTEasy Reactive and Jackson extensions.
 
-`ReactiveGreetingResource.kt` looks like this:
+`ReactiveGreetingResource` looks like this:
 
 [source,kotlin]
+.ReactiveGreetingResource.kt
 ----
 package org.acme
 
@@ -61,16 +62,17 @@ class ReactiveGreetingResource {
 
 === Update code
 
-In order to show a more practical example of Kotlin usage we will add a simple link:https://kotlinlang.org/docs/reference/data-classes.html[data class] called `Greeting.kt` like so:
+In order to show a more practical example of Kotlin usage we will add a simple link:https://kotlinlang.org/docs/reference/data-classes.html[data class] called `Greeting` like so:
 
 [source,kotlin]
+.Greeting.kt
 ----
 package org.acme.rest
 
 data class Greeting(val message: String = "")
 ----
 
-We also update the `ReactiveGreetingResource.kt` like so:
+We also update the `ReactiveGreetingResource` class like so:
 
 [source,kotlin]
 ----
@@ -88,7 +90,7 @@ class GreetingResource {
 
 With these changes in place the `/hello` endpoint will reply with a JSON object instead of a simple String.
 
-To make the test pass, we also need to update `ReactiveGreetingResourceTest.kt` like so:
+To make the test pass, we also need to update `ReactiveGreetingResourceTest` like so:
 
 [source,kotlin]
 ----
@@ -109,6 +111,14 @@ class ReactiveGreetingResourceTest {
 }
 ----
 
+== Kotlin version
+
+The Quarkus Kotlin extension already declares a dependency on some base Kotlin libraries like `kotlin-stdlib-jdk8` and `kotlin-reflect`. The Kotlin version of these dependencies is declared in the Quarkus BOM and is currently at {kotlin-version}. It is therefore recommended to use the same Kotlin version for other Kotlin libraries. When adding a dependency to another base Kotlin library (e.g. `kotlin-test-junit5`) you don't need to specify the version, since the Quarkus BOM includes the link:https://search.maven.org/artifact/org.jetbrains.kotlin/kotlin-bom[Kotlin BOM].
+
+This being said, you still need to specify the version of the Kotlin compiler to use. Again, it is recommended to use the same version which Quarkus uses for the Kotlin libraries.
+
+WARNING: Using a different Kotlin version in a Quarkus application is typically not recommended. But in order to do so, you must import the Kotlin BOM *before* the Quarkus BOM.
+
 == Important Maven configuration points
 
 The generated `pom.xml` contains the following modifications compared to its counterpart when Kotlin is not selected:
@@ -119,6 +129,7 @@ The generated `pom.xml` contains the following modifications compared to its cou
 * The `kotlin-maven-plugin` is configured as follows:
 
 [source,xml]
+.pom.xml
 ----
 <plugin>
     <artifactId>kotlin-maven-plugin</artifactId>
@@ -140,7 +151,7 @@ The generated `pom.xml` contains the following modifications compared to its cou
     </executions>
     <configuration>
         <compilerPlugins>
-            <plugin>all-open</plugin>
+            <plugin>all-open</plugin> <1>
         </compilerPlugins>
 
         <pluginOptions>
@@ -158,6 +169,7 @@ The generated `pom.xml` contains the following modifications compared to its cou
     </dependencies>
 </plugin>
 ----
+<1> Enables the `all-open` annotation plugin (see discussion below)
 
 The important thing to note is the use of the https://kotlinlang.org/docs/reference/compiler-plugins.html#all-open-compiler-plugin[all-open] Kotlin compiler plugin.
 In order to understand why this plugin is needed, first we need to note that by default all the classes generated from the Kotlin compiler are marked as `final`.
@@ -167,7 +179,7 @@ Having `final` classes however does not work well with various frameworks that n
 Thus, the `all-open` Kotlin compiler plugin allows us to configure the compiler to *not* mark as `final` classes that have certain annotations. In the snippet above,
 we have specified that classes annotated with `javax.ws.rs.Path` should not be `final`.
 
-If your application contains classes annotated with `javax.enterprise.context.ApplicationScoped`
+If your application contains Kotlin classes annotated with `javax.enterprise.context.ApplicationScoped`
 for example, then `<option>all-open:annotation=javax.enterprise.context.ApplicationScoped</option>` needs to be added as well. Same goes for any class that needs to have a dynamic proxy created at runtime.
 
 Future versions of Quarkus will configure the Kotlin compiler plugin in a way that will make it unnecessary to alter this configuration.


### PR DESCRIPTION
The `quarkus-bom` now includes the `org.jetbrains.kotlin:kotlin-bom` so that applications can easily add dependencies to other libraries part of that BOM (e.g. `kotlin-test-junit5`.

Additionally, the Kotlin guide now documents which version of Kotlin Quarkus.

Fixes #26093