### PR TITLE
Clean up AsciiDoc documentation in Config Dev UI to make it (barely) readable

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/ConfigEditorProcessor.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -67,7 +68,7 @@ public class ConfigEditorProcessor {
         for (ConfigDescriptionBuildItem item : configDescriptionBuildItems) {
             configDescriptions.add(
                     new ConfigDescription(item.getPropertyName(),
-                            item.getDocs(),
+                            cleanUpAsciiDocIfNecessary(item.getDocs()),
                             item.getDefaultValue(),
                             isSetByDevServices(devServicesLauncherConfig, item.getPropertyName()),
                             item.getValueTypeName(),
@@ -127,6 +128,20 @@ public class ConfigEditorProcessor {
             }
         }));
 
+    }
+
+    private String cleanUpAsciiDocIfNecessary(String docs) {
+        if (docs == null || !docs.toLowerCase(Locale.ROOT).contains("@asciidoclet")) {
+            return docs;
+        }
+        // TODO #26199 Ideally we'd use a proper AsciiDoc renderer, but for now we'll just clean it up a bit.
+        return docs.replace("@asciidoclet", "")
+                // Avoid problems with links.
+                .replace("<<", "&lt;&lt;")
+                .replace(">>", "&gt;&gt;")
+                // Try to render line breaks... kind of.
+                .replace("\n\n", "<p>")
+                .replace("\n", "<br>");
     }
 
     @BuildStep


### PR DESCRIPTION
Relates to #26199, though this is by no means a fix. At best this is a temporary workaround until we find a way to actually render asciidoc in the dev UI.

Before:

![Screenshot from 2022-06-17 10-13-17](https://user-images.githubusercontent.com/412878/174262044-55b282e5-0fc6-4e78-bce6-23d25df4d2db.png)

After:

![Screenshot from 2022-06-17 10-41-28](https://user-images.githubusercontent.com/412878/174262056-f9b24e96-7cf5-4a36-b38f-1835dd817855.png)

