### PR TITLE
Support Panache Sort Null Handling

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -606,9 +606,12 @@ List<Person> persons = Person.list(Sort.by("name").and("birth"));
 
 // and with more restrictions
 List<Person> persons = Person.list("status", Sort.by("name").and("birth"), Status.Alive);
+
+// and list first the entries with null values in the field "birth"
+List<Person> persons = Person.list(Sort.by("birth", Sort.NullPrecedence.NULLS_FIRST));
 ----
 
-The `Sort` class has plenty of methods for adding columns and specifying sort direction.
+The `Sort` class has plenty of methods for adding columns and specifying sort direction or the null precedence.
 
 === Simplified queries
 

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -491,9 +491,12 @@ Uni<List<Person>> persons = Person.list(Sort.by("name").and("birth"));
 
 // and with more restrictions
 Uni<List<Person>> persons = Person.list("status", Sort.by("name").and("birth"), Status.Alive);
+
+// and list first the entries with null values in the field "birth"
+Uni<List<Person>> persons = Person.list(Sort.by("birth", Sort.NullPrecedence.NULLS_FIRST));
 ----
 
-The `Sort` class has plenty of methods for adding columns and specifying sort direction.
+The `Sort` class has plenty of methods for adding columns and specifying sort direction or the null precedence.
 
 === Simplified queries
 

--- a/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
+++ b/extensions/panache/hibernate-orm-panache/deployment/src/test/java/io/quarkus/hibernate/orm/panache/deployment/test/JpaOperationsSortTest.java
@@ -27,4 +27,16 @@ public class JpaOperationsSortTest {
         assertEquals("", PanacheJpaUtil.toOrderBy(emptySort));
     }
 
+    @Test
+    public void testSortByNullsFirst() {
+        Sort emptySort = Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
+        assertEquals(" ORDER BY foo NULLS FIRST", PanacheJpaUtil.toOrderBy(emptySort));
+    }
+
+    @Test
+    public void testSortByNullsLast() {
+        Sort emptySort = Sort.by("foo", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST);
+        assertEquals(" ORDER BY foo DESC NULLS LAST", PanacheJpaUtil.toOrderBy(emptySort));
+    }
+
 }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/reactive/runtime/ReactiveMongoOperations.java
@@ -567,6 +567,9 @@ public abstract class ReactiveMongoOperations<QueryType, UpdateType> {
         Document sortDoc = new Document();
         for (Sort.Column col : sort.getColumns()) {
             sortDoc.append(col.getName(), col.getDirection() == Sort.Direction.Ascending ? 1 : -1);
+            if (col.getNullPrecedence() != null) {
+                throw new UnsupportedOperationException("Cannot sort by nulls first or nulls last");
+            }
         }
         return sortDoc;
     }

--- a/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
+++ b/extensions/panache/mongodb-panache-common/runtime/src/main/java/io/quarkus/mongodb/panache/common/runtime/MongoOperations.java
@@ -638,6 +638,9 @@ public abstract class MongoOperations<QueryType, UpdateType> {
         Document sortDoc = new Document();
         for (Sort.Column col : sort.getColumns()) {
             sortDoc.append(col.getName(), col.getDirection() == Sort.Direction.Ascending ? 1 : -1);
+            if (col.getNullPrecedence() != null) {
+                throw new UnsupportedOperationException("Cannot sort by nulls first or nulls last");
+            }
         }
         return sortDoc;
     }

--- a/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
+++ b/extensions/panache/panache-common/runtime/src/main/java/io/quarkus/panache/common/Sort.java
@@ -40,9 +40,24 @@ public class Sort {
         Descending;
     }
 
