### PR TITLE
Enable `mvn install` to be run twice

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -567,7 +567,11 @@ public class JarResultBuildStep {
                 Files.createDirectories(userProviders);
                 //we add this dir so that it can be copied into container images if required
                 //and will still be copied even if empty
-                Files.createFile(userProviders.resolve(".keep"));
+                Path keepFile = userProviders.resolve(".keep");
+                if (!keepFile.toFile().exists()) {
+                    // check if the file exists to avoid a FileAlreadyExistsException
+                    Files.createFile(keepFile);
+                }
             }
         } else {
             IoUtils.createOrEmptyDir(quarkus);


### PR DESCRIPTION
This should succeed even if the `.keep` file already exists.
Any contents of the folder will be cleared as with the buildDir.

Closes #26476