### PR TITLE
Vert.x Http - Bunch of compression support fixes for static resources

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AbstractStaticResourcesTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/AbstractStaticResourcesTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.vertx.http;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+public abstract class AbstractStaticResourcesTest {
+
+    @Test
+    public void shouldEncodeHtmlPage() {
+        RestAssured.when().get("/static-file.html")
+                .then()
+                .header("Content-Encoding", "gzip")
+                .header("Transfer-Encoding", "chunked")
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void shouldEncodeRootPage() {
+        RestAssured.when().get("/")
+                .then()
+                .header("Content-Encoding", "gzip")
+                .header("Transfer-Encoding", "chunked")
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+    }
+
+    @Test
+    public void shouldNotEncodeSVG() {
+        RestAssured.when().get("/image.svg")
+                .then()
+                .header("Content-Encoding", Matchers.nullValue())
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/StaticResourcesTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/StaticResourcesTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.vertx.http;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StaticResourcesTest extends AbstractStaticResourcesTest {
+
+    @RegisterExtension
+    final static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .add(new StringAsset("quarkus.http.enable-compression=true\n"),
+                            "application.properties")
+                    .addAsResource("static-file.html", "META-INF/resources/static-file.html")
+                    .addAsResource("static-file.html", "META-INF/resources/index.html")
+                    .addAsResource("static-file.html", "META-INF/resources/image.svg"));
+
+}

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/StaticResourcesDevModeTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devmode/StaticResourcesDevModeTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.vertx.http.devmode;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.vertx.http.AbstractStaticResourcesTest;
+import io.restassured.RestAssured;
+
+public class StaticResourcesDevModeTest extends AbstractStaticResourcesTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .add(new StringAsset("quarkus.http.enable-compression=true\n"),
+                            "application.properties")
+                    .addAsResource("static-file.html", "META-INF/resources/static-file.html")
+                    .addAsResource("static-file.html", "META-INF/resources/index.html")
+                    .addAsResource("static-file.html", "META-INF/resources/image.svg"));
+
+    @Test
+    void shouldChangeContentOnModification() {
+        RestAssured.when().get("/static-file.html")
+                .then()
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+        RestAssured.when().get("/")
+                .then()
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+        test.modifyResourceFile("META-INF/resources/static-file.html", s -> s.replace("webpage", "Andy"));
+        RestAssured.when().get("/static-file.html")
+                .then()
+                .body(Matchers.containsString("This is the title of the Andy!"))
+                .statusCode(200);
+        RestAssured.when().get("/")
+                .then()
+                .body(Matchers.containsString("This is the title of the webpage!"))
+                .statusCode(200);
+    }
+}

--- a/extensions/vertx-http/deployment/src/test/resources/static-file.html
+++ b/extensions/vertx-http/deployment/src/test/resources/static-file.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+    <title>This is the title of the webpage!</title>
+</head>
+<body>
+<p>This is an example paragraph. Anything in the <strong>body</strong> tag will appear on the page, just like this <strong>p</strong> tag and its contents.</p>
+</body>
+</html>


### PR DESCRIPTION
- Static resource compression was not working in dev-mode: Failing test + Fix
- Static resource compression was not working in prod-mode for `/`: Failing test + Fix
- In prod-mode, some requests might not be compressed because of a synchronisation problem 
- Add small optim for compression checking
- Add more tests for static resources (live coding...)