### PR TITLE
Add @ConfigItem#generateDocumentation to enable/disable generation of documentation

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoItemFinder.java
@@ -166,6 +166,7 @@ class ConfigDoItemFinder {
             String hyphenatedFieldName = hyphenate(fieldName);
             String configDocMapKey = hyphenatedFieldName;
             boolean isDeprecated = false;
+            boolean generateDocumentation = true;
             ConfigDocSection configSection = new ConfigDocSection();
             configSection.setTopLevelGrouping(rootName);
             configSection.setWithinAMap(withinAMap);
@@ -182,12 +183,12 @@ class ConfigDoItemFinder {
                     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
                             .getElementValues().entrySet()) {
                         final String key = entry.getKey().toString();
-                        final String value = entry.getValue().getValue().toString();
+                        final Object value = entry.getValue().getValue();
                         if (annotationName.equals(ANNOTATION_CONFIG_DOC_MAP_KEY) && "value()".equals(key)) {
-                            configDocMapKey = value;
+                            configDocMapKey = value.toString();
                         } else if (annotationName.equals(ANNOTATION_CONFIG_ITEM)) {
                             if ("name()".equals(key)) {
-                                switch (value) {
+                                switch (value.toString()) {
                                     case HYPHENATED_ELEMENT_NAME:
                                         name = parentName + DOT + hyphenatedFieldName;
                                         break;
@@ -198,9 +199,11 @@ class ConfigDoItemFinder {
                                         name = parentName + DOT + value;
                                 }
                             } else if ("defaultValue()".equals(key)) {
-                                defaultValue = value;
+                                defaultValue = value.toString();
                             } else if ("defaultValueDocumentation()".equals(key)) {
-                                defaultValueDoc = value;
+                                defaultValueDoc = value.toString();
+                            } else if ("generateDocumentation()".equals(key)) {
+                                generateDocumentation = (Boolean) value;
                             }
                         }
                     }
@@ -218,6 +221,9 @@ class ConfigDoItemFinder {
 
             if (isDeprecated) {
                 continue; // do not include deprecated config items
+            }
+            if (!generateDocumentation) {
+                continue; // documentation for this item was explicitly disabled
             }
 
             if (name == null) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/ConfigItem.java
@@ -61,4 +61,15 @@ public @interface ConfigItem {
      * @return the default value documentation
      */
     String defaultValueDocumentation() default "";
+
+    /**
+     * Specify whether documentation should be generated for this config item.
+     * <p>
+     * This is only useful in very niche use cases where the build-time and runtime config
+     * both contain a configuration property with the exact same name,
+     * and we only want to generate documentation from one of them.
+     *
+     * @return whether documentation should be generated
+     */
+    boolean generateDocumentation() default true;
 }


### PR DESCRIPTION
In order to address #19129, I had to introduce a configuration property in both the build config and runtime config, because the same `Map<String, String>` configuration can affect static init (when building the Hibernate ORM metadata) or runtime init (when building the Hibernate ORM session factory), depending on the keys being used. I don't want to expose two separate configuration properties because that would complicate an already complex (and unsupported) feature.

The problem is, documentation is generated for the same configuration property twice: once for the build config, and once for the runtime config. This leads to problems when rendering the asciidoc (duplicate section IDs, in particular).

My solution: annotate the build-time configuration property with `@ConfigItem(generateDocumentation = false)`, so that we generate documentation only for the runtime configuration property. It works :shrug: 