### PR TITLE
Attempt to fix podman DNS issue

### DIFF
--- a/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
+++ b/extensions/devservices/common/src/main/java/io/quarkus/devservices/common/ConfigureUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,7 +42,7 @@ public final class ConfigureUtil {
             container.setNetwork(Network.SHARED);
         }
 
-        String hostName = hostNamePrefix + "-" + Base58.randomString(5);
+        String hostName = (hostNamePrefix + "-" + Base58.randomString(5)).toLowerCase(Locale.ROOT);
         container.setNetworkAliases(Collections.singletonList(hostName));
 
         return hostName;


### PR DESCRIPTION
As found by @holly-cummins, podman's internal DNS
is case-sensitive. This seems to be causing issues
for some our dev-services being run on podman.
This changes ensures that the hostname is always lowercase
thus circumventing the problem.

See [this](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/DNS.20woes.3A.20Podman.20.2B.20Mongo.20.2B.20Dev.20services.20.2FTestcontainers.20-.2E.2E.2E/near/287736870) for a complete discussion