### PR TITLE
Ensure ExcludeConfigBuildItem produces quoted arguments to fix Windows compatibility

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -876,8 +876,8 @@ public class NativeImageBuildStep {
 
                 for (ExcludeConfigBuildItem excludeConfig : excludeConfigs) {
                     nativeImageArgs.add("--exclude-config");
-                    nativeImageArgs.add(excludeConfig.getJarFile());
-                    nativeImageArgs.add(excludeConfig.getResourceName());
+                    nativeImageArgs.add('"' + excludeConfig.getJarFile() + '"');
+                    nativeImageArgs.add('"' + excludeConfig.getResourceName() + '"');
                 }
 
                 // Work around https://github.com/quarkusio/quarkus/issues/21372


### PR DESCRIPTION

Fixes #25954 (temptatively: someone with Windows should verify)