### PR TITLE
Fix wrong endpoint paths in openid-connect-client guide

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -26,8 +26,8 @@ In this example, we will build an application which consists of two JAX-RS resou
 
 `FrontendResource` has 4 endpoints:
 
-* `/frontend/user-name-with-oidc-client`
-* `/frontend/admin-name-with-oidc-client`
+* `/frontend/user-name-with-oidc-client-token`
+* `/frontend/admin-name-with-oidc-client-token`
 * `/frontend/user-name-with-propagated-token`
 * `/frontend/admin-name-with-propagated-token`
 


### PR DESCRIPTION
In the [security-openid-connect-client guide](https://quarkus.io/guides/security-openid-connect-client#architecture), two endpoints have a wrong resource path.
Both `user-name-with-oidc-client` and `admin-name-with-oidc-client` have a missing `-token` suffix, see the sources [here](https://github.com/quarkusio/quarkus-quickstarts/blob/11835519a1e8ee38866cadede830129c468c8074/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/FrontendResource.java#L23) and [here](https://github.com/quarkusio/quarkus-quickstarts/blob/11835519a1e8ee38866cadede830129c468c8074/security-openid-connect-client-quickstart/src/main/java/org/acme/security/openid/connect/client/FrontendResource.java#L30).