### PR TITLE
Add a JCEKS keystore test

### DIFF
--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/SecurityProcessor.java
@@ -344,6 +344,7 @@ public class SecurityProcessor {
     void addBouncyCastleExportsToNativeImage(BuildProducer<JPMSExportBuildItem> jpmsExports,
             List<BouncyCastleProviderBuildItem> bouncyCastleProviders,
             List<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProviders) {
+        jpmsExports.produce(new JPMSExportBuildItem("java.base", "com.sun.crypto.provider"));
         Optional<BouncyCastleJsseProviderBuildItem> bouncyCastleJsseProvider = getOne(bouncyCastleJsseProviders);
         if (bouncyCastleJsseProvider.isPresent() && bouncyCastleJsseProvider.get().isInFipsMode()) {
             jpmsExports.produce(new JPMSExportBuildItem("java.base", "sun.security.internal.spec"));

--- a/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
+++ b/integration-tests/bouncycastle/src/main/java/io/quarkus/it/bouncycastle/BouncyCastleEndpoint.java
@@ -1,9 +1,14 @@
 package io.quarkus.it.bouncycastle;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
 import java.security.Security;
 import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -11,6 +16,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -21,6 +27,36 @@ import org.bouncycastle.util.io.pem.PemReader;
 
 @Path("/jca")
 public class BouncyCastleEndpoint {
+
+    @GET
+    @Path("createjceks")
+    public String createjceks() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, null);
+
+        KeyGenerator keyGen = KeyGenerator.getInstance("DES");
+        keyGen.init(56);
+        ;
+        Key key = keyGen.generateKey();
+
+        keyStore.setKeyEntry("secret", key, "password".toCharArray(), null);
+
+        OutputStream os = new FileOutputStream("output.jceks");
+        keyStore.store(os, "password".toCharArray());
+        os.close();
+        return "";
+    }
+
+    @GET
+    @Path("jceks")
+    public String jceks() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(new FileInputStream("output.jceks"), "password".toCharArray());
+
+        Key key = keyStore.getKey("secret", "password".toCharArray());
+
+        return key.toString();
+    }
 
     @GET
     @Path("listProviders")

--- a/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleITCase.java
+++ b/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleITCase.java
@@ -1,7 +1,13 @@
 package io.quarkus.it.bouncycastle;
 
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class BouncyCastleITCase extends BouncyCastleTestCase {
+    @Test
+    public void testJceKS() throws Exception {
+        super.doTestJceKS();
+    }
 }

--- a/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
+++ b/integration-tests/bouncycastle/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.bouncycastle;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,21 @@ import io.restassured.RestAssured;
 
 @QuarkusTest
 public class BouncyCastleTestCase {
+
+    public void doTestJceKS() throws Exception {
+        RestAssured.given()
+                .when()
+                .get("/jca/createjceks")
+                .then()
+                .statusCode(200);
+
+        RestAssured.given()
+                .when()
+                .get("/jca/jceks")
+                .then()
+                .statusCode(200)
+                .body(startsWith("javax.crypto.spec.SecretKeySpec"));
+    }
 
     @Test
     public void testListProviders() {


### PR DESCRIPTION
@zakkak Hi Foivos, I'm trying to prove here that a JCEKS store can only be read if it was created by the same Java version (in this case native image). This test (which will be refactored) creates a JCEKS store first and then reads it, all in native mode. Test passes in JVM. I've coped this code from one of the public resources, it can be tweaked as well.

In native mode, when an attempt is made to create a store, I'm getting
```
Caused by: com.oracle.svm.core.jdk.UnsupportedFeatureError: Trying to access the code base of class com.sun.crypto.provider.CipherForKeyProtector. 
	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:89)
	at javax.crypto.JceSecurity.getCodeBase(JceSecurity.java:384)
	at javax.crypto.JceSecurityManager.isCallerTrusted(JceSecurityManager.java:241)
```

where `com.sun.crypto.provider` package contains a java file were two independent final package private classes are defined, `final class KeyProtector {}` and `final class CipherForKeyProtector {}`. 

I've attempted to export `com.sun.crypto.provider` but without any luck.
Does it ring any bell at all ? I've found nothing in GraalVM issues...

Thanks