### PR TITLE
Simplify Windows path for Docker Desktop and Podman

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -40,8 +40,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         List<String> containerRuntimeArgs = super.getContainerRuntimeBuildArgs();
         String volumeOutputPath = outputPath;
         if (SystemUtils.IS_OS_WINDOWS) {
-            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath,
-                    containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN);
+            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
         }
 
         Collections.addAll(containerRuntimeArgs, "-v",

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/UpxCompressionBuildStep.java
@@ -122,8 +122,7 @@ public class UpxCompressionBuildStep {
 
         String volumeOutputPath = nativeImage.getPath().toFile().getParentFile().getAbsolutePath();
         if (SystemUtils.IS_OS_WINDOWS) {
-            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath,
-                    containerRuntime == ContainerRuntimeUtil.ContainerRuntime.PODMAN);
+            volumeOutputPath = FileUtil.translateToVolumePath(volumeOutputPath);
         } else if (SystemUtils.IS_OS_LINUX) {
             String uid = getLinuxID("-ur");
             String gid = getLinuxID("-gr");

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java
@@ -65,28 +65,25 @@ public class FileUtil {
     }
 
     /**
-     * Translates a file path from the Windows Style to a syntax accepted by Docker,
-     * so that volumes be safely mounted in both Docker for Windows and the legacy
-     * Docker Toolbox.
+     * Translates a file path from the Windows Style to a syntax accepted by Docker and Podman,
+     * so that volumes be safely mounted in both Docker Desktop for Windows and Podman Windows.
      * <p>
-     * <code>docker run -v //c/foo/bar:/somewhere (...)</code>
+     * <code>docker run -v /c/foo/bar:/somewhere (...)</code>
      * <p>
      * You should only use this method on Windows-style paths, and not Unix-style
      * paths.
      *
-     * @see https://github.com/quarkusio/quarkus/issues/5360
      * @param windowsStylePath A path formatted in Windows-style, e.g. "C:\foo\bar".
-     * @return A translated path accepted by Docker, e.g. "//c/foo/bar".
+     * @return A translated path accepted by Docker, e.g. "/c/foo/bar".
      */
-    public static String translateToVolumePath(String windowsStylePath, boolean isPodman) {
+    public static String translateToVolumePath(String windowsStylePath) {
         String translated = windowsStylePath.replace('\\', '/');
         Pattern p = Pattern.compile("^(\\w)(?:$|:(/)?(.*))");
         Matcher m = p.matcher(translated);
         if (m.matches()) {
             String slash = Optional.ofNullable(m.group(2)).orElse("/");
             String path = Optional.ofNullable(m.group(3)).orElse("");
-            // Ad `/' and `//' see https://github.com/containers/podman/issues/14414
-            return (isPodman ? "/" : "//") + m.group(1).toLowerCase() + slash + path;
+            return "/" + m.group(1).toLowerCase() + slash + path;
         }
         return translated;
     }

--- a/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/util/FileUtilTest.java
@@ -10,20 +10,20 @@ public class FileUtilTest {
     @Test
     public void testTranslateToVolumePath() {
         // Windows-Style paths are formatted.
-        assertEquals("/c/tmp/code-with-quarkus", translateToVolumePath("C:\\tmp\\code-with-quarkus", true));
-        assertEquals("//c/", translateToVolumePath("C", false));
-        assertEquals("//c/", translateToVolumePath("C:", false));
-        assertEquals("//c/", translateToVolumePath("C:\\", false));
-        assertEquals("//c/Users", translateToVolumePath("C:\\Users", false));
-        assertEquals("//c/Users/Quarkus/lambdatest-1.0-SNAPSHOT-native-image-source-jar",
-                translateToVolumePath("C:\\Users\\Quarkus\\lambdatest-1.0-SNAPSHOT-native-image-source-jar", false));
+        assertEquals("/c/tmp/code-with-quarkus", translateToVolumePath("C:\\tmp\\code-with-quarkus"));
+        assertEquals("/c/", translateToVolumePath("C"));
+        assertEquals("/c/", translateToVolumePath("C:"));
+        assertEquals("/c/", translateToVolumePath("C:\\"));
+        assertEquals("/c/Users", translateToVolumePath("C:\\Users"));
+        assertEquals("/c/Users/Quarkus/lambdatest-1.0-SNAPSHOT-native-image-source-jar",
+                translateToVolumePath("C:\\Users\\Quarkus\\lambdatest-1.0-SNAPSHOT-native-image-source-jar"));
 
         // Side effect for Unix-style path.
-        assertEquals("//c/Users/Quarkus", translateToVolumePath("c:/Users/Quarkus", false));
+        assertEquals("/c/Users/Quarkus", translateToVolumePath("c:/Users/Quarkus"));
 
         // Side effects for fancy inputs - for the sake of documentation.
-        assertEquals("something/bizarre", translateToVolumePath("something\\bizarre", false));
-        assertEquals("something.bizarre", translateToVolumePath("something.bizarre", false));
+        assertEquals("something/bizarre", translateToVolumePath("something\\bizarre"));
+        assertEquals("something.bizarre", translateToVolumePath("something.bizarre"));
     }
 
 }


### PR DESCRIPTION
Using modern Docker Desktop and Podman on Windows, the path can be simplified (as suggested by @n1hility on #25867).

Tested on:
```
Windows 10 Enterprise, OS Build 19044.1766
Podman: Version 4.1.0
                WSL2 Kernel:        5.10.102.1
                Podman machine: podman-machine-default_fedora-35-x86_64
Docker Desktop: v4.9.0
                             Engine: v20.10.16
```

e.g. 
## Docker Desktop
```
C:\tmp\quarkus-quickstarts(development -> origin)
λ mvnw package -pl getting-started-reactive -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=%IMAGE% -Dquarkus.native.container-runtime=docker
...
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on native-image 21.3.2.0-1b6 Mandrel Distribution (Java Version 11.0.15+10-LTS)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/getting-started-reactive/target/getting-started-reactive-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --name build-native-eFoJR %IMAGE% -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 --features=io.quarkus.runner.Feature,io.quarkus.runtime.graal.ResourcesFeature,io.quarkus.runtime.graal.DisableLoggingFeature -H:-ParseOnce -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -J-Djava.awt.headless=true -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.base/com.oracle.svm.util=ALL-UNNAMED getting-started-reactive-1.0.0-SNAPSHOT-runner -jar getting-started-reactive-1.0.0-SNAPSHOT-runner.jar
<SNIP>
# Printing build artifacts to: /project/getting-started-reactive-1.0.0-SNAPSHOT-runner.build_artifacts.txt
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] docker run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/getting-started-reactive/target/getting-started-reactive-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash %IMAGE% -c objcopy --strip-debug getting-started-reactive-1.0.0-SNAPSHOT-runner
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 408581ms
```

## Podman

```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/getting-started-reactive/target/getting-started-reactive-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --name build-native-RAiYs %IMAGE% -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 --features=io.quarkus.runner.Feature,io.quarkus.runtime.graal.ResourcesFeature,io.quarkus.runtime.graal.DisableLoggingFeature -H:-ParseOnce -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -H:+AllowFoldMethods -J-Djava.awt.headless=true -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.base/com.oracle.svm.util=ALL-UNNAMED getting-started-reactive-1.0.0-SNAPSHOT-runner -jar getting-started-reactive-1.0.0-SNAPSHOT-runner.jar
<SNIP>
# Printing build artifacts to: /project/getting-started-reactive-1.0.0-SNAPSHOT-runner.build_artifacts.txt
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/getting-started-reactive/target/getting-started-reactive-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash %IMAGE% -c objcopy --strip-debug getting-started-reactive-1.0.0-SNAPSHOT-runner
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 230955ms
```

Image URL replaced with `%IMAGE%` for brevity. Part of the log snipped by `<SNIP>` for brevity.