### PR TITLE
Qute: Remove old cdata delimiter

### DIFF
--- a/docs/src/main/asciidoc/qute-reference.adoc
+++ b/docs/src/main/asciidoc/qute-reference.adoc
@@ -149,7 +149,10 @@ Unparsed Character Data::
 It is used to mark the content that should be rendered but _not parsed_.
 It starts with the sequence `{|`  and ends with the sequence `|}`: `{| <script>if(true){alert('Qute is cute!')};</script> |}`, and could be multi-line.
 +
-NOTE: Previously, unparsed character data had to start with `{[` and end with `]}`. This syntax is still supported, but we encourage users to switch to the new syntax to avoid some common collisions with constructs from other languages.
+[WARNING]
+====
+Previously, unparsed character data could start with `{[` and end with `]}`. This syntax is now removed due to common collisions with constructs from other languages.
+====
 
 [[identifiers]]
 === Identifiers and Tags

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/Parser.java
@@ -42,9 +42,7 @@ class Parser implements Function<String, Expression>, ParserHelper, ParserDelega
     private static final char END_DELIMITER = '}';
     private static final char COMMENT_DELIMITER = '!';
     private static final char CDATA_START_DELIMITER = '|';
-    private static final char CDATA_START_DELIMITER_OLD = '[';
     private static final char CDATA_END_DELIMITER = '|';
-    private static final char CDATA_END_DELIMITER_OLD = ']';
     private static final char UNDERSCORE = '_';
     private static final char ESCAPE_CHAR = '\\';
     private static final char NAMESPACE_SEPARATOR = ':';
@@ -307,7 +305,7 @@ class Parser implements Function<String, Expression>, ParserHelper, ParserDelega
     }
 
     private boolean isCdataEnd(char character) {
-        return character == CDATA_END_DELIMITER || character == CDATA_END_DELIMITER_OLD;
+        return character == CDATA_END_DELIMITER;
     }
 
     private void tag(char character) {
@@ -335,7 +333,7 @@ class Parser implements Function<String, Expression>, ParserHelper, ParserDelega
             if (character == COMMENT_DELIMITER) {
                 buffer.append(character);
                 state = State.COMMENT;
-            } else if (character == CDATA_START_DELIMITER || character == CDATA_START_DELIMITER_OLD) {
+            } else if (character == CDATA_START_DELIMITER) {
                 state = State.CDATA;
             } else {
                 buffer.append(character);
@@ -356,7 +354,6 @@ class Parser implements Function<String, Expression>, ParserHelper, ParserDelega
     private boolean isValidIdentifierStart(char character) {
         // A valid identifier must start with a digit, alphabet, underscore, comment delimiter, cdata start delimiter or a tag command (e.g. # for sections)
         return Tag.isCommand(character) || character == COMMENT_DELIMITER || character == CDATA_START_DELIMITER
-                || character == CDATA_START_DELIMITER_OLD
                 || character == UNDERSCORE
                 || Character.isDigit(character)
                 || Character.isAlphabetic(character);

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -231,10 +231,7 @@ public class ParserTest {
         String jsSnippet = "<script>const foo = function(){alert('bar');};</script>";
         assertThatExceptionOfType(Exception.class)
                 .isThrownBy(() -> engine.parse("Hello {name} " + jsSnippet));
-        assertEquals("Hello world <script>const foo = function(){alert('bar');};</script>", engine.parse("Hello {name} {["
-                + jsSnippet
-                + "]}").data("name", "world").render());
-        assertEquals("Hello world <strong>", engine.parse("Hello {name} {[<strong>]}").data("name", "world").render());
+
         assertEquals("Hello world <script>const foo = function(){alert('bar');};</script>", engine.parse("Hello {name} {|"
                 + jsSnippet
                 + "|}").data("name", "world").render());


### PR DESCRIPTION
Removes the old cdata delimiters (`{[` and `]}`) from Qute templating engine as requested by @mkouba in the discussion #25948