### PR TITLE
Remove unused hibernate artifacts from mongo test

### DIFF
--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/main/resources/application.properties
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/main/resources/application.properties
@@ -1,3 +1,2 @@
-quarkus.hibernate-orm.database.generation=drop-and-create
-#quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.mongodb.write-concern.journal=false
+quarkus.mongodb.parameter-injection.write-concern.journal=false

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/main/resources/import.sql
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/main/resources/import.sql
@@ -1,3 +1,0 @@
-INSERT INTO known_fruits(id, name) VALUES (1, 'Cherry');
-INSERT INTO known_fruits(id, name) VALUES (2, 'Apple');
-INSERT INTO known_fruits(id, name) VALUES (3, 'Banana');

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/FruitsEndpointTest.java
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-mongo/src/test/java/org/acme/FruitsEndpointTest.java
@@ -17,6 +17,8 @@ public class FruitsEndpointTest {
                 .then()
                 .statusCode(200)
                 .body("$.size()", is(0));
+        // This test is rather weak, because we don't pre-populate the mongo db before running the tests
+        // There's not a nice out-of-band method for initialising the db, so we assume if we can connect the db, we are good
     }
 
 }


### PR DESCRIPTION
It looks like some things got copied and pasted from hibernate tests which are not relevant for nosql tests. They're confusing, so removing them.

See https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Mongo.20container.20image.20invoker.20test/near/287365485 for discussion.