### PR TITLE
Use mavenLocal() *first* for repositories in Gradle integration tests

### DIFF
--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -1,11 +1,7 @@
 buildscript {
 
     repositories {
-        if (System.getProperties().containsKey("maven.repo.local")) {
-            maven(url = System.getProperties().get("maven.repo.local")!!)
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -38,11 +34,7 @@ subprojects {
     }
 
     repositories {
-        if (System.getProperties().containsKey("maven.repo.local")) {
-            maven(url = System.getProperties().get("maven.repo.local")!!)
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -1,7 +1,11 @@
 buildscript {
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -34,7 +38,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/settings.gradle.kts
@@ -1,11 +1,7 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        if (System.getProperties().containsKey("maven.repo.local")) {
-            maven(url = System.getProperties().get("maven.repo.local")!!)
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/settings.gradle.kts
@@ -1,7 +1,11 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
@@ -1,7 +1,11 @@
 buildscript {
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -30,7 +34,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
@@ -1,13 +1,7 @@
 buildscript {
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -36,13 +30,7 @@ subprojects {
     }
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
@@ -4,11 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.getProperties().containsKey("maven.repo.local")) {
-        maven(url = System.getProperties().get("maven.repo.local")!!)
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex("io.quarkus.*")
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/settings.gradle.kts
@@ -1,11 +1,7 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        if (System.getProperties().containsKey("maven.repo.local")) {
-            maven(url = System.getProperties().get("maven.repo.local")!!)
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/settings.gradle.kts
@@ -1,7 +1,11 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
@@ -1,12 +1,6 @@
 buildscript {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -29,13 +23,7 @@ subprojects {
     }
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
@@ -13,13 +13,7 @@ test {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
@@ -13,7 +13,11 @@ test {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
@@ -13,7 +13,6 @@ test {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -21,6 +20,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/avro-simple-project/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/main/resources/avro-simple-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/avro-simple-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/avro-simple-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/avro-simple-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
@@ -5,13 +5,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }
@@ -12,7 +16,11 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/build.gradle
@@ -1,12 +1,6 @@
 buildscript {
      repositories {
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }
@@ -18,13 +12,7 @@ allprojects {
 
 subprojects{
      repositories {
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/library/build.gradle
@@ -3,7 +3,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/library/build.gradle
@@ -3,13 +3,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
@@ -18,7 +18,6 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenCentral()
           if (System.properties.containsKey('maven.repo.local')) {
                maven {
                     url System.properties.get('maven.repo.local')
@@ -26,5 +25,6 @@ subprojects{
           } else {
                mavenLocal()
           }
+          mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }
@@ -12,7 +16,11 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
@@ -1,12 +1,6 @@
 buildscript {
      repositories {
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }
@@ -18,13 +12,7 @@ allprojects {
 
 subprojects{
      repositories {
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/platform/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/platform/build.gradle
@@ -3,7 +3,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/platform/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/platform/build.gradle
@@ -3,13 +3,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -26,7 +30,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
@@ -1,12 +1,6 @@
 buildscript {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -32,13 +26,7 @@ subprojects {
     }
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
@@ -1,12 +1,6 @@
 buildscript {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -29,13 +23,7 @@ subprojects {
     }
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -6,13 +6,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -14,6 +13,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -6,7 +6,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
                 url System.properties.get('maven.repo.local')
@@ -9,6 +7,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
     plugins {
         id 'io.quarkus' version "${quarkusPluginVersion}"

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
@@ -3,13 +3,7 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
@@ -3,7 +3,11 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
@@ -5,7 +5,11 @@ plugins {
 
 repositories {
     mavenCentral()
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -9,6 +8,7 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
         gradlePluginPortal()
     }
     plugins {

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
@@ -13,6 +12,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -9,6 +8,7 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
         gradlePluginPortal()
     }
     plugins {

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/build.gradle
@@ -5,6 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/build.gradle
@@ -5,13 +5,6 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
@@ -7,7 +7,6 @@ allprojects {
 
 
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -16,5 +15,6 @@ allprojects {
         } else {
             mavenLocal()
         }
+        mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
@@ -7,7 +7,12 @@ allprojects {
 
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/build.gradle
@@ -7,14 +7,7 @@ allprojects {
 
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-a/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
@@ -7,14 +7,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/build.gradle
@@ -7,7 +7,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-b/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-c/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
@@ -5,7 +5,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/build.gradle
@@ -5,14 +5,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-d/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
@@ -5,7 +5,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/build.gradle
@@ -5,14 +5,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-e/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-f/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-g/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-h/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-i/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-j/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-k/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-l/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-m/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-n/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-o/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-p/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-r/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-s/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-t/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
@@ -6,7 +6,12 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroup 'org.acme' // for dependencies built in this test
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/build.gradle
@@ -6,14 +6,7 @@ allprojects {
     apply plugin: 'maven-publish'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/ext-u/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
@@ -13,6 +12,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -10,6 +8,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/simple-dependency/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
@@ -13,6 +12,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 publishing {

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -10,6 +8,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-dependencies/transitive-dependency/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
@@ -4,6 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
@@ -4,13 +4,6 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -12,6 +11,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-exclude/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -12,6 +11,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner-with-explicit-import/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -12,6 +11,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/runner/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/runner/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -12,6 +11,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
@@ -4,7 +4,12 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroup 'org.acme' // for dependencies built in this test
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/scenario-two/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
@@ -7,7 +7,6 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -15,6 +14,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
@@ -7,7 +7,11 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
@@ -7,13 +7,7 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
@@ -1,14 +1,7 @@
 buildscript {
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -32,14 +25,7 @@ subprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
@@ -1,7 +1,11 @@
 buildscript {
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -25,7 +29,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
@@ -7,7 +7,6 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -15,6 +14,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
@@ -7,7 +7,11 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
@@ -7,13 +7,7 @@ group = 'com.quarkus.demo'
 version = '1.0'
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
@@ -3,14 +3,7 @@ subprojects {
 
     version '0.0.1-SNAPSHOT'
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
@@ -3,7 +3,6 @@ subprojects {
 
     version '0.0.1-SNAPSHOT'
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -12,5 +11,6 @@ subprojects {
         } else {
             mavenLocal()
         }
+        mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
@@ -3,7 +3,11 @@ subprojects {
 
     version '0.0.1-SNAPSHOT'
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
     gradlePluginPortal()
 }

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/grpc-include-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-include-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -30,14 +23,7 @@ subprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
@@ -30,7 +30,6 @@ subprojects {
     }
 
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -39,6 +38,7 @@ subprojects {
         } else {
             mavenLocal()
         }
+        mavenCentral()
     }
 
     dependencies {

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
+++ b/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -30,14 +23,7 @@ subprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
+++ b/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/implementation-files/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/implementation-files/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/implementation-files/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/implementation-files/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
      repositories {
-          // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }
@@ -19,14 +12,7 @@ allprojects {
 
 subprojects{
      repositories {
-          // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-          if (System.properties.containsKey('maven.repo.local')) {
-               maven {
-                    url System.properties.get('maven.repo.local')
-               }
-          } else {
-               mavenLocal()
-          }
+          mavenLocal()
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }
@@ -12,7 +16,11 @@ allprojects {
 
 subprojects{
      repositories {
-          mavenLocal()
+          mavenLocal {
+              content {
+                  includeGroupByRegex 'io.quarkus.*'
+              }
+          }
           mavenCentral()
      }
 }

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/library/build.gradle
@@ -3,7 +3,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/library/build.gradle
@@ -3,14 +3,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -30,14 +23,7 @@ subprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -5,14 +5,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
@@ -14,6 +13,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -10,6 +8,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
     plugins {
         id 'io.quarkus' version "${quarkusPluginVersion}"

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -12,6 +11,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
@@ -4,13 +4,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -11,6 +10,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
@@ -3,7 +3,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
@@ -3,13 +3,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
                 url System.properties.get('maven.repo.local')
@@ -9,6 +7,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
     plugins {
         id 'io.quarkus' version "${quarkusPluginVersion}"

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
@@ -25,7 +25,11 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
@@ -25,14 +25,7 @@ allprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/build.gradle
@@ -25,7 +25,6 @@ allprojects {
     }
 
     repositories {
-        mavenCentral()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -34,6 +33,7 @@ allprojects {
         } else {
             mavenLocal()
         }
+        mavenCentral()
     }
 
     dependencies {

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -10,6 +8,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
     plugins {
       id 'io.quarkus' version "${quarkusPluginVersion}"

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
@@ -2,14 +2,7 @@ plugins {
 }
 
 repositories {
-     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-     if (System.properties.containsKey('maven.repo.local')) {
-          maven {
-               url System.properties.get('maven.repo.local')
-          }
-     } else {
-          mavenLocal()
-     }
+     mavenLocal()
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
@@ -2,7 +2,11 @@ plugins {
 }
 
 repositories {
-     mavenLocal()
+     mavenLocal {
+         content {
+             includeGroupByRegex 'io.quarkus.*'
+         }
+     }
      mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
@@ -3,7 +3,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/common/build.gradle
@@ -3,14 +3,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
@@ -8,14 +8,7 @@ subprojects {
     version = '1.0.0-SNAPSHOT'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
@@ -8,7 +8,11 @@ subprojects {
     version = '1.0.0-SNAPSHOT'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/build.gradle.kts
@@ -9,11 +9,7 @@ allprojects {
   version = "1.0.0-SNAPSHOT"
 
   repositories {
-    if (System.getProperties().containsKey("maven.repo.local")) {
-      maven(url = System.getProperties().get("maven.repo.local")!!)
-    } else {
-      mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
   }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/build.gradle.kts
@@ -9,7 +9,11 @@ allprojects {
   version = "1.0.0-SNAPSHOT"
 
   repositories {
-    mavenLocal()
+    mavenLocal {
+      content {
+        includeGroupByRegex("io.quarkus.*")
+      }
+    }
     mavenCentral()
   }
 

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/settings.gradle.kts
@@ -1,11 +1,7 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        if (System.getProperties().containsKey("maven.repo.local")) {
-            maven(url = System.getProperties().get("maven.repo.local")!!)
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/settings.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/settings.gradle.kts
@@ -1,7 +1,11 @@
 pluginManagement {
     val quarkusPluginVersion: String by settings
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex("io.quarkus.*")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -6,7 +6,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
@@ -15,6 +14,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/build.gradle
@@ -6,14 +6,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
         if (System.properties.containsKey('maven.repo.local')) {
             maven {
@@ -10,6 +8,8 @@ pluginManagement {
         } else {
             mavenLocal()
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
     plugins {
         id 'io.quarkus' version "${quarkusPluginVersion}"

--- a/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/mutable-jar/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/mutable-jar/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
@@ -5,13 +5,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -13,6 +12,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencies {

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
@@ -5,13 +5,7 @@ plugins {
 }
 
 repositories {
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     if (System.properties.containsKey('maven.repo.local')) {
         maven {
             url System.properties.get('maven.repo.local')
@@ -13,6 +12,7 @@ repositories {
     } else {
         mavenLocal()
     }
+    mavenCentral()
 }
 
 dependencyManagement {

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
@@ -5,14 +5,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-fixtures-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-module/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/application/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/application/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
@@ -1,12 +1,5 @@
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/build.gradle
@@ -1,5 +1,9 @@
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-1/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-1/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-1/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-1/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-2/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-2/build.gradle
@@ -5,14 +5,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-2/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/library-2/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-fixtures-multi-module/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -18,7 +22,11 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -25,14 +18,7 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
@@ -4,14 +4,7 @@ plugins {
 }
 
 repositories {
-    // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-    if (System.properties.containsKey('maven.repo.local')) {
-        maven {
-            url System.properties.get('maven.repo.local')
-        }
-    } else {
-        mavenLocal()
-    }
+    mavenLocal()
     mavenCentral()
 }
 

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
@@ -1,13 +1,6 @@
 buildscript {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -23,7 +27,11 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
     }
 

--- a/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/settings.gradle
@@ -1,6 +1,10 @@
 pluginManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/settings.gradle
@@ -1,13 +1,6 @@
 pluginManagement {
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }


### PR DESCRIPTION
This solves random failures we've been seeing when trying to fetch
snapshots of Quarkus artifacts from the Gradle plugin portal (see #26126, #26128). When executing the builds locally with --debug to reproduce the errors, I spotted this:

```
    Caused by: org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException: Could not HEAD 'https://repo.gradle.org/artifactory/jcenter/io/quarkus/quarkus-build-parent/999-SNAPSHOT/quarkus-build-parent-999-SNAPSHOT.pom'. Received status code 409 from server: Conflict
```

I don't know why this repository would return HTTP 409 conflict, but the
more important problem is that we shouldn't be looking for this artifact
in this repository in the first place.

If we use mavenLocal(), we might as well look into the maven local
repository *first*.

Indeed, in these integration tests, a Gradle plugin or a dependency
is always either:

- a snapshot dependency, in which case it's part of the Quarkus build
  and we just built it, so we really want to fetch it from the Maven
  local repository.
- or a non-snapshot dependency, in which case the artifact we find in the
  Maven local repository (if any) will always be exactly the one we're
  looking for; and if it's not there we'll fall back to Maven Central
  or the Gradle plugin Portal anyway.