### PR TITLE
Minor updates to OIDC dev template to support Okta

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-dev-services.adoc
@@ -261,7 +261,9 @@ If the provider metadata discovery has been successful then, after you open the 
 
 image::dev-ui-oidc-devconsole-card.png[alt=Generic Dev UI OpenID Connect Card,role="center"]
 
-Follow the link, and you will be able to log in to your provider, get the tokens and test the application. The experience will be the same as described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section, where `Dev Services for Keycloak` container has been started, especially if you work with Keycloak (please also pay attention to a `redirect_uri` note in that section).
+Follow the link, and you will be able to log in to your provider, get the tokens and test the application. The experience will be the same as described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section, where `Dev Services for Keycloak` container has been started, especially if you work with Keycloak.
+
+You will most likely need to configure your OpenId Connect provider to support redirecting back to the `Dev Console`. Add `http://localhost:8080/q/dev/io.quarkus.quarkus-oidc/provider` as one of the supported redirect and logout URLs.
 
 If you work with other providers then a Dev UI experience described in the <<keycloak-authorization-code-grant,Authorization Code Grant for Keycloak>> section might differ slightly. For example, an access token may not be in a JWT format, so it won't be possible to show its internal content, though all providers should return an ID Token as JWT.
 

--- a/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
+++ b/extensions/oidc/deployment/src/main/resources/dev-templates/provider.html
@@ -104,13 +104,15 @@ var port = {config:property('quarkus.http.port')};
           + "?client_id=" + '{info:clientId}'
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
           + "&scope=openid&response_type=token id_token&response_mode=query&prompt=login"
-          + "&nonce=" + makeid();
+          + "&nonce=" + makeid()
+          + "&state=" + makeid();
       {#else}
         window.location.href = '{info:authorizationUrl??}'
           + "?client_id=" + '{info:clientId}'
           + "&redirect_uri=" + "http%3A%2F%2Flocalhost%3A" + port + encodedDevRoot + "%2Fio.quarkus.quarkus-oidc%2Fprovider"
           + "&scope=openid&response_type=code&response_mode=query&prompt=login"
-          + "&nonce=" + makeid();
+          + "&nonce=" + makeid()
+          + "&state=" + makeid();
       {/if}    
     }
 
@@ -222,11 +224,11 @@ var port = {config:property('quarkus.http.port')};
                     userName = jsonPayload.upn;
                 } else if (jsonPayload.preferred_username) {
                     userName = jsonPayload.preferred_username;
+                }  else if (jsonPayload.name) {
+                    userName = jsonPayload.name;
                 }
                 if (userName) {
                     $('#loggedInUser').append("Logged in as " + userName + " ");
-                } else {
-                    $('#loggedInUser').append("Logged in ");
                 }
             }
             return "<pre class='text-danger' title='Header'>" + 


### PR DESCRIPTION
Okta requires a `state` parameter which is indeed required for Quarkus `web-app` too. It may be because I've registered an application as `web-app` in Okta, but in any case it won't harm having the dev template producing it too.

I also dropped an empty `Logged In` when no user name can be determined as it ends up showing as `Logged in Logged In` (double append) - but even if this duplication is possible to fix, it does not really add anything informative, since there is an icon there suggesting to `logout and start again` in any case.

Also added one more (standard) claim check to determine a user name, as Okta does not include `preferred_username` (or `upn`).

CC @kenyee