### PR TITLE
Calling `HttpServletRequest.login` to perform servlet authentication in Undertow causes NPE

### DIFF
--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/LoginLogoutServlet.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/LoginLogoutServlet.java
@@ -1,0 +1,37 @@
+package io.quarkus.undertow.test;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.quarkus.security.AuthenticationFailedException;
+
+@WebServlet(urlPatterns = { "/login", "/logout" })
+public class LoginLogoutServlet extends HttpServlet {
+
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if ("/login".equals(req.getServletPath())) {
+            try {
+                req.login(req.getParameter(USER), req.getParameter(PASSWORD));
+            } catch (ServletException ex) {
+                if (ex.getRootCause() instanceof AuthenticationFailedException) {
+                    resp.sendError(401);
+                } else {
+                    resp.sendError(500);
+                }
+            }
+        } else if ("/logout".equals(req.getServletPath())) {
+            req.getSession().invalidate();
+        } else {
+            resp.sendError(404);
+        }
+    }
+}

--- a/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/RolesAllowedServletLoginTestCase.java
+++ b/extensions/undertow/deployment/src/test/java/io/quarkus/undertow/test/RolesAllowedServletLoginTestCase.java
@@ -1,0 +1,61 @@
+package io.quarkus.undertow.test;
+
+import static io.quarkus.undertow.test.LoginLogoutServlet.PASSWORD;
+import static io.quarkus.undertow.test.LoginLogoutServlet.USER;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+public class RolesAllowedServletLoginTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(
+                            LoginLogoutServlet.class,
+                            RolesAllowedBeanServlet.class,
+                            TestIdentityProvider.class,
+                            TestIdentityController.class));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testRolesAllowed() {
+        RestAssured.get("/roles-bean").then().statusCode(401);
+        RestAssured.given().queryParams(Map.of(USER, "admin", PASSWORD, "wrong")).get("/login").then().statusCode(401);
+
+        {
+            final Response response = RestAssured.given().queryParams(Map.of(USER, "admin", PASSWORD, "admin")).get("/login");
+            response.then().statusCode(200);
+            final String sessionId = response.sessionId();
+
+            RestAssured.given().sessionId(sessionId).get("/roles-bean").then().statusCode(200);
+            RestAssured.given().sessionId(sessionId).get("/logout").then().statusCode(200);
+            RestAssured.given().sessionId(sessionId).get("/roles-bean").then().statusCode(401);
+        }
+
+        {
+            final Response response = RestAssured.given().queryParams(Map.of(USER, "user", PASSWORD, "user")).get("/login");
+            response.then().statusCode(200);
+            final String sessionId = response.sessionId();
+
+            RestAssured.given().sessionId(sessionId).get("/roles-bean").then().statusCode(403);
+            RestAssured.given().sessionId(sessionId).get("/logout").then().statusCode(200);
+            RestAssured.given().sessionId(sessionId).get("/roles-bean").then().statusCode(401);
+        }
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusIdentityManager.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/QuarkusIdentityManager.java
@@ -1,0 +1,49 @@
+package io.quarkus.undertow.runtime;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.undertow.security.idm.Account;
+import io.undertow.security.idm.Credential;
+import io.undertow.security.idm.IdentityManager;
+import io.undertow.security.idm.PasswordCredential;
+
+@Singleton
+public class QuarkusIdentityManager implements IdentityManager {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    IdentityProviderManager ipm;
+
+    @Override
+    public Account verify(final Account account) {
+        log.debugf("verify1: %s", account.getPrincipal().getName());
+        return account;
+    }
+
+    @Override
+    public Account verify(final String id, final Credential credential) {
+        log.debugf("verify2: %s - %s", id, credential.getClass());
+
+        if (credential instanceof PasswordCredential) {
+            final PasswordCredential password = PasswordCredential.class.cast(credential);
+            final UsernamePasswordAuthenticationRequest upar = new UsernamePasswordAuthenticationRequest(id,
+                    new io.quarkus.security.credential.PasswordCredential(password.getPassword()));
+            return new QuarkusUndertowAccount(ipm.authenticateBlocking(upar));
+        }
+
+        return null;
+    }
+
+    @Override
+    public Account verify(final Credential credential) {
+        log.debugf("verify3: %s", credential.getClass());
+        return null;
+    }
+}

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -59,6 +59,7 @@ import io.undertow.httpcore.UndertowOptions;
 import io.undertow.security.api.AuthenticationMode;
 import io.undertow.security.api.NotificationReceiver;
 import io.undertow.security.api.SecurityNotification;
+import io.undertow.security.idm.IdentityManager;
 import io.undertow.server.DefaultExchangeHandler;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
@@ -164,7 +165,7 @@ public class UndertowDeploymentRecorder {
     public RuntimeValue<DeploymentInfo> createDeployment(String name, Set<String> knownFile, Set<String> knownDirectories,
             LaunchMode launchMode, ShutdownContext context, String mountPoint, String defaultCharset,
             String requestCharacterEncoding, String responseCharacterEncoding, boolean proactiveAuth,
-            List<String> welcomeFiles) {
+            List<String> welcomeFiles, final boolean hasSecurityCapability) {
         DeploymentInfo d = new DeploymentInfo();
         d.setDefaultRequestEncoding(requestCharacterEncoding);
         d.setDefaultResponseEncoding(responseCharacterEncoding);
@@ -230,6 +231,10 @@ public class UndertowDeploymentRecorder {
             d.setAuthenticationMode(AuthenticationMode.PRO_ACTIVE);
         } else {
             d.setAuthenticationMode(AuthenticationMode.CONSTRAINT_DRIVEN);
+        }
+        if (hasSecurityCapability) {
+            //Fixes NPE at io.undertow.security.impl.SecurityContextImpl.login(SecurityContextImpl.java:198)
+            d.setIdentityManager(CDI.current().select(IdentityManager.class).get());
         }
         return new RuntimeValue<>(d);
     }


### PR DESCRIPTION
When trying to authenticate from a vaadin-flow application (undertow servlet) it causes a NPE in undertow.

# Request for Comment

`QuarkusIdentityManager` is an example implementation to try authentication via `IdentityProviderManager` using a username/password combination.

Its possible to inject an alternative bean from your application by annotating it with `@Alternative` and `@Priority`.

Is there a better approach?

# How to reproduce the NPE

Example project: 
https://github.com/TFyre/quarkus-vaadin-flow
Run with: `mvn quarkus:dev`
URL: http://127.0.0.1:8080

* MainView allows anonymous access
* AdminView only allows user with admin role
* Login will attempt to login via `HttpServletRequest.login`

The project is forked from https://github.com/vaadin/base-starter-flow-quarkus. Ive added `quarkus-security-jpa` to be able to use [Vaadin Access](https://vaadin.com/docs/latest/security/advanced-topics/securing-plain-java-app/#access-annotations) (`@RolesAllowed` / `@AnonymousAllowed`) annotations on views.

Credentials to login: admin / admin

# Stacktrace
```java
SEVERE [com.exa.sta.bas.MainView] (executor-thread-5) null: java.lang.NullPointerException: Cannot invoke "io.undertow.security.idm.IdentityManager.verify(String, io.undertow.security.idm.Credential)" because "this.identityManager" is null
	at io.undertow.security.impl.SecurityContextImpl.login(SecurityContextImpl.java:198)
	at io.undertow.servlet.spec.HttpServletRequestImpl.login(HttpServletRequestImpl.java:467)
	at javax.servlet.http.HttpServletRequestWrapper.login(HttpServletRequestWrapper.java:294)
	at com.example.starter.base.security.SecurityUtils.login(SecurityUtils.java:18)
	at com.example.starter.base.LoginView.onLogin(LoginView.java:50)
	at com.vaadin.flow.component.ComponentEventBus.fireEventForListener(ComponentEventBus.java:206)
	at com.vaadin.flow.component.ComponentEventBus.handleDomEvent(ComponentEventBus.java:448)
	at com.vaadin.flow.component.ComponentEventBus.lambda$addDomTrigger$dd1b7957$1(ComponentEventBus.java:265)
	at com.vaadin.flow.internal.nodefeature.ElementListenerMap.lambda$fireEvent$2(ElementListenerMap.java:447)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at com.vaadin.flow.internal.nodefeature.ElementListenerMap.fireEvent(ElementListenerMap.java:447)
	at com.vaadin.flow.server.communication.rpc.EventRpcHandler.handleNode(EventRpcHandler.java:62)
	at com.vaadin.flow.server.communication.rpc.AbstractRpcInvocationHandler.handle(AbstractRpcInvocationHandler.java:75)
	at com.vaadin.flow.server.communication.ServerRpcHandler.handleInvocationData(ServerRpcHandler.java:438)
	at com.vaadin.flow.server.communication.ServerRpcHandler.lambda$handleInvocations$1(ServerRpcHandler.java:419)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at com.vaadin.flow.server.communication.ServerRpcHandler.handleInvocations(ServerRpcHandler.java:419)
	at com.vaadin.flow.server.communication.ServerRpcHandler.handleRpc(ServerRpcHandler.java:320)
	at com.vaadin.flow.server.communication.UidlRequestHandler.synchronizedHandleRequest(UidlRequestHandler.java:115)
	at com.vaadin.flow.server.SynchronizedRequestHandler.handleRequest(SynchronizedRequestHandler.java:40)
	at com.vaadin.flow.server.VaadinService.handleRequest(VaadinService.java:1564)
	at com.vaadin.flow.server.VaadinServlet.service(VaadinServlet.java:299)
	at com.vaadin.quarkus.QuarkusVaadinServlet.service(QuarkusVaadinServlet.java:84)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:590)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:63)
	at io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:67)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:133)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:65)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:247)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:56)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:111)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:108)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.quarkus.undertow.runtime.UndertowDeploymentRecorder$9$1.call(UndertowDeploymentRecorder.java:590)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:227)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleRequest(ServletInitialHandler.java:152)
	at io.quarkus.undertow.runtime.UndertowDeploymentRecorder$1.handleRequest(UndertowDeploymentRecorder.java:119)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:284)
	at io.undertow.server.DefaultExchangeHandler.handle(DefaultExchangeHandler.java:18)
	at io.quarkus.undertow.runtime.UndertowDeploymentRecorder$5$1.run(UndertowDeploymentRecorder.java:412)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:554)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```