### PR TITLE
Use uppercase UP in ReactiveDatasourceHealthCheck

### DIFF
--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactiveDatasourceHealthCheck.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/ReactiveDatasourceHealthCheck.java
@@ -76,7 +76,7 @@ public abstract class ReactiveDatasourceHealthCheck implements HealthCheck {
                 //20 seconds is rather high, but using just 10 is often not enough on slow CI
                 //systems, especially if the connections have to be established for the first time.
                 databaseConnectionAttempt.get(20, TimeUnit.SECONDS);
-                builder.withData(dataSourceName, "up");
+                builder.withData(dataSourceName, "UP");
             } catch (RuntimeException | ExecutionException exception) {
                 operationsError(dataSourceName, exception);
                 builder.down();


### PR DESCRIPTION
request to change the data default value to uppercase to match the status case.  the status enum in HealthCheckResponse is uppercase, so this would make them both the same case for consistency, which is good for those of us with OCD and  looks good when getting values from json from q/health or viewing webpage at q/health-ui 😀


![image](https://user-images.githubusercontent.com/18206189/176307395-3227a7e3-052e-4c2b-a42f-5e6315a7d0b9.png)
