### PR TITLE
Improve stereotypes support

### DIFF
--- a/docs/src/main/asciidoc/cdi-integration.adoc
+++ b/docs/src/main/asciidoc/cdi-integration.adoc
@@ -478,6 +478,28 @@ QualifierRegistrarBuildItem addQualifiers() {
 }
 ----
 
+== Use Case - Additional Stereotypes
+
+It is sometimes useful to register an existing annotation that is not annotated with `@javax.enterprise.inject.Stereotype` as a CDI stereotype.
+This is similar to what CDI achieves through `BeforeBeanDiscovery#addStereotype()`.
+We are going to use `StereotypeRegistrarBuildItem` to get it done.
+
+.`StereotypeRegistrarBuildItem` Example
+[source,java]
+----
+@BuildStep
+StereotypeRegistrarBuildItem addStereotypes() {
+    return new StereotypeRegistrarBuildItem(new StereotypeRegistrar() {
+        @Override
+        public Set<DotName> getAdditionalStereotypes() {
+            return Collections.singleton(DotName.createSimple(NotAStereotype.class.getName()));
+        }
+    });
+}
+----
+
+If the newly registered stereotype annotation doesn't have the appropriate meta-annotations, such as scope or interceptor bindings, use an <<annotations_transformer_build_item,annotation transformation>> to add them.
+
 [[injection_point_transformation]]
 == Use Case - Injection Point Transformation
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalStereotypeBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalStereotypeBuildItem.java
@@ -9,8 +9,13 @@ import org.jboss.jandex.DotName;
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
- * A map of additional stereotype classes to their instances that we want to process.
+ * A map of additional annotation types (that have the same meaning as the {@code @Stereotype} meta-annotation)
+ * to their occurences on other annotations (that become custom stereotypes).
+ *
+ * @deprecated use {@link StereotypeRegistrarBuildItem};
+ *             this class will be removed at some time after Quarkus 3.0
  */
