### PR TITLE
Update Kotlin and dokka to 1.7.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -144,7 +144,7 @@
         <aws-lambda-java-events.version>3.11.0</aws-lambda-java-events.version>
         <aws-xray.version>2.11.2</aws-xray.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.6.21</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <kotlin.coroutine.version>1.6.2</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.3</kotlin-serialization.version>
         <kubernetes-client.version>5.12.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,8 +20,8 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.6.21</kotlin.version>
-        <dokka.version>1.6.21</dokka.version>
+        <kotlin.version>1.7.0</kotlin.version>
+        <dokka.version>1.7.0</dokka.version>
         <scala.version>2.13.8</scala.version>
         <scala-maven-plugin.version>4.6.3</scala-maven-plugin.version>
         <!-- not pretty but this is used in the codestarts and we don't want to break compatibility -->

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.6.21</version>
+            <version>1.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -34,7 +34,7 @@ if [ "${REWRITE_OFFLINE-false}" != "true" ]; then
   # Build Kotlin Maven Plugin to allow skipping main compilation
   # (skipping test compilation is supported but not main)
   rm -rf target/kotlin
-  git clone -b v1.6.21-jakarta --depth 1 https://github.com/gsmet/kotlin.git target/kotlin
+  git clone -b v1.7.0-jakarta --depth 1 https://github.com/gsmet/kotlin.git target/kotlin
   pushd target/kotlin/libraries/tools/kotlin-maven-plugin
   mvn -B clean install -DskipTests -DskipITs
   popd


### PR DESCRIPTION
I haven't checked yet whether [those Gradle tests are still failing on Java 19-EA](https://github.com/quarkusio/quarkus/pull/24086/files#diff-c4df82b52272e0d864fe167a9f60cedc3934c19527161ce00ff3aef2aaaf0387), but I don't think anything has changed in that regard.