### PR TITLE
Add Java 18 to matrix of 'JVM Tests' CI job

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -291,6 +291,13 @@ jobs:
             os-name: "ubuntu-latest"
           }
           - {
+            name: "18",
+            java-version: 18,
+            maven_args: "$JVM_TEST_MAVEN_ARGS",
+            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
+            os-name: "ubuntu-latest"
+          }
+          - {
             name: "11 Windows",
             java-version: 11,
             maven_args: "-DskipDocs -Dformat.skip",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/quarkusio/quarkus?style=for-the-badge&logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Project Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?style=for-the-badge&logo=zulip)](https://quarkusio.zulipchat.com/)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?style=for-the-badge&logo=gitpod&logoColor=white)](https://gitpod.io/#https://github.com/quarkusio/quarkus/-/tree/main/)
-[![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17-brightgreen.svg?style=for-the-badge&logo=openjdk)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
+[![Supported JVM Versions](https://img.shields.io/badge/JVM-11--17--18-brightgreen.svg?style=for-the-badge&logo=openjdk)](https://github.com/quarkusio/quarkus/actions/runs/113853915/)
 
 # Quarkus - Supersonic Subatomic Java
 


### PR DESCRIPTION
With the EA job now running with java 19-ea (#26374), it pobably makes sense to have _some_ continuous coverage of Java 18.

Related to #24789 