### PR TITLE
Re-create Elasticsearch schema on startup in tests/dev mode with Hibernate Search and Elasticsearch dev services

### DIFF
--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -544,39 +544,51 @@ quarkus.ssl.native=false <1>
 
 quarkus.datasource.db-kind=postgresql <2>
 
-%dev.quarkus.hibernate-orm.database.generation=drop-and-create <3>
-%test.quarkus.hibernate-orm.database.generation=drop-and-create <3>
-quarkus.hibernate-orm.sql-load-script=import.sql <4>
+quarkus.hibernate-orm.sql-load-script=import.sql <3>
 
-quarkus.hibernate-search-orm.elasticsearch.version=7 <5>
-quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:myAnalysisConfigurer <6>
-%dev.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
-%test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
-%test.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8>
+quarkus.hibernate-search-orm.elasticsearch.version=7 <4>
+quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:myAnalysisConfigurer <5>
+%test.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <6>
 
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test <9>
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test <7>
 %prod.quarkus.datasource.username=quarkus_test
 %prod.quarkus.datasource.password=quarkus_test
-%prod.hibernate-search-orm.elasticsearch.hosts=localhost:9200 <9>
+%prod.hibernate-search-orm.elasticsearch.hosts=localhost:9200 <7>
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
 <2> Let's create a PostgreSQL datasource.
-<3> In dev mode and in tests, we will drop and recreate the schema on startup.
-<4> We load some initial data on startup.
-<5> We need to tell Hibernate Search about the version of Elasticsearch we will use.
+<3> We load some initial data on startup.
+<4> We need to tell Hibernate Search about the version of Elasticsearch we will use.
 It is important because there are significant differences between Elasticsearch mapping syntax depending on the version.
 Since the mapping is created at build time to reduce startup time, Hibernate Search cannot connect to the cluster to automatically detect the version.
 Note that, for OpenSearch, you need to prefix the version with `opensearch:`; see <<opensearch>>.
-<6> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
-<7> In dev mode and in tests, we will drop and recreate the index on startup.
-<8> This means that we wait for the entities to be searchable before considering a write complete.
+<5> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
+<6> This means that we wait for the entities to be searchable before considering a write complete.
 On a production setup, the `write-sync` default will provide better performance.
 Using `sync` is especially important when testing as you need the entities to be searchable immediately.
-<9> For development and tests, we rely on <<dev-services,Dev Services>>,
+<7> For development and tests, we rely on <<dev-services,Dev Services>>,
 which means Quarkus will start a PostgreSQL database and Elasticsearch cluster automatically.
 In production mode, however,
 you will want to start a PostgreSQL database and Elasticsearch cluster manually,
 which is why we provide Quarkus with this connection info in the `prod` profile (`%prod.` prefix).
+
+[NOTE]
+====
+Because we rely on <<dev-services,Dev Services>>, the database and Elasticsearch schema
+will automatically be dropped and re-created on each application startup
+in tests and dev mode.
+
+If for some reason you cannot use dev-services,
+you will have to set the following properties to get similar behavior:
+
+```
+%test.quarkus.hibernate-orm.database.generation=drop-and-create
+%test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
+```
+
+See also link:#quarkus-hibernate-search-orm-elasticsearch_quarkus.hibernate-search-orm.schema-management.strategy[`quarkus.hibernate-search-orm.schema-management.strategy`].
+====
+
 
 [TIP]
 For more information about the Hibernate Search extension configuration please refer to the <<configuration-reference, Configuration Reference>>.

--- a/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
+++ b/docs/src/main/asciidoc/hibernate-search-orm-elasticsearch.adoc
@@ -544,13 +544,15 @@ quarkus.ssl.native=false <1>
 
 quarkus.datasource.db-kind=postgresql <2>
 
-quarkus.hibernate-orm.database.generation=drop-and-create <3>
+%dev.quarkus.hibernate-orm.database.generation=drop-and-create <3>
+%test.quarkus.hibernate-orm.database.generation=drop-and-create <3>
 quarkus.hibernate-orm.sql-load-script=import.sql <4>
 
 quarkus.hibernate-search-orm.elasticsearch.version=7 <5>
 quarkus.hibernate-search-orm.elasticsearch.analysis.configurer=bean:myAnalysisConfigurer <6>
-quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8>
+%dev.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
+%test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create <7>
+%test.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8>
 
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost/quarkus_test <9>
 %prod.quarkus.datasource.username=quarkus_test
@@ -559,14 +561,14 @@ quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync <8
 ----
 <1> We won't use SSL so we disable it to have a more compact native executable.
 <2> Let's create a PostgreSQL datasource.
