### PR TITLE
Properly initialize elements from the datasource configs

### DIFF
--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.agroal.runtime;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -130,18 +131,18 @@ public class DataSourceJdbcRuntimeConfig {
      * validation. Setting this setting to STRICT may lead to failures in those cases.
      */
     @ConfigItem
-    public Optional<AgroalConnectionPoolConfiguration.TransactionRequirement> transactionRequirement;
+    public Optional<AgroalConnectionPoolConfiguration.TransactionRequirement> transactionRequirement = Optional.empty();
 
     /**
      * Other unspecified properties to be passed to the JDBC driver when creating new connections.
      */
     @ConfigItem
-    public Map<String, String> additionalJdbcProperties;
+    public Map<String, String> additionalJdbcProperties = Collections.emptyMap();
 
     /**
      * Enable JDBC tracing.
      */
     @ConfigItem
-    public DataSourceJdbcTracingRuntimeConfig tracing;
+    public DataSourceJdbcTracingRuntimeConfig tracing = new DataSourceJdbcTracingRuntimeConfig();
 
 }

--- a/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
+++ b/extensions/reactive-datasource/runtime/src/main/java/io/quarkus/reactive/datasource/runtime/DataSourceReactiveRuntimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.reactive.datasource.runtime;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -145,12 +146,12 @@ public class DataSourceReactiveRuntimeConfig {
      * Set the pool name, used when the pool is shared among datasources, otherwise ignored.
      */
     @ConfigItem
-    public Optional<String> name;
+    public Optional<String> name = Optional.empty();
 
     /**
      * Other unspecified properties to be passed through the Reactive SQL Client directly to the database when new connections
      * are initiated.
      */
     @ConfigItem
-    public Map<String, String> additionalProperties;
+    public Map<String, String> additionalProperties = Collections.emptyMap();
 }


### PR DESCRIPTION
When using named datasources, we might create these objects directly
instead of relying on the config framework. In this case, we need the
objects to be fully initialized.

Fix #26455