### PR TITLE
Automatic drop-and-create of schema when using dev services in (native) integration tests

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
@@ -1,0 +1,43 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * An additional configuration property to set when a dev service sets another, specific configuration property.
+ * <p>
+ * Quarkus will make sure the relevant settings are present in both JVM and native modes.
+ * <p>
+ * This is used to change the defaults of extension configuration when dev services are in use,
+ * for example to enable schema management in the Hibernate ORM extension.
+ */
+public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
+
+    private final String triggeringKey;
+    private final String key;
+    private final String value;
+    private final Runnable callbackWhenEnabled;
+
+    public DevServicesAdditionalConfigBuildItem(String triggeringKey,
+            String key, String value, Runnable callbackWhenEnabled) {
+        this.triggeringKey = triggeringKey;
+        this.key = key;
+        this.value = value;
+        this.callbackWhenEnabled = callbackWhenEnabled;
+    }
+
+    public String getTriggeringKey() {
+        return triggeringKey;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Runnable getCallbackWhenEnabled() {
+        return callbackWhenEnabled;
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/dev-services.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/dev-services.html
@@ -11,6 +11,7 @@
             {service.name}
           </div>
           <div class="card-body">
+                {#if service.containerInfo}
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item">
                         <i class="fas fa-box-open" data-toggle="tooltip" data-placement="top" title="Container"></i> {service.containerInfo.getShortId()} {service.containerInfo.formatNames()}
@@ -26,6 +27,7 @@
                     </li>
                 </ul>
                 <hr/>
+                {/if}
                 <h5 class="card-title">Config</h5>
                 <code class="h-100">
                 {#for config in service.configs}


### PR DESCRIPTION
Fixes #26177 

Tested locally with the quickstart; I don't think we have any test for this feature, even in JVM mode...

~~Creating as draft, because this PR is based on #26179, which must be merged first.~~ => Done