### PR TITLE
Refactored resteasy-mutiny IT to be a RESTEasy Reactive + Mutiny IT test

### DIFF
--- a/integration-tests/resteasy-mutiny/pom.xml
+++ b/integration-tests/resteasy-mutiny/pom.xml
@@ -12,21 +12,20 @@
 
     <artifactId>quarkus-integration-test-resteasy-mutiny</artifactId>
 
-    <name>Quarkus - Integration Tests - RESTEasy Mutiny</name>
-    
+    <name>Quarkus - Integration Tests - RESTEasy and Mutiny</name>
 
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -47,7 +46,7 @@
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-deployment</artifactId>
+            <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -60,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -73,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -101,6 +100,5 @@
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MutinyResource.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/MutinyResource.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.annotations.SseElementType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
@@ -61,7 +61,7 @@ public class MutinyResource {
     @GET
     @Path("/pets")
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.APPLICATION_JSON)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Pet> sse() {
         return service.getMorePets();
     }

--- a/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
+++ b/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/MutinyTest.java
@@ -52,10 +52,8 @@ public class MutinyTest {
     public void testHelloAsMulti() {
         get("/mutiny/hello/stream")
                 .then()
-                .contentType("application/json")
-                .body("[0]", is("he"))
-                .body("[1]", is("ll"))
-                .body("[2]", is("o"))
+                .contentType("text/plain")
+                .body(is("hello"))
                 .statusCode(200);
     }
 


### PR DESCRIPTION
This will host future IT tests / reproducers focusing on the specific bits of using Mutiny APIs
in RESTEasy Reactive.

- Removed `quarkus-resteasy-mutiny` dependency
- Added `quarkus-resteasy-reactive`
- Fixed one SSE test that produces a stream of plain text, not JSON fragments
