### PR TITLE
Make filesystem:-prefixed Flyway-Locations work with HotDeploymentWatchedFileBuildItems

### DIFF
--- a/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
+++ b/extensions/flyway/deployment/src/main/java/io/quarkus/flyway/FlywayProcessor.java
@@ -110,7 +110,12 @@ class FlywayProcessor {
         Collection<String> applicationMigrations = applicationMigrationsToDs.values().stream().collect(HashSet::new,
                 AbstractCollection::addAll, HashSet::addAll);
         for (String applicationMigration : applicationMigrations) {
-            hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem(applicationMigration));
+            Location applicationMigrationLocation = new Location(applicationMigration);
+            String applicationMigrationPath = applicationMigrationLocation.getPath();
+
+            if (applicationMigrationPath != null) {
+                hotDeploymentProducer.produce(new HotDeploymentWatchedFileBuildItem(applicationMigrationPath));
+            }
         }
         recorder.setApplicationMigrationFiles(applicationMigrations);
 


### PR DESCRIPTION
After the introduction of `HotDeploymentWatchedFileBuildItem`s in the flyway extension, when using `filesystem:`-prefixed locations, the extension fails complaining about the syntax of a path (see [here](https://github.com/quarkusio/quarkus/commit/913308b6411d5f294ef39829b345c091c06e3035#commitcomment-76201558)).