### PR TITLE
Add Gitpod badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Commits](https://img.shields.io/github/commit-activity/m/quarkusio/quarkus.svg?label=commits&style=for-the-badge&logo=git&logoColor=white)](https://github.com/quarkusio/quarkus/pulse)
 [![License](https://img.shields.io/github/license/quarkusio/quarkus?style=for-the-badge&logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?style=for-the-badge&logo=gitpod&logoColor=white)](https://gitpod.io/#https://github.com/quarkusio/quarkus/-/tree/main/)
 [![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17-brightgreen.svg?style=for-the-badge&logo=openjdk)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
 
 # Quarkus - Supersonic Subatomic Java


### PR DESCRIPTION
Add a badge to README.md to open a new GitPod workspace. This allows to quickly contribute to Quarkus without installing anything on your computer. And having a link on README.md is also more convenient than having to look for the link on the contribution guide.

The Gitpod Ready-to-Code badge has been discussed on https://github.com/gitpod-io/gitpod/issues/1023#issuecomment-706829436. The link 'https://gitpod.io/from-referrer/' has not been used because depending on the browser, its configuration and GitHub Referrer-Policy (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) the referer may not be provided.