+@Deprecated
 public final class AdditionalStereotypeBuildItem extends MultiBuildItem {
 
     private final Map<DotName, Collection<AnnotationInstance>> stereotypes;

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoProducerMethodsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AutoProducerMethodsProcessor.java
@@ -3,7 +3,7 @@ package io.quarkus.arc.deployment;
 import static io.quarkus.arc.processor.Annotations.contains;
 import static io.quarkus.arc.processor.Annotations.containsAny;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -32,20 +32,20 @@ public class AutoProducerMethodsProcessor {
     @BuildStep
     void annotationTransformer(ArcConfig config, BeanArchiveIndexBuildItem beanArchiveIndex,
             CustomScopeAnnotationsBuildItem scopes,
-            List<AdditionalStereotypeBuildItem> additionalStereotypes,
+            List<StereotypeRegistrarBuildItem> stereotypeRegistrars,
             BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformer) throws Exception {
         if (!config.autoProducerMethods) {
             return;
         }
-        List<DotName> qualifiersAndStereotypes = new ArrayList<>();
+        Set<DotName> qualifiersAndStereotypes = new HashSet<>();
         for (AnnotationInstance qualifier : beanArchiveIndex.getIndex().getAnnotations(DotNames.QUALIFIER)) {
             qualifiersAndStereotypes.add(qualifier.target().asClass().name());
         }
-        for (AnnotationInstance qualifier : beanArchiveIndex.getIndex().getAnnotations(DotNames.STEREOTYPE)) {
-            qualifiersAndStereotypes.add(qualifier.target().asClass().name());
+        for (AnnotationInstance stereotype : beanArchiveIndex.getIndex().getAnnotations(DotNames.STEREOTYPE)) {
+            qualifiersAndStereotypes.add(stereotype.target().asClass().name());
         }
-        for (AdditionalStereotypeBuildItem additionalStereotype : additionalStereotypes) {
-            qualifiersAndStereotypes.addAll(additionalStereotype.getStereotypes().keySet());
+        for (StereotypeRegistrarBuildItem stereotypeRegistrar : stereotypeRegistrars) {
+            qualifiersAndStereotypes.addAll(stereotypeRegistrar.getStereotypeRegistrar().getAdditionalStereotypes());
         }
         LOGGER.debugf("Add missing @Produces to methods annotated with %s", qualifiersAndStereotypes);
         annotationsTransformer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/StereotypeRegistrarBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/StereotypeRegistrarBuildItem.java
@@ -1,0 +1,21 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.processor.StereotypeRegistrar;
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Makes it possible to register annotations that should be considered stereotypes but are not annotated with
+ * {@code javax.enterprise.inject.Stereotype}.
+ */
+public final class StereotypeRegistrarBuildItem extends MultiBuildItem {
+
+    private final StereotypeRegistrar registrar;
+
+    public StereotypeRegistrarBuildItem(StereotypeRegistrar registrar) {
+        this.registrar = registrar;
+    }
+
+    public StereotypeRegistrar getStereotypeRegistrar() {
+        return registrar;
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfigurator.java
@@ -43,6 +43,30 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
             if (implClass == null) {
                 throw new IllegalStateException("Unable to find the bean class in the index: " + implClazz);
             }
+
+            ScopeInfo scope = this.scope;
+            if (scope == null) {
+                scope = Beans.initStereotypeScope(stereotypes, implClass, beanDeployment);
+            }
+            if (scope == null) {
+                scope = BuiltinScope.DEPENDENT.getInfo();
+            }
+
+            String name = this.name;
+            if (name == null) {
+                name = Beans.initStereotypeName(stereotypes, implClass);
+            }
+
+            Boolean alternative = this.alternative;
+            if (alternative == null) {
+                alternative = Beans.initStereotypeAlternative(stereotypes);
+            }
+
+            Integer priority = this.priority;
+            if (priority == null) {
+                priority = Beans.initStereotypeAlternativePriority(stereotypes);
+            }
+
             beanConsumer.accept(new BeanInfo.Builder()
                     .implClazz(implClass)
                     .providerType(providerType)
@@ -52,6 +76,7 @@ public final class BeanConfigurator<T> extends BeanConfiguratorBase<BeanConfigur
                     .qualifiers(qualifiers)
                     .alternative(alternative)
                     .priority(priority)
+                    .stereotypes(stereotypes)
                     .name(name)
                     .creator(creatorConsumer)
                     .destroyer(destroyerConsumer)

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanConfiguratorBase.java
@@ -9,8 +9,10 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -32,7 +34,8 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
     protected final Set<Type> types;
     protected final Set<AnnotationInstance> qualifiers;
     protected ScopeInfo scope;
-    protected boolean alternative;
+    protected Boolean alternative;
+    protected final List<StereotypeInfo> stereotypes;
     protected String name;
     protected Consumer<MethodCreator> creatorConsumer;
     protected Consumer<MethodCreator> destroyerConsumer;
@@ -47,7 +50,7 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
         this.implClazz = implClazz;
         this.types = new HashSet<>();
         this.qualifiers = new HashSet<>();
-        this.scope = BuiltinScope.DEPENDENT.getInfo();
+        this.stereotypes = new ArrayList<>();
         this.removable = true;
     }
 
@@ -68,6 +71,8 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
         scope(base.scope);
         alternative = base.alternative;
         priority = base.priority;
+        stereotypes.clear();
+        stereotypes.addAll(base.stereotypes);
         name(base.name);
         creator(base.creatorConsumer);
         destroyer(base.destroyerConsumer);
@@ -194,6 +199,16 @@ public abstract class BeanConfiguratorBase<THIS extends BeanConfiguratorBase<THI
 
     public THIS priority(int value) {
         this.priority = value;
+        return self();
+    }
+
+    public THIS addStereotype(StereotypeInfo stereotype) {
+        this.stereotypes.add(stereotype);
+        return self();
+    }
+
+    public THIS stereotypes(StereotypeInfo... stereotypes) {
+        Collections.addAll(this.stereotypes, stereotypes);
         return self();
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -287,7 +287,7 @@ public final class Beans {
                 + scopes.stream().map(s -> s.getDotName().toString()).collect(Collectors.joining(", ")));
     }
 
-    private static ScopeInfo initStereotypeScope(List<StereotypeInfo> stereotypes, AnnotationTarget target,
+    static ScopeInfo initStereotypeScope(List<StereotypeInfo> stereotypes, AnnotationTarget target,
             BeanDeployment beanDeployment) {
         if (stereotypes.isEmpty()) {
             return null;
@@ -316,7 +316,7 @@ public final class Beans {
         return BeanDeployment.getValidScope(stereotypeScopes.isEmpty() ? additionalBDAScopes : stereotypeScopes, target);
     }
 
-    private static boolean initStereotypeAlternative(List<StereotypeInfo> stereotypes) {
+    static boolean initStereotypeAlternative(List<StereotypeInfo> stereotypes) {
         if (stereotypes.isEmpty()) {
             return false;
         }
@@ -328,7 +328,7 @@ public final class Beans {
         return false;
     }
 
-    private static Integer initStereotypeAlternativePriority(List<StereotypeInfo> stereotypes) {
+    static Integer initStereotypeAlternativePriority(List<StereotypeInfo> stereotypes) {
         if (stereotypes.isEmpty()) {
             return null;
         }
@@ -340,7 +340,7 @@ public final class Beans {
         return null;
     }
 
-    private static String initStereotypeName(List<StereotypeInfo> stereotypes, AnnotationTarget target) {
+    static String initStereotypeName(List<StereotypeInfo> stereotypes, AnnotationTarget target) {
         if (stereotypes.isEmpty()) {
             return null;
         }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
@@ -17,12 +17,12 @@ public class StereotypeInfo {
     private final ClassInfo target;
     // allows to differentiate between standard stereotype and one that is in fact additional bean defining annotation
     private final boolean isAdditionalBeanDefiningAnnotation;
-    // allows to differentiate between standard stereotype and one that was added through an AdditionalStereotypeBuildItem
-    private final boolean isAdditionalStereotypeBuildItem;
+    // allows to differentiate between standard stereotype and one that was added through StereotypeRegistrarBuildItem
+    private final boolean isAdditionalStereotype;
 
     public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean alternative,
             Integer alternativePriority,
-            boolean isNamed, boolean isAdditionalBeanDefiningAnnotation, boolean isAdditionalStereotypeBuildItem,
+            boolean isNamed, boolean isAdditionalBeanDefiningAnnotation, boolean isAdditionalStereotype,
             ClassInfo target, boolean isInherited, List<AnnotationInstance> parentStereotypes) {
         this.defaultScope = defaultScope;
         this.interceptorBindings = interceptorBindings;
@@ -31,7 +31,7 @@ public class StereotypeInfo {
         this.isNamed = isNamed;
         this.target = target;
         this.isAdditionalBeanDefiningAnnotation = isAdditionalBeanDefiningAnnotation;
-        this.isAdditionalStereotypeBuildItem = isAdditionalStereotypeBuildItem;
+        this.isAdditionalStereotype = isAdditionalStereotype;
         this.isInherited = isInherited;
         this.parentStereotypes = parentStereotypes;
     }
@@ -79,12 +79,21 @@ public class StereotypeInfo {
         return isAdditionalBeanDefiningAnnotation;
     }
 
+    /**
+     * @deprecated use {@link #isAdditionalStereotype()};
+     *             this method will be removed at some time after Quarkus 3.0
+     */
+    @Deprecated
     public boolean isAdditionalStereotypeBuildItem() {
-        return isAdditionalStereotypeBuildItem;
+        return isAdditionalStereotype;
+    }
+
+    public boolean isAdditionalStereotype() {
+        return isAdditionalStereotype;
     }
 
     public boolean isGenuine() {
-        return !isAdditionalBeanDefiningAnnotation && !isAdditionalStereotypeBuildItem;
+        return !isAdditionalBeanDefiningAnnotation && !isAdditionalStereotype;
     }
 
     public List<AnnotationInstance> getParentStereotypes() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeRegistrar.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeRegistrar.java
@@ -1,0 +1,17 @@
+package io.quarkus.arc.processor;
+
+import java.util.Set;
+import javax.enterprise.inject.Stereotype;
+import org.jboss.jandex.DotName;
+
+/**
+ * Makes it possible to turn an annotation into a stereotype without adding a {@link Stereotype} annotation to it.
+ */
+public interface StereotypeRegistrar extends BuildExtension {
+
+    /**
+     * Returns a set of annotation types (their names) that should be treated as stereotypes.
+     * To modify (meta-)annotations on these annotations, use {@link AnnotationsTransformer}.
+     */
+    Set<DotName> getAdditionalStereotypes();
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AlternativePriority.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/AlternativePriority.java
@@ -10,7 +10,7 @@ import javax.enterprise.inject.Alternative;
  * If a bean is annotated with this annotation, it is considered an enabled alternative with given priority.
  * Effectively, this is a shortcut for {@code Alternative} plus {@code Priority} annotations.
  *
- * This annotation can be used not only on bean classes, but also method and field producers (unlike pure {@code Priority}.
+ * This annotation can be used not only on bean classes, but also method and field producers (unlike pure {@code Priority}).
  *
  * @deprecated Use {@link Alternative} and {@link io.quarkus.arc.Priority}/{@link javax.annotation.Priority} instead
  */

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/ArcTestContainer.java
@@ -17,6 +17,7 @@ import io.quarkus.arc.processor.ObserverRegistrar;
 import io.quarkus.arc.processor.ObserverTransformer;
 import io.quarkus.arc.processor.QualifierRegistrar;
 import io.quarkus.arc.processor.ResourceOutput;
+import io.quarkus.arc.processor.StereotypeRegistrar;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -74,6 +75,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         private final List<ContextRegistrar> contextRegistrars;
         private final List<QualifierRegistrar> qualifierRegistrars;
         private final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
+        private final List<StereotypeRegistrar> stereotypeRegistrars;
         private final List<AnnotationsTransformer> annotationsTransformers;
         private final List<InjectionPointsTransformer> injectionsPointsTransformers;
         private final List<ObserverTransformer> observerTransformers;
@@ -93,6 +95,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             contextRegistrars = new ArrayList<>();
             qualifierRegistrars = new ArrayList<>();
             interceptorBindingRegistrars = new ArrayList<>();
+            stereotypeRegistrars = new ArrayList<>();
             annotationsTransformers = new ArrayList<>();
             injectionsPointsTransformers = new ArrayList<>();
             observerTransformers = new ArrayList<>();
@@ -161,6 +164,11 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             return this;
         }
 
+        public Builder stereotypeRegistrars(StereotypeRegistrar... registrars) {
+            Collections.addAll(this.stereotypeRegistrars, registrars);
+            return this;
+        }
+
         public Builder beanDeploymentValidators(BeanDeploymentValidator... validators) {
             Collections.addAll(this.beanDeploymentValidators, validators);
             return this;
@@ -204,6 +212,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
     private final List<ContextRegistrar> contextRegistrars;
     private final List<QualifierRegistrar> qualifierRegistrars;
     private final List<InterceptorBindingRegistrar> interceptorBindingRegistrars;
+    private final List<StereotypeRegistrar> stereotypeRegistrars;
     private final List<AnnotationsTransformer> annotationsTransformers;
     private final List<InjectionPointsTransformer> injectionPointsTransformers;
     private final List<ObserverTransformer> observerTransformers;
@@ -226,6 +235,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.observerRegistrars = Collections.emptyList();
         this.contextRegistrars = Collections.emptyList();
         this.interceptorBindingRegistrars = Collections.emptyList();
+        this.stereotypeRegistrars = Collections.emptyList();
         this.qualifierRegistrars = Collections.emptyList();
         this.annotationsTransformers = Collections.emptyList();
         this.injectionPointsTransformers = Collections.emptyList();
@@ -248,6 +258,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
         this.contextRegistrars = builder.contextRegistrars;
         this.qualifierRegistrars = builder.qualifierRegistrars;
         this.interceptorBindingRegistrars = builder.interceptorBindingRegistrars;
+        this.stereotypeRegistrars = builder.stereotypeRegistrars;
         this.annotationsTransformers = builder.annotationsTransformers;
         this.injectionPointsTransformers = builder.injectionsPointsTransformers;
         this.observerTransformers = builder.observerTransformers;
@@ -370,6 +381,7 @@ public class ArcTestContainer implements BeforeEachCallback, AfterEachCallback {
             contextRegistrars.forEach(builder::addContextRegistrar);
             qualifierRegistrars.forEach(builder::addQualifierRegistrar);
             interceptorBindingRegistrars.forEach(builder::addInterceptorBindingRegistrar);
+            stereotypeRegistrars.forEach(builder::addStereotypeRegistrar);
             annotationsTransformers.forEach(builder::addAnnotationTransformer);
             injectionPointsTransformers.forEach(builder::addInjectionPointTransformer);
             observerTransformers.forEach(builder::addObserverTransformer);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithStereotypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SyntheticBeanWithStereotypeTest.java
@@ -1,0 +1,128 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.AlternativePriority;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.processor.StereotypeInfo;
+import io.quarkus.arc.processor.StereotypeRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.gizmo.MethodDescriptor;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SyntheticBeanWithStereotypeTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ToBeStereotype.class, SimpleBinding.class, SimpleInterceptor.class)
+            .additionalClasses(SomeBean.class)
+            .stereotypeRegistrars(new MyStereotypeRegistrar())
+            .annotationsTransformers(new MyAnnotationTrasnformer())
+            .beanRegistrars(new MyBeanRegistrar())
+            .build();
+
+    @Test
+    public void test() {
+        InstanceHandle<SomeBean> bean = Arc.container().select(SomeBean.class).getHandle();
+        assertEquals(ApplicationScoped.class, bean.getBean().getScope());
+        assertEquals("someBean", bean.getBean().getName());
+        assertTrue(bean.getBean().isAlternative());
+        assertEquals(11, bean.getBean().getPriority());
+
+        SomeBean instance = bean.get();
+        assertNotNull(instance);
+        assertEquals("hello", instance.hello());
+        // interceptors are _not_ applied to synthetic beans
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface ToBeStereotype {
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface SimpleBinding {
+    }
+
+    @Interceptor
+    @Priority(1)
+    @SimpleBinding
+    static class SimpleInterceptor {
+        @AroundInvoke
+        public Object invoke(InvocationContext context) throws Exception {
+            return "intercepted: " + context.proceed();
+        }
+    }
+
+    @ToBeStereotype
+    static class SomeBean {
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    static class MyStereotypeRegistrar implements StereotypeRegistrar {
+        @Override
+        public Set<DotName> getAdditionalStereotypes() {
+            return Set.of(DotName.createSimple(ToBeStereotype.class.getName()));
+        }
+    }
+
+    static class MyAnnotationTrasnformer implements AnnotationsTransformer {
+        @Override
+        public boolean appliesTo(AnnotationTarget.Kind kind) {
+            return kind == AnnotationTarget.Kind.CLASS;
+        }
+
+        @Override
+        public void transform(TransformationContext transformationContext) {
+            if (transformationContext.getTarget().asClass().name()
+                    .equals(DotName.createSimple(ToBeStereotype.class.getName()))) {
+                transformationContext.transform()
+                        .add(ApplicationScoped.class)
+                        .add(SimpleBinding.class)
+                        .add(Named.class)
+                        .add(AlternativePriority.class, AnnotationValue.createIntegerValue("value", 11))
+                        .done();
+            }
+        }
+    }
+
+    static class MyBeanRegistrar implements BeanRegistrar {
+        @Override
+        public void register(RegistrationContext context) {
+            StereotypeInfo stereotype = context.get(Key.STEREOTYPES).get(DotName.createSimple(ToBeStereotype.class.getName()));
+
+            context.configure(SomeBean.class)
+                    .types(SomeBean.class)
+                    .stereotypes(stereotype)
+                    .creator(mc -> mc.returnValue(mc.newInstance(MethodDescriptor.ofConstructor(SomeBean.class))))
+                    .done();
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/stereotypes/AdditionalStereotypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/stereotypes/AdditionalStereotypesTest.java
@@ -1,0 +1,111 @@
+package io.quarkus.arc.test.buildextension.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.StereotypeRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Named;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.DotName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AdditionalStereotypesTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(ToBeStereotype.class, SimpleBinding.class, SimpleInterceptor.class, SomeBean.class)
+            .stereotypeRegistrars(new MyStereotypeRegistrar())
+            .annotationsTransformers(new MyAnnotationTrasnformer())
+            .build();
+
+    @Test
+    public void test() {
+        InstanceHandle<SomeBean> bean = Arc.container().select(SomeBean.class).getHandle();
+        assertEquals(ApplicationScoped.class, bean.getBean().getScope());
+        assertEquals("someBean", bean.getBean().getName());
+        assertTrue(bean.getBean().isAlternative());
+        assertEquals(11, bean.getBean().getPriority());
+
+        SomeBean instance = bean.get();
+        assertNotNull(instance);
+        assertEquals("intercepted: hello", instance.hello());
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface ToBeStereotype {
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    @InterceptorBinding
+    @interface SimpleBinding {
+    }
+
+    @Interceptor
+    @Priority(1)
+    @SimpleBinding
+    static class SimpleInterceptor {
+        @AroundInvoke
+        public Object invoke(InvocationContext context) throws Exception {
+            return "intercepted: " + context.proceed();
+        }
+    }
+
+    @ToBeStereotype
+    static class SomeBean {
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    static class MyStereotypeRegistrar implements StereotypeRegistrar {
+        @Override
+        public Set<DotName> getAdditionalStereotypes() {
+            return Set.of(DotName.createSimple(ToBeStereotype.class.getName()));
+        }
+    }
+
+    static class MyAnnotationTrasnformer implements AnnotationsTransformer {
+        @Override
+        public boolean appliesTo(AnnotationTarget.Kind kind) {
+            return kind == AnnotationTarget.Kind.CLASS;
+        }
+
+        @Override
+        public void transform(TransformationContext transformationContext) {
+            if (transformationContext.getTarget().asClass().name()
+                    .equals(DotName.createSimple(ToBeStereotype.class.getName()))) {
+                transformationContext.transform()
+                        .add(ApplicationScoped.class)
+                        .add(SimpleBinding.class)
+                        .add(Named.class)
+                        .add(Alternative.class)
+                        .add(Priority.class, AnnotationValue.createIntegerValue("value", 11))
+                        .done();
+            }
+        }
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeArcPriorityTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/StereotypeAlternativeArcPriorityTest.java
@@ -1,0 +1,137 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.AlternativePriority;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.Priority;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+// copy of `StereotypeAlternativeTest` that uses ArC `@Priority` and `@AlternativePriority`
+// instead of Jakarta Common Annotations `@Priority`
+public class StereotypeAlternativeArcPriorityTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(BeAlternative.class, BeAlternativeWithPriority.class,
+            NonAlternative.class, IamAlternative.class, NotAtAllAlternative.class, IamAlternativeWithPriority.class,
+            ToBeOverridenFoo.class, MockedFoo.class, MockedFooWithExplicitPriority.class, Mock.class);
+
+    @Test
+    public void testStereotype() {
+        assertEquals("OK", Arc.container().instance(NonAlternative.class).get().getId());
+        assertEquals("OK", Arc.container().instance(NotAtAllAlternative.class).get().getId());
+
+        assertEquals(MockedFooWithExplicitPriority.class.getSimpleName(),
+                Arc.container().instance(ToBeOverridenFoo.class).get().ping());
+        assertEquals(MockedFoo.class.getSimpleName(), Arc.container().instance(MockedFoo.class).get().ping());
+    }
+
+    @Alternative
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface BeAlternative {
+    }
+
+    @AlternativePriority(1)
+    @Stereotype
+    @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface BeAlternativeWithPriority {
+    }
+
+    @Dependent
+    static class NonAlternative {
+
+        public String getId() {
+            return "NOK";
+        }
+
+    }
+
+    @Priority(1)
+    @BeAlternative
+    static class IamAlternative extends NonAlternative {
+
+        @Override
+        public String getId() {
+            return "OK";
+        }
+
+    }
+
+    @Dependent
+    static class NotAtAllAlternative {
+
+        public String getId() {
+            return "NOK";
+        }
+
+    }
+
+    @BeAlternativeWithPriority
+    static class IamAlternativeWithPriority extends NotAtAllAlternative {
+
+        @Override
+        public String getId() {
+            return "OK";
+        }
+
+    }
+
+    @Dependent
+    static class ToBeOverridenFoo {
+
+        public String ping() {
+            return ToBeOverridenFoo.class.getSimpleName();
+        }
+    }
+
+    @Mock
+    // should not be selected because of lower priority (has 1)
+    static class MockedFoo extends ToBeOverridenFoo {
+
+        @Override
+        public String ping() {
+            return MockedFoo.class.getSimpleName();
+        }
+
+    }
+
+    @Mock
+    @Priority(2)
+    static class MockedFooWithExplicitPriority extends ToBeOverridenFoo {
+
+        @Override
+        public String ping() {
+            return MockedFooWithExplicitPriority.class.getSimpleName();
+        }
+    }
+
+    /**
+     * The built-in stereotype intended for use with mock beans injected in tests.
+     */
+    @Priority(1)
+    @Dependent
+    @Alternative
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    public @interface Mock {
+
+    }
+
+}


### PR DESCRIPTION
This commit adds a better API for registering custom stereotypes, similar
to existing APIs: `StereotypeRegistrar` and `StereotypeRegistrarBuildItem`.
The existing `AdditionalStereotypeBuildItem` is very confusing to use, so
it is deprecated and all its usages are replaced with the new API.

Also, this commit allows defining stereotypes for synthetic beans. Scope,
name, alternative status and priority are all applied to the synthetic bean,
but interceptor bindings are not. We don't apply interceptors to synthetic
beans in general, this case is not an exception.