### PR TITLE
Propagate startup failure for custom Vert.x instance of RESTEasy Reactive tests

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -358,7 +358,11 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
                         .onComplete(new io.vertx.core.Handler<AsyncResult<HttpServer>>() {
                             @Override
                             public void handle(AsyncResult<HttpServer> event) {
-                                startPromise.complete();
+                                if (event.failed()) {
+                                    startPromise.fail(event.cause());
+                                } else {
+                                    startPromise.complete();
+                                }
                             }
                         });
             }


### PR DESCRIPTION
If we don't do this and there is an exception at startup (like a BindException
for example) then the developer never sees the error and is left wondering
why the tests fail with meaningless validation errors.