### PR TITLE
Fix missing UdsNettyChannelProvider<init> in native mode

### DIFF
--- a/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcSubstitutions.java
+++ b/extensions/grpc-common/runtime/src/main/java/io/quarkus/grpc/common/runtime/graal/GrpcSubstitutions.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ServiceConfigurationError;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
@@ -14,6 +15,23 @@ import com.oracle.svm.core.annotate.TargetClass;
 @SuppressWarnings("unused")
 @TargetClass(className = "io.grpc.ServiceProviders")
 final class Target_io_grpc_ServiceProviders { // NOSONAR
+
+    @Substitute
+    static boolean isAndroid(ClassLoader cl) {
+        return false;
+    }
+
+    @Substitute
+    private static <T> T createForHardCoded(Class<T> klass, Class<?> rawClass) {
+        try {
+            return rawClass.asSubclass(klass).getConstructor().newInstance();
+        } catch (NoSuchMethodException | ClassCastException e) {
+            return null;
+        } catch (Throwable t) {
+            throw new ServiceConfigurationError(
+                    String.format("Provider %s could not be instantiated %s", rawClass.getName(), t), t);
+        }
+    }
 
     @Substitute
     public static <T> List<T> loadAll(


### PR DESCRIPTION
PR #26047 updated gRPC to 1.47.0.
However, gRPC is also used from OpenTelemetry, and the execution paths are slightly different, and #26047 did not cover that path.
As a result, gRPC tried to create an instance from a class in which the constructor has been eliminated by gRPC (on purpose, we have ensured it gets eliminated), so fail to create the instance.

This PR extends the checks when creating the instance to check for class issues and missing constructors.

Fix #26083