-<3> We will drop and recreate the schema every time we start the application.
-<4> We load some initial data.
+<3> In dev mode and in tests, we will drop and recreate the schema on startup.
+<4> We load some initial data on startup.
 <5> We need to tell Hibernate Search about the version of Elasticsearch we will use.
 It is important because there are significant differences between Elasticsearch mapping syntax depending on the version.
 Since the mapping is created at build time to reduce startup time, Hibernate Search cannot connect to the cluster to automatically detect the version.
 Note that, for OpenSearch, you need to prefix the version with `opensearch:`; see <<opensearch>>.
 <6> We point to the custom `AnalysisConfigurer` which defines the configuration of our analyzers and normalizers.
-<7> Obviously, this is not for production: we drop and recreate the index every time we start the application.
+<7> In dev mode and in tests, we will drop and recreate the index on startup.
 <8> This means that we wait for the entities to be searchable before considering a write complete.
 On a production setup, the `write-sync` default will provide better performance.
 Using `sync` is especially important when testing as you need the entities to be searchable immediately.
@@ -690,7 +692,7 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 
 quarkus.hibernate-search-orm.elasticsearch.hosts=es1.mycompany.com:9200
 quarkus.hibernate-search-orm.elasticsearch.version=7
-quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=write-sync
+%test.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
 ----
 
 Using a map based approach, it is also possible to configure named persistence units:
@@ -711,11 +713,11 @@ quarkus.hibernate-orm."inventory".packages=org.acme.model.inventory
 
 quarkus.hibernate-search-orm."users".elasticsearch.hosts=es1.mycompany.com:9200 <5>
 quarkus.hibernate-search-orm."users".elasticsearch.version=7
-quarkus.hibernate-search-orm."users".automatic-indexing.synchronization.strategy=write-sync
+%test.quarkus.hibernate-search-orm."users".automatic-indexing.synchronization.strategy=sync
 
 quarkus.hibernate-search-orm."inventory".elasticsearch.hosts=es2.mycompany.com:9200 <6>
 quarkus.hibernate-search-orm."inventory".elasticsearch.version=7