+    /**
+     * Represents the order of null columns.
+     */
+    public enum NullPrecedence {
+        /**
+         * Sort by the null columns listed first in the resulting query.
+         */
+        NULLS_FIRST,
+        /**
+         * Sort by the null columns listed last in the resulting query.
+         */
+        NULLS_LAST;
+    }
+
     public static class Column {
         private String name;
         private Direction direction;
+        private NullPrecedence nullPrecedence;
 
         public Column(String name) {
             this(name, Direction.Ascending);
@@ -51,6 +66,12 @@ public class Sort {
         public Column(String name, Direction direction) {
             this.name = name;
             this.direction = direction;
+        }
+
+        public Column(String name, Direction direction, NullPrecedence nullPrecedence) {
+            this.name = name;
+            this.direction = direction;
+            this.nullPrecedence = nullPrecedence;
         }
 
         public String getName() {
@@ -67,6 +88,14 @@ public class Sort {
 
         public void setDirection(Direction direction) {
             this.direction = direction;
+        }
+
+        public NullPrecedence getNullPrecedence() {
+            return nullPrecedence;
+        }
+
+        public void setNullPrecedence(NullPrecedence nullPrecedence) {
+            this.nullPrecedence = nullPrecedence;
         }
     }
 
@@ -91,13 +120,40 @@ public class Sort {
      * Sort by the given column, in the given order.
      *
      * @param column the column to sort on, in the given order.
-     * @param direction the direction to sort on
+     * @param direction the direction to sort on.
      * @return a new Sort instance which sorts on the given column in the given order.
      * @see #by(String)
      * @see #by(String...)
      */
     public static Sort by(String column, Direction direction) {
         return new Sort().and(column, direction);
+    }
+
+    /**
+     * Sort by the given column, in the given order and in the given null precedence.
+     *
+     * @param column the column to sort on, in the given order.
+     * @param nullPrecedence the null precedence to use.
+     * @return a new Sort instance which sorts on the given column in the given order and null precedence.
+     * @see #by(String)
+     * @see #by(String...)
+     */
+    public static Sort by(String column, NullPrecedence nullPrecedence) {
+        return by(column, Direction.Ascending, nullPrecedence);
+    }
+
+    /**
+     * Sort by the given column, in the given order and in the given null precedence.
+     *
+     * @param column the column to sort on, in the given order.
+     * @param direction the direction to sort on.
+     * @param nullPrecedence the null precedence to use.
+     * @return a new Sort instance which sorts on the given column in the given order and null precedence.
+     * @see #by(String)
+     * @see #by(String...)
+     */
+    public static Sort by(String column, Direction direction, NullPrecedence nullPrecedence) {
+        return new Sort().and(column, direction, nullPrecedence);
     }
 
     /**
@@ -202,11 +258,38 @@ public class Sort {
      * Adds a sort column, in the given order.
      *
      * @param name the new column to sort on, in the given order.
+     * @param direction the direction to sort on.
      * @return this instance, modified.
      * @see #and(String)
      */
     public Sort and(String name, Direction direction) {
         columns.add(new Column(name, direction));
+        return this;
+    }
+
+    /**
+     * Adds a sort column, in the given null precedence.
+     *
+     * @param name the new column to sort on, in the given null precedence.
+     * @param nullPrecedence the null precedence to use.
+     * @return this instance, modified.
+     * @see #and(String)
+     */
+    public Sort and(String name, NullPrecedence nullPrecedence) {
+        return and(name, Direction.Ascending, nullPrecedence);
+    }
+
+    /**
+     * Adds a sort column, in the given order and null precedence.
+     *
+     * @param name the new column to sort on, in the given order and null precedence.
+     * @param direction the direction to sort on.
+     * @param nullPrecedence the null precedence to use.
+     * @return this instance, modified.
+     * @see #and(String)
+     */
+    public Sort and(String name, Direction direction, NullPrecedence nullPrecedence) {
+        columns.add(new Column(name, direction, nullPrecedence));
         return this;
     }
 

--- a/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
+++ b/extensions/panache/panache-hibernate-common/runtime/src/main/java/io/quarkus/panache/hibernate/common/runtime/PanacheJpaUtil.java
@@ -177,8 +177,18 @@ public class PanacheJpaUtil {
             if (i > 0)
                 sb.append(" , ");
             sb.append(column.getName());
-            if (column.getDirection() != Sort.Direction.Ascending)
+            if (column.getDirection() != Sort.Direction.Ascending) {
                 sb.append(" DESC");
+            }
+
+            if (column.getNullPrecedence() != null) {
+                if (column.getNullPrecedence() == Sort.NullPrecedence.NULLS_FIRST) {
+                    sb.append(" NULLS FIRST");
+                } else {
+                    sb.append(" NULLS LAST");
+                }
+            }
+
         }
         return sb.toString();
     }

--- a/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/TypesConverter.java
+++ b/extensions/spring-data-jpa/runtime/src/main/java/io/quarkus/spring/data/runtime/TypesConverter.java
@@ -18,14 +18,14 @@ public final class TypesConverter {
         }
 
         org.springframework.data.domain.Sort.Order firstOrder = orders.get(0);
-        Sort result = Sort.by(firstOrder.getProperty(), getDirection(firstOrder));
+        Sort result = Sort.by(firstOrder.getProperty(), getDirection(firstOrder), getNullPrecedence(firstOrder));
         if (orders.size() == 1) {
             return result;
         }
 
         for (int i = 1; i < orders.size(); i++) {
             org.springframework.data.domain.Sort.Order order = orders.get(i);
-            result = result.and(order.getProperty(), getDirection(order));
+            result = result.and(order.getProperty(), getDirection(order), getNullPrecedence(order));
         }
         return result;
     }
@@ -33,6 +33,19 @@ public final class TypesConverter {
     private static Sort.Direction getDirection(org.springframework.data.domain.Sort.Order order) {
         return order.getDirection() == org.springframework.data.domain.Sort.Direction.ASC ? Sort.Direction.Ascending
                 : Sort.Direction.Descending;
+    }
+
+    private static Sort.NullPrecedence getNullPrecedence(org.springframework.data.domain.Sort.Order order) {
+        if (order.getNullHandling() != null) {
+            switch (order.getNullHandling()) {
+                case NULLS_FIRST:
+                    return Sort.NullPrecedence.NULLS_FIRST;
+                case NULLS_LAST:
+                    return Sort.NullPrecedence.NULLS_LAST;
+            }
+        }
+
+        return null;
     }
 
     public static io.quarkus.panache.common.Page toPanachePage(org.springframework.data.domain.Pageable pageable) {

--- a/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
+++ b/integration-tests/hibernate-orm-panache/src/main/java/io/quarkus/it/panache/TestEndpoint.java
@@ -1519,4 +1519,28 @@ public class TestEndpoint {
 
         return "OK";
     }
+
+    @GET
+    @Path("testSortByNullPrecedence")
+    @Transactional
+    public String testSortByNullPrecedence() {
+        Person.deleteAll();
+
+        Person stefPerson = new Person();
+        stefPerson.name = "Stef";
+        stefPerson.persist();
+
+        Person josePerson = new Person();
+        josePerson.name = null;
+        josePerson.persist();
+
+        List<Person> persons = Person.findAll(Sort.by("name", Sort.NullPrecedence.NULLS_FIRST)).list();
+        assertEquals(josePerson.id, persons.get(0).id);
+        persons = Person.findAll(Sort.by("name", Sort.NullPrecedence.NULLS_LAST)).list();
+        assertEquals(josePerson.id, persons.get(persons.size() - 1).id);
+
+        Person.deleteAll();
+
+        return "OK";
+    }
 }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -86,6 +86,11 @@ public class PanacheFunctionalityTest {
     }
 
     @Test
+    public void testSortByNullPrecedence() {
+        RestAssured.when().get("/test/testSortByNullPrecedence").then().body(is("OK"));
+    }
+
+    @Test
     public void testJaxbAnnotationTransfer() {
         RestAssured.when()
                 .get("/test/testJaxbAnnotationTransfer")

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -151,6 +151,11 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/9036").then().body(is("OK"));
     }
 
+    @Test
+    public void testSortByNullPrecedence() {
+        RestAssured.when().get("/test/testSortByNullPrecedence").then().body(is("OK"));
+    }
+
     @DisabledOnNativeImage
     @ReactiveTransactional
     @Test

--- a/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/resources/PersonRepositoryResource.java
+++ b/integration-tests/mongodb-panache/src/main/java/io/quarkus/it/mongodb/panache/person/resources/PersonRepositoryResource.java
@@ -104,4 +104,11 @@ public class PersonRepositoryResource {
         personRepository.update("lastname", newName).where("lastname", previousName);
         return Response.ok().build();
     }
+
+    @GET
+    @Path("/search/by/nulls/precedence")
+    public Response searchPersonsByNullsPrecedence() {
+        personRepository.listAll(Sort.by("lastname", Sort.NullPrecedence.NULLS_FIRST));
+        return Response.ok().build();
+    }
 }

--- a/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
+++ b/integration-tests/mongodb-panache/src/test/java/io/quarkus/it/mongodb/panache/MongodbPanacheResourceTest.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.apache.http.HttpStatus;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,12 @@ class MongodbPanacheResourceTest {
     @Test
     public void testPersonRepository() {
         callPersonEndpoint("/persons/repository");
+    }
+
+    @Test
+    public void testShouldThrowExceptionWhenUsingNullsPrecedence() {
+        get("/persons/repository/search/by/nulls/precedence")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
 
     private void callBookEndpoint(String endpoint) {


### PR DESCRIPTION
Allow users sorting by either nulls first or nulls last.
Example of usage:

```java
Sort.by("foo", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_FIRST);
```

(See more examples in tests)

This PR also adds support of nulls handling for the Spring Data JPA Quarkus extension: it translates the Spring Sort object to the new Panache Sort object. 

Finally, as the Panache Sort API is also used by the Mongo Quarkus extension and Mongo does not easily support sorting by nulls, I decided to simply print a WARNING message if users try to use it.

Fix https://github.com/quarkusio/quarkus/issues/26172