### PR TITLE
OpenAPI: Ignore CDI filters during buildtime

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyOASFilter.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/MyOASFilter.java
@@ -2,6 +2,8 @@ package io.quarkus.smallrye.openapi.test.jaxrs;
 
 import java.util.Optional;
 
+import javax.enterprise.inject.spi.CDI;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -19,6 +21,9 @@ public class MyOASFilter implements OASFilter {
         Optional<String> maybeVersion = config.getOptionalValue("my.openapi.version", String.class);
         String version = maybeVersion.orElse("3.0.3");
         openAPI.setOpenapi(version);
+
+        // Below is to test runtime filters that use CDI
+        CDI.current().getBeanManager().createInstance();
     }
 
 }


### PR DESCRIPTION
As discussed here: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Quarkus.202.2E10.20OpenApiFilter.20Problem

This PR will ignore RuntimeFilters when trying to store / forward (via builditem) if that RuntimeFilter can not work during build.

This was actually an existing issue, we just never knew :) So anyone that would have created their own filter and store the openapi document (via the config property) would have gotten this. It's now been highlighted due to the change that we pass the generated openapi document in the build item for other extensions to consume.

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>