### PR TITLE
Fix Mutiny schedulers context propagation bug

### DIFF
--- a/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
+++ b/extensions/mutiny/deployment/src/main/java/io/quarkus/mutiny/deployment/MutinyProcessor.java
@@ -1,10 +1,14 @@
 package io.quarkus.mutiny.deployment;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+
+import org.jboss.threads.ContextHandler;
 
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ContextHandlerBuildItem;
 import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.mutiny.runtime.MutinyInfrastructure;
@@ -13,10 +17,13 @@ public class MutinyProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void runtimeInit(ExecutorBuildItem executorBuildItem, MutinyInfrastructure recorder,
-            ShutdownContextBuildItem shutdownContext) {
+    public void runtimeInit(ExecutorBuildItem executorBuildItem,
+            MutinyInfrastructure recorder,
+            ShutdownContextBuildItem shutdownContext,
+            Optional<ContextHandlerBuildItem> contextHandler) {
         ExecutorService executor = executorBuildItem.getExecutorProxy();
-        recorder.configureMutinyInfrastructure(executor, shutdownContext);
+        ContextHandler<Object> handler = contextHandler.map(ContextHandlerBuildItem::contextHandler).orElse(null);
+        recorder.configureMutinyInfrastructure(executor, shutdownContext, handler);
     }
 
     @BuildStep

--- a/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/ContextualRunnableScheduledFuture.java
+++ b/extensions/mutiny/runtime/src/main/java/io/quarkus/mutiny/runtime/ContextualRunnableScheduledFuture.java
@@ -1,0 +1,71 @@
+package io.quarkus.mutiny.runtime;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.threads.ContextHandler;
+
+class ContextualRunnableScheduledFuture<V> implements RunnableScheduledFuture<V> {
+    private final RunnableScheduledFuture<V> runnable;
+    private final Object context;
+    private final ContextHandler<Object> contextHandler;
+
+    public ContextualRunnableScheduledFuture(ContextHandler<Object> contextHandler, Object context,
+            RunnableScheduledFuture<V> runnable) {
+        this.contextHandler = contextHandler;
+        this.context = context;
+        this.runnable = runnable;
+    }
+
+    @Override
+    public boolean isPeriodic() {
+        return runnable.isPeriodic();
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return runnable.getDelay(unit);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return runnable.compareTo(o);
+    }
+
+    @Override
+    public void run() {
+        if (contextHandler != null) {
+            contextHandler.runWith(runnable, context);
+        } else {
+            runnable.run();
+        }
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return runnable.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return runnable.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return runnable.isDone();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        return runnable.get();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return runnable.get(timeout, unit);
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -546,14 +546,15 @@ public class VertxCoreRecorder {
 
             @Override
             public void runWith(Runnable task, Object context) {
-                if (context != null) {
+                ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
+                if (context != null && context != currentContext) {
                     // Only do context handling if it's non-null
                     final ContextInternal vertxContext = (ContextInternal) context;
                     vertxContext.beginDispatch();
                     try {
                         task.run();
                     } finally {
-                        vertxContext.endDispatch(null);
+                        vertxContext.endDispatch(currentContext);
                     }
                 } else {
                     task.run();

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/regression/bug25818/BlockingService.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/regression/bug25818/BlockingService.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.resteasy.mutiny.regression.bug25818;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@ApplicationScoped
+public class BlockingService {
+
+    public String getBlocking() {
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        Context context = Vertx.currentContext();
+        if (context == null) {
+            return "~~ context is null ~~";
+        } else {
+            return "hello-" + context.getLocal("hello-target");
+        }
+    }
+}

--- a/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/regression/bug25818/ReproducerResource.java
+++ b/integration-tests/resteasy-mutiny/src/main/java/io/quarkus/it/resteasy/mutiny/regression/bug25818/ReproducerResource.java
@@ -1,0 +1,83 @@
+package io.quarkus.it.resteasy.mutiny.regression.bug25818;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Path("/reproducer/25818")
+public class ReproducerResource {
+
+    private final Logger logger = Logger.getLogger(ReproducerResource.class);
+
+    @Inject
+    BlockingService service;
+
+    private void addToContext() {
+        Vertx.currentContext().putLocal("hello-target", "you");
+    }
+
+    @GET
+    @Path("/worker-pool")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> workerPool() {
+        logger.info("worker pool endpoint");
+        addToContext();
+        return Uni.createFrom()
+                .item(service::getBlocking)
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool());
+    }
+
+    @GET
+    @Path("/default-executor")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> defaultExecutor() {
+        logger.info("default executor endpoint");
+        addToContext();
+        return Uni.createFrom()
+                .item(service::getBlocking)
+                .runSubscriptionOn(Infrastructure.getDefaultExecutor());
+    }
+
+    @GET
+    @Path("/worker-pool-submit")
+    public Uni<String> workerPoolSubmit() {
+        Vertx.currentContext().putLocal("yolo", "yolo");
+        return Uni.createFrom().emitter(emitter -> {
+            Infrastructure.getDefaultWorkerPool().submit(() -> {
+                Context ctx = Vertx.currentContext();
+                if (ctx != null) {
+                    emitter.complete("yolo -> " + ctx.getLocal("yolo"));
+                } else {
+                    emitter.complete("Context was null");
+                }
+            });
+        });
+    }
+
+    @GET
+    @Path("/worker-pool-schedule")
+    public Uni<String> workerPoolSchedule() {
+        Vertx.currentContext().putLocal("yolo", "yolo");
+        return Uni.createFrom().emitter(emitter -> {
+            Infrastructure.getDefaultWorkerPool().schedule(() -> {
+                Context ctx = Vertx.currentContext();
+                if (ctx != null) {
+                    emitter.complete("yolo -> " + ctx.getLocal("yolo"));
+                } else {
+                    emitter.complete("Context was null");
+                }
+            }, 25, TimeUnit.MILLISECONDS);
+        });
+    }
+}

--- a/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/RegressionTest.java
+++ b/integration-tests/resteasy-mutiny/src/test/java/io/quarkus/it/resteasy/mutiny/RegressionTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.it.resteasy.mutiny;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RegressionTest {
+
+    @Nested
+    @DisplayName("Regression tests for #25818 (see https://github.com/quarkusio/quarkus/issues/25818)")
+    public class Bug25818 {
+
+        @Test
+        public void testDefaultExecutor() {
+            get("/reproducer/25818/default-executor")
+                    .then()
+                    .body(is("hello-you"))
+                    .statusCode(200);
+        }
+
+        @Test
+        public void testWorkerPool() {
+            get("/reproducer/25818/worker-pool")
+                    .then()
+                    .body(is("hello-you"))
+                    .statusCode(200);
+        }
+
+        @Test
+        public void yolo1() {
+            get("/reproducer/25818/worker-pool-submit")
+                    .then()
+                    .body(is("yolo -> yolo"))
+                    .statusCode(200);
+        }
+
+        @Test
+        public void yolo2() {
+            get("/reproducer/25818/worker-pool-schedule")
+                    .then()
+                    .body(is("yolo -> yolo"))
+                    .statusCode(200);
+        }
+    }
+}


### PR DESCRIPTION
This is part of a coordinated fix across Quarkus and Mutiny where scheduler wrapping would cause Vert.x context propagation not to be done.

See https://github.com/smallrye/smallrye-mutiny/pull/955

Fixes #25818
