### PR TITLE
Fix JAX-RS annotations in rest-client examples

### DIFF
--- a/docs/src/main/asciidoc/rest-client-multipart.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart.adoc
@@ -128,7 +128,7 @@ The purpose of the annotations in the code above is the following:
 
 * `@RegisterRestClient` allows Quarkus to know that this interface is meant to be available for
 CDI injection as a REST Client
-* `@Path`, `@GET` and `@PathParam` are the standard JAX-RS annotations used to define how to access the service
+* `@Path` and `@POST` are the standard JAX-RS annotations used to define how to access the service
 * `@MultipartForm` defines the parameter as a value object for incoming/outgoing request/responses of the multipart/form-data mime type.
 * `@Consumes` defines the expected content-type consumed by this request (parameters)
 * `@Produces` defines the expected content-type produced by this request (return type)

--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -117,7 +117,7 @@ The purpose of the annotations in the code above is the following:
 
 * `@RegisterRestClient` allows Quarkus to know that this interface is meant to be available for
 CDI injection as a REST Client
-* `@Path`, `@GET` and `@PathParam` are the standard JAX-RS annotations used to define how to access the service
+* `@Path`, `@GET` and `@QueryParam` are the standard JAX-RS annotations used to define how to access the service
 
 [NOTE]
 ====

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -113,6 +113,7 @@ import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import java.util.Set;
 
 @Path("/extensions")
@@ -130,7 +131,7 @@ The purpose of the annotations in the code above is the following:
 
 * `@RegisterRestClient` allows Quarkus to know that this interface is meant to be available for
 CDI injection as a REST Client
-* `@Path`, `@GET` and `@PathParam` are the standard JAX-RS annotations used to define how to access the service
+* `@Path`, `@GET` and `@QueryParam` are the standard JAX-RS annotations used to define how to access the service
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR fixes several minor differences between imports, usage and description of JAX-RS annotations in code examples in the rest-client documentation pages.