### PR TITLE
Adjusted config for removed resources in the ExtensionDescriptorMojo to have valid XML

### DIFF
--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -87,6 +87,11 @@ import org.eclipse.aether.util.artifact.JavaScopes;
 @Mojo(name = "extension-descriptor", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
 public class ExtensionDescriptorMojo extends AbstractMojo {
 
+    public static class RemovedResources {
+        String key;
+        String resources;
+    }
+
     private static final String GROUP_ID = "group-id";
     private static final String ARTIFACT_ID = "artifact-id";
     private static final String METADATA = "metadata";
@@ -169,7 +174,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
      * but in the `META-INF/quarkus-extension.properties`.
      */
     @Parameter
-    Map<String, String> removedResources = Map.of();
+    List<RemovedResources> removedResources = List.of();
 
     /**
      * Artifacts that are always loaded parent first when running in dev or test mode. This is an advanced option
@@ -336,18 +341,18 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         }
 
         if (!removedResources.isEmpty()) {
-            for (Map.Entry<String, String> entry : removedResources.entrySet()) {
+            for (RemovedResources entry : removedResources) {
                 final ArtifactKey key;
                 try {
-                    key = ArtifactKey.fromString(entry.getKey());
+                    key = ArtifactKey.fromString(entry.key);
                 } catch (IllegalArgumentException e) {
                     throw new MojoExecutionException(
-                            "Failed to parse removed resource '" + entry.getKey() + '=' + entry.getValue() + "'", e);
+                            "Failed to parse removed resource '" + entry.key + '=' + entry.resources + "'", e);
                 }
-                if (entry.getValue() == null || entry.getValue().isBlank()) {
+                if (entry.resources == null || entry.resources.isBlank()) {
                     continue;
                 }
-                final String[] resources = entry.getValue().split(",");
+                final String[] resources = entry.resources.split(",");
                 if (resources.length == 0) {
                     continue;
                 }

--- a/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/runtime/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/extension-removed-resources/extension/runtime/pom.xml
@@ -34,7 +34,10 @@
             <configuration>
               <deployment>\${project.groupId}:\${project.artifactId}-deployment:\${project.version}</deployment>
               <removedResources>
-                <org.acme:acme-resources>META-INF/a</org.acme:acme-resources>
+                <artifact>
+                  <key>org.acme:acme-resources</key>
+                  <resources>META-INF/a</resources>
+                </artifact>
               </removedResources>
             </configuration>
           </execution>


### PR DESCRIPTION


Follow up to https://github.com/quarkusio/quarkus/pull/26025

Now it looks like
````
      <plugin>
        <groupId>io.quarkus</groupId>
        <artifactId>quarkus-extension-maven-plugin</artifactId>
        <version>${quarkus.platform.version}</version>
        <executions>
          <execution>
            <phase>compile</phase>
            <goals>
              <goal>extension-descriptor</goal>
            </goals>
            <configuration>
              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
              <removedResources>
                <artifact>
                  <key>org.acme:acme-resources</key>
                  <resources>META-INF/a</resources>
                </artifact>
              </removedResources>
            </configuration>
````