### PR TITLE
Ignore maven-wrapper.jar in generated maven projects

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/base/.mvn/wrapper/..gitignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/base/.mvn/wrapper/..gitignore
@@ -1,0 +1,1 @@
+maven-wrapper.jar


### PR DESCRIPTION
`mvnw` downloads the maven wrapper jar and places it in _.mvn/wrapper/maven-wrapper.jar_ on its first invocation, see [here](https://github.com/quarkusio/quarkus/blob/617d484bc6827cec6c01b16f300ccacc0e798b05/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/maven-wrapper/base/.mvn/wrapper/MavenWrapperDownloader.tpl.qute.java#L93-L94)

As binary files file should be kept out of version control, the jar should be on the git ignore list.