### PR TITLE
Update `apicurio-common-rest-client-vertx` version

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -191,7 +191,7 @@
         <log4j-jboss-logmanager.version>1.3.0.Final</log4j-jboss-logmanager.version>
         <avro.version>1.11.0</avro.version>
         <apicurio-registry.version>2.2.4.Final</apicurio-registry.version>
-        <apicurio-common-rest-client.version>0.1.9.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
+        <apicurio-common-rest-client.version>0.1.11.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <jacoco.version>0.8.8</jacoco.version>
         <testcontainers.version>1.17.2</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.2.13</docker-java.version> <!-- must be the version Testcontainers use -->


### PR DESCRIPTION
Update `apicurio-common-rest-client-vertx` version to the most recent version. The current version (`0.1.9.Final`) does not work with some versions of apicurio. `0.1.11.Final` does, and is being used already. See https://github.com/quarkusio/quarkus-super-heroes/blob/280ba7d522d8f3a30a809cd92c8c89987276d8f9/rest-fights/pom.xml#L104-L122

Specifically see https://github.com/quarkusio/quarkus/issues/25378#issuecomment-1118669593

Closes #25378