### PR TITLE
Generate Quarkus Maven Plugin Config Docs

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/Constants.java
@@ -28,6 +28,8 @@ final public class Constants {
     public static final String DASH = "-";
     public static final String ADOC_EXTENSION = ".adoc";
     public static final String DIGIT_OR_LOWERCASE = "^[a-z0-9]+$";
+    public static final String NEW_LINE = "\n";
+    public static final String SECTION_TITLE_L1 = "= ";
 
     public static final String PARENT = "<<parent>>";
     public static final String NO_DEFAULT = "<<no default>>";

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoc.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDoc.java
@@ -1,0 +1,20 @@
+package io.quarkus.annotation.processor.generate_doc;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+/**
+ * Represent one output file, its items are going to be appended to the file
+ */
+interface ConfigDoc {
+
+    List<WriteItem> getWriteItems();
+
+    /**
+     * An item is a summary table, note below the table, ...
+     */
+    interface WriteItem {
+        void accept(Writer writer) throws IOException;
+    }
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocBuilder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocBuilder.java
@@ -1,0 +1,91 @@
+package io.quarkus.annotation.processor.generate_doc;
+
+import static io.quarkus.annotation.processor.Constants.SUMMARY_TABLE_ID_VARIABLE;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.annotation.processor.Constants;
+
+/**
+ * {@link ConfigDoc} builder
+ */
+class ConfigDocBuilder {
+
+    /**
+     * Declare AsciiDoc variable
+     */
+    private static final String DECLARE_VAR = "\n:%s: %s\n";
+    private final DocFormatter summaryTableDocFormatter;
+    protected final List<ConfigDoc.WriteItem> writeItems = new ArrayList<>();
+
+    public ConfigDocBuilder() {
+        summaryTableDocFormatter = new SummaryTableDocFormatter();
+    }
+
+    protected ConfigDocBuilder(boolean showEnvVars) {
+        summaryTableDocFormatter = new SummaryTableDocFormatter(showEnvVars);
+    }
+
+    /**
+     * Add documentation in a summary table and descriptive format
+     */
+    public final ConfigDocBuilder addSummaryTable(String initialAnchorPrefix, boolean activateSearch,
+            List<ConfigDocItem> configDocItems, String fileName,
+            boolean includeConfigPhaseLegend) {
+
+        writeItems.add(writer -> {
+
+            // Create var with unique value for each summary table that will make DURATION_FORMAT_NOTE (see below) unique
+            var fileNameWithoutExtension = fileName.substring(0, fileName.length() - Constants.ADOC_EXTENSION.length());
+            writer.append(String.format(DECLARE_VAR, SUMMARY_TABLE_ID_VARIABLE, fileNameWithoutExtension));
+
+            summaryTableDocFormatter.format(writer, initialAnchorPrefix, activateSearch, configDocItems,
+                    includeConfigPhaseLegend);
+
+            boolean hasDuration = false, hasMemory = false;
+            for (ConfigDocItem item : configDocItems) {
+                if (item.hasDurationInformationNote()) {
+                    hasDuration = true;
+                }
+
+                if (item.hasMemoryInformationNote()) {
+                    hasMemory = true;
+                }
+            }
+
+            if (hasDuration) {
+                writer.append(Constants.DURATION_FORMAT_NOTE);
+            }
+
+            if (hasMemory) {
+                writer.append(Constants.MEMORY_SIZE_FORMAT_NOTE);
+            }
+        });
+        return this;
+    }
+
+    public boolean hasWriteItems() {
+        return !writeItems.isEmpty();
+    }
+
+    /**
+     * Passed strings are appended to the file
+     */
+    public final ConfigDocBuilder write(String... strings) {
+        requireNonNull(strings);
+        writeItems.add(writer -> {
+            for (String str : strings) {
+                writer.append(str);
+            }
+        });
+        return this;
+    }
+
+    public final ConfigDoc build() {
+        final List<ConfigDoc.WriteItem> docItemsCopy = List.copyOf(writeItems);
+        return () -> docItemsCopy;
+    }
+
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/ConfigDocWriter.java
@@ -1,65 +1,47 @@
 package io.quarkus.annotation.processor.generate_doc;
 
-import static io.quarkus.annotation.processor.Constants.SUMMARY_TABLE_ID_VARIABLE;
-
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import io.quarkus.annotation.processor.Constants;
 
 final public class ConfigDocWriter {
-    private final DocFormatter summaryTableDocFormatter = new SummaryTableDocFormatter();
-    private static final String DECLARE_VAR = "\n:%s: %s\n";
 
     /**
      * Write all extension configuration in AsciiDoc format in `{root}/target/asciidoc/generated/config/` directory
      */
     public void writeAllExtensionConfigDocumentation(ConfigDocGeneratedOutput output)
             throws IOException {
-        generateDocumentation(Constants.GENERATED_DOCS_PATH.resolve(output.getFileName()), output.getAnchorPrefix(),
-                output.isSearchable(), output.getConfigDocItems(), output.getFileName());
-    }
 
-    /**
-     * Generate documentation in a summary table and descriptive format
-     *
-     */
-    private void generateDocumentation(Path targetPath, String initialAnchorPrefix, boolean activateSearch,
-            List<ConfigDocItem> configDocItems, String fileName)
-            throws IOException {
-        if (configDocItems.isEmpty()) {
+        if (output.getConfigDocItems().isEmpty()) {
             return;
         }
 
+        // Create single summary table
+        final var configDocBuilder = new ConfigDocBuilder().addSummaryTable(output.getAnchorPrefix(), output.isSearchable(),
+                output.getConfigDocItems(), output.getFileName(), true);
+
+        generateDocumentation(output.getFileName(), configDocBuilder);
+    }
+
+    public void generateDocumentation(String fileName, ConfigDocBuilder configDocBuilder) throws IOException {
+        generateDocumentation(
+                // Resolve output file path
+                Constants.GENERATED_DOCS_PATH.resolve(fileName),
+                // Write all items
+                configDocBuilder.build());
+    }
+
+    private void generateDocumentation(Path targetPath, ConfigDoc configDoc)
+            throws IOException {
         try (Writer writer = Files.newBufferedWriter(targetPath)) {
-
-            // Create var with unique value for each summary table that will make DURATION_FORMAT_NOTE (see below) unique
-            var fileNameWithoutExtension = fileName.substring(0, fileName.length() - Constants.ADOC_EXTENSION.length());
-            writer.append(String.format(DECLARE_VAR, SUMMARY_TABLE_ID_VARIABLE, fileNameWithoutExtension));
-
-            summaryTableDocFormatter.format(writer, initialAnchorPrefix, activateSearch, configDocItems);
-
-            boolean hasDuration = false, hasMemory = false;
-            for (ConfigDocItem item : configDocItems) {
-                if (item.hasDurationInformationNote()) {
-                    hasDuration = true;
-                }
-
-                if (item.hasMemoryInformationNote()) {
-                    hasMemory = true;
-                }
-            }
-
-            if (hasDuration) {
-                writer.append(Constants.DURATION_FORMAT_NOTE);
-            }
-
-            if (hasMemory) {
-                writer.append(Constants.MEMORY_SIZE_FORMAT_NOTE);
+            for (ConfigDoc.WriteItem writeItem : configDoc.getWriteItems()) {
+                // Write documentation item, f.e. summary table
+                writeItem.accept(writer);
             }
         }
     }
+
 }

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocFormatter.java
@@ -61,8 +61,8 @@ interface DocFormatter {
         return string.toLowerCase();
     }
 
-    void format(Writer writer, String initialAnchorPrefix, boolean activateSearch, List<ConfigDocItem> configDocItems)
-            throws IOException;
+    void format(Writer writer, String initialAnchorPrefix, boolean activateSearch, List<ConfigDocItem> configDocItems,
+            boolean includeConfigPhaseLegend) throws IOException;
 
     void format(Writer writer, ConfigDocKey configDocKey) throws IOException;
 

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/MavenConfigDocBuilder.java
@@ -1,0 +1,98 @@
+package io.quarkus.annotation.processor.generate_doc;
+
+import static io.quarkus.annotation.processor.Constants.EMPTY;
+import static io.quarkus.annotation.processor.Constants.NEW_LINE;
+import static io.quarkus.annotation.processor.Constants.SECTION_TITLE_L1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.annotation.processor.Constants;
+
+public final class MavenConfigDocBuilder extends ConfigDocBuilder {
+
+    public MavenConfigDocBuilder() {
+        super(false);
+    }
+
+    private final JavaDocParser javaDocParser = new JavaDocParser();
+
+    public void addTableTitle(String goalTitle) {
+        write(SECTION_TITLE_L1, goalTitle, NEW_LINE);
+    }
+
+    public void addNewLine() {
+        write(NEW_LINE);
+    }
+
+    public void addTableDescription(String goalDescription) {
+        write(NEW_LINE, javaDocParser.parseConfigDescription(goalDescription), NEW_LINE);
+    }
+
+    public GoalParamsBuilder newGoalParamsBuilder() {
+        return new GoalParamsBuilder(javaDocParser);
+    }
+
+    private static abstract class TableBuilder {
+
+        protected final List<ConfigDocItem> configDocItems = new ArrayList<>();
+
+        /**
+         * Section name that is displayed in a table header
+         */
+        abstract protected String getSectionName();
+
+        public List<ConfigDocItem> build() {
+
+            // a summary table
+            final ConfigDocSection parameterSection = new ConfigDocSection();
+            parameterSection.setShowSection(true);
+            parameterSection.setName(getSectionName());
+            parameterSection.setSectionDetailsTitle(getSectionName());
+            parameterSection.setOptional(false);
+            parameterSection.setConfigDocItems(List.copyOf(configDocItems));
+
+            // topConfigDocItem wraps the summary table
+            final ConfigDocItem topConfigDocItem = new ConfigDocItem();
+            topConfigDocItem.setConfigDocSection(parameterSection);
+
+            return List.of(topConfigDocItem);
+        }
+
+        public boolean tableIsNotEmpty() {
+            return !configDocItems.isEmpty();
+        }
+    }
+
+    public static final class GoalParamsBuilder extends TableBuilder {
+
+        private final JavaDocParser javaDocParser;
+
+        private GoalParamsBuilder(JavaDocParser javaDocParser) {
+            this.javaDocParser = javaDocParser;
+        }
+
+        public void addParam(String type, String name, String defaultValue, boolean required, String description) {
+            final ConfigDocKey configDocKey = new ConfigDocKey();
+            configDocKey.setType(type);
+            configDocKey.setKey(name);
+            configDocKey.setConfigPhase(ConfigPhase.RUN_TIME);
+            configDocKey.setDefaultValue(defaultValue == null ? Constants.EMPTY : defaultValue);
+            if (description != null && !description.isBlank()) {
+                configDocKey.setConfigDoc(javaDocParser.parseConfigDescription(description));
+            } else {
+                configDocKey.setConfigDoc(EMPTY);
+            }
+            configDocKey.setOptional(!required);
+            final ConfigDocItem configDocItem = new ConfigDocItem();
+            configDocItem.setConfigDocKey(configDocKey);
+            configDocItems.add(configDocItem);
+        }
+
+        @Override
+        protected String getSectionName() {
+            return "Parameter";
+        }
+    }
+
+}

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -1,5 +1,7 @@
 package io.quarkus.annotation.processor.generate_doc;
 
+import static io.quarkus.annotation.processor.Constants.CONFIG_PHASE_LEGEND;
+import static io.quarkus.annotation.processor.Constants.NEW_LINE;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.toEnvVarName;
 
 import java.io.IOException;
@@ -15,22 +17,34 @@ final class SummaryTableDocFormatter implements DocFormatter {
     public static final String CONFIGURATION_TABLE_CLASS = ".configuration-reference";
     private static final String TABLE_ROW_FORMAT = "\n\na|%s [[%s]]`link:#%s[%s]`\n\n[.description]\n--\n%s\n--%s|%s %s\n|%s\n";
     private static final String SECTION_TITLE = "[[%s]]link:#%s[%s]";
+    private static final String TABLE_HEADER_FORMAT = "[%s, cols=\"80,.^10,.^10\"]\n|===";
     private static final String TABLE_SECTION_ROW_FORMAT = "\n\nh|%s\n%s\nh|Type\nh|Default";
-    private static final String TABLE_HEADER_FORMAT = "[.configuration-legend]%s\n[%s, cols=\"80,.^10,.^10\"]\n|===";
+    private final boolean showEnvVars;
 
     private String anchorPrefix = "";
+
+    public SummaryTableDocFormatter(boolean showEnvVars) {
+        this.showEnvVars = showEnvVars;
+    }
+
+    public SummaryTableDocFormatter() {
+        this(true);
+    }
 
     /**
      * Generate configuration keys in table format with search engine activated or not.
      * Useful when we want to optionally activate or deactivate search engine
      */
     @Override
-    public void format(Writer writer, String initialAnchorPrefix, boolean activateSearch, List<ConfigDocItem> configDocItems)
+    public void format(Writer writer, String initialAnchorPrefix, boolean activateSearch,
+            List<ConfigDocItem> configDocItems, boolean includeConfigPhaseLegend)
             throws IOException {
+        if (includeConfigPhaseLegend) {
+            writer.append("[.configuration-legend]").append(CONFIG_PHASE_LEGEND).append(NEW_LINE);
+        }
         String searchableClass = activateSearch ? SEARCHABLE_TABLE_CLASS : Constants.EMPTY;
         String tableClasses = CONFIGURATION_TABLE_CLASS + searchableClass;
-        final String tableHeaders = String.format(TABLE_HEADER_FORMAT, Constants.CONFIG_PHASE_LEGEND, tableClasses);
-        writer.append(tableHeaders);
+        writer.append(String.format(TABLE_HEADER_FORMAT, tableClasses));
         anchorPrefix = initialAnchorPrefix;
 
         // make sure that section-less configs get a legend
@@ -74,18 +88,20 @@ final class SummaryTableDocFormatter implements DocFormatter {
 
         String doc = configDocKey.getConfigDoc();
 
-        // Convert a property name to an environment variable name and show it in the config description
-        final String envVarExample = String.format("ifdef::add-copy-button-to-env-var[]\n" +
-                "Environment variable: env_var_with_copy_button:+++%1$s+++[]\n" +
-                "endif::add-copy-button-to-env-var[]\n" +
-                "ifndef::add-copy-button-to-env-var[]\n" +
-                "Environment variable: `+++%1$s+++`\n" +
-                "endif::add-copy-button-to-env-var[]", toEnvVarName(configDocKey.getKey()));
-        if (configDocKey.getConfigDoc().isEmpty()) {
-            doc = envVarExample;
-        } else {
-            // Add 2 new lines in order to show the environment variable on next line
-            doc += TWO_NEW_LINES + envVarExample;
+        if (showEnvVars) {
+            // Convert a property name to an environment variable name and show it in the config description
+            final String envVarExample = String.format("ifdef::add-copy-button-to-env-var[]\n" +
+                    "Environment variable: env_var_with_copy_button:+++%1$s+++[]\n" +
+                    "endif::add-copy-button-to-env-var[]\n" +
+                    "ifndef::add-copy-button-to-env-var[]\n" +
+                    "Environment variable: `+++%1$s+++`\n" +
+                    "endif::add-copy-button-to-env-var[]", toEnvVarName(configDocKey.getKey()));
+            if (configDocKey.getConfigDoc().isEmpty()) {
+                doc = envVarExample;
+            } else {
+                // Add 2 new lines in order to show the environment variable on next line
+                doc += TWO_NEW_LINES + envVarExample;
+            }
         }
 
         final String typeDetail = DocGeneratorUtil.getTypeFormatInformationNote(configDocKey);

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/JavaDocConfigDescriptionParserTest.java
@@ -26,6 +26,12 @@ public class JavaDocConfigDescriptionParserTest {
     }
 
     @Test
+    public void removeParagraphIndentation() {
+        String parsed = parser.parseConfigDescription("First paragraph<br><br> Second Paragraph");
+        assertEquals("First paragraph\n\nSecond Paragraph", parsed);
+    }
+
+    @Test
     public void parseUntrimmedJavaDoc() {
         String parsed = parser.parseConfigDescription("                ");
         assertEquals("", parsed);

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2803,6 +2803,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>generate-quarkus-mvn-plugin-docs</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipDocs}</skip>
+                            <mainClass>io.quarkus.docs.generation.QuarkusMavenPluginDocsGenerator</mainClass>
+                            <arguments>
+                                <argument>${project.basedir}/../devtools/maven/target/classes/META-INF/maven/plugin.xml</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>all-build-item-classes</id>
                         <phase>process-classes</phase>
                         <goals>

--- a/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
+++ b/docs/src/main/asciidoc/quarkus-maven-plugin.adoc
@@ -1,0 +1,27 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Quarkus Maven Plugin
+
+The Quarkus Maven Plugin builds the Quarkus applications, and provides helpers to launch dev mode or build native executables.
+For more information about how to use the Quarkus Maven Plugin, please refer to the xref:maven-tooling.adoc[Maven Tooling guide].
+
+include::./attributes.adoc[]
+
+== Discover Maven goals
+
+Like most Maven plugins, the Quarkus Maven Plugin has a `help` goal that prints the description of the plugin, listing all available goals as well as their description.
+It is also possible to print out detailed information about a goal, all its parameters and their default values. For instance, to see the help for the `create` goal, run:
+
+[source,shell]
+----
+./mvnw quarkus:help -Ddetail -Dgoal=create
+----
+
+== Maven goals reference
+
+Here is the list of all the Quarkus Maven Plugin goals:
+
+include::{generated-dir}/config/quarkus-maven-plugin-goals.adoc[opts=optional, leveloffset=+2]

--- a/docs/src/main/java/io/quarkus/docs/generation/QuarkusMavenPluginDocsGenerator.java
+++ b/docs/src/main/java/io/quarkus/docs/generation/QuarkusMavenPluginDocsGenerator.java
@@ -1,0 +1,106 @@
+package io.quarkus.docs.generation;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
+
+import io.quarkus.annotation.processor.Constants;
+import io.quarkus.annotation.processor.generate_doc.ConfigDocWriter;
+import io.quarkus.annotation.processor.generate_doc.MavenConfigDocBuilder;
+import io.quarkus.annotation.processor.generate_doc.MavenConfigDocBuilder.GoalParamsBuilder;
+
+/**
+ * Generates documentation for the Quarkus Maven Plugin from plugin descriptor.
+ */
+public class QuarkusMavenPluginDocsGenerator {
+
+    private static final String QUARKUS_MAVEN_PLUGIN = "quarkus-maven-plugin-";
+    private static final String GOALS_OUTPUT_FILE_NAME = QUARKUS_MAVEN_PLUGIN + "goals" + Constants.ADOC_EXTENSION;
+    private static final String GOAL_PARAMETER_ANCHOR_PREFIX = QUARKUS_MAVEN_PLUGIN + "goal-%s-";
+
+    public static void main(String[] args) throws Exception {
+
+        String errorMessage = null;
+
+        // Path to Quarkus Maven Plugin descriptor (plugin.xml)
+        final Path pluginXmlDescriptorPath;
+        if (args.length == 1) {
+            pluginXmlDescriptorPath = Path.of(args[0]);
+        } else {
+            pluginXmlDescriptorPath = null;
+            errorMessage = String.format("Expected 1 argument ('plugin.xml' file path), got %s", args.length);
+        }
+
+        // Check the file exist
+        if (pluginXmlDescriptorPath != null
+                && (!Files.exists(pluginXmlDescriptorPath) || !Files.isRegularFile(pluginXmlDescriptorPath))) {
+            errorMessage = String.format("File does not exist: %s", pluginXmlDescriptorPath.toAbsolutePath());
+        }
+
+        // Deserialize plugin.xml to PluginDescriptor
+        PluginDescriptor pluginDescriptor = null;
+        if (errorMessage == null) {
+            try (Reader input = new XmlStreamReader(new FileInputStream(pluginXmlDescriptorPath.toFile()))) {
+                pluginDescriptor = new PluginDescriptorBuilder().build(input);
+            } catch (IOException e) {
+                errorMessage = String.format("Failed to deserialize PluginDescriptor: %s", e.getMessage());
+            }
+        }
+
+        // Don't generate documentation if there are no goals (shouldn't happen if correct descriptor is available)
+        if (pluginDescriptor != null && (pluginDescriptor.getMojos() == null || pluginDescriptor.getMojos().isEmpty())) {
+            errorMessage = "Found no goals";
+        }
+
+        // Don't break the build if Quarkus Maven Plugin Descriptor is not available
+        if (errorMessage != null) {
+            System.err.printf("Can't generate the documentation for the Quarkus Maven Plugin\n: %s\n", errorMessage);
+            return;
+        }
+
+        // Build Goals documentation
+        final var goalsConfigDocBuilder = new MavenConfigDocBuilder();
+        for (MojoDescriptor mojo : pluginDescriptor.getMojos()) {
+
+            // Add Goal Title
+            goalsConfigDocBuilder.addTableTitle(mojo.getFullGoalName());
+
+            // Add Goal Description
+            if (mojo.getDescription() != null && !mojo.getDescription().isBlank()) {
+                goalsConfigDocBuilder.addTableDescription(mojo.getDescription());
+            }
+
+            // Collect Goal Parameters
+            final GoalParamsBuilder goalParamsBuilder = goalsConfigDocBuilder.newGoalParamsBuilder();
+            if (mojo.getParameters() != null) {
+                for (Parameter parameter : mojo.getParameters()) {
+                    goalParamsBuilder.addParam(parameter.getType(), parameter.getName(), parameter.getDefaultValue(),
+                            parameter.isRequired(), parameter.getDescription());
+                }
+            }
+
+            // Add Parameters Summary Table if the goal has parameters
+            if (goalParamsBuilder.tableIsNotEmpty()) {
+                goalsConfigDocBuilder.addSummaryTable(String.format(GOAL_PARAMETER_ANCHOR_PREFIX, mojo.getGoal()), false,
+                        goalParamsBuilder.build(), GOALS_OUTPUT_FILE_NAME, false);
+
+                // Start next table on a new line
+                goalsConfigDocBuilder.addNewLine();
+            }
+        }
+
+        // Generate Goals documentation
+        if (goalsConfigDocBuilder.hasWriteItems()) {
+            new ConfigDocWriter().generateDocumentation(GOALS_OUTPUT_FILE_NAME, goalsConfigDocBuilder);
+        }
+    }
+
+}


### PR DESCRIPTION
partially resolves: #1204

I used Quarkus Maven Plugin descriptor to generate list of goals, their parameters and default values to one config file, and list of compile and runtime dependencies to second config file. I also created `quarkus-maven-plugin.adoc`, to make it clear how could newly generated files be used.

If you are building docs as usual (e.g. `mvn -DquicklyDocs`), `QuarkusMavenPluginDocsGenerator` will pick up `plugin.xml` and extract required information. I also adjusted `JavaDocParser` in a way that we strip starting space of the HTML text node after new line as it leads to a literal block. I did it mainly because of `CreateExtensionMojo`, but it makes sense in general to prevent this literal block as author of JavaDoc with HTML certainly didn't mean to create one.

There are some open questions:
- Should we translate `${open-lang-package}`, `${noDeps}`, etc. and how?
- Required flag is not very useful here as  `org.apache.maven.plugins.annotations.Parameter#required` is used by the Quarkus Maven plugin authors AFAIK, instead information that parameter is required is usually mentioned in JavaDoc.

You can find generated "QUARKUS MAVEN PLUGIN" docs here: 
[quarkus-maven-plugin-page.zip](https://github.com/quarkusio/quarkus/files/9309853/quarkus-maven-plugin-page.zip)

