### PR TITLE
Allow to override the Oracle JDBC metadata for native images also on Windows

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -35,7 +35,8 @@ import io.quarkus.maven.dependency.ArtifactKey;
 public final class OracleMetadataOverrides {
 
     static final String DRIVER_JAR_MATCH_REGEX = ".*com\\.oracle\\.database\\.jdbc.*";
-    static final String NATIVE_IMAGE_RESOURCE_MATCH_REGEX = "/META-INF/native-image/(?:native-image\\.properties|reflect-config\\.json)";
+    static final String NATIVE_IMAGE_RESOURCE_MATCH_REGEX = "/META-INF/native-image/native-image\\.properties";
+    static final String NATIVE_IMAGE_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/reflect-config\\.json";
 
     /**
      * Should match the contents of {@literal reflect-config.json}
@@ -106,9 +107,13 @@ public final class OracleMetadataOverrides {
     }
 
     @BuildStep
-    ExcludeConfigBuildItem excludeOracleDirectives() {
-        // Excludes both native-image.properties and reflect-config.json, which are reimplemented above
-        return new ExcludeConfigBuildItem(DRIVER_JAR_MATCH_REGEX, NATIVE_IMAGE_RESOURCE_MATCH_REGEX);
+    void excludeOracleDirectives(BuildProducer<ExcludeConfigBuildItem> nativeImageExclusions) {
+        // Excludes both native-image.properties and reflect-config.json, which are reimplemented above.
+        // N.B. this could be expressed by using a single regex to match both resources,
+        // but such a regex would include a ? char, which breaks arguments parsing on Windows.
+        nativeImageExclusions.produce(new ExcludeConfigBuildItem(DRIVER_JAR_MATCH_REGEX, NATIVE_IMAGE_RESOURCE_MATCH_REGEX));
+        nativeImageExclusions
+                .produce(new ExcludeConfigBuildItem(DRIVER_JAR_MATCH_REGEX, NATIVE_IMAGE_REFLECT_CONFIG_MATCH_REGEX));
     }
 
     @BuildStep

--- a/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/RegexMatchTest.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/test/java/io/quarkus/jdbc/oracle/deployment/RegexMatchTest.java
@@ -26,20 +26,33 @@ public class RegexMatchTest {
     }
 
     @Test
-    public void resourceRegexIsMatching() {
-        //We need to exclude both of these:
+    public void nativeImageResourceRegexIsMatching() {
+        //We need to exclude this one:
         final String RES1 = "/META-INF/native-image/native-image.properties";
-        final String RES2 = "/META-INF/native-image/reflect-config.json";
         final Pattern pattern = Pattern.compile(OracleMetadataOverrides.NATIVE_IMAGE_RESOURCE_MATCH_REGEX);
 
         Assert.assertTrue(pattern.matcher(RES1).find());
-        Assert.assertTrue(pattern.matcher(RES2).find());
 
-        //While this one should NOT be ignored:
-        final String RES3 = "/META-INF/native-image/resource-config.json";
-        final String RES4 = "/META-INF/native-image/jni-config.json";
+        //While these should NOT be ignored:
+        final String RES2 = "/META-INF/native-image/resource-config.json";
+        final String RES3 = "/META-INF/native-image/jni-config.json";
+        Assert.assertFalse(pattern.matcher(RES2).find());
         Assert.assertFalse(pattern.matcher(RES3).find());
-        Assert.assertFalse(pattern.matcher(RES4).find());
+    }
+
+    @Test
+    public void nativeImageReflectConfigRegexIsMatching() {
+        //We need to exclude this one:
+        final String RES1 = "/META-INF/native-image/reflect-config.json";
+        final Pattern pattern = Pattern.compile(OracleMetadataOverrides.NATIVE_IMAGE_REFLECT_CONFIG_MATCH_REGEX);
+
+        Assert.assertTrue(pattern.matcher(RES1).find());
+
+        //While these should NOT be ignored:
+        final String RES2 = "/META-INF/native-image/resource-config.json";
+        final String RES3 = "/META-INF/native-image/jni-config.json";
+        Assert.assertFalse(pattern.matcher(RES2).find());
+        Assert.assertFalse(pattern.matcher(RES3).find());
     }
 
 }


### PR DESCRIPTION
Fixes #25954 

Turns out the issue is that we include a "?" symbol in the regex to match both resources that we need excluded in the Oracle JDBC driver; this breaks the build on Windows as it causes something odd in parameter parsing.

We also can't quote it as GraalVM wouldn't accept a quoted regex - and we can't escape it.

We can workaround this problem by emitting two different sets of `--exclude-config` options, one for each resource, rather than attempting to conflate both resources in a single regex.