### PR TITLE
Use variable for volume modifier because :Z does not play nicely on M1

### DIFF
--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -161,7 +161,7 @@
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <log>
-                                            <prefix>Elasticsearch: </prefix>
+                                            <prefix>Elasticsearch:</prefix>
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
@@ -192,13 +192,13 @@
                                             <port>9600:9600</port>
                                         </ports>
                                         <log>
-                                            <prefix>Logstash: </prefix>
+                                            <prefix>Logstash:</prefix>
                                             <date>default</date>
                                             <color>cyan</color>
                                         </log>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/src/test/resources/pipeline:/usr/share/logstash/pipeline:Z</volume>
+                                                <volume>${project.basedir}/src/test/resources/pipeline:/usr/share/logstash/pipeline${volume.access.modifier}</volume>
                                             </bind>
                                         </volumes>
                                         <wait>


### PR DESCRIPTION
Partial resolution of #25428. See also discussion in #25648. It looks like sometime between me raising #25648, @yrodiere fixing the elastic search part with #25663 , and me trying again some time later, a volume mount got added to the elasticsearch docker config. As per #25805, volume mounts need a different access modifier on M1.  

Symptom being fixed: Build fails with `setxattr … operation not supported`

To test: 

TESTCONTAINERS_RYUK_DISABLED="true" ./mvnw -Dquickly -DskipTests=false -Dstart-containers -Dtest-containers -f integration-tests/logging-gelf

