### PR TITLE
Allows Avro Specific Record classes (generated from Avro schema) to be serialized using Jackson

### DIFF
--- a/extensions/avro/deployment/pom.xml
+++ b/extensions/avro/deployment/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-spi</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
+++ b/extensions/avro/deployment/src/main/java/io/quarkus/avro/deployment/AvroProcessor.java
@@ -3,11 +3,14 @@ package io.quarkus.avro.deployment;
 import java.util.Collection;
 
 import org.apache.avro.specific.AvroGenerated;
+import org.apache.avro.specific.SpecificRecordBase;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.avro.runtime.AvroRecorder;
+import io.quarkus.avro.runtime.jackson.SpecificRecordBaseSerializer;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -17,6 +20,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.jackson.spi.JacksonModuleBuildItem;
 
 public class AvroProcessor {
 
@@ -48,5 +52,22 @@ public class AvroProcessor {
         builder.addRuntimeInitializedClass("org.apache.avro.reflect.ReflectData");
         conf.produce(builder.build());
         sys.produce(new NativeImageSystemPropertyBuildItem("avro.disable.unsafe", "true"));
+    }
+
+    @BuildStep
+    void registerJacksonSerializer(CombinedIndexBuildItem indexBuildItem, BuildProducer<JacksonModuleBuildItem> producer) {
+        Collection<AnnotationInstance> annotations = indexBuildItem.getIndex()
+                .getAnnotations(DotName.createSimple(AvroGenerated.class.getName()));
+        JacksonModuleBuildItem.Builder builder = new JacksonModuleBuildItem.Builder("AvroSpecificRecordModule");
+        for (AnnotationInstance annotation : annotations) {
+            if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
+                ClassInfo classInfo = annotation.target().asClass();
+                String className = classInfo.name().toString();
+                if (classInfo.superName().equals(DotName.createSimple(SpecificRecordBase.class.getName()))) {
+                    builder.addSerializer(SpecificRecordBaseSerializer.class.getName(), className);
+                }
+            }
+        }
+        producer.produce(builder.build());
     }
 }

--- a/extensions/avro/runtime/pom.xml
+++ b/extensions/avro/runtime/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>

--- a/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/jackson/SpecificDataSerializer.java
+++ b/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/jackson/SpecificDataSerializer.java
@@ -1,0 +1,23 @@
+package io.quarkus.avro.runtime.jackson;
+
+import java.io.IOException;
+
+import org.apache.avro.specific.SpecificData;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class SpecificDataSerializer extends StdSerializer<SpecificData> {
+    public SpecificDataSerializer() {
+        super(SpecificData.class);
+    }
+
+    @Override
+    public void serialize(SpecificData data, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        System.out.println("here! ");
+        // Skip the specific data instance
+    }
+
+}

--- a/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/jackson/SpecificRecordBaseSerializer.java
+++ b/extensions/avro/runtime/src/main/java/io/quarkus/avro/runtime/jackson/SpecificRecordBaseSerializer.java
@@ -1,0 +1,34 @@
+package io.quarkus.avro.runtime.jackson;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecordBase;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * By default, you cannot serialize Avro specific records to JSON, as they contain non-serializable members.
+ * This serializer iterates over the declared fields (in the schema), and build an object only containing these fields.
+ * It means that the Avro "metadata" won't be included in the JSON representation.
+ */
+public class SpecificRecordBaseSerializer extends StdSerializer<SpecificRecordBase> {
+
+    public SpecificRecordBaseSerializer() {
+        super(SpecificRecordBase.class);
+    }
+
+    @Override
+    public void serialize(SpecificRecordBase record, JsonGenerator gen,
+            SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        List<Schema.Field> fields = record.getSchema().getFields();
+        for (Schema.Field field : fields) {
+            provider.defaultSerializeField(field.name(), record.get(field.pos()), gen);
+        }
+        gen.writeEndObject();
+    }
+}

--- a/integration-tests/kafka-avro/pom.xml
+++ b/integration-tests/kafka-avro/pom.xml
@@ -36,6 +36,14 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
 
         <!-- Kafka, also includes support for Apicurio Registry 1.x serde -->
         <dependency>
@@ -265,6 +273,32 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/AvroSpecificRecordJacksonSerializationTest.java
+++ b/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/AvroSpecificRecordJacksonSerializationTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.kafka;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.it.kafka.avro.Pet;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * This test verifies that the Avro classes can be serialized using Jackson.
+ * By default, they can't as the Avro class contains non-serializable fields.
+ *
+ * There is a custom serializer registered explicitly that allow the serialization.
+ */
+@QuarkusTest
+public class AvroSpecificRecordJacksonSerializationTest {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Test
+    void testSerialization() throws JsonProcessingException {
+        Assertions.assertTrue(mapper.getRegisteredModuleIds().contains("AvroSpecificRecordModule"));
+
+        Pet pet = new Pet("roxanne", "gray");
+        String s = mapper.writer().writeValueAsString(pet);
+        // The serializer preserves the order of the field.
+        Assertions.assertEquals(s, "{\"name\":\"roxanne\",\"color\":\"gray\"}");
+    }
+
+}


### PR DESCRIPTION
They cannot be serialized by default. This commit registers serializers to make them serializable.
It particularly convenient when you receive an Avro record (from Kafka) and want to returns it from a HTTP endpoint.


@geoand this is the feature that was missing to make my demo works :-D 