### PR TITLE
Use `Secret Value` instead of `Secret ID` in Microsoft OIDC config guide

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-providers.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-providers.adoc
@@ -127,7 +127,7 @@ Click on `Add` in that dialog without changing anything:
 
 image::oidc-microsoft-6.png[role="thumb"]
 
-On the resulting page, copy your `Secret ID`:
+On the resulting page, copy your `Secret Value`:
 
 image::oidc-microsoft-7.png[role="thumb"]
 


### PR DESCRIPTION
In the guide "CONFIGURING WELL-KNOWN OPENID CONNECT PROVIDERS" under Microsoft, we need to copy the Secret Value and not the Secret ID.