### PR TITLE
Work around M1 regression in Azure Edge Server by pinning to 1.0.6

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -1254,8 +1254,8 @@
                 <!-- See
                 https://github.com/microsoft/mssql-docker/issues/668 and https://stackoverflow.com/questions/65398641/docker-connect-sql-server-container-non-zero-code-1/66919852#66919852.
                 The MS SQL image segfaults on ARM. Azure Edge is not fully compatible, but it is better than not running the tests at all.
-                DockerHub does not list any tags so we have to use latest for the moment.-->
-                <mssql.image>mcr.microsoft.com/azure-sql-edge:latest</mssql.image>
+                The :latest tag segfaults with the same segfault as MSSQL Server but 1.0.6 seems to behave well -->
+                <mssql.image>mcr.microsoft.com/azure-sql-edge:1.0.6</mssql.image>
             </properties>
         </profile>
 


### PR DESCRIPTION
While working on #25230, I noticed that even the Azure Edge Server is now segfaulting on M1. This is a shame, since it's the recommended workaround to the MSSQL server segfaulting. It seems to be a recent regression, so by specifying a version we can avoid the issue. 

It can be tested with ./mvnw -Dquickly  -DskipTests=false -Dstart-containers=true -Dtest-containers=true -Dquarkus.test.hang-detection-timeout=20M -f integration-tests/reactive-mssql-client but the Azure Edge image is only used on M1, so it would be a boring test for other systems.