### PR TITLE
Add a test confirming a role claim path with the namespace works

### DIFF
--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/AdminResource.java
@@ -34,6 +34,14 @@ public class AdminResource {
         return "granted:" + identity.getRoles();
     }
 
+    @Path("bearer-role-claim-path")
+    @GET
+    @RolesAllowed("custom")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String adminCustomRolePath() {
+        return "granted:" + identity.getRoles();
+    }
+
     @Path("bearer-key-without-kid-thumbprint")
     @GET
     @RolesAllowed("admin")

--- a/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-wiremock/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -35,6 +35,9 @@ public class CustomTenantResolver implements TenantResolver {
         if (path.endsWith("bearer-no-introspection")) {
             return "bearer-no-introspection";
         }
+        if (path.endsWith("bearer-role-claim-path")) {
+            return "bearer-role-claim-path";
+        }
         if (path.endsWith("bearer-key-without-kid-thumbprint")) {
             return "bearer-key-without-kid-thumbprint";
         }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -67,15 +67,19 @@ quarkus.oidc.token-cache.max-size=1
 quarkus.oidc.bearer.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer.client-id=quarkus-app
 quarkus.oidc.bearer.credentials.secret=secret
-quarkus.oidc.bearer.authentication.scopes=profile,email,phone
-quarkus.oidc.bearer.token.audience=https://service.example.com
 quarkus.oidc.bearer.token.audience=https://service.example.com
 quarkus.oidc.bearer.allow-token-introspection-cache=false
+
+quarkus.oidc.bearer-role-claim-path.auth-server-url=${keycloak.url}/realms/quarkus/
+quarkus.oidc.bearer-role-claim-path.client-id=quarkus-app
+quarkus.oidc.bearer-role-claim-path.credentials.secret=secret
+quarkus.oidc.bearer-role-claim-path.token.audience=https://service.example.com
+quarkus.oidc.bearer-role-claim-path.roles.role-claim-path="https://roles.example.com"
+quarkus.oidc.bearer-role-claim-path.allow-token-introspection-cache=false
 
 quarkus.oidc.bearer-no-introspection.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-no-introspection.client-id=quarkus-app
 quarkus.oidc.bearer-no-introspection.credentials.secret=secret
-quarkus.oidc.bearer-no-introspection.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer-no-introspection.token.audience=https://service.example.com
 quarkus.oidc.bearer-no-introspection.token.allow-jwt-introspection=false
 
@@ -84,14 +88,12 @@ quarkus.oidc.bearer-key-without-kid-thumbprint.discovery-enabled=false
 quarkus.oidc.bearer-key-without-kid-thumbprint.jwks-path=single-key-without-kid-thumbprint
 quarkus.oidc.bearer-key-without-kid-thumbprint.client-id=quarkus-app
 quarkus.oidc.bearer-key-without-kid-thumbprint.credentials.secret=secret
-quarkus.oidc.bearer-key-without-kid-thumbprint.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer-key-without-kid-thumbprint.token.audience=https://service.example.com
 quarkus.oidc.bearer-key-without-kid-thumbprint.token.allow-jwt-introspection=false
 
 quarkus.oidc.bearer-wrong-role-path.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.bearer-wrong-role-path.client-id=quarkus-app
 quarkus.oidc.bearer-wrong-role-path.credentials.secret=secret
-quarkus.oidc.bearer-wrong-role-path.authentication.scopes=profile,email,phone
 quarkus.oidc.bearer-wrong-role-path.token.audience=https://service.example.com
 quarkus.oidc.bearer-wrong-role-path.roles.role-claim-path=path
 

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -58,6 +58,23 @@ public class BearerTokenAuthorizationTest {
     }
 
     @Test
+    public void testAccessAdminResourceWithCustomRolePathForbidden() {
+        RestAssured.given().auth().oauth2(getAccessTokenWithCustomRolePath("admin", Set.of("admin")))
+                .when().get("/api/admin/bearer-role-claim-path")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void testAccessAdminResourceWithCustomRolePath() {
+        RestAssured.given().auth().oauth2(getAccessTokenWithCustomRolePath("admin", Set.of("custom")))
+                .when().get("/api/admin/bearer-role-claim-path")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString("custom"));
+    }
+
+    @Test
     public void testAccessAdminResourceWithoutKidAndThumbprint() {
         RestAssured.given().auth().oauth2(getAccessTokenWithoutKidAndThumbprint("admin", Set.of("admin")))
                 .when().get("/api/admin/bearer-no-introspection")
@@ -174,6 +191,14 @@ public class BearerTokenAuthorizationTest {
     private String getAccessToken(String userName, Set<String> groups) {
         return Jwt.preferredUserName(userName)
                 .groups(groups)
+                .issuer("https://server.example.com")
+                .audience("https://service.example.com")
+                .sign();
+    }
+
+    private String getAccessTokenWithCustomRolePath(String userName, Set<String> groups) {
+        return Jwt.preferredUserName(userName)
+                .claim("https://roles.example.com", groups)
                 .issuer("https://server.example.com")
                 .audience("https://service.example.com")
                 .sign();


### PR DESCRIPTION
Fixes #26185.

This PR adds one more test where the custom role claim path is configured in `application.properties`. The unit test which already exists and is linked to from #26185 uses `OidcUtils` directly.

Also removed some unused properties from `integration-tests/oidc-wiremock/.../application.properties` and added a trim to the roles path just in case