### PR TITLE
Limit scope of jsoup to only quarkus-extension-processor

### DIFF
--- a/core/processor/pom.xml
+++ b/core/processor/pom.xml
@@ -21,6 +21,8 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
+            <!-- Avoid adding this to the BOM -->
+            <version>1.15.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,10 +27,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -55,10 +51,6 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jsoup</groupId>
-                    <artifactId>jsoup</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -339,11 +339,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.jsoup</groupId>
-                <artifactId>jsoup</artifactId>
-                <version>${jsoup.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.github.crac</groupId>
                 <artifactId>org-crac</artifactId>
                 <version>${org-crac.version}</version>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -41,7 +41,6 @@
         <assertj.version>3.23.1</assertj.version>
         <eclipse-minimal-json.version>0.9.5</eclipse-minimal-json.version>
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
-        <jsoup.version>1.14.2</jsoup.version> <!-- wagon-http dependency -->
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <maven-core.version>3.8.6</maven-core.version><!-- Keep in sync with sisu.version -->
         <sisu.version>0.3.5</sisu.version><!-- Keep in sync with maven-core.version -->


### PR DESCRIPTION
Fixes #26141

jsoup scope is now limited as much as possible and follows the example of xstream: https://github.com/quarkusio/quarkus/blob/main/test-framework/junit5/pom.xml#L54-L55

/cc @rsvoboda @aloubyansky @gsmet 