### PR TITLE
Update gitflow-incremental-builder to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>4.1.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.1.1</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.51</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
I released it 4 days ago and it still hasn't made it through the dependabot jam, so I'm doing it myself.

---

https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.1.1

> Most notable changes are:
> - Classloading fix w.r.t `Xpp3Dom` when using GIB via `.mvn/extensions.xml`:  https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/538
> - Update JGit from 6.1.0 to 6.2.0:  https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/537
> 
> ## What's Changed
> * Update to Maven 3.8.6 by @famod in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/535
> * Bump maven-failsafe-plugin from 3.0.0-M6 to 3.0.0-M7 by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/532
> * Bump maven-surefire-plugin from 3.0.0-M6 to 3.0.0-M7 by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/533
> * Bump version.jgit from 6.1.0.202203080745-r to 6.2.0.202206071550-r by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/537
> * Fix Xpp3Dom casting when using GIB as core extension by @famod in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/539
> * Bump maven-release-plugin from 3.0.0-M5 to 3.0.0-M6 by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/534
> * Bump maven-enforcer-plugin from 3.0.0 to 3.1.0 by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/536
> * CI: Add Java 19 EA, switch 18 EA to 18 by @famod in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/540
> * Bump version.mockito from 4.6.0 to 4.6.1 by @dependabot in https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/pull/531
> 
> 
> **Full Changelog**: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/compare/v4.1.0...v4.1.1

---

So, nothing critical for Quarkus.