### PR TITLE
Construct URITemplate with prefixMatch when used for sub-resource locators

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -132,7 +132,7 @@ public class RuntimeResourceDeployment {
 
     public RuntimeResource buildResourceMethod(ResourceClass clazz,
             ServerResourceMethod method, boolean locatableResource, URITemplate classPathTemplate, DeploymentInfo info) {
-        URITemplate methodPathTemplate = new URITemplate(method.getPath(), false);
+        URITemplate methodPathTemplate = new URITemplate(method.getPath(), method.isResourceLocator());
         MultivaluedMap<ScoreSystem.Category, ScoreSystem.Diagnostic> score = new QuarkusMultivaluedHashMap<>();
 
         Map<String, Integer> pathParameterIndexes = buildParamIndexMap(classPathTemplate, methodPathTemplate);

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/SubresourceCustomRegexTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/SubresourceCustomRegexTest.java
@@ -1,0 +1,68 @@
+package org.jboss.resteasy.reactive.server.vertx.test.matching;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.function.Supplier;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SubresourceCustomRegexTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest test = new ResteasyReactiveUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClass(RootResource.class)
+                            .addClass(SubResource.class);
+                }
+            });
+
+    @Test
+    public void testRequestForwardedToSubresource() {
+        given()
+                .when().get("/TomOther/greet")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Tom"));
+        given()
+                .when().get("/TimOther/greet")
+                .then()
+                .statusCode(200)
+                .body(is("Hello Tim"));
+        given()
+                .when().get("/Tom/greet")
+                .then()
+                .statusCode(404);
+    }
+
+    @Path("/")
+    public static class RootResource {
+
+        @Path("{id}Other")
+        public SubResource sub() {
+            return new SubResource();
+        }
+    }
+
+    @Produces("text/plain")
+    public static class SubResource {
+
+        @Path("/greet")
+        @GET
+        public String greet(@PathParam("id") String id) {
+            return "Hello " + id;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fixes #26028 