### PR TITLE
Fixed GraphQL  Adapters being removed

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLFinalIndexBuildItem.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLFinalIndexBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class SmallRyeGraphQLFinalIndexBuildItem extends SimpleBuildItem {
+
+    private final IndexView index;
+
+    public SmallRyeGraphQLFinalIndexBuildItem(IndexView index) {
+        this.index = index;
+    }
+
+    public IndexView getFinalIndex() {
+        return index;
+    }
+}

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLModifiedClasesBuildItem.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLModifiedClasesBuildItem.java
@@ -4,11 +4,11 @@ import java.util.Map;
 
 import io.quarkus.builder.item.SimpleBuildItem;
 
-final class SmallRyeGraphQLIndexBuildItem extends SimpleBuildItem {
+final class SmallRyeGraphQLModifiedClasesBuildItem extends SimpleBuildItem {
 
     private final Map<String, byte[]> modifiedClases;
 
-    public SmallRyeGraphQLIndexBuildItem(Map<String, byte[]> modifiedClases) {
+    public SmallRyeGraphQLModifiedClasesBuildItem(Map<String, byte[]> modifiedClases) {
         this.modifiedClases = modifiedClases;
     }
 

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -18,6 +18,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 
@@ -63,6 +67,7 @@ import io.quarkus.vertx.http.deployment.WebsocketSubProtocolsBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarBuildItem;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResourcesFilter;
 import io.quarkus.vertx.http.deployment.webjar.WebJarResultsBuildItem;
+import io.smallrye.graphql.api.AdaptWith;
 import io.smallrye.graphql.api.Entry;
 import io.smallrye.graphql.cdi.config.ConfigKey;
 import io.smallrye.graphql.cdi.config.MicroProfileConfig;
@@ -145,7 +150,8 @@ public class SmallRyeGraphQLProcessor {
     }
 
     @BuildStep
-    void additionalBean(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
+    void additionalBean(Capabilities capabilities, CombinedIndexBuildItem combinedIndex,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
 
         additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClass(GraphQLProducer.class)
@@ -153,6 +159,14 @@ public class SmallRyeGraphQLProcessor {
         if (capabilities.isPresent(Capability.HIBERNATE_VALIDATOR)) {
             additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
                     .addBeanClass(SmallRyeGraphQLLocaleResolver.class)
+                    .setUnremovable().build());
+        }
+
+        // Make sure the adapters does not get removed
+        Set<String> adapterClasses = getAllAdapterClasses(combinedIndex.getIndex());
+        for (String adapterClass : adapterClasses) {
+            additionalBeanProducer.produce(AdditionalBeanBuildItem.builder()
+                    .addBeanClass(adapterClass)
                     .setUnremovable().build());
         }
     }
@@ -179,7 +193,7 @@ public class SmallRyeGraphQLProcessor {
     }
 
     @BuildStep
-    SmallRyeGraphQLIndexBuildItem createIndex(TransformedClassesBuildItem transformedClassesBuildItem) {
+    SmallRyeGraphQLModifiedClasesBuildItem createIndex(TransformedClassesBuildItem transformedClassesBuildItem) {
         Map<String, byte[]> modifiedClasses = new HashMap<>();
         Map<Path, Set<TransformedClassesBuildItem.TransformedClass>> transformedClassesByJar = transformedClassesBuildItem
                 .getTransformedClassesByJar();
@@ -191,20 +205,14 @@ public class SmallRyeGraphQLProcessor {
                 modifiedClasses.put(transformedClass.getClassName(), transformedClass.getData());
             }
         }
-        return new SmallRyeGraphQLIndexBuildItem(modifiedClasses);
+        return new SmallRyeGraphQLModifiedClasesBuildItem(modifiedClasses);
     }
 
-    @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
-    void buildExecutionService(
-            BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer,
-            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer,
-            BuildProducer<SmallRyeGraphQLInitializedBuildItem> graphQLInitializedProducer,
-            SmallRyeGraphQLRecorder recorder,
-            SmallRyeGraphQLIndexBuildItem graphQLIndexBuildItem,
-            BeanContainerBuildItem beanContainer,
+    void buildFinalIndex(
+            BuildProducer<SmallRyeGraphQLFinalIndexBuildItem> smallRyeGraphQLFinalIndexProducer,
             CombinedIndexBuildItem combinedIndex,
-            SmallRyeGraphQLConfig graphQLConfig) {
+            SmallRyeGraphQLModifiedClasesBuildItem graphQLIndexBuildItem) {
 
         Indexer indexer = new Indexer();
         Map<String, byte[]> modifiedClases = graphQLIndexBuildItem.getModifiedClases();
@@ -228,7 +236,21 @@ public class SmallRyeGraphQLProcessor {
 
         OverridableIndex overridableIndex = OverridableIndex.create(combinedIndex.getIndex(), indexer.complete());
 
-        Schema schema = SchemaBuilder.build(overridableIndex, graphQLConfig.autoNameStrategy);
+        smallRyeGraphQLFinalIndexProducer.produce(new SmallRyeGraphQLFinalIndexBuildItem(overridableIndex));
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @BuildStep
+    void buildExecutionService(
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClassProducer,
+            BuildProducer<ReflectiveHierarchyBuildItem> reflectiveHierarchyProducer,
+            BuildProducer<SmallRyeGraphQLInitializedBuildItem> graphQLInitializedProducer,
+            SmallRyeGraphQLRecorder recorder,
+            SmallRyeGraphQLFinalIndexBuildItem graphQLFinalIndexBuildItem,
+            BeanContainerBuildItem beanContainer,
+            SmallRyeGraphQLConfig graphQLConfig) {
+
+        Schema schema = SchemaBuilder.build(graphQLFinalIndexBuildItem.getFinalIndex(), graphQLConfig.autoNameStrategy);
 
         RuntimeValue<Boolean> initialized = recorder.createExecutionService(beanContainer.getValue(), schema);
         graphQLInitializedProducer.produce(new SmallRyeGraphQLInitializedBuildItem(initialized));
@@ -334,6 +356,29 @@ public class SmallRyeGraphQLProcessor {
 
         routeProducer.produce(requestBuilder.build());
 
+    }
+
+    private Set<String> getAllAdapterClasses(IndexView index) {
+        Set<String> adapterClasses = new HashSet<>();
+        adapterClasses.addAll(getAdapterClasses(index, DotName.createSimple(AdaptWith.class.getName())));
+        adapterClasses.addAll(
+                getAdapterClasses(index, DotName.createSimple("jakarta.json.bind.annotation.JsonbTypeAdapter")));
+        adapterClasses.addAll(
+                getAdapterClasses(index, DotName.createSimple("javax.json.bind.annotation.JsonbTypeAdapter")));
+        return adapterClasses;
+    }
+
+    private Set<String> getAdapterClasses(IndexView index, DotName adapterClass) {
+        Set<String> adapterClasses = new HashSet<>();
+        Collection<AnnotationInstance> adaptWithAnnotations = index.getAnnotations(adapterClass);
+        for (AnnotationInstance adaptWithAnnotation : adaptWithAnnotations) {
+            AnnotationValue annotationValue = adaptWithAnnotation.value();
+            if (annotationValue != null) {
+                org.jboss.jandex.Type classType = annotationValue.asClass();
+                adapterClasses.add(classType.name().toString());
+            }
+        }
+        return adapterClasses;
     }
 
     private boolean shouldRunBlockingRoute(SmallRyeGraphQLConfig graphQLConfig) {

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AdapterTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/AdapterTest.java
@@ -1,0 +1,142 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.graphql.api.AdaptWith;
+import io.smallrye.graphql.api.Adapter;
+
+/**
+ * Basic test to make sure adapters is working
+ */
+public class AdapterTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(AdapterApi.class, Person.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testSourcePost() {
+        String personRequest = getPayload("{\n" +
+                "    person {\n" +
+                "       name\n" +
+                "       address {\n" +
+                "           city\n" +
+                "       }\n" +
+                "    }\n" +
+                "}");
+
+        RestAssured.given()
+                .when()
+                .accept(MEDIATYPE_JSON)
+                .contentType(MEDIATYPE_JSON)
+                .body(personRequest)
+                .post("/graphql")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .and()
+                .body(CoreMatchers.containsString("\"address\":{\"city\":\"City\"}"));
+
+    }
+
+    @GraphQLApi
+    public static class AdapterApi {
+
+        @Query
+        public Person getPerson() {
+            Address a = new Address();
+            a.code = "1234";
+            a.addLine("1 Street street");
+            a.addLine("City");
+            a.addLine("Province");
+
+            Person p = new Person();
+            p.setName("Phillip Kruger");
+            p.setAddress(a);
+            return p;
+        }
+
+    }
+
+    public static class Person {
+
+        private String name;
+        @AdaptWith(AddressAdapter.class)
+        private Address address;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+    }
+
+    public static class Address {
+        public List<String> lines;
+        public String code;
+
+        public void addLine(String line) {
+            if (lines == null)
+                lines = new LinkedList<>();
+            lines.add(line);
+        }
+
+    }
+
+    public static class Home {
+        public String street;
+        public String city;
+        public String province;
+        public String code;
+
+    }
+
+    public static class AddressAdapter implements Adapter<Address, Home> {
+
+        @Override
+        public Home to(Address address) throws Exception {
+            Home home = new Home();
+            home.code = address.code;
+            home.street = address.lines.get(0);
+            home.city = address.lines.get(1);
+            home.province = address.lines.get(2);
+            return home;
+        }
+
+        @Override
+        public Address from(Home home) throws Exception {
+            Address address = new Address();
+            address.code = home.code;
+            address.addLine(home.street);
+            address.addLine(home.city);
+            address.addLine(home.province);
+
+            return address;
+        }
+    }
+
+}


### PR DESCRIPTION
Arc is removing graphql adapters. This make sure adapters being used stays in the runtime.

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>