### PR TITLE
Improve server side multipart exception handling

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -482,7 +482,7 @@ TIP: The use of `@MultipartForm` is actually unnecessary as RESTEasy Reactive ca
 
 WARNING: When handling file uploads, it is very important to move the file to permanent storage (like a database, a dedicated file system or a cloud storage) in your code that handles the POJO.
 Otherwise, the file will no longer be accessible when the request terminates.
-Moreoever if `quarkus.http.body.delete-uploaded-files-on-end` is set to true, Quarkus will delete the uploaded file when the HTTP response is sent. If the setting is disabled,
+Moreover, if `quarkus.http.body.delete-uploaded-files-on-end` is set to true, Quarkus will delete the uploaded file when the HTTP response is sent. If the setting is disabled,
 the file will reside on the file system of the server (in the directory defined by the `quarkus.http.body.uploads-directory` configuration option), but as the uploaded files are saved
 with a UUID file name and no additional metadata is saved, these files are essentially a random dump of files.
 
@@ -528,7 +528,13 @@ public class Endpoint {
 }
 ----
 
-WARNING: For the time being, returning Multipart data is limited to be blocking endpoints. 
+WARNING: For the time being, returning Multipart data is limited to be blocking endpoints.
+
+==== Handling malformed input
+
+As part of reading the multipart body, RESTEasy Reactive invokes the proper MessageBodyReaderlink:{jaxrsapi}/javax/ws/rs/ext/MessageBodyReader.html[`MessageBodyReader`] for each part of the request.
+If an `IOException` occurs for one of these parts (for example if Jackson was unable to deserialize a JSON part), then a `org.jboss.resteasy.reactive.server.multipart.MultipartPartReadingException` is thrown.
+If this exception is not handled by the application as mentioned in <<exception-mapping>>, an HTTP 400 response is returned by default.
 
 === Returning a response body
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MalformedMultipartInputTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/multipart/MalformedMultipartInputTest.java
@@ -1,0 +1,140 @@
+package io.quarkus.resteasy.reactive.server.test.multipart;
+
+import static io.restassured.RestAssured.given;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.function.Supplier;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.reactive.MultipartForm;
+import org.jboss.resteasy.reactive.PartType;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.common.providers.serialisers.PrimitiveBodyHandler;
+import org.jboss.resteasy.reactive.server.multipart.MultipartPartReadingException;
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MalformedMultipartInputTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(MyEnumMessageBodyReader.class, TestMapper.class,
+                                    TestEndpoint.class,
+                                    Input.class, MyEnum.class);
+                }
+
+            });
+
+    @Test
+    public void properInput() {
+        given()
+                .multiPart("format", "FOO", "text/myenum")
+                .accept("text/plain")
+                .when()
+                .post("/test")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void malformedInput() {
+        given()
+                .multiPart("format", "FOO2", "text/myenum")
+                .accept("text/plain")
+                .when()
+                .post("/test")
+                .then()
+                .statusCode(999);
+    }
+
+    @Path("test")
+    public static class TestEndpoint {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        @POST
+        public MyEnum test(@MultipartForm Input formData) {
+            return formData.format;
+        }
+    }
+
+    public static class Input {
+        @RestForm
+        @PartType("text/myenum")
+        public MyEnum format;
+    }
+
+    public enum MyEnum {
+        FOO,
+        BAR
+    }
+
+    @Provider
+    public static class TestMapper implements ExceptionMapper<MultipartPartReadingException> {
+        @Override
+        public Response toResponse(MultipartPartReadingException e) {
+            return Response.status(999).build();
+        }
+    }
+
+    @Provider
+    @Consumes("text/myenum")
+    public static class MyEnumMessageBodyReader extends PrimitiveBodyHandler implements ServerMessageBodyReader<MyEnum> {
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, ResteasyReactiveResourceInfo lazyMethod,
+                MediaType mediaType) {
+            return type.equals(MyEnum.class);
+        }
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.equals(MyEnum.class);
+        }
+
+        @Override
+        public MyEnum readFrom(Class<MyEnum> type, Type genericType, MediaType mediaType, ServerRequestContext context)
+                throws WebApplicationException, IOException {
+            try {
+                return MyEnum.valueOf(readFrom(context.getInputStream(), false));
+            } catch (IllegalArgumentException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public MyEnum readFrom(Class<MyEnum> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+                throws IOException, WebApplicationException {
+            try {
+                return MyEnum.valueOf(readFrom(entityStream, false));
+            } catch (IllegalArgumentException e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.MediaType;
@@ -23,6 +22,7 @@ import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
 import org.jboss.resteasy.reactive.server.core.multipart.FormData.FormValue;
 import org.jboss.resteasy.reactive.server.handlers.RequestDeserializeHandler;
+import org.jboss.resteasy.reactive.server.multipart.MultipartPartReadingException;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 
 /**
@@ -78,7 +78,7 @@ public final class MultipartSupport {
                     } catch (IOException e) {
                         log.error("Unable to convert value provided for attribute '" + attributeName
                                 + "' of the multipart request into type '" + type.getName() + "'", e);
-                        throw new InternalServerErrorException(e);
+                        throw new MultipartPartReadingException(e);
                     } finally {
                         context.setInputStream(originalInputStream);
                     }
@@ -94,7 +94,7 @@ public final class MultipartSupport {
                     } catch (IOException e) {
                         log.error("Unable to convert value provided for attribute '" + attributeName
                                 + "' of the multipart request into type '" + type.getName() + "'", e);
-                        throw new InternalServerErrorException(e);
+                        throw new MultipartPartReadingException(e);
                     }
                 }
             }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartSupport.java
@@ -48,7 +48,7 @@ public final class MultipartSupport {
                 if (fileUploadsForName != null) {
                     for (FormData.FormValue fileUpload : fileUploadsForName) {
                         if (fileUpload.isFileItem()) {
-                            log.debug("Attribute '" + attributeName
+                            log.warn("Attribute '" + attributeName
                                     + "' of the multipart request is a file and therefore its value is not set. To obtain the contents of the file, use type '"
                                     + FileUpload.class + "' as the field type.");
                             break;
@@ -76,7 +76,8 @@ public final class MultipartSupport {
                         context.setInputStream(formAttributeValueToInputStream(value));
                         return serverMessageBodyReader.readFrom(type, genericType, mediaType, context);
                     } catch (IOException e) {
-                        log.debug("Error occurred during deserialization of input", e);
+                        log.error("Unable to convert value provided for attribute '" + attributeName
+                                + "' of the multipart request into type '" + type.getName() + "'", e);
                         throw new InternalServerErrorException(e);
                     } finally {
                         context.setInputStream(originalInputStream);
@@ -91,7 +92,8 @@ public final class MultipartSupport {
                                 context.getHttpHeaders().getRequestHeaders(),
                                 formAttributeValueToInputStream(value));
                     } catch (IOException e) {
-                        log.debug("Error occurred during deserialization of input", e);
+                        log.error("Unable to convert value provided for attribute '" + attributeName
+                                + "' of the multipart request into type '" + type.getName() + "'", e);
                         throw new InternalServerErrorException(e);
                     }
                 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/multipart/MultipartPartReadingException.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/multipart/MultipartPartReadingException.java
@@ -1,0 +1,16 @@
+package org.jboss.resteasy.reactive.server.multipart;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Exception thrown when some part of the multipart input cannot be read using the appropriate
+ * {@link javax.ws.rs.ext.MessageBodyReader}.
+ * This exception is useful to application because it can be by an {@link javax.ws.rs.ext.ExceptionMapper} in order to customize
+ * the input error handling.
+ */
+public class MultipartPartReadingException extends BadRequestException {
+
+    public MultipartPartReadingException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Fixes: #26158

The second commit of this PR is a breaking change because it changes the default HTTP response (from 500 to 400) to be in line with what we do for non-multipart request bodies.