### PR TITLE
Move excludes for jaeger-thrift to the bom

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -3138,6 +3138,17 @@
                         <groupId>org.apache.tomcat.embed</groupId>
                         <artifactId>tomcat-embed-core</artifactId>
                     </exclusion>
+                    <!-- jaeger-thrift 3.43.3 pulls in a banned version of annotation-api -->
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                    <!-- it also pulls in the jakarta annotations via the 'org.apache.tomcat:tomcat-annotations-api' which seems to be a copy of 'jakarta.annotation:jakarta.annotation-api'-->
+                    <!-- https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-annotations-api -->
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>tomcat-annotations-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/extensions/jaeger/runtime/pom.xml
+++ b/extensions/jaeger/runtime/pom.xml
@@ -24,19 +24,6 @@
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-thrift</artifactId>
-            <exclusions>
-                <!-- jaeger-thrift 3.43.3 pulls in a banned version of annotation-api -->
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <!-- it also pulls in the jakarta annotations via the 'org.apache.tomcat:tomcat-annotations-api' which seems to be a copy of 'jakarta.annotation:jakarta.annotation-api'-->
-                <!-- https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-annotations-api -->
-                <exclusion>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-annotations-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Move excludes for jaeger-thrift to the bom.

At the moment there is one exclude in the BOM and two excludes in jaeger extension.
This PR moves them into one place and will prevent troubles on RHBQ side.

Related to https://issues.redhat.com/browse/QUARKUS-2239, jaeger-client / jaeger-thrift is the the most concerning item.