### PR TITLE
Allow to provide custom HTTP options in REST Client Reactive

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -331,6 +331,78 @@ public class ExtensionsResource {
 }
 ----
 
+== Use Custom HTTP Options
+
+The REST Client Reactive internally uses https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClient.html[the Vert.x HTTP Client] to make the network connections. The REST Client Reactive extensions allows configuring some settings via properties, for example:
+
+- `quarkus.rest-client.client-prefix.connect-timeout` to configure the connect timeout in milliseconds.
+- `quarkus.rest-client.client-prefix.max-redirects` to limit the number of redirects.
+
+However, there are many more options within the Vert.x HTTP Client to configure the connections. See all the options in the Vert.x HTTP Client Options API in https://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientOptions.html[this link].
+
+To fully customize the Vert.x HTTP Client instance that the REST Client Reactive is internally using, you can provide your custom HTTP Client Options instance via CDI or when programmatically creating your client.
+
+Let's see an example about how to provide the HTTP Client Options via CDI:
+
+[source,java]
+----
+package org.acme.rest.client;
+
+import javax.enterprise.inject.Produces;
+
+import io.vertx.core.http.HttpClientOptions;
+import io.quarkus.arc.Unremovable;
+
+public static class Configuration {
+    @Produces
+    @Unremovable
+    public HttpClientOptions customHttpClientOptions() {
+        HttpClientOptions options = new HttpClientOptions();
+        // ...
+        return options;
+    }
+}
+----
+
+Now, all the REST Clients will be using your custom HTTP Client Options.
+
+Another approach is to provide the custom HTTP Client options when creating the client programmatically:
+
+[source,java]
+----
+package org.acme.rest.client;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.net.URI;
+import java.util.Set;
+
+import io.vertx.core.http.HttpClientOptions;
+
+@Path("/extension")
+public class ExtensionsResource {
+
+    private final ExtensionsService extensionsService;
+
+    public ExtensionsResource() {
+        HttpClientOptions httpOptions = new HttpClientOptions();
+        // configure the options
+        // ...
+
+        extensionsService = RestClientBuilder.newBuilder()
+            .baseUri(URI.create("https://stage.code.quarkus.io/api"))
+            .register(httpOptions) <1>
+            .build(ExtensionsService.class);
+    }
+
+    // ...
+}
+----
+
+<1> the client will use the registered HTTP Client options over the HTTP Client options provided via CDI if any.
+
 == Update the test
 
 Next, we need to update the functional test to reflect the changes made to the endpoint.

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaInjectedRestClientTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaInjectedRestClientTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.http.HttpClientOptions;
+
+public class CustomHttpOptionsViaInjectedRestClientTest {
+
+    private static final String EXPECTED_VALUE = "success";
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @RestClient
+    Client client;
+
+    @RegisterExtension
+    static final QuarkusUnitTest app = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Client.class)
+                    .addAsResource(new StringAsset(
+                            "custom-http-options/mp-rest/url=http://localhost:${quarkus.http.test-port:8081}"),
+                            "application.properties"));
+
+    @Test
+    void shouldUseCustomHttpOptions() {
+        assertThatThrownBy(() -> client.get()).hasMessageContaining("HTTP header is larger than 1 bytes.");
+    }
+
+    @Test
+    void shouldProgrammaticallyCreatedUseTheCustomHttpOptions() {
+        Client programmaticClient = RestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class);
+        assertThatThrownBy(() -> programmaticClient.get()).hasMessageContaining("HTTP header is larger than 1 bytes.");
+    }
+
+    @Test
+    void shouldCustomHttpOptionsFromRegisterHavePriorityOverCDI() {
+        Client programmaticClient = RestClientBuilder.newBuilder().baseUri(baseUri)
+                .register(new HttpClientOptions()) // reset HTTP Header size limit
+                .build(Client.class);
+        assertThat(programmaticClient.get()).isEqualTo(EXPECTED_VALUE);
+    }
+
+    @Path("/")
+    @ApplicationScoped
+    public static class Resource {
+        @GET
+        public RestResponse<String> get() {
+            return RestResponse.ResponseBuilder.ok(EXPECTED_VALUE)
+                    .header("long-header", "VERY LONNGGGGGGGGGGGGGGGGGGGGGGGGGGGG!")
+                    .build();
+        }
+    }
+
+    public static class ProvidesCustomHttpClientOptions {
+        @Produces
+        @Unremovable
+        public HttpClientOptions httpClientOptions() {
+            HttpClientOptions options = new HttpClientOptions();
+            options.setMaxHeaderSize(1); // this is just to verify that this HttpClientOptions is indeed used.
+            return options;
+        }
+    }
+
+    @RegisterRestClient(configKey = "custom-http-options")
+    public interface Client {
+        @GET
+        String get();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaProgrammaticallyClientCreatedTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/CustomHttpOptionsViaProgrammaticallyClientCreatedTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.vertx.core.http.HttpClientOptions;
+
+public class CustomHttpOptionsViaProgrammaticallyClientCreatedTest {
+
+    private static final String EXPECTED_VALUE = "success";
+
+    @TestHTTPResource
+    URI baseUri;
+
+    @RegisterExtension
+    static final QuarkusUnitTest app = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Client.class));
+
+    @Test
+    void shouldUseCustomHttpOptions() {
+        // First verify the standard configuration
+        assertThat(RestClientBuilder.newBuilder().baseUri(baseUri).build(Client.class).get())
+                .isEqualTo(EXPECTED_VALUE);
+
+        // Now, it should fail if we use a custom http client options with a very limited max header size:
+        HttpClientOptions options = new HttpClientOptions();
+        options.setMaxHeaderSize(1); // this is just to verify that this HttpClientOptions is indeed used.
+        Client client = RestClientBuilder.newBuilder().baseUri(baseUri)
+                .register(options)
+                .build(Client.class);
+        assertThatThrownBy(() -> client.get()).hasMessageContaining("HTTP header is larger than 1 bytes.");
+    }
+
+    @Path("/")
+    @ApplicationScoped
+    public static class Resource {
+        @GET
+        public RestResponse<String> get() {
+            return RestResponse.ResponseBuilder.ok(EXPECTED_VALUE)
+                    .header("long-header", "VERY LONNGGGGGGGGGGGGGGGGGGGGGGGGGGGG!")
+                    .build();
+        }
+    }
+
+    public interface Client {
+        @GET
+        String get();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -37,6 +37,7 @@ import io.quarkus.arc.InstanceHandle;
 import io.quarkus.rest.client.reactive.runtime.ProxyAddressUtil.HostAndPort;
 import io.quarkus.restclient.config.RestClientLoggingConfig;
 import io.quarkus.restclient.config.RestClientsConfig;
+import io.vertx.core.http.HttpClientOptions;
 
 /**
  * Builder implementation for MicroProfile Rest Client
@@ -286,6 +287,13 @@ public class RestClientBuilderImpl implements RestClientBuilder {
                 .instance(AnnotationRegisteredProviders.class).get();
         for (Map.Entry<Class<?>, Integer> mapper : annotationRegisteredProviders.getProviders(aClass).entrySet()) {
             register(mapper.getKey(), mapper.getValue());
+        }
+
+        if (!getConfiguration().isRegistered(HttpClientOptions.class)) {
+            InstanceHandle<HttpClientOptions> httpClientOptions = Arc.container().instance(HttpClientOptions.class);
+            if (httpClientOptions.isAvailable()) {
+                clientBuilder.register(httpClientOptions.get());
+            }
         }
 
         Object defaultMapperDisabled = getConfiguration().getProperty(DEFAULT_MAPPER_DISABLED);

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/api/QuarkusRestClientProperties.java
@@ -10,6 +10,14 @@ public class QuarkusRestClientProperties {
      * maximum number of redirects for a client call. Works only if the client has `followingRedirects enabled
      */
     public static final String MAX_REDIRECTS = "io.quarkus.rest.client.max-redirects";
+    /**
+     * maximum length of all headers for HTTP/1.x.
+     */
+    public static final String MAX_HEADER_SIZE = "io.quarkus.rest.client.max-header-size";
+    /**
+     * maximum length of the initial line for HTTP/1.x.
+     */
+    public static final String MAX_INITIAL_LINE_LENGTH = "io.quarkus.rest.client.max-initial-line-length";
 
     public static final String READ_TIMEOUT = "io.quarkus.rest.client.read-timeout";
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -14,6 +14,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +60,6 @@ public class ClientBuilderImpl extends ClientBuilder {
     private Integer loggingBodySize = 100;
     private MultiQueryParamMode multiQueryParamMode;
 
-    private HttpClientOptions httpClientOptions = new HttpClientOptions();
     private ClientLogger clientLogger = new DefaultClientLogger();
     private String userAgent = "Resteasy Reactive Client";
 
@@ -136,11 +136,6 @@ public class ClientBuilderImpl extends ClientBuilder {
         return this;
     }
 
-    public ClientBuilder httpClientOptions(HttpClientOptions httpClientOptions) {
-        this.httpClientOptions = httpClientOptions;
-        return this;
-    }
-
     public ClientBuilder followRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
         return this;
@@ -171,7 +166,8 @@ public class ClientBuilderImpl extends ClientBuilder {
         Buffer keyStore = asBuffer(this.keyStore, keystorePassword);
         Buffer trustStore = asBuffer(this.trustStore, EMPTY_CHAR_ARARAY);
 
-        HttpClientOptions options = httpClientOptions == null ? new HttpClientOptions() : httpClientOptions;
+        HttpClientOptions options = Optional.ofNullable(configuration.getInstance(HttpClientOptions.class))
+                .orElseGet(HttpClientOptions::new);
 
         if (trustAll) {
             options.setTrustAll(true);
@@ -243,7 +239,7 @@ public class ClientBuilderImpl extends ClientBuilder {
 
         clientLogger.setBodySize(loggingBodySize);
 
-        return new ClientImpl(httpClientOptions,
+        return new ClientImpl(options,
                 configuration,
                 CLIENT_CONTEXT_RESOLVER.resolve(Thread.currentThread().getContextClassLoader()),
                 hostnameVerifier,

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java
@@ -3,6 +3,8 @@ package org.jboss.resteasy.reactive.client.impl;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.CONNECTION_POOL_SIZE;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.CONNECTION_TTL;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.CONNECT_TIMEOUT;
+import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.MAX_HEADER_SIZE;
+import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.MAX_INITIAL_LINE_LENGTH;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.MAX_REDIRECTS;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.NAME;
 import static org.jboss.resteasy.reactive.client.api.QuarkusRestClientProperties.SHARED;
@@ -96,8 +98,6 @@ public class ClientImpl implements Client {
             ClientLogger clientLogger, String userAgent) {
         this.userAgent = userAgent;
         configuration = configuration != null ? configuration : new ConfigurationImpl(RuntimeType.CLIENT);
-        // TODO: ssl context
-        // TODO: hostnameVerifier
         this.configuration = configuration;
         this.clientContext = clientContext;
         this.hostnameVerifier = hostnameVerifier;
@@ -126,6 +126,16 @@ public class ClientImpl implements Client {
         Object maxRedirects = configuration.getProperty(MAX_REDIRECTS);
         if (maxRedirects != null) {
             options.setMaxRedirects((Integer) maxRedirects);
+        }
+
+        Object maxHeaderSize = configuration.getProperty(MAX_HEADER_SIZE);
+        if (maxHeaderSize != null) {
+            options.setMaxHeaderSize((Integer) maxHeaderSize);
+        }
+
+        Object maxInitialLineLength = configuration.getProperty(MAX_INITIAL_LINE_LENGTH);
+        if (maxInitialLineLength != null) {
+            options.setMaxInitialLineLength((Integer) maxInitialLineLength);
         }
 
         Object connectionTTL = configuration.getProperty(CONNECTION_TTL);


### PR DESCRIPTION
Allow providing custom HTTP options via CDI and for a programmatically created client. 

Fix https://github.com/quarkusio/quarkus/issues/26116