### PR TITLE
Resolve Sec. Identity in RESTEasy Reactive when Proactive Auth disabled

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -122,6 +122,10 @@ application this will fail (as you cannot do blocking operations on the IO threa
 `Uni<SecurityIdentity> getDeferredIdentity();` method. You can then subscribe to the resulting `Uni` and will be notified
 when authentication is complete and the identity is available.
 
+NOTE: It's still possible to access the `SecurityIdentity` synchronously with `public SecurityIdentity getIdentity()`
+in the xref:resteasy-reactive.adoc[RESTEasy Reactive] from endpoints annotated with `@RolesAllowed`, `@Authenticated`,
+or with respective configuration authorization checks as authentication has already happened.
+
 === How to customize authentication exception responses
 
 By default, the authentication security constraints are enforced before the JAX-RS chain starts.

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1025,7 +1025,8 @@ public class ResteasyReactiveProcessor {
     }
 
     @BuildStep
-    MethodScannerBuildItem integrateEagerSecurity(Capabilities capabilities, CombinedIndexBuildItem indexBuildItem) {
+    MethodScannerBuildItem integrateEagerSecurity(Capabilities capabilities, CombinedIndexBuildItem indexBuildItem,
+            HttpBuildTimeConfig httpBuildTimeConfig) {
         if (!capabilities.isPresent(Capability.SECURITY)) {
             return null;
         }
@@ -1036,7 +1037,8 @@ public class ResteasyReactiveProcessor {
                     Map<String, Object> methodContext) {
                 return Objects.requireNonNullElse(
                         consumeStandardSecurityAnnotations(method, actualEndpointClass, index,
-                                (c) -> Collections.singletonList(new EagerSecurityHandler.Customizer())),
+                                (c) -> Collections.singletonList(
+                                        EagerSecurityHandler.Customizer.newInstance(httpBuildTimeConfig.auth.proactive))),
                         Collections.emptyList());
             }
         });

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/LazyAuthRolesAllowedJaxRsTestCase.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Arrays;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,8 @@ public class LazyAuthRolesAllowedJaxRsTestCase {
             RestAssured.given().auth().basic("user", "user").get(path).then().statusCode(200);
             RestAssured.given().auth().basic("admin", "admin").get(path + "/admin").then().statusCode(200);
             RestAssured.given().auth().basic("user", "user").get(path + "/admin").then().statusCode(403);
+            RestAssured.given().auth().basic("admin", "admin").get(path + "/admin/security-identity").then().statusCode(200)
+                    .body(Matchers.is("admin"));
         });
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedBlockingResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedBlockingResource.java
@@ -2,10 +2,13 @@ package io.quarkus.resteasy.reactive.server.test.security;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.common.annotation.Blocking;
+import io.smallrye.common.annotation.NonBlocking;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -14,6 +17,10 @@ import io.smallrye.common.annotation.Blocking;
 @PermitAll
 @Blocking
 public class RolesAllowedBlockingResource {
+
+    @Inject
+    CurrentIdentityAssociation currentIdentityAssociation;
+
     @GET
     @RolesAllowed({ "user", "admin" })
     public String defaultSecurity() {
@@ -25,6 +32,14 @@ public class RolesAllowedBlockingResource {
     @GET
     public String admin() {
         return "admin";
+    }
+
+    @NonBlocking
+    @Path("/admin/security-identity")
+    @RolesAllowed("admin")
+    @GET
+    public String getSecurityIdentity() {
+        return currentIdentityAssociation.getIdentity().getPrincipal().getName();
     }
 
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedResource.java
@@ -2,8 +2,12 @@ package io.quarkus.resteasy.reactive.server.test.security;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+
+import io.quarkus.security.identity.CurrentIdentityAssociation;
+import io.smallrye.common.annotation.NonBlocking;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
@@ -11,6 +15,10 @@ import javax.ws.rs.Path;
 @Path("/roles")
 @PermitAll
 public class RolesAllowedResource {
+
+    @Inject
+    CurrentIdentityAssociation currentIdentityAssociation;
+
     @GET
     @RolesAllowed({ "user", "admin" })
     public String defaultSecurity() {
@@ -22,6 +30,14 @@ public class RolesAllowedResource {
     @GET
     public String admin() {
         return "admin";
+    }
+
+    @NonBlocking
+    @Path("/admin/security-identity")
+    @RolesAllowed("admin")
+    @GET
+    public String getSecurityIdentity() {
+        return currentIdentityAssociation.getIdentity().getPrincipal().getName();
     }
 
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -176,7 +176,8 @@ public class RuntimeResourceDeployment {
         }
 
         ResteasyReactiveResourceInfo lazyMethod = new ResteasyReactiveResourceInfo(method.getName(), resourceClass,
-                parameterDeclaredUnresolvedTypes, classAnnotationNames, method.getMethodAnnotationNames());
+                parameterDeclaredUnresolvedTypes, classAnnotationNames, method.getMethodAnnotationNames(),
+                !defaultBlocking && !method.isBlocking());
 
         RuntimeInterceptorDeployment.MethodInterceptorContext interceptorDeployment = runtimeInterceptorDeployment
                 .forMethod(method, lazyMethod);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/spi/ResteasyReactiveResourceInfo.java
@@ -20,6 +20,10 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
     private final Class[] parameterTypes;
     private final Set<String> classAnnotationNames;
     private final Set<String> methodAnnotationNames;
+    /**
+     * If it's non-blocking method within the runtime that won't always default to blocking
+     */
+    public final boolean isNonBlocking;
 
     private volatile Annotation[] classAnnotations;
     private volatile Method method;
@@ -28,12 +32,13 @@ public class ResteasyReactiveResourceInfo implements ResourceInfo {
     private volatile String methodId;
 
     public ResteasyReactiveResourceInfo(String name, Class<?> declaringClass, Class[] parameterTypes,
-            Set<String> classAnnotationNames, Set<String> methodAnnotationNames) {
+            Set<String> classAnnotationNames, Set<String> methodAnnotationNames, boolean isNonBlocking) {
         this.name = name;
         this.declaringClass = declaringClass;
         this.parameterTypes = parameterTypes;
         this.classAnnotationNames = classAnnotationNames;
         this.methodAnnotationNames = methodAnnotationNames;
+        this.isNonBlocking = isNonBlocking;
     }
 
     public String getName() {


### PR DESCRIPTION
f ix #23547 for RESTEasy Reactive cases (e.g. the issue reproducer)

Disabling proactive authentication [makes accessing the `SecurityIdentity` the blocking operation](https://quarkus.io/guides/security-built-in-authentication#proactive-authentication). In RR security checks for these of standard security annotations that requires access to `SecurityIdentity` (e.g. `@RollesAllowed`) are [further up the handler chain](https://github.com/quarkusio/quarkus/pull/19598) then same checks run by Quarkus Security Runtime (`io.quarkus.security.deployment.SecurityProcessor#registerSecurityInterceptors`). Checks run in RR access SecurityIndentity by `getDeferredIdentity` (non-blocking), however in Quarkus Security the checks are using `getIdentity`. That leads to `BlockingOperationNotAllowedException` when running synchronously on IO thread. The `quarkus-security-runtime-spi` does not allow to disable security checks (that make sense from security point of view, but f.e `io.quarkus.security.runtime.interceptor.check.RolesAllowedCheck` is always run twice if successful), but as checks in RR always run first, this PR sets the identity there to make it available later in the chain.