-quarkus.hibernate-search-orm."inventory".automatic-indexing.synchronization.strategy=write-sync
+%test.quarkus.hibernate-search-orm."inventory".automatic-indexing.synchronization.strategy=sync
 ----
 <1> Define a datasource named `users`.
 <2> Define a datasource named `inventory`.

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -22,17 +22,21 @@ import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategy;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.IndexView;
+import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
@@ -51,11 +55,14 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.ElasticsearchIndexBuildTimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 class HibernateSearchElasticsearchProcessor {
 
     private static final String HIBERNATE_SEARCH_ELASTICSEARCH = "Hibernate Search ORM + Elasticsearch";
+
+    private static final Logger LOG = Logger.getLogger(HibernateSearchElasticsearchProcessor.class);
 
     HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
 
@@ -319,6 +326,15 @@ class HibernateSearchElasticsearchProcessor {
         return backendPropertyKey(persistenceUnitName, backendName, null, "version");
     }
 
+    private static String mapperPropertyKey(String persistenceUnitName, String radical) {
+        StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
+        if (!PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
+            keyBuilder.append(persistenceUnitName).append(".");
+        }
+        keyBuilder.append(radical);
+        return keyBuilder.toString();
+    }
+
     private static String backendPropertyKey(String persistenceUnitName, String backendName, String indexName, String radical) {
         StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
         if (!PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {
@@ -346,7 +362,9 @@ class HibernateSearchElasticsearchProcessor {
         // If the version is not set, the default backend is not in use.
                 && buildTimeConfig.defaultPersistenceUnit.defaultBackend.version.isPresent()) {
             ElasticsearchVersion version = buildTimeConfig.defaultPersistenceUnit.defaultBackend.version.get();
-            return new DevservicesElasticsearchBuildItem("quarkus.hibernate-search-orm.elasticsearch.hosts",
+            String hostsPropertyKey = backendPropertyKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, null, null,
+                    "hosts");
+            return new DevservicesElasticsearchBuildItem(hostsPropertyKey,
                     version.versionString(),
                     DevservicesElasticsearchBuildItem.Distribution.valueOf(version.distribution().toString().toUpperCase()));
         } else {
@@ -355,4 +373,28 @@ class HibernateSearchElasticsearchProcessor {
             return null;
         }
     }
+
+    @BuildStep(onlyIfNot = IsNormal.class)
+    void devServicesDropAndCreateAndDropByDefault(
+            List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
+            DevServicesLauncherConfigResultBuildItem devServicesResult,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfigurationDefaultBuildItemBuildProducer) {
+        for (HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem configuredPersistenceUnit : configuredPersistenceUnits) {
+            String puName = configuredPersistenceUnit.getPersistenceUnitName();
+            String hostsPropertyKey = backendPropertyKey(puName, null, null, "hosts");
+
+            if (!ConfigUtils.isPropertyPresent(hostsPropertyKey)
+                    && devServicesResult.getConfig().containsKey(hostsPropertyKey)) {
+                String schemaManagementStrategyKey = mapperPropertyKey(puName, "schema-management.strategy");
+                if (!ConfigUtils.isPropertyPresent(schemaManagementStrategyKey)) {
+                    String strategyName = "drop-and-create-and-drop";
+                    LOG.infof("Setting %s=%s to initialize Dev Services managed Elasticsearch server",
+                            schemaManagementStrategyKey, strategyName);
+                    runTimeConfigurationDefaultBuildItemBuildProducer.produce(new RunTimeConfigurationDefaultBuildItem(
+                            schemaManagementStrategyKey, strategyName));
+                }
+            }
+        }
+    }
+
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -380,7 +380,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * For indexes that already exist, do nothing: assume that their schema matches Hibernate Search's expectations.
          *
-         * !create-or-validate (**default**)
+         * !create-or-validate (**default** unless using dev services)
          * !For indexes that do not exist, create them along with their schema.
          *
          * For indexes that already exist, validate that their schema matches Hibernate Search's expectations.
@@ -402,7 +402,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          *
          * For indexes that already exist, drop them, then create them along with their schema.
          *
-         * !drop-and-create-and-drop
+         * !drop-and-create-and-drop (**default** when using dev services)
          * !For indexes that do not exist, create them along with their schema.
          *
          * For indexes that already exist, drop them, then create them along with their schema.
@@ -416,7 +416,7 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem(defaultValue = "create-or-validate")
+        @ConfigItem(defaultValue = "create-or-validate", defaultValueDocumentation = "drop-and-create-and-drop when using dev services; create-or-validate otherwise")
         SchemaManagementStrategyName strategy;
 
     }

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchDevServicesTestResource.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchDevServicesTestResource.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 
 @Path("/test/dev-services")
@@ -32,6 +33,15 @@ public class HibernateSearchDevServicesTestResource {
     @SuppressWarnings("unchecked")
     public String hosts() {
         return ((List<String>) sessionFactory.getProperties().get("hibernate.search.backend.hosts")).iterator().next();
+    }
+
+    @GET
+    @Path("/schema-management-strategy")
+    @Transactional
+    public String schemaManagementStrategy() {
+        var strategy = ((SchemaManagementStrategyName) sessionFactory.getProperties()
+                .get("hibernate.search.schema_management.strategy"));
+        return strategy == null ? null : strategy.externalRepresentation();
     }
 
     @PUT

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/main/resources/application.properties
@@ -14,8 +14,12 @@ quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis2TestingEntity.analys
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis3TestingEntity.analysis.configurer=io.quarkus.it.hibernate.search.orm.elasticsearch.analysis.IndexAnalysis3Configurer
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis4TestingEntity.analysis.configurer=index-analysis-4
 quarkus.hibernate-search-orm.elasticsearch.indexes.Analysis5TestingEntity.analysis.configurer=io.quarkus.it.hibernate.search.orm.elasticsearch.analysis.IndexAnalysis5Configurer
-quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create-and-drop
 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
 
+# Use drop-and-create instead of drop-and-create-and-drop
+# so we can differentiate between the value we set here
+# and the value set automatically by the extension when using dev services
+# See io.quarkus.it.hibernate.search.orm.elasticsearch.devservices.HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.testHibernateSearch
+%test.quarkus.hibernate-search-orm.schema-management.strategy=drop-and-create
 %test.quarkus.hibernate-search-orm.elasticsearch.hosts=${elasticsearch.hosts:localhost:9200}
 %test.quarkus.hibernate-search-orm.elasticsearch.protocol=${elasticsearch.protocol:http}

--- a/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch/src/test/java/io/quarkus/it/hibernate/search/orm/elasticsearch/devservices/HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest.java
@@ -52,6 +52,12 @@ public class HibernateSearchElasticsearchDevServicesEnabledImplicitlyTest {
                 .statusCode(200)
                 .body(is(context.devServicesProperties().get("quarkus.hibernate-search-orm.elasticsearch.hosts")));
 
+        RestAssured.when().get("/test/dev-services/schema-management-strategy").then()
+                .statusCode(200)
+                // If the value is drop-and-create, this would indicate we're using the %test profile:
+                // that would be a bug in this test (see the Profile class above).
+                .body(is("drop-and-create-and-drop"));
+
         RestAssured.when().get("/test/dev-services/count").then()
                 .statusCode(200)
                 .body(is("0"));


### PR DESCRIPTION
Fixes #24923

As explained in #24923, the "validation on startup" feature doesn't make sense here, but dropping and re-creating indexes on startup when using dev services does make sense, especially for tests.

See how much simpler configuration becomes :)