### PR TITLE
Support mounting volumes for secrets/configmaps items

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
+import java.util.Map;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -20,6 +22,12 @@ public class ConfigMapVolumeConfig {
      */
     @ConfigItem(defaultValue = "0600")
     String defaultMode;
+
+    /**
+     * The list of files to be mounted.
+     */
+    @ConfigItem
+    Map<String, VolumeItemConfig> items;
 
     /**
      * Optional

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ConfigMapVolumeConverter.java
@@ -1,10 +1,14 @@
 
 package io.quarkus.kubernetes.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import io.dekorate.kubernetes.config.ConfigMapVolume;
 import io.dekorate.kubernetes.config.ConfigMapVolumeBuilder;
+import io.dekorate.kubernetes.config.Item;
+import io.dekorate.kubernetes.config.ItemBuilder;
 
 public class ConfigMapVolumeConverter {
 
@@ -17,6 +21,18 @@ public class ConfigMapVolumeConverter {
         b.withConfigMapName(cm.configMapName);
         b.withDefaultMode(FilePermissionUtil.parseInt(cm.defaultMode));
         b.withOptional(cm.optional);
+        if (cm.items != null && !cm.items.isEmpty()) {
+            List<Item> items = new ArrayList<>(cm.items.size());
+            for (Map.Entry<String, VolumeItemConfig> item : cm.items.entrySet()) {
+                items.add(new ItemBuilder()
+                        .withKey(item.getKey())
+                        .withPath(item.getValue().path)
+                        .withMode(item.getValue().mode)
+                        .build());
+            }
+
+            b.withItems(items.toArray(new Item[items.size()]));
+        }
         return b;
     }
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.kubernetes.deployment;
 
+import java.util.Map;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -20,6 +22,12 @@ public class SecretVolumeConfig {
      */
     @ConfigItem(defaultValue = "0600")
     String defaultMode;
+
+    /**
+     * The list of files to be mounted.
+     */
+    @ConfigItem
+    Map<String, VolumeItemConfig> items;
 
     /**
      * Optional

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/SecretVolumeConverter.java
@@ -1,7 +1,11 @@
 package io.quarkus.kubernetes.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import io.dekorate.kubernetes.config.Item;
+import io.dekorate.kubernetes.config.ItemBuilder;
 import io.dekorate.kubernetes.config.SecretVolume;
 import io.dekorate.kubernetes.config.SecretVolumeBuilder;
 
@@ -16,6 +20,18 @@ public class SecretVolumeConverter {
         b.withSecretName(c.secretName);
         b.withDefaultMode(FilePermissionUtil.parseInt(c.defaultMode));
         b.withOptional(c.optional);
+        if (c.items != null && !c.items.isEmpty()) {
+            List<Item> items = new ArrayList<>(c.items.size());
+            for (Map.Entry<String, VolumeItemConfig> item : c.items.entrySet()) {
+                items.add(new ItemBuilder()
+                        .withKey(item.getKey())
+                        .withPath(item.getValue().path)
+                        .withMode(item.getValue().mode)
+                        .build());
+            }
+
+            b.withItems(items.toArray(new Item[items.size()]));
+        }
         return b;
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VolumeItemConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/VolumeItemConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class VolumeItemConfig {
+    /**
+     * The path where the file will be mounted.
+     */
+    @ConfigItem
+    String path;
+
+    /**
+     * It must be a value between 0000 and 0777. If not specified, the volume defaultMode will be used.
+     */
+    @ConfigItem(defaultValue = "-1")
+    int mode;
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMappingVolumeConfigMapItemsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMappingVolumeConfigMapItemsTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithMappingVolumeConfigMapItemsTest {
+    private static final String APPLICATION_NAME = "mapping-volume-configmap-items";
+    private static final String VOLUME_NAME = "volume-config";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + ".properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void ensureVolumeIsCorrectlyMappedWithItems() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getVolumeMounts()).singleElement().satisfies(volumeMount -> {
+                                assertThat(volumeMount.getName()).isEqualTo(VOLUME_NAME);
+                                assertThat(volumeMount.getMountPath()).isEqualTo("/etc/config");
+                            });
+                        });
+
+                        assertThat(podSpec.getVolumes()).singleElement().satisfies(volume -> {
+                            assertThat(volume.getName()).isEqualTo(VOLUME_NAME);
+                            assertThat(volume.getConfigMap()).isNotNull();
+                            assertThat(volume.getConfigMap().getName()).isEqualTo("the-config-map-name");
+                            assertThat(volume.getConfigMap().getItems()).singleElement().satisfies(keyToPath -> {
+                                assertThat(keyToPath.getKey()).isEqualTo("key");
+                                assertThat(keyToPath.getPath()).isEqualTo("/from/path");
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMappingVolumeSecretItemsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMappingVolumeSecretItemsTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithMappingVolumeSecretItemsTest {
+    private static final String APPLICATION_NAME = "mapping-volume-secret-items";
+    private static final String VOLUME_NAME = "volume-certs";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APPLICATION_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + ".properties");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void ensureVolumeIsCorrectlyMappedWithItems() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> kubernetesList = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        assertThat(kubernetesList.get(0)).isInstanceOfSatisfying(Deployment.class, d -> {
+            assertThat(d.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APPLICATION_NAME);
+            });
+
+            assertThat(d.getSpec()).satisfies(deploymentSpec -> {
+                assertThat(deploymentSpec.getTemplate()).satisfies(t -> {
+                    assertThat(t.getSpec()).satisfies(podSpec -> {
+                        assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
+                            assertThat(container.getVolumeMounts()).singleElement().satisfies(volumeMount -> {
+                                assertThat(volumeMount.getName()).isEqualTo(VOLUME_NAME);
+                                assertThat(volumeMount.getMountPath()).isEqualTo("/etc/certs");
+                            });
+                        });
+
+                        assertThat(podSpec.getVolumes()).singleElement().satisfies(volume -> {
+                            assertThat(volume.getName()).isEqualTo(VOLUME_NAME);
+                            assertThat(volume.getSecret()).isNotNull();
+                            assertThat(volume.getSecret().getSecretName()).isEqualTo("root-secret");
+                            assertThat(volume.getSecret().getItems()).singleElement().satisfies(keyToPath -> {
+                                assertThat(keyToPath.getKey()).isEqualTo("keystore.p12");
+                                assertThat(keyToPath.getPath()).isEqualTo("keystore.p12");
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mapping-volume-configmap-items.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mapping-volume-configmap-items.properties
@@ -1,0 +1,3 @@
+quarkus.kubernetes.mounts.volume-config.path=/etc/config
+quarkus.kubernetes.config-map-volumes.volume-config.config-map-name=the-config-map-name
+quarkus.kubernetes.config-map-volumes.volume-config.items.key.path=/from/path

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mapping-volume-secret-items.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-mapping-volume-secret-items.properties
@@ -1,0 +1,3 @@
+quarkus.kubernetes.mounts.volume-certs.path=/etc/certs
+quarkus.kubernetes.secret-volumes.volume-certs.secret-name=root-secret
+quarkus.kubernetes.secret-volumes.volume-certs.items.\"keystore.p12\".path=keystore.p12


### PR DESCRIPTION
Adding support of volume items only for secrets and configmap for Knative, OpenShift and Kubernetes deployments.

The new properties looks like:

```
quarkus.kubernetes.mounts.volume-certs.path=/etc/certs
quarkus.kubernetes.secret-volumes.volume-certs.secret-name=root-secret
quarkus.kubernetes.secret-volumes.volume-certs.items.keystore.path=keystore.p12
```

Where items is a map of string (the item key) and items (the item path + the item mode).

Fix https://github.com/quarkusio/quarkus/issues/25058