### PR TITLE
Define gradle exec config in `devtools/gradle` parent instead of each submodule

### DIFF
--- a/devtools/gradle/gradle-application-plugin/pom.xml
+++ b/devtools/gradle/gradle-application-plugin/pom.xml
@@ -15,6 +15,10 @@
     <name>Quarkus - Gradle Plugin</name>
     <description>Quarkus - Gradle Plugin</description>
 
+    <properties>
+        <artifactFilePrefix>gradle-application-plugin</artifactFilePrefix>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -62,68 +66,6 @@
                 <configuration>
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>gradle</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <executable>${gradle.executable}</executable>
-                            <arguments>
-                                <argument>clean</argument>
-                                <argument>${gradle.task}</argument>
-                                <argument>-Pdescription=${project.description}</argument>
-                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
-                                <argument>-S</argument>
-                                <argument>--stacktrace</argument>
-                                <argument>--no-daemon</argument>
-                            </arguments>
-                            <environmentVariables>
-                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
-                                <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
-                            </environmentVariables>
-                            <skip>${skip.gradle.build}</skip>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-artifacts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}.jar</file>
-                                    <type>jar</type>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}-javadoc.jar</file>
-                                    <type>jar</type>
-                                    <classifier>javadoc</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-application-plugin-${project.version}-sources.jar</file>
-                                    <type>jar</type>
-                                    <classifier>sources</classifier>
-                                </artifact>
-                            </artifacts>
-                            <skipAttach>${skip.gradle.build}</skipAttach>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/devtools/gradle/gradle-extension-plugin/pom.xml
+++ b/devtools/gradle/gradle-extension-plugin/pom.xml
@@ -16,6 +16,10 @@
     <name>Quarkus - Extension Gradle Plugin</name>
     <description>Quarkus - Extension Gradle Plugin</description>
 
+    <properties>
+        <artifactFilePrefix>gradle-extension-plugin</artifactFilePrefix>
+    </properties>
+
     <dependencies>
         <!-- Compile -->
         <dependency>
@@ -46,68 +50,6 @@
                 <configuration>
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>gradle</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <executable>${gradle.executable}</executable>
-                            <arguments>
-                                <argument>clean</argument>
-                                <argument>${gradle.task}</argument>
-                                <argument>-Pdescription=${project.description}</argument>
-                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
-                                <argument>-S</argument>
-                                <argument>--stacktrace</argument>
-                                <argument>--no-daemon</argument>
-                            </arguments>
-                            <environmentVariables>
-                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
-                                <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
-                            </environmentVariables>
-                            <skip>${skip.gradle.build}</skip>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-artifacts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>build/libs/gradle-extension-plugin-${project.version}.jar</file>
-                                    <type>jar</type>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-extension-plugin-${project.version}-javadoc.jar</file>
-                                    <type>jar</type>
-                                    <classifier>javadoc</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-extension-plugin-${project.version}-sources.jar</file>
-                                    <type>jar</type>
-                                    <classifier>sources</classifier>
-                                </artifact>
-                            </artifacts>
-                            <skipAttach>${skip.gradle.build}</skipAttach>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/devtools/gradle/gradle-model/pom.xml
+++ b/devtools/gradle/gradle-model/pom.xml
@@ -16,6 +16,10 @@
     <name>Quarkus - Gradle Model</name>
     <description>Quarkus - Gradle Model</description>
 
+    <properties>
+        <artifactFilePrefix>gradle-model</artifactFilePrefix>
+    </properties>
+
     <dependencies>
         <!-- Compile -->
         <dependency>
@@ -29,70 +33,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>gradle</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <executable>${gradle.executable}</executable>
-                            <arguments>
-                                <argument>clean</argument>
-                                <argument>${gradle.task}</argument>
-                                <argument>-Pdescription=${project.description}</argument>
-                                <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
-                                <argument>-S</argument>
-                                <argument>--stacktrace</argument>
-                                <argument>--no-daemon</argument>
-                            </arguments>
-                            <environmentVariables>
-                                <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
-                                <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
-                            </environmentVariables>
-                            <skip>${skip.gradle.build}</skip>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-artifacts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>build/libs/gradle-model-${project.version}.jar</file>
-                                    <type>jar</type>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-model-${project.version}-javadoc.jar</file>
-                                    <type>jar</type>
-                                    <classifier>javadoc</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>build/libs/gradle-model-${project.version}-sources.jar</file>
-                                    <type>jar</type>
-                                    <classifier>sources</classifier>
-                                </artifact>
-                            </artifacts>
-                            <skipAttach>${skip.gradle.build}</skipAttach>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/devtools/gradle/pom.xml
+++ b/devtools/gradle/pom.xml
@@ -52,6 +52,80 @@
             </properties>
         </profile>
         <profile>
+            <id>run-gradle</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/src</exists> <!-- basically for all submodules -->
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>gradle</id>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <executable>${gradle.executable}</executable>
+                                    <arguments>
+                                        <argument>clean</argument>
+                                        <argument>${gradle.task}</argument>
+                                        <argument>-Pdescription=${project.description}</argument>
+                                        <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                        <argument>-S</argument>
+                                        <argument>--stacktrace</argument>
+                                        <argument>--no-daemon</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <MAVEN_REPO_LOCAL>${settings.localRepository}</MAVEN_REPO_LOCAL>
+                                        <GRADLE_OPTS>${env.MAVEN_OPTS}</GRADLE_OPTS>
+                                    </environmentVariables>
+                                    <skip>${skip.gradle.build}</skip>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>build/libs/${artifactFilePrefix}-${project.version}.jar</file>
+                                            <type>jar</type>
+                                        </artifact>
+                                        <artifact>
+                                            <file>build/libs/${artifactFilePrefix}-${project.version}-javadoc.jar</file>
+                                            <type>jar</type>
+                                            <classifier>javadoc</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>build/libs/${artifactFilePrefix}-${project.version}-sources.jar</file>
+                                            <type>jar</type>
+                                            <classifier>sources</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                    <skipAttach>${skip.gradle.build}</skipAttach>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>skipTests</id>
             <activation>
                 <property>


### PR DESCRIPTION
Something I noticed while working on #26354