### PR TITLE
Mention coordinated omission in performance docs

### DIFF
--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -21,7 +21,7 @@ It goes without saying but it's better when you say it.
 
 When measuring performance of a framework like Quarkus the latency experience by users are especially interesting and for that there are many different tools. Unfortunately, many fail to measure the latency correctly and instead fall short and create the Coordinate Omission problem. Meaning tools fails to acoomodate for delays to submit new requests when system is under load and aggregate these numbers making the latency and throughput numbers very misleading.
 
-A good walkthrough of the issue is https://www.youtube.com/watch?v=lJ8ydIuPFeU[this video] where Gil Tene the author of wrk2 explains the issue. 
+A good walkthrough of the issue is https://www.youtube.com/watch?v=lJ8ydIuPFeU[this video] where Gil Tene the author of wrk2 explains the issue and https://www.youtube.com/watch?v=xdG8b9iDYbE[Quarkus Insights #22] have John O'Hara from Quarkus performance team show how it can show up.
 
 Although that video and related papers and articles date all back to 2015 then even today you will find tools that fall short with the coordinated oission problem
 

--- a/docs/src/main/asciidoc/performance-measure.adoc
+++ b/docs/src/main/asciidoc/performance-measure.adoc
@@ -9,12 +9,33 @@ include::./attributes.adoc[]
 
 This guide covers:
 
+* Coordinated omission Problem in Tools
 * how we measure memory usage
 * how we measure startup time
 * which additional flags will Quarkus apply to native-image by default
 
 All of our tests are run on the same hardware for a given batch.
 It goes without saying but it's better when you say it.
+
+== Coordinated Omission Problem in Tools
+
+When measuring performance of a framework like Quarkus the latency experience by users are especially interesting and for that there are many different tools. Unfortunately, many fail to measure the latency correctly and instead fall short and create the Coordinate Omission problem. Meaning tools fails to acoomodate for delays to submit new requests when system is under load and aggregate these numbers making the latency and throughput numbers very misleading.
+
+A good walkthrough of the issue is https://www.youtube.com/watch?v=lJ8ydIuPFeU[this video] where Gil Tene the author of wrk2 explains the issue. 
+
+Although that video and related papers and articles date all back to 2015 then even today you will find tools that fall short with the coordinated oission problem
+
+Tools that at current time of writing is known to excert the problem and should NOT be used for measuring latency/throughput (it may be used for other things):
+
+ * JMeter
+ * wrk
+
+Tools that are known to not be affected are:
+
+ * https://github.com/giltene/wrk2[wrk2]
+ * https://hyperfoil.io[HyperFoil]
+
+Mind you, the tools are not better than your own understanding of what they measure thus even when using `wrk2` or `hyperfoil` make sure you understand what the numbers mean.
 
 == How do we measure memory usage
 


### PR DESCRIPTION
trying to explain to users that when doing performance measurements be aware of coordinated ommision in various tools but noticed we did not mention it in our own performance guide.

here is a suggestion on a way we could inform/educate. feedback welcome!