### PR TITLE
Apply test scope to testing only dependencies

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/pom.xml
+++ b/independent-projects/resteasy-reactive/server/vertx/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
@@ -73,6 +74,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
The test scope is applied from the BOM, but it's very
confusing, so let's make them explicitly