### PR TITLE
Make quarkus.container-image.push=false effective in all k8s extensions

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -31,6 +31,7 @@ import io.dekorate.processor.SimpleFileWriter;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Maps;
 import io.dekorate.utils.Strings;
+import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsTest;
@@ -79,6 +80,14 @@ class KubernetesProcessor {
             }
         }
         return new EnabledKubernetesDeploymentTargetsBuildItem(entries);
+    }
+
+    @BuildStep
+    public void preventContainerPush(ContainerImageConfig containerImageConfig,
+            BuildProducer<PreventImplicitContainerImagePushBuildItem> producer) {
+        if (containerImageConfig.isPushExplicitlyDisabled()) {
+            producer.produce(new PreventImplicitContainerImagePushBuildItem());
+        }
     }
 
     @BuildStep(onlyIfNot = IsTest.class)

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PreventImplicitContainerImagePushBuildItem.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/PreventImplicitContainerImagePushBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * A build item that is used to prevent the Kubernetes processing from requesting
+ * a container image push request.
+ * This is useful for cases where the kubernetes cluster is local and the container image
+ * is built directly into a context (i.e. a docker daemon) which the cluster has access to.
+ */
+public final class PreventImplicitContainerImagePushBuildItem extends MultiBuildItem {
+
+}


### PR DESCRIPTION
This change makes sure that `quarkus.container-image.push=false` is
 taken into account and always prevents container images from being
 pushed, even if a kubernetes extension requests a deployment.

Resolves: #26385