### PR TITLE
Clear reloadable flag for workspace modules that happen to be dependencies of non-reloadable dependencies

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/CascadingConditionalDependenciesTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/CascadingConditionalDependenciesTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.deployment.runnerjar.BootstrapFromOriginalJarTestBase;
@@ -66,7 +67,7 @@ public class CascadingConditionalDependenciesTest extends BootstrapFromOriginalJ
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
@@ -86,6 +87,6 @@ public class CascadingConditionalDependenciesTest extends BootstrapFromOriginalJ
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-f-deployment", TsArtifact.DEFAULT_VERSION), "runtime",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithTwoConditionsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/ConditionalDependencyWithTwoConditionsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.deployment.runnerjar.BootstrapFromOriginalJarTestBase;
@@ -42,7 +43,7 @@ public class ConditionalDependencyWithTwoConditionsTest extends BootstrapFromOri
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
@@ -56,6 +57,6 @@ public class ConditionalDependencyWithTwoConditionsTest extends BootstrapFromOri
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-d-deployment", TsArtifact.DEFAULT_VERSION), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/UnsatisfiedConditionalDependencyWithTwoConditionsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/conditionaldeps/UnsatisfiedConditionalDependencyWithTwoConditionsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 import io.quarkus.deployment.runnerjar.BootstrapFromOriginalJarTestBase;
@@ -39,7 +40,7 @@ public class UnsatisfiedConditionalDependencyWithTwoConditionsTest extends Boots
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-c-deployment", TsArtifact.DEFAULT_VERSION), "compile",
@@ -47,6 +48,6 @@ public class UnsatisfiedConditionalDependencyWithTwoConditionsTest extends Boots
         expected.add(new ArtifactDependency(
                 new GACTV(TsArtifact.DEFAULT_GROUP_ID, "ext-a-deployment", TsArtifact.DEFAULT_VERSION), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
@@ -1,26 +1,55 @@
 package io.quarkus.deployment.runnerjar;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.Profile;
 import org.junit.jupiter.api.BeforeEach;
 
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.bootstrap.resolver.TsArtifact;
-import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
 import io.quarkus.bootstrap.util.IoUtils;
 import io.quarkus.fs.util.ZipUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACTV;
 
 public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBase {
 
     private TsArtifact appJar;
-    private boolean createWorkspace;
+    private List<TsArtifact> wsModules = List.of();
+    private Map<String, List<TsArtifact>> profileWsModules = Map.of();
 
-    protected void createWorkspace() {
-        this.createWorkspace = true;
+    protected boolean createWorkspace() {
+        return false;
+    }
+
+    protected void addWorkspaceModule(TsArtifact a) {
+        if (wsModules.isEmpty()) {
+            wsModules = new ArrayList<>();
+        }
+        wsModules.add(a);
+    }
+
+    protected void addWorkspaceModuleToProfile(TsArtifact a, String profile) {
+        if (profileWsModules.isEmpty()) {
+            profileWsModules = new LinkedHashMap<>();
+        }
+        profileWsModules.computeIfAbsent(profile, k -> new ArrayList<>()).add(a);
     }
 
     @BeforeEach
@@ -31,29 +60,170 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
 
     protected abstract TsArtifact composeApplication() throws Exception;
 
-    protected QuarkusBootstrap.Builder initBootstrapBuilder()
-            throws AppModelResolverException, IOException, Exception, BootstrapMavenException {
+    protected QuarkusBootstrap.Builder initBootstrapBuilder() throws Exception {
         final Path ws = workDir.resolve("workspace");
         IoUtils.recursiveDelete(ws);
-        final Path outputDir = IoUtils.mkdirs(ws.resolve("target"));
+        IoUtils.mkdirs(ws);
 
         Path applicationRoot = resolver.resolve(appJar.toArtifact()).getResolvedPaths().getSinglePath();
         final QuarkusBootstrap.Builder bootstrap = QuarkusBootstrap.builder()
                 .setApplicationRoot(applicationRoot)
                 .setProjectRoot(applicationRoot)
-                .setTargetDirectory(outputDir)
                 .setAppModelResolver(resolver)
                 .setTest(isBootstrapForTestMode());
 
-        if (createWorkspace) {
+        if (createWorkspace()) {
             System.setProperty("basedir", ws.toAbsolutePath().toString());
-            final Path classesDir = outputDir.resolve("classes");
-            ZipUtils.unzip(applicationRoot, classesDir);
-            ModelUtils.persistModel(ws.resolve("pom.xml"), appJar.getPomModel());
-            bootstrap.setProjectRoot(ws);
-            bootstrap.setLocalProjectDiscovery(true);
-            bootstrap.setAppModelResolver(initResolver(LocalProject.loadWorkspace(classesDir)));
+            final Model appPom = appJar.getPomModel();
+
+            final List<Dependency> moduleDeps = appPom.getDependencies().stream()
+                    .filter(d -> d.getGroupId().equals(appPom.getGroupId()) &&
+                            (d.getType().isEmpty() || ArtifactCoords.TYPE_JAR.equals(d.getType())))
+                    .collect(Collectors.toList());
+
+            final Path appModule;
+            final Path appPomXml;
+            if (moduleDeps.isEmpty() || appPom.getParent() != null) {
+                appModule = ws;
+                appPomXml = ws.resolve("pom.xml");
+                ModelUtils.persistModel(appPomXml, appPom);
+            } else {
+                Model parentPom = new Model();
+                parentPom.setModelVersion(appPom.getModelVersion());
+                parentPom.setPackaging(ArtifactCoords.TYPE_POM);
+                parentPom.setGroupId(appPom.getGroupId());
+                parentPom.setArtifactId(appPom.getArtifactId() + "-parent");
+                parentPom.setVersion(appPom.getVersion());
+
+                Parent parent = new Parent();
+                parent.setGroupId(parentPom.getGroupId());
+                parent.setArtifactId(parentPom.getArtifactId());
+                parent.setVersion(parentPom.getVersion());
+
+                parentPom.getModules().add(appPom.getArtifactId());
+                appModule = ws.resolve(appPom.getArtifactId());
+                Files.createDirectories(appModule);
+                appPom.setParent(parent);
+                appPomXml = appModule.resolve("pom.xml");
+                ModelUtils.persistModel(appPomXml, appPom);
+
+                final Map<ArtifactKey, String> managedVersions = new HashMap<>();
+                collectManagedDeps(appPom, managedVersions);
+                for (Dependency moduleDep : moduleDeps) {
+                    parentPom.getModules().add(moduleDep.getArtifactId());
+                    final String moduleVersion = moduleDep.getVersion() == null
+                            ? managedVersions.get(ArtifactKey.gact(moduleDep.getGroupId(), moduleDep.getArtifactId(),
+                                    moduleDep.getClassifier(), moduleDep.getType()))
+                            : moduleDep.getVersion();
+                    Model modulePom = ModelUtils.readModel(resolver
+                            .resolve(ArtifactCoords.pom(moduleDep.getGroupId(), moduleDep.getArtifactId(), moduleVersion))
+                            .getResolvedPaths().getSinglePath());
+                    modulePom.setParent(parent);
+                    final Path moduleDir = IoUtils.mkdirs(ws.resolve(modulePom.getArtifactId()));
+                    ModelUtils.persistModel(moduleDir.resolve("pom.xml"), modulePom);
+                    final Path resolvedJar = resolver.resolve(new GACTV(modulePom.getGroupId(), modulePom.getArtifactId(),
+                            moduleDep.getClassifier(), moduleDep.getType(), modulePom.getVersion())).getResolvedPaths()
+                            .getSinglePath();
+                    final Path moduleTargetDir = moduleDir.resolve("target");
+                    ZipUtils.unzip(resolvedJar, moduleTargetDir.resolve("classes"));
+                    IoUtils.copy(resolvedJar,
+                            moduleTargetDir.resolve(modulePom.getArtifactId() + "-" + modulePom.getVersion() + ".jar"));
+                }
+
+                for (TsArtifact module : wsModules) {
+                    parentPom.getModules().add(module.getArtifactId());
+                    Model modulePom = module.getPomModel();
+                    modulePom.setParent(parent);
+                    final Path moduleDir = IoUtils.mkdirs(ws.resolve(modulePom.getArtifactId()));
+                    ModelUtils.persistModel(moduleDir.resolve("pom.xml"), modulePom);
+                    final Path resolvedJar = resolver.resolve(new GACTV(modulePom.getGroupId(), modulePom.getArtifactId(),
+                            module.getClassifier(), module.getType(), modulePom.getVersion())).getResolvedPaths()
+                            .getSinglePath();
+                    final Path moduleTargetDir = moduleDir.resolve("target");
+                    ZipUtils.unzip(resolvedJar, moduleTargetDir.resolve("classes"));
+                    IoUtils.copy(resolvedJar,
+                            moduleTargetDir.resolve(modulePom.getArtifactId() + "-" + modulePom.getVersion() + ".jar"));
+                }
+
+                for (Map.Entry<String, List<TsArtifact>> profileModules : profileWsModules.entrySet()) {
+
+                    Profile profile = null;
+                    for (Profile p : parentPom.getProfiles()) {
+                        if (p.getId().equals(profileModules.getKey())) {
+                            profile = p;
+                            break;
+                        }
+                    }
+                    if (profile == null) {
+                        for (Profile p : appPom.getProfiles()) {
+                            if (p.getId().equals(profileModules.getKey())) {
+                                profile = p;
+                                break;
+                            }
+                        }
+                        if (profile == null) {
+                            throw new IllegalStateException(
+                                    "Failed to locate profile " + profileModules.getKey() + " in the application POM");
+                        }
+                        final Profile tmp = new Profile();
+                        tmp.setActivation(profile.getActivation());
+                        profile = tmp;
+                        parentPom.getProfiles().add(profile);
+                    }
+
+                    for (TsArtifact a : profileModules.getValue()) {
+                        profile.getModules().add(a.getArtifactId());
+                        Model modulePom = a.getPomModel();
+                        modulePom.setParent(parent);
+                        final Path moduleDir = IoUtils.mkdirs(ws.resolve(modulePom.getArtifactId()));
+                        ModelUtils.persistModel(moduleDir.resolve("pom.xml"), modulePom);
+                        final Path resolvedJar = resolver.resolve(new GACTV(modulePom.getGroupId(), modulePom.getArtifactId(),
+                                a.getClassifier(), a.getType(), modulePom.getVersion())).getResolvedPaths()
+                                .getSinglePath();
+                        final Path moduleTargetDir = moduleDir.resolve("target");
+                        ZipUtils.unzip(resolvedJar, moduleTargetDir.resolve("classes"));
+                        IoUtils.copy(resolvedJar,
+                                moduleTargetDir.resolve(modulePom.getArtifactId() + "-" + modulePom.getVersion() + ".jar"));
+                    }
+                }
+
+                ModelUtils.persistModel(ws.resolve("pom.xml"), parentPom);
+            }
+
+            final Path appOutputDir = IoUtils.mkdirs(appModule.resolve("target"));
+            final Path appClassesDir = appOutputDir.resolve("classes");
+            ZipUtils.unzip(applicationRoot, appClassesDir);
+
+            final LocalProject appProject = new BootstrapMavenContext(BootstrapMavenContext.config()
+                    .setWorkspaceDiscovery(true)
+                    .setRootProjectDir(ws)
+                    .setCurrentProject(appPomXml.toString()))
+                    .getCurrentProject();
+
+            bootstrap.setProjectRoot(appModule)
+                    .setTargetDirectory(appOutputDir)
+                    .setLocalProjectDiscovery(true)
+                    .setAppModelResolver(newAppModelResolver(appProject));
+        } else {
+            bootstrap.setTargetDirectory(IoUtils.mkdirs(ws.resolve("target")));
         }
+
         return bootstrap;
+    }
+
+    private void collectManagedDeps(Model appPom, Map<ArtifactKey, String> managedVersions)
+            throws IOException, AppModelResolverException {
+        final List<Dependency> managed = appPom.getDependencyManagement() == null ? List.of()
+                : appPom.getDependencyManagement().getDependencies();
+        for (Dependency d : managed) {
+            managedVersions.put(ArtifactKey.gact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType()),
+                    d.getVersion());
+            if (d.getType().equals(ArtifactCoords.TYPE_POM) && d.getScope().equals("import")) {
+                collectManagedDeps(ModelUtils
+                        .readModel(resolver.resolve(ArtifactCoords.pom(d.getGroupId(), d.getArtifactId(), d.getVersion()))
+                                .getResolvedPaths().getSinglePath()),
+                        managedVersions);
+            }
+        }
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyAddedInProfileTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyAddedInProfileTest.java
@@ -11,6 +11,11 @@ import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 public class DependencyAddedInProfileTest extends BootstrapFromOriginalJarTestBase {
 
     @Override
+    protected boolean createWorkspace() {
+        return true;
+    }
+
+    @Override
     protected TsArtifact composeApplication() {
 
         final TsQuarkusExt extA_100 = new TsQuarkusExt("ext-a", "1.0.0");

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultEffectiveModelBuilderTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultEffectiveModelBuilderTest.java
@@ -1,0 +1,148 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Profile;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public class DependencyInProfileActiveByDefaultEffectiveModelBuilderTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected boolean createWorkspace() {
+        return true;
+    }
+
+    @Override
+    protected void setSystemProperties() {
+        setSystemProperty("quarkus.bootstrap.effective-model-builder", "true");
+    }
+
+    @Override
+    protected TsArtifact composeApplication() {
+
+        final TsQuarkusExt extA_100 = new TsQuarkusExt("ext-a", "1.0.0");
+        addToExpectedLib(extA_100.getRuntime());
+
+        final TsQuarkusExt extB_100 = new TsQuarkusExt("ext-b", "1.0.0");
+        install(extB_100);
+        final TsArtifact extB_100_rt = extB_100.getRuntime();
+        addToExpectedLib(extB_100_rt);
+
+        final TsArtifact commonLibraryJar = TsArtifact.jar("common-library");
+        addToExpectedLib(commonLibraryJar);
+        addWorkspaceModule(commonLibraryJar);
+
+        final TsArtifact module1Jar = TsArtifact.jar("module-one");
+        module1Jar.addDependency(commonLibraryJar);
+        addToExpectedLib(module1Jar);
+
+        final TsArtifact module2Jar = TsArtifact.jar("module-two");
+        module2Jar.addDependency(commonLibraryJar);
+        addToExpectedLib(module2Jar);
+        install(module2Jar);
+        addWorkspaceModuleToProfile(module2Jar, "extra");
+
+        final TsArtifact appJar = TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(extA_100)
+                .addDependency(module1Jar);
+
+        final Profile profile = new Profile();
+        profile.setId("extra");
+        Activation activation = new Activation();
+        activation.setActiveByDefault(true);
+        profile.setActivation(activation);
+
+        Dependency dep = new Dependency();
+        dep.setGroupId(extB_100_rt.getGroupId());
+        dep.setArtifactId(extB_100_rt.getArtifactId());
+        dep.setVersion(extB_100_rt.getVersion());
+        profile.addDependency(dep);
+
+        dep = new Dependency();
+        dep.setGroupId(module2Jar.getGroupId());
+        dep.setArtifactId(module2Jar.getArtifactId());
+        dep.setVersion(module2Jar.getVersion());
+        profile.addDependency(dep);
+
+        appJar.addProfile(profile);
+
+        createWorkspace();
+
+        return appJar;
+    }
+
+    @Override
+    protected void assertAppModel(ApplicationModel model) {
+
+        final Map<String, ResolvedDependency> deps = new HashMap<>();
+        model.getDependencies().forEach(d -> deps.put(d.getArtifactId(), d));
+        assertThat(deps).hasSize(7);
+
+        ResolvedDependency d = deps.get("module-one");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isTrue();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("module-two");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isTrue();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("common-library");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isTrue();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("ext-a");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isTrue();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-b");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isTrue();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-a-deployment");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+        assertThat(d.isRuntimeCp()).isFalse();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-b-deployment");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+        assertThat(d.isRuntimeCp()).isFalse();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultRawModelBuilderTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyInProfileActiveByDefaultRawModelBuilderTest.java
@@ -1,0 +1,143 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.model.Activation;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Profile;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public class DependencyInProfileActiveByDefaultRawModelBuilderTest extends BootstrapFromOriginalJarTestBase {
+
+    @Override
+    protected boolean createWorkspace() {
+        return true;
+    }
+
+    @Override
+    protected TsArtifact composeApplication() {
+
+        final TsQuarkusExt extA_100 = new TsQuarkusExt("ext-a", "1.0.0");
+        addToExpectedLib(extA_100.getRuntime());
+
+        final TsQuarkusExt extB_100 = new TsQuarkusExt("ext-b", "1.0.0");
+        install(extB_100);
+        final TsArtifact extB_100_rt = extB_100.getRuntime();
+        addToExpectedLib(extB_100_rt);
+
+        final TsArtifact commonLibraryJar = TsArtifact.jar("common-library");
+        addToExpectedLib(commonLibraryJar);
+        addWorkspaceModule(commonLibraryJar);
+
+        final TsArtifact module1Jar = TsArtifact.jar("module-one");
+        module1Jar.addDependency(commonLibraryJar);
+        addToExpectedLib(module1Jar);
+
+        final TsArtifact module2Jar = TsArtifact.jar("module-two");
+        module2Jar.addDependency(commonLibraryJar);
+        addToExpectedLib(module2Jar);
+        install(module2Jar);
+        addWorkspaceModuleToProfile(module2Jar, "extra");
+
+        final TsArtifact appJar = TsArtifact.jar("app")
+                .addManagedDependency(platformDescriptor())
+                .addManagedDependency(platformProperties())
+                .addDependency(extA_100)
+                .addDependency(module1Jar);
+
+        final Profile profile = new Profile();
+        profile.setId("extra");
+        Activation activation = new Activation();
+        activation.setActiveByDefault(true);
+        profile.setActivation(activation);
+
+        Dependency dep = new Dependency();
+        dep.setGroupId(extB_100_rt.getGroupId());
+        dep.setArtifactId(extB_100_rt.getArtifactId());
+        dep.setVersion(extB_100_rt.getVersion());
+        profile.addDependency(dep);
+
+        dep = new Dependency();
+        dep.setGroupId(module2Jar.getGroupId());
+        dep.setArtifactId(module2Jar.getArtifactId());
+        dep.setVersion(module2Jar.getVersion());
+        profile.addDependency(dep);
+
+        appJar.addProfile(profile);
+
+        createWorkspace();
+
+        return appJar;
+    }
+
+    @Override
+    protected void assertAppModel(ApplicationModel model) {
+
+        final Map<String, ResolvedDependency> deps = new HashMap<>();
+        model.getDependencies().forEach(d -> deps.put(d.getArtifactId(), d));
+        assertThat(deps).hasSize(7);
+
+        ResolvedDependency d = deps.get("module-one");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isTrue();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("module-two");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse(); // limitation of the raw pom-based workspace discovery
+        assertThat(d.isReloadable()).isFalse();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("common-library");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isFalse(); // since it's a dependency of a non-reloadable module
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+
+        d = deps.get("ext-a");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isTrue();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isTrue();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-b");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isTrue();
+        assertThat(d.isRuntimeCp()).isTrue();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-a-deployment");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+        assertThat(d.isRuntimeCp()).isFalse();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+
+        d = deps.get("ext-b-deployment");
+        assertThat(d).isNotNull();
+        assertThat(d.isRuntimeExtensionArtifact()).isFalse();
+        assertThat(d.isRuntimeCp()).isFalse();
+        assertThat(d.isDeploymentCp()).isTrue();
+        assertThat(d.isWorkspaceModule()).isFalse();
+        assertThat(d.isReloadable()).isFalse();
+    }
+}

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyVersionOverridesManagedVersionTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/DependencyVersionOverridesManagedVersionTest.java
@@ -7,6 +7,11 @@ import io.quarkus.bootstrap.resolver.TsQuarkusExt;
 public class DependencyVersionOverridesManagedVersionTest extends BootstrapFromOriginalJarTestBase {
 
     @Override
+    protected boolean createWorkspace() {
+        return true;
+    }
+
+    @Override
     protected TsArtifact composeApplication() {
 
         final TsQuarkusExt extA_100 = new TsQuarkusExt("ext-a", "1.0.0");

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/OptionalDepsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
@@ -67,7 +68,7 @@ public class OptionalDepsTest extends BootstrapFromOriginalJarTestBase {
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
                 DependencyFlags.OPTIONAL,
@@ -80,6 +81,6 @@ public class OptionalDepsTest extends BootstrapFromOriginalJarTestBase {
                 DependencyFlags.DEPLOYMENT_CP));
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-d-deployment", "1"), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/PackageAppTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/PackageAppTestBase.java
@@ -51,7 +51,7 @@ public abstract class PackageAppTestBase extends BootstrapTestBase {
         expectedLib.add(entry.getGroupId() + '.' + entry.getArtifactId() + '-' + entry.getVersion() + '.' + entry.getType());
     }
 
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertDeploymentDep(Set<Dependency> deploymentDeps) throws Exception {
     }
 
     protected void assertAppModel(ApplicationModel appModel) throws Exception {
@@ -113,6 +113,11 @@ public abstract class PackageAppTestBase extends BootstrapTestBase {
         return platformPropsDep;
     }
 
+    public static Collection<Dependency> getDeploymentOnlyDeps(ApplicationModel model) {
+        return model.getDependencies().stream().filter(d -> d.isDeploymentCp() && !d.isRuntimeCp())
+                .map(d -> new ArtifactDependency(d)).collect(Collectors.toSet());
+    }
+
     @Override
     protected void testBootstrap(QuarkusBootstrap creator) throws Exception {
         System.setProperty("quarkus.package.type", "legacy-jar");
@@ -123,9 +128,6 @@ public abstract class PackageAppTestBase extends BootstrapTestBase {
             if (expectedExtensions != null) {
                 assertExtensionDependencies(curated.getApplicationModel(), expectedExtensions);
             }
-            assertDeploymentDeps(
-                    curated.getApplicationModel().getDependencies().stream().filter(d -> d.isDeploymentCp() && !d.isRuntimeCp())
-                            .map(d -> new ArtifactDependency(d)).collect(Collectors.toSet()));
             AugmentAction action = curated.createAugmentor();
             AugmentResult outcome = action.createProductionApplication();
 

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsInTestModeTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsInTestModeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
@@ -56,7 +57,7 @@ public class ProvidedExtensionDepsInTestModeTest extends BootstrapFromOriginalJa
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
@@ -64,6 +65,6 @@ public class ProvidedExtensionDepsInTestModeTest extends BootstrapFromOriginalJa
                 DependencyFlags.DEPLOYMENT_CP));
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-b-deployment", "1"), "provided",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/ProvidedExtensionDepsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.resolver.TsArtifact;
 import io.quarkus.bootstrap.resolver.TsDependency;
 import io.quarkus.bootstrap.resolver.TsQuarkusExt;
@@ -49,12 +50,12 @@ public class ProvidedExtensionDepsTest extends BootstrapFromOriginalJarTestBase 
     }
 
     @Override
-    protected void assertDeploymentDeps(Set<Dependency> deploymentDeps) throws Exception {
+    protected void assertAppModel(ApplicationModel model) throws Exception {
         final Set<Dependency> expected = new HashSet<>();
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-deployment", "1"), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
         expected.add(new ArtifactDependency(new GACTV("io.quarkus.bootstrap.test", "ext-a-deployment-dep", "1"), "compile",
                 DependencyFlags.DEPLOYMENT_CP));
-        assertEquals(expected, deploymentDeps);
+        assertEquals(expected, getDeploymentOnlyDeps(model));
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -199,26 +199,31 @@ public class QuarkusBootstrapProvider implements Closeable {
 
             final BootstrapAppModelResolver modelResolver = new BootstrapAppModelResolver(artifactResolver(mojo, mode))
                     .setDevMode(mode == LaunchMode.DEVELOPMENT)
-                    .setTest(mode == LaunchMode.TEST);
+                    .setTest(mode == LaunchMode.TEST)
+                    .setCollectReloadableDependencies(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST);
 
-            final ArtifactCoords artifactCoords = appArtifact(mojo);
-            final List<MavenProject> localProjects = mojo.mavenProject().getCollectedProjects();
-            final Set<ArtifactKey> localProjectKeys = new HashSet<>(localProjects.size());
-            for (MavenProject p : localProjects) {
-                localProjectKeys.add(new GACT(p.getGroupId(), p.getArtifactId()));
-            }
-            final Set<ArtifactKey> reloadableModules = new HashSet<>(localProjects.size() + 1);
-            for (Artifact a : mojo.mavenProject().getArtifacts()) {
-                if (localProjectKeys.contains(new GACT(a.getGroupId(), a.getArtifactId()))) {
-                    reloadableModules.add(new GACT(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getType()));
+            final ArtifactCoords appArtifact = appArtifact(mojo);
+            Set<ArtifactKey> reloadableModules = Set.of();
+            if (mode == LaunchMode.NORMAL) {
+                // collect reloadable artifacts for remote-dev
+                final List<MavenProject> localProjects = mojo.mavenProject().getCollectedProjects();
+                final Set<ArtifactKey> localProjectKeys = new HashSet<>(localProjects.size());
+                for (MavenProject p : localProjects) {
+                    localProjectKeys.add(new GACT(p.getGroupId(), p.getArtifactId()));
                 }
+                reloadableModules = new HashSet<>(localProjects.size() + 1);
+                for (Artifact a : mojo.mavenProject().getArtifacts()) {
+                    if (localProjectKeys.contains(new GACT(a.getGroupId(), a.getArtifactId()))) {
+                        reloadableModules.add(new GACT(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getType()));
+                    }
+                }
+                reloadableModules.add(appArtifact.getKey());
             }
-            reloadableModules.add(artifactCoords.getKey());
 
             final List<Dependency> forcedDependencies = mojo.forcedDependencies(mode);
             final ApplicationModel appModel;
             try {
-                appModel = modelResolver.resolveManagedModel(artifactCoords, forcedDependencies, managingProject(mojo),
+                appModel = modelResolver.resolveManagedModel(appArtifact, forcedDependencies, managingProject(mojo),
                         reloadableModules);
             } catch (AppModelResolverException e) {
                 throw new MojoExecutionException("Failed to bootstrap application in " + mode + " mode", e);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/MutableJarApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/MutableJarApplicationModel.java
@@ -77,9 +77,7 @@ public class MutableJarApplicationModel implements Serializable {
         for (ArtifactKey i : lesserPriorityArtifacts) {
             model.addLesserPriorityArtifact(i);
         }
-        for (ArtifactKey i : localProjectArtifacts) {
-            model.addReloadableWorkspaceModule(i);
-        }
+        model.addReloadableWorkspaceModules(localProjectArtifacts);
         for (Map.Entry<ArtifactKey, Set<String>> i : excludedResources.entrySet()) {
             model.addRemovedResources(i.getKey(), i.getValue());
         }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
@@ -148,12 +148,12 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
         return scope;
     }
 
-    public String toGACTVString() {
-        return getGroupId() + ":" + getArtifactId() + ":" + getClassifier() + ":" + getType() + ":" + getVersion();
+    public ArtifactKey getKey() {
+        return ArtifactKey.gact(groupId, artifactId, classifier, type);
     }
 
-    public ArtifactKey getKey() {
-        return new GACT(groupId, artifactId, classifier, type);
+    public String toGACTVString() {
+        return getGroupId() + ":" + getArtifactId() + ":" + getClassifier() + ":" + getType() + ":" + getVersion();
     }
 
     public abstract T build();

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependencyBuilder.java
@@ -34,6 +34,9 @@ public class ResolvedDependencyBuilder extends AbstractDependencyBuilder<Resolve
 
     public ResolvedDependencyBuilder setWorkspaceModule(WorkspaceModule projectModule) {
         this.workspaceModule = projectModule;
+        if (projectModule != null) {
+            setWorkspaceModule();
+        }
         return this;
     }
 

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/ResolverSetupCleanup.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/ResolverSetupCleanup.java
@@ -1,11 +1,13 @@
 package io.quarkus.bootstrap.resolver;
 
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.util.IoUtils;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,13 +23,14 @@ public class ResolverSetupCleanup {
     protected BootstrapAppModelResolver resolver;
     protected TsRepoBuilder repo;
 
-    protected Properties originalProps;
+    protected Map<String, String> originalProps;
 
     @BeforeEach
     public void setup() throws Exception {
+        setSystemProperties();
         workDir = initWorkDir();
         repoHome = IoUtils.mkdirs(workDir.resolve("repo"));
-        resolver = initResolver(null);
+        resolver = newAppModelResolver(null);
         repo = TsRepoBuilder.getInstance(resolver, workDir);
     }
 
@@ -37,15 +40,28 @@ public class ResolverSetupCleanup {
             IoUtils.recursiveDelete(workDir);
         }
         if (originalProps != null) {
-            System.setProperties(originalProps);
+            for (Map.Entry<String, String> prop : originalProps.entrySet()) {
+                if (prop.getValue() == null) {
+                    System.clearProperty(prop.getKey());
+                } else {
+                    System.setProperty(prop.getKey(), prop.getValue());
+                }
+            }
+            originalProps = null;
         }
+    }
+
+    protected void setSystemProperties() {
     }
 
     protected void setSystemProperty(String name, String value) {
         if (originalProps == null) {
-            originalProps = new Properties(System.getProperties());
+            originalProps = new HashMap<>();
         }
-        System.setProperty(name, value);
+        final String prevValue = System.setProperty(name, value);
+        if (!originalProps.containsKey(name)) {
+            originalProps.put(name, prevValue);
+        }
     }
 
     protected Path initWorkDir() {
@@ -60,17 +76,21 @@ public class ResolverSetupCleanup {
         return false;
     }
 
-    protected BootstrapAppModelResolver initResolver(LocalProject currentProject) throws Exception {
-        final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(MavenArtifactResolver.builder()
-                .setLocalRepository(repoHome.toString())
-                .setOffline(true)
-                .setWorkspaceDiscovery(false)
-                .setCurrentProject(currentProject)
-                .build());
+    protected BootstrapAppModelResolver newAppModelResolver(LocalProject currentProject) throws Exception {
+        final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(newArtifactResolver(currentProject));
         if (isBootstrapForTestMode()) {
             appModelResolver.setTest(true);
         }
         return appModelResolver;
+    }
+
+    protected MavenArtifactResolver newArtifactResolver(LocalProject currentProject) throws BootstrapMavenException {
+        return MavenArtifactResolver.builder()
+                .setLocalRepository(repoHome.toString())
+                .setOffline(true)
+                .setWorkspaceDiscovery(false)
+                .setCurrentProject(currentProject)
+                .build();
     }
 
     protected TsJar newJar() throws IOException {

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/NearestDependencyVersionTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/NearestDependencyVersionTestCase.java
@@ -1,0 +1,43 @@
+package io.quarkus.bootstrap.resolver.test;
+
+import io.quarkus.bootstrap.resolver.CollectDependenciesBase;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsDependency;
+import io.quarkus.maven.dependency.DependencyFlags;
+
+public class NearestDependencyVersionTestCase extends CollectDependenciesBase {
+
+    @Override
+    protected void setupDependencies() {
+
+        TsArtifact a = new TsArtifact("a");
+        TsArtifact b1 = new TsArtifact("b", "1");
+        TsArtifact b2 = new TsArtifact("b", "2");
+        TsArtifact c = new TsArtifact("c");
+        TsArtifact d = new TsArtifact("d");
+        TsArtifact e = new TsArtifact("e");
+        TsArtifact f = new TsArtifact("f");
+
+        a.addDependency(c);
+        c.addDependency(b2);
+        c.addManagedDependency(new TsDependency(b2).exclude("f"));
+        d.addDependency(b1);
+        d.addManagedDependency(new TsDependency(b1).exclude("e"));
+        b1.addDependency(e);
+        b1.addDependency(f);
+        b2.addDependency(e);
+        b2.addDependency(f);
+
+        installAsDep(a);
+        install(b1);
+        install(b2);
+        install(c);
+        install(e);
+        install(f);
+        installAsDep(d);
+
+        addCollectedDep(c, DependencyFlags.RUNTIME_CP);
+        addCollectedDep(b1, DependencyFlags.RUNTIME_CP);
+        addCollectedDep(f, DependencyFlags.RUNTIME_CP);
+    }
+}

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/SystemPropertyOverridesPomPropertyDependencyTestCase.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/test/SystemPropertyOverridesPomPropertyDependencyTestCase.java
@@ -48,6 +48,6 @@ public class SystemPropertyOverridesPomPropertyDependencyTestCase extends Collec
         // workspace reader for the root project
         final LocalProject currentProject = LocalProject.loadWorkspace(projectDir);
 
-        return initResolver(currentProject);
+        return newAppModelResolver(currentProject);
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/MavenArtifactResolver.java
@@ -3,17 +3,16 @@
  */
 package io.quarkus.bootstrap.resolver.maven;
 
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.resolver.maven.workspace.ProjectModuleResolver;
+import io.quarkus.bootstrap.util.DependencyUtils;
 import io.quarkus.bootstrap.util.PropertyUtils;
+import io.quarkus.maven.dependency.ArtifactKey;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,10 +242,9 @@ public class MavenArtifactResolver {
 
     public CollectResult collectDependencies(Artifact artifact, List<Dependency> deps, List<RemoteRepository> mainRepos,
             Collection<Exclusion> exclusions) throws BootstrapMavenException {
-        final CollectRequest request = newCollectRequest(artifact, mainRepos, exclusions);
-        request.setDependencies(deps);
         try {
-            return repoSystem.collectDependencies(repoSession, request);
+            return repoSystem.collectDependencies(repoSession,
+                    newCollectRequest(artifact, mainRepos, exclusions).setDependencies(deps));
         } catch (DependencyCollectionException e) {
             throw new BootstrapMavenException("Failed to collect dependencies for " + artifact, e);
         }
@@ -263,17 +261,6 @@ public class MavenArtifactResolver {
         try {
             return repoSystem.resolveDependencies(repoSession,
                     new DependencyRequest().setCollectRequest(request));
-        } catch (DependencyResolutionException e) {
-            throw new BootstrapMavenException("Failed to resolve dependencies for " + artifact, e);
-        }
-    }
-
-    public DependencyResult resolveManagedDependencies(Artifact artifact, List<Dependency> deps, List<Dependency> managedDeps,
-            List<RemoteRepository> mainRepos, String... excludedScopes) throws BootstrapMavenException {
-        try {
-            return repoSystem.resolveDependencies(repoSession,
-                    new DependencyRequest().setCollectRequest(
-                            newCollectManagedRequest(artifact, deps, managedDeps, mainRepos, List.of(), excludedScopes)));
         } catch (DependencyResolutionException e) {
             throw new BootstrapMavenException("Failed to resolve dependencies for " + artifact, e);
         }
@@ -311,64 +298,54 @@ public class MavenArtifactResolver {
         return result;
     }
 
-    public CollectResult collectManagedDependencies(Artifact artifact, List<Dependency> deps, List<Dependency> managedDeps,
+    public CollectResult collectManagedDependencies(Artifact artifact, List<Dependency> directDeps,
+            List<Dependency> managedDeps,
             List<RemoteRepository> mainRepos, Collection<Exclusion> exclusions, String... excludedScopes)
             throws BootstrapMavenException {
         try {
             return repoSystem.collectDependencies(repoSession,
-                    newCollectManagedRequest(artifact, deps, managedDeps, mainRepos, exclusions, excludedScopes));
+                    newCollectManagedRequest(artifact, List.of(), managedDeps, mainRepos, exclusions, Set.of(excludedScopes)));
         } catch (DependencyCollectionException e) {
             throw new BootstrapMavenException("Failed to collect dependencies for " + artifact, e);
         }
     }
 
-    private CollectRequest newCollectManagedRequest(Artifact artifact, List<Dependency> deps, List<Dependency> managedDeps,
-            List<RemoteRepository> mainRepos, Collection<Exclusion> exclusions, String... excludedScopes)
+    public CollectRequest newCollectManagedRequest(Artifact artifact, List<Dependency> directDeps, List<Dependency> managedDeps,
+            List<RemoteRepository> mainRepos, Collection<Exclusion> exclusions, Set<String> excludedScopes)
             throws BootstrapMavenException {
-        final List<RemoteRepository> aggregatedRepos = aggregateRepositories(mainRepos, remoteRepos);
+        List<RemoteRepository> aggregatedRepos = aggregateRepositories(mainRepos, remoteRepos);
         final ArtifactDescriptorResult descr = resolveDescriptorInternal(artifact, aggregatedRepos);
-        Collection<String> excluded;
-        if (excludedScopes.length == 0) {
-            excluded = Collections.emptyList();
-        } else if (excludedScopes.length == 1) {
-            excluded = Collections.singleton(excludedScopes[0]);
-        } else {
-            excluded = Arrays.asList(excludedScopes);
-            if (excludedScopes.length > 3) {
-                excluded = new HashSet<>(Arrays.asList(excludedScopes));
-            }
-        }
-        final List<Dependency> originalDeps = new ArrayList<>(descr.getDependencies().size());
-        for (Dependency dep : descr.getDependencies()) {
-            if (excluded.contains(dep.getScope())) {
-                continue;
-            }
-            originalDeps.add(dep);
-        }
 
-        final List<Dependency> mergedManagedDeps = new ArrayList<Dependency>(
-                managedDeps.size() + descr.getManagedDependencies().size());
-        Map<AppArtifactKey, String> managedVersions = Collections.emptyMap();
+        final List<Dependency> mergedManagedDeps;
+        Map<ArtifactKey, String> managedVersions = Map.of();
         if (!managedDeps.isEmpty()) {
+            mergedManagedDeps = new ArrayList<Dependency>(managedDeps.size() + descr.getManagedDependencies().size());
             managedVersions = new HashMap<>(managedDeps.size());
             for (Dependency dep : managedDeps) {
-                managedVersions.put(getId(dep.getArtifact()), dep.getArtifact().getVersion());
+                managedVersions.put(getKey(dep.getArtifact()), dep.getArtifact().getVersion());
                 mergedManagedDeps.add(dep);
             }
-        }
-        if (!descr.getManagedDependencies().isEmpty()) {
             for (Dependency dep : descr.getManagedDependencies()) {
-                final AppArtifactKey key = getId(dep.getArtifact());
+                final ArtifactKey key = getKey(dep.getArtifact());
                 if (!managedVersions.containsKey(key)) {
                     mergedManagedDeps.add(dep);
                 }
             }
+        } else {
+            mergedManagedDeps = descr.getManagedDependencies();
         }
 
+        directDeps = DependencyUtils.mergeDeps(directDeps, descr.getDependencies(), managedVersions, excludedScopes);
+        aggregatedRepos = aggregateRepositories(aggregatedRepos, newResolutionRepositories(descr.getRepositories()));
+        return newCollectRequest(artifact, directDeps, mergedManagedDeps, exclusions, aggregatedRepos);
+    }
+
+    public static CollectRequest newCollectRequest(Artifact artifact, List<Dependency> directDeps, List<Dependency> managedDeps,
+            Collection<Exclusion> exclusions, List<RemoteRepository> repos) {
         final CollectRequest request = new CollectRequest()
-                .setDependencies(mergeDeps(deps, originalDeps, managedVersions))
-                .setManagedDependencies(mergedManagedDeps)
-                .setRepositories(aggregateRepositories(aggregatedRepos, newResolutionRepositories(descr.getRepositories())));
+                .setDependencies(directDeps)
+                .setManagedDependencies(managedDeps)
+                .setRepositories(repos);
         if (exclusions.isEmpty()) {
             request.setRootArtifact(artifact);
         } else {
@@ -405,37 +382,7 @@ public class MavenArtifactResolver {
                 .setRepositories(aggregateRepositories(mainRepos, remoteRepos));
     }
 
-    private List<Dependency> mergeDeps(List<Dependency> dominant, List<Dependency> recessive,
-            Map<AppArtifactKey, String> managedVersions) {
-        final int initialCapacity = dominant.size() + recessive.size();
-        if (initialCapacity == 0) {
-            return Collections.emptyList();
-        }
-        final List<Dependency> result = new ArrayList<Dependency>(initialCapacity);
-        final Set<AppArtifactKey> ids = new HashSet<AppArtifactKey>(initialCapacity, 1.0f);
-        for (Dependency dependency : dominant) {
-            final AppArtifactKey id = getId(dependency.getArtifact());
-            ids.add(id);
-            final String managedVersion = managedVersions.get(id);
-            if (managedVersion != null) {
-                dependency = dependency.setArtifact(dependency.getArtifact().setVersion(managedVersion));
-            }
-            result.add(dependency);
-        }
-        for (Dependency dependency : recessive) {
-            final AppArtifactKey id = getId(dependency.getArtifact());
-            if (!ids.contains(id)) {
-                final String managedVersion = managedVersions.get(id);
-                if (managedVersion != null) {
-                    dependency = dependency.setArtifact(dependency.getArtifact().setVersion(managedVersion));
-                }
-                result.add(dependency);
-            }
-        }
-        return result;
-    }
-
-    private static AppArtifactKey getId(Artifact a) {
-        return new AppArtifactKey(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension());
+    private static ArtifactKey getKey(Artifact a) {
+        return DependencyUtils.getKey(a);
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
@@ -243,8 +243,8 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
     }
 
     @Override
-    public WorkspaceModule getProjectModule(String groupId, String artifactId) {
-        final LocalProject project = getProject(groupId, artifactId);
+    public WorkspaceModule getProjectModule(ArtifactKey key) {
+        final LocalProject project = getProject(key);
         return project == null ? null : project.toWorkspaceModule();
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ProjectModuleResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ProjectModuleResolver.java
@@ -5,9 +5,9 @@ import io.quarkus.maven.dependency.ArtifactKey;
 
 public interface ProjectModuleResolver {
 
-    WorkspaceModule getProjectModule(String groupId, String artifactId);
-
-    default WorkspaceModule getProjectModule(ArtifactKey key) {
-        return getProjectModule(key.getGroupId(), key.getArtifactId());
+    default WorkspaceModule getProjectModule(String groupId, String artifactId) {
+        return getProjectModule(ArtifactKey.ga(groupId, artifactId));
     }
+
+    WorkspaceModule getProjectModule(ArtifactKey key);
 }

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -12,15 +12,13 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.quarkus.bootstrap.BootstrapConstants;
-import io.quarkus.bootstrap.model.AppArtifactCoords;
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
-import io.quarkus.bootstrap.util.DependencyNodeUtils;
+import io.quarkus.bootstrap.util.DependencyUtils;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.capabilities.CapabilitiesConfig;
 import io.quarkus.maven.capabilities.CapabilityConfig;
@@ -236,7 +234,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     @Parameter(property = "skipCodestartValidation")
     boolean skipCodestartValidation;
 
-    AppArtifactCoords deploymentCoords;
+    ArtifactCoords deploymentCoords;
     CollectResult collectedDeploymentDeps;
     DependencyResult runtimeDeps;
 
@@ -289,18 +287,18 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (!conditionalDependencies.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             int i = 0;
-            buf.append(AppArtifactCoords.fromString(conditionalDependencies.get(i++)).toString());
+            buf.append(ArtifactCoords.fromString(conditionalDependencies.get(i++)).toString());
             while (i < conditionalDependencies.size()) {
-                buf.append(' ').append(AppArtifactCoords.fromString(conditionalDependencies.get(i++)).toString());
+                buf.append(' ').append(ArtifactCoords.fromString(conditionalDependencies.get(i++)).toString());
             }
             props.setProperty(BootstrapConstants.CONDITIONAL_DEPENDENCIES, buf.toString());
         }
         if (!dependencyCondition.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             int i = 0;
-            buf.append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
+            buf.append(ArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
             while (i < dependencyCondition.size()) {
-                buf.append(' ').append(AppArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
+                buf.append(' ').append(ArtifactKey.fromString(dependencyCondition.get(i++)).toGacString());
             }
             props.setProperty(BootstrapConstants.DEPENDENCY_CONDITION, buf.toString());
 
@@ -496,11 +494,11 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
         }
         if (artifactNode == null || groupId == null || artifactId == null || version == null) {
-            final AppArtifactCoords coords = new AppArtifactCoords(
+            final ArtifactCoords coords = new GACTV(
                     groupId == null ? project.getGroupId() : groupId,
                     artifactId == null ? project.getArtifactId() : artifactId,
                     null,
-                    "jar",
+                    ArtifactCoords.TYPE_JAR,
                     version == null ? project.getVersion() : version);
             extObject.put("artifact", coords.toString());
         }
@@ -656,7 +654,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                             deps = getMetadataNode(extObject).putArray("extension-dependencies");
                             extensionDeps.set(deps);
                         }
-                        deps.add(new AppArtifactKey(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
+                        deps.add(ArtifactKey.gact(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
                                 .toGacString());
                     }
                 }
@@ -705,10 +703,10 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private void validateExtensionDeps() throws MojoExecutionException {
 
-        final AppArtifactKey rootDeploymentGact = getDeploymentCoords().getKey();
+        final ArtifactKey rootDeploymentGact = getDeploymentCoords().getKey();
         final RootNode rootDeployment = new RootNode(rootDeploymentGact, 2);
         final Artifact artifact = project.getArtifact();
-        final Node rootRuntime = rootDeployment.newChild(new AppArtifactKey(artifact.getGroupId(), artifact.getArtifactId(),
+        final Node rootRuntime = rootDeployment.newChild(ArtifactKey.gact(artifact.getGroupId(), artifact.getArtifactId(),
                 artifact.getClassifier(), artifact.getType()), 1);
 
         rootDeployment.expectedDeploymentNodes.put(rootDeployment.gact, rootDeployment);
@@ -735,11 +733,11 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             if (rootDeployment.deploymentDepsTotal != 0) {
                 log.error("Deployment artifact " + getDeploymentCoords() +
                         " was found to be missing dependencies on the Quarkus extension artifacts marked with '-' below:");
-                final List<AppArtifactKey> missing = rootDeployment.collectMissingDeploymentDeps(log);
+                final List<ArtifactKey> missing = rootDeployment.collectMissingDeploymentDeps(log);
                 buf.append("Deployment artifact ");
                 buf.append(getDeploymentCoords());
                 buf.append(" is missing the following dependencies from its configuration: ");
-                final Iterator<AppArtifactKey> i = missing.iterator();
+                final Iterator<ArtifactKey> i = missing.iterator();
                 buf.append(i.next());
                 while (i.hasNext()) {
                     buf.append(", ").append(i.next());
@@ -755,7 +753,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                     buf.append(System.lineSeparator());
                 }
                 buf.append("The following deployment artifact(s) appear on the runtime classpath: ");
-                final Iterator<AppArtifactKey> i = rootDeployment.deploymentsOnRtCp.iterator();
+                final Iterator<ArtifactKey> i = rootDeployment.deploymentsOnRtCp.iterator();
                 buf.append(i.next());
                 while (i.hasNext()) {
                     buf.append(", ").append(i.next());
@@ -763,9 +761,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
 
             if (!rootDeployment.unexpectedDeploymentDeps.isEmpty()) {
-                final List<AppArtifactKey> unexpectedRtDeps = new ArrayList<>(0);
-                final List<AppArtifactKey> unexpectedDeploymentDeps = new ArrayList<>(0);
-                for (Map.Entry<AppArtifactKey, org.eclipse.aether.artifact.Artifact> e : rootDeployment.unexpectedDeploymentDeps
+                final List<ArtifactKey> unexpectedRtDeps = new ArrayList<>(0);
+                final List<ArtifactKey> unexpectedDeploymentDeps = new ArrayList<>(0);
+                for (Map.Entry<ArtifactKey, org.eclipse.aether.artifact.Artifact> e : rootDeployment.unexpectedDeploymentDeps
                         .entrySet()) {
                     if (rootDeployment.allDeploymentDeps.contains(e.getKey())) {
                         unexpectedDeploymentDeps.add(e.getKey());
@@ -781,7 +779,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                     buf.append("The deployment artifact " + rootDeploymentGact
                             + " depends on the following Quarkus extension runtime artifacts that weren't found among the dependencies of "
                             + project.getArtifact() + ":");
-                    for (AppArtifactKey a : unexpectedRtDeps) {
+                    for (ArtifactKey a : unexpectedRtDeps) {
                         buf.append(' ').append(a);
                     }
                     log.error("The deployment artifact " + rootDeploymentGact
@@ -797,7 +795,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                     buf.append("The deployment artifact " + rootDeploymentGact
                             + " depends on the following Quarkus extension deployment artifacts whose corresponding runtime artifacts were not found among the dependencies of "
                             + project.getArtifact() + ":");
-                    for (AppArtifactKey a : unexpectedDeploymentDeps) {
+                    for (ArtifactKey a : unexpectedDeploymentDeps) {
                         buf.append(' ').append(a);
                     }
                     log.error("The deployment artifact " + rootDeploymentGact
@@ -824,13 +822,13 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         return runtimeDeps;
     }
 
-    private void highlightInTree(DependencyNode node, Collection<AppArtifactKey> keys) {
+    private void highlightInTree(DependencyNode node, Collection<ArtifactKey> keys) {
         highlightInTree(0, node, keys, new HashSet<>(), new StringBuilder(), new ArrayList<>());
     }
 
-    private void highlightInTree(int depth, DependencyNode node, Collection<AppArtifactKey> keysToHighlight,
-            Set<AppArtifactKey> visited, StringBuilder buf, List<String> branch) {
-        final AppArtifactKey key = toKey(node.getArtifact());
+    private void highlightInTree(int depth, DependencyNode node, Collection<ArtifactKey> keysToHighlight,
+            Set<ArtifactKey> visited, StringBuilder buf, List<String> branch) {
+        final ArtifactKey key = toKey(node.getArtifact());
         if (!visited.add(key)) {
             return;
         }
@@ -869,7 +867,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         if (artifact == null) {
             return;
         }
-        final AppArtifactKey key = toKey(artifact);
+        final ArtifactKey key = toKey(artifact);
         if (!rootDeployment.allDeploymentDeps.add(key)) {
             return;
         }
@@ -884,7 +882,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                 }
             }
         } else if (!rootDeployment.allRtDeps.contains(key)) {
-            final AppArtifactKey deployment = getDeploymentKey(artifact);
+            final ArtifactKey deployment = getDeploymentKey(artifact);
             if (deployment != null) {
                 rootDeployment.unexpectedDeploymentDeps.put(deployment, artifact);
             }
@@ -896,7 +894,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             DependencyNode node) throws MojoExecutionException {
         final org.eclipse.aether.artifact.Artifact a = node.getArtifact();
         root.allRtDeps.add(toKey(a));
-        final AppArtifactKey deployment = getDeploymentKey(a);
+        final ArtifactKey deployment = getDeploymentKey(a);
         if (deployment != null) {
             currentNode = currentNode.newChild(deployment, ++currentId);
             root.expectedDeploymentNodes.put(currentNode.gact, currentNode);
@@ -927,7 +925,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         }
     }
 
-    private AppArtifactKey getDeploymentKey(org.eclipse.aether.artifact.Artifact a) throws MojoExecutionException {
+    private ArtifactKey getDeploymentKey(org.eclipse.aether.artifact.Artifact a) throws MojoExecutionException {
         final org.eclipse.aether.artifact.Artifact deployment = getDeploymentArtifact(a);
         return deployment == null ? null : toKey(deployment);
     }
@@ -944,7 +942,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                     + BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT + " property in its "
                     + BootstrapConstants.DESCRIPTOR_PATH);
         }
-        return DependencyNodeUtils.toArtifact(deploymentStr);
+        return DependencyUtils.toArtifact(deploymentStr);
     }
 
     private Properties getExtensionDescriptor(org.eclipse.aether.artifact.Artifact a, boolean packaged) {
@@ -998,13 +996,13 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         return props;
     }
 
-    private static AppArtifactKey toKey(org.eclipse.aether.artifact.Artifact a) {
-        return DependencyNodeUtils.toKey(a);
+    private static ArtifactKey toKey(org.eclipse.aether.artifact.Artifact a) {
+        return DependencyUtils.getKey(a);
     }
 
     private CollectResult collectDeploymentDeps() throws MojoExecutionException {
         if (collectedDeploymentDeps == null) {
-            final AppArtifactCoords deploymentCoords = getDeploymentCoords();
+            final ArtifactCoords deploymentCoords = getDeploymentCoords();
             try {
                 collectedDeploymentDeps = repoSystem.collectDependencies(repoSession,
                         newCollectRequest(new DefaultArtifact(deploymentCoords.getGroupId(), deploymentCoords.getArtifactId(),
@@ -1017,8 +1015,8 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         return collectedDeploymentDeps;
     }
 
-    private AppArtifactCoords getDeploymentCoords() {
-        return deploymentCoords == null ? deploymentCoords = AppArtifactCoords.fromString(deployment) : deploymentCoords;
+    private ArtifactCoords getDeploymentCoords() {
+        return deploymentCoords == null ? deploymentCoords = ArtifactCoords.fromString(deployment) : deploymentCoords;
     }
 
     private CollectRequest newCollectRuntimeDepsRequest() throws MojoExecutionException {
@@ -1136,16 +1134,16 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private static class RootNode extends Node {
 
-        final Map<AppArtifactKey, Node> expectedDeploymentNodes = new HashMap<>();
-        final Set<AppArtifactKey> directRuntimeDeps = new HashSet<>();
-        final Set<AppArtifactKey> allRtDeps = new HashSet<>();
-        final Set<AppArtifactKey> allDeploymentDeps = new HashSet<>();
-        final Map<AppArtifactKey, org.eclipse.aether.artifact.Artifact> unexpectedDeploymentDeps = new HashMap<>(0);
+        final Map<ArtifactKey, Node> expectedDeploymentNodes = new HashMap<>();
+        final Set<ArtifactKey> directRuntimeDeps = new HashSet<>();
+        final Set<ArtifactKey> allRtDeps = new HashSet<>();
+        final Set<ArtifactKey> allDeploymentDeps = new HashSet<>();
+        final Map<ArtifactKey, org.eclipse.aether.artifact.Artifact> unexpectedDeploymentDeps = new HashMap<>(0);
 
         int deploymentDepsTotal = 1;
-        List<AppArtifactKey> deploymentsOnRtCp = new ArrayList<>(0);
+        List<ArtifactKey> deploymentsOnRtCp = new ArrayList<>(0);
 
-        RootNode(AppArtifactKey gact, int id) {
+        RootNode(ArtifactKey gact, int id) {
             super(null, gact, id);
         }
 
@@ -1157,26 +1155,26 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
 
     private static class Node {
         final Node parent;
-        final AppArtifactKey gact;
+        final ArtifactKey gact;
         final int id;
         boolean present;
         int runtimeCp;
         List<Node> children = new ArrayList<>(0);
 
-        Node(Node parent, AppArtifactKey gact, int id) {
+        Node(Node parent, ArtifactKey gact, int id) {
             this.parent = parent;
             this.gact = gact;
             this.id = id;
         }
 
-        Node newChild(AppArtifactKey gact, int id) {
+        Node newChild(ArtifactKey gact, int id) {
             final Node child = new Node(this, gact, id);
             children.add(child);
             return child;
         }
 
-        List<AppArtifactKey> collectMissingDeploymentDeps(Log log) {
-            final List<AppArtifactKey> missing = new ArrayList<>();
+        List<ArtifactKey> collectMissingDeploymentDeps(Log log) {
+            final List<ArtifactKey> missing = new ArrayList<>();
             handleChildren(log, 0, missing, (log1, depth, n, collected) -> {
                 final StringBuilder buf = new StringBuilder();
                 if (n.present) {
@@ -1195,8 +1193,8 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             return missing;
         }
 
-        List<AppArtifactKey> collectDeploymentsOnRtCp(Log log) {
-            final List<AppArtifactKey> missing = new ArrayList<>();
+        List<ArtifactKey> collectDeploymentsOnRtCp(Log log) {
+            final List<ArtifactKey> missing = new ArrayList<>();
             handleChildren(log, 0, missing, (log1, depth, n, collected) -> {
                 if (n.runtimeCp == 0) {
                     return;
@@ -1218,12 +1216,12 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             return missing;
         }
 
-        private void handle(Log log, int depth, List<AppArtifactKey> collected, NodeHandler handler) {
+        private void handle(Log log, int depth, List<ArtifactKey> collected, NodeHandler handler) {
             handler.handle(log, depth, this, collected);
             handleChildren(log, depth, collected, handler);
         }
 
-        private void handleChildren(Log log, int depth, List<AppArtifactKey> collected, NodeHandler handler) {
+        private void handleChildren(Log log, int depth, List<ArtifactKey> collected, NodeHandler handler) {
             for (Node child : children) {
                 child.handle(log, depth + 1, collected, handler);
             }
@@ -1231,7 +1229,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     }
 
     private static interface NodeHandler {
-        void handle(Log log, int depth, Node n, List<AppArtifactKey> collected);
+        void handle(Log log, int depth, Node n, List<ArtifactKey> collected);
     }
 
     private MavenArtifactResolver resolver() throws MojoExecutionException {

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/CodestartResourceLoadersBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/CodestartResourceLoadersBuilder.java
@@ -6,7 +6,7 @@ import static io.quarkus.platform.descriptor.loader.json.ResourceLoaders.resolve
 import static java.util.Objects.requireNonNull;
 
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
-import io.quarkus.bootstrap.util.DependencyNodeUtils;
+import io.quarkus.bootstrap.util.DependencyUtils;
 import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
 import io.quarkus.registry.catalog.Extension;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -108,13 +108,13 @@ public final class CodestartResourceLoadersBuilder {
                 if (artifactCoords == null || codestartsArtifacts.containsKey(artifactCoords)) {
                     continue;
                 }
-                codestartsArtifacts.put(artifactCoords, DependencyNodeUtils.toArtifact(artifactCoords));
+                codestartsArtifacts.put(artifactCoords, DependencyUtils.toArtifact(artifactCoords));
             }
         }
 
         // Load base codestart artifacts
         if (baseCodestartsArtifactCoords != null) {
-            codestartsArtifacts.put(baseCodestartsArtifactCoords, DependencyNodeUtils.toArtifact(baseCodestartsArtifactCoords));
+            codestartsArtifacts.put(baseCodestartsArtifactCoords, DependencyUtils.toArtifact(baseCodestartsArtifactCoords));
         }
 
         if (catalog != null) {
@@ -124,13 +124,13 @@ public final class CodestartResourceLoadersBuilder {
                 if (codestartsArtifacts.containsKey(artifactCoords)) {
                     continue;
                 }
-                codestartsArtifacts.put(artifactCoords, DependencyNodeUtils.toArtifact(artifactCoords));
+                codestartsArtifacts.put(artifactCoords, DependencyUtils.toArtifact(artifactCoords));
             }
         }
 
         // Load codestarts from the given artifacts
         for (String codestartArtifactCoords : extraCodestartsArtifactCoords) {
-            codestartsArtifacts.put(codestartArtifactCoords, DependencyNodeUtils.toArtifact(codestartArtifactCoords));
+            codestartsArtifacts.put(codestartArtifactCoords, DependencyUtils.toArtifact(codestartArtifactCoords));
         }
 
         final List<ResourceLoader> codestartResourceLoaders = new ArrayList<>(codestartsArtifacts.size());


### PR DESCRIPTION
Fix #24895

This change makes sure that local project dependencies are not flagged as reloadable if they happen to be dependencies (direct or transitive) of non-reloadable dependencies.