### PR TITLE
Fix missing `plexus-utils:3.4.1` when building gradle plugins

### DIFF
--- a/devtools/gradle/build.gradle
+++ b/devtools/gradle/build.gradle
@@ -21,14 +21,7 @@ subprojects {
     }
 
     repositories {
-        // in case a custom local repo is configured we are going to use that instead of the default mavenLocal()
-        if (System.properties.containsKey('maven.repo.local')) {
-            maven {
-                url System.properties.get('maven.repo.local')
-            }
-        } else {
-            mavenLocal()
-        }
+        mavenLocal()
         mavenCentral()
     }
 


### PR DESCRIPTION
Fixes #26336

See issue for more details on this.

tl;dr:
`mavenLocal()` does seem to handle "incomplete" dependencies in local Maven repo, but `maven { someUrl }` does not seem to do so.
But since `maven.repo.local` (which we set in the Maven part via exec-plugin) is used in Gradle to find the path for `mavenLocal()` (see https://github.com/gradle/gradle/pull/315), we don't even need `maven { someUrl }`.

Now, why does Maven only download the pom.xml of `plexus-utils:3.4.1`, even though there does not seem to be a real dependency on it? I don't know and it shouldn't really matter at this point.