### PR TITLE
Docs - show binding env var for each config property in description

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtil.java
@@ -474,6 +474,27 @@ public class DocGeneratorUtil {
         }
     }
 
+    /**
+     * Replace each character that is neither alphanumeric nor _ with _ then convert the name to upper case, e.g.
+     * quarkus.datasource.jdbc.initial-size -> QUARKUS_DATASOURCE_JDBC_INITIAL_SIZE
+     * See also: io.smallrye.config.common.utils.StringUtil#replaceNonAlphanumericByUnderscores(java.lang.String)
+     */
+    static String toEnvVarName(final String name) {
+        int length = name.length();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            char c = name.charAt(i);
+            if ('a' <= c && c <= 'z' ||
+                    'A' <= c && c <= 'Z' ||
+                    '0' <= c && c <= '9') {
+                sb.append(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        return sb.toString().toUpperCase();
+    }
+
     static String deriveConfigRootName(String simpleClassName, String prefix, ConfigPhase configPhase) {
         String simpleNameInLowerCase = simpleClassName.toLowerCase();
         int length = simpleNameInLowerCase.length();

--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -1,5 +1,7 @@
 package io.quarkus.annotation.processor.generate_doc;
 
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.toEnvVarName;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.List;
 import io.quarkus.annotation.processor.Constants;
 
 final class SummaryTableDocFormatter implements DocFormatter {
+    private static final String TWO_NEW_LINES = "\n\n";
     private static final String TABLE_CLOSING_TAG = "\n|===";
     public static final String SEARCHABLE_TABLE_CLASS = ".searchable"; // a css class indicating if a table is searchable
     public static final String CONFIGURATION_TABLE_CLASS = ".configuration-reference";
@@ -70,6 +73,15 @@ final class SummaryTableDocFormatter implements DocFormatter {
         }
 
         String doc = configDocKey.getConfigDoc();
+
+        // Convert a property name to an environment variable name and show it in the config description
+        final var envVarExample = String.format("Environment variable: `+++%s+++`", toEnvVarName(configDocKey.getKey()));
+        if (configDocKey.getConfigDoc().isEmpty()) {
+            doc = envVarExample;
+        } else {
+            // Add 2 new lines in order to show the environment variable on next line
+            doc += TWO_NEW_LINES + envVarExample;
+        }
 
         final String typeDetail = DocGeneratorUtil.getTypeFormatInformationNote(configDocKey);
         final String defaultValue = configDocKey.getDefaultValue();

--- a/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
+++ b/core/processor/src/test/java/io/quarkus/annotation/processor/generate_doc/DocGeneratorUtilTest.java
@@ -11,6 +11,7 @@ import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.deri
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getJavaDocSiteLink;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.getName;
 import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.normalizeDurationValue;
+import static io.quarkus.annotation.processor.generate_doc.DocGeneratorUtil.toEnvVarName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
@@ -103,6 +104,16 @@ public class DocGeneratorUtilTest {
 
         value = getJavaDocSiteLink("java.util.List<java.lang.String>");
         assertEquals(OFFICIAL_JAVA_DOC_BASE_LINK + "java/util/List.html", value);
+    }
+
+    @Test
+    public void replaceNonAlphanumericByUnderscoresThenConvertToUpperCase() {
+        assertEquals("QUARKUS_DATASOURCE__DATASOURCE_NAME__JDBC_BACKGROUND_VALIDATION_INTERVAL",
+                toEnvVarName("quarkus.datasource.\"datasource-name\".jdbc.background-validation-interval"));
+        assertEquals(
+                "QUARKUS_SECURITY_JDBC_PRINCIPAL_QUERY__NAMED_PRINCIPAL_QUERIES__BCRYPT_PASSWORD_MAPPER_ITERATION_COUNT_INDEX",
+                toEnvVarName(
+                        "quarkus.security.jdbc.principal-query.\"named-principal-queries\".bcrypt-password-mapper.iteration-count-index"));
     }
 
     @Test


### PR DESCRIPTION
resolves: #22546

Config property description now contain binding from an environment variable, so developer instead of converting a property name to the environment variable can just copy & paste it. Implementation strictly follows suggested solution from #22546 (Option 2) - "Environment: QUARKUS_PROPERTY_1234" is appended to the Config property description on the next line.

Config property is is converted to the [3rd form specified by MicroProfile Config](https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#environment-variables-mapping-rules) as uppercase is most comon env. var form AFAIK.

If there is concrete, less conspicuous implementation idea that would be preferrable way how to do this, please let me know. Here is generated output (all config page):
[env-var-in-config-property-desc.zip](https://github.com/quarkusio/quarkus/files/9002676/env-var-in-config-property-desc.zip)
 