### PR TITLE
Add proto-google-common-protos to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,6 +125,7 @@ updates:
       - dependency-name: org.apache.avro:*
       # gRPC
       - dependency-name: io.grpc:*
+      - dependency-name: com.google.api.grpc:proto-google-common-protos
       # jaeger
       - dependency-name: io.jaegertracing:*
       # Kotlin


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus-platform/pull/569#pullrequestreview-1023168703 .