### PR TITLE
Provide the possibility to log user data from exchange

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/ExchangeDataAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/ExchangeDataAttribute.java
@@ -1,0 +1,48 @@
+package io.quarkus.vertx.http.runtime.attribute;
+
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Provide entries from the "user data" section of the RoutingContext
+ */
+public class ExchangeDataAttribute implements ExchangeAttribute {
+
+    private final String dataKey;
+
+    public ExchangeDataAttribute(String dataKey) {
+        this.dataKey = dataKey;
+    }
+
+    @Override
+    public String readAttribute(RoutingContext exchange) {
+        return exchange.get(dataKey);
+    }
+
+    @Override
+    public void writeAttribute(RoutingContext exchange, String newValue) throws ReadOnlyAttributeException {
+        throw new ReadOnlyAttributeException();
+    }
+
+    public static final class Builder implements ExchangeAttributeBuilder {
+
+        @Override
+        public String name() {
+            return "Exchange data";
+        }
+
+        @Override
+        public ExchangeAttribute build(final String token) {
+            if (token.startsWith("%{d,") && token.endsWith("}")) {
+                final String dataItemName = token.substring(4, token.length() - 1);
+                return new ExchangeDataAttribute(dataItemName);
+            }
+            return null;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
@@ -84,6 +84,7 @@ import io.vertx.ext.web.RoutingContext;
  * <li><code>%{c,xxx}</code> for a specific cookie
  * <li><code>%{r,xxx}</code> xxx is an attribute in the ServletRequest
  * <li><code>%{s,xxx}</code> xxx is an attribute in the HttpSession
+ * <li><code>%{d,xxx}</code> xxx is a data item in the exchange</li>
  * </ul>
  *
  * @author Stuart Douglas

--- a/extensions/vertx-http/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
+++ b/extensions/vertx-http/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
@@ -28,3 +28,4 @@ io.quarkus.vertx.http.runtime.attribute.RemoteHostAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.RequestPathAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.NullAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.AllRequestHeadersAttribute$Builder
+io.quarkus.vertx.http.runtime.attribute.ExchangeDataAttribute$Builder


### PR DESCRIPTION
It is now possible to use `%{d,data-key}` in access log expressions to log an attribute from the Vert.X `RoutingContext.data` map

E.g.

`quarkus.http.access-log.pattern="%h %l %u %t \"%r\" %s %b accountId=%{d,x-rh-account}" `

would result in 

`2022-06-24 09:05:48,960 INFO  [access_log] (executor-thread-2) "127.0.0.1 - joe-doe-user 24/Jun/2022:09:05:48 +0200 "GET / HTTP/1.1" 403 - accountId= 1234" 
`

Fixes #26338