### PR TITLE
Add missing .gitattributes declarations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # ./mvnw fails on Windows in git bash if -Xmx in that file has a trailing CRLF
 .mvn/jvm.config		text eol=lf
-*.java	text eol=lf
 *.xml	text eol=lf
+*.java	text diff=java eol=lf
+*.kt	text diff=kotlin eol=lf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # ./mvnw fails on Windows in git bash if -Xmx in that file has a trailing CRLF
 .mvn/jvm.config		text eol=lf
+*.java	text eol=lf
+*.xml	text eol=lf
 

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/src/main/java/org/acme/gradle/multi/dao/Product.java
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/src/main/java/org/acme/gradle/multi/dao/Product.java
@@ -8,6 +8,7 @@ import javax.persistence.NamedQuery;
 @Entity
 @NamedQuery(name = "Product.findAll", query = "SELECT p FROM Product p ORDER BY p.name")
 public class Product {
+
 	@Id
 	private Integer id;
 	
@@ -29,7 +30,6 @@ public class Product {
 	public void setName(String name) {
 		this.name = name;
 	}
-	
-	
 
 }
+

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/src/main/java/org/acme/gradle/multi/dao/ProductService.java
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/src/main/java/org/acme/gradle/multi/dao/ProductService.java
@@ -15,4 +15,5 @@ public class ProductService {
 	public List<Product> getProducts() {
 		return em.createNamedQuery("Product.findAll", Product.class).getResultList();
 	}
+
 }


### PR DESCRIPTION
This would be very useful, especially for Windows contributors to not get all files flagged as "touched" by git just because of different line endings.

Also allowed me to spot some inconsistent sources we already have.