### PR TITLE
Construct URITemplate with prefixMatch when used for sub-resource locators

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -131,7 +131,7 @@ public class RuntimeResourceDeployment {
 
     public RuntimeResource buildResourceMethod(ResourceClass clazz,
             ServerResourceMethod method, boolean locatableResource, URITemplate classPathTemplate, DeploymentInfo info) {
-        URITemplate methodPathTemplate = new URITemplate(method.getPath(), false);
+        URITemplate methodPathTemplate = new URITemplate(method.getPath(), method.isResourceLocator());
         MultivaluedMap<ScoreSystem.Category, ScoreSystem.Diagnostic> score = new QuarkusMultivaluedHashMap<>();
 
         Map<String, Integer> pathParameterIndexes = buildParamIndexMap(classPathTemplate, methodPathTemplate);


### PR DESCRIPTION
Fixes #26028 