### PR TITLE
Improve permission error reporting when using unix domain socket

### DIFF
--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -999,8 +999,8 @@ quarkus.http.so-reuse-port=true
 == Listening to a Unix Domain Socket
 
 Listening on a Unix domain socket allows us to dispense with the overhead of TCP
-if the connection to the quarkus service is established from the same host. This can happen
-if access to the service goes through a proxy which is often the case
+if the connection to the quarkus service is established from the same host.
+This can happen if access to the service goes through a proxy which is often the case
 if you're setting up a service mesh with a proxy like Envoy.
 
 IMPORTANT: This will only work on platforms that support <<native-transport>>.
@@ -1011,6 +1011,8 @@ environment property:
 ----
 quarkus.http.domain-socket=/var/run/io.quarkus.app.socket
 quarkus.http.domain-socket-enabled=true
+
+quarkus.vertx.prefer-native-transport=true
 ----
 
 By itself this will not disable the tcp socket which by default will open on
@@ -1022,6 +1024,10 @@ quarkus.http.host-enabled=false
 
 These properties can be set through Java's `-D` command line parameter or
 on `application.properties`.
+
+IMPORTANT: Do not forget to add the native transport dependency. See <<native-transport>> for details.
+
+IMPORTANT: Make sure your application has the right permissions to write to the socket.
 
 == Read only deployment environments
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -980,6 +980,15 @@ public class VertxHttpRecorder {
         // Override the host (0.0.0.0 by default) with the configured domain socket.
         options.setHost(httpConfiguration.domainSocket);
 
+        // Check if we can write into the domain socket directory
+        // We can do this check using a blocking API as the execution is done from the main thread (not an I/O thread)
+        File file = new File(httpConfiguration.domainSocket);
+        if (!file.getParentFile().canWrite()) {
+            LOGGER.warnf(
+                    "Unable to write in the domain socket directory (`%s`). Binding to the socket is likely going to fail.",
+                    httpConfiguration.domainSocket);
+        }
+
         return options;
     }
 
@@ -1136,7 +1145,13 @@ public class VertxHttpRecorder {
                         startFuture.complete(null);
                     }
                 } else {
-                    if (event.cause() instanceof IllegalArgumentException) {
+                    if (event.cause() != null && event.cause().getMessage() != null
+                            && event.cause().getMessage().contains("Permission denied")) {
+                        startFuture.fail(new IllegalStateException(
+                                String.format(
+                                        "Unable to bind to Unix domain socket (%s) as the application does not have the permission to write in the directory.",
+                                        domainSocketOptions.getHost())));
+                    } else if (event.cause() instanceof IllegalArgumentException) {
                         startFuture.fail(new IllegalArgumentException(
                                 String.format(
                                         "Unable to bind to Unix domain socket. Consider adding the 'io.netty:%s' dependency. See the Quarkus Vert.x reference guide for more details.",


### PR DESCRIPTION
Fix #25923 

@rsvoboda this PR adds:

- an important admonition in the doc
- a warning in the recorder
- a better error message when it happens