### PR TITLE
Stork guide minor improvements and cross linking

### DIFF
--- a/docs/src/main/asciidoc/stork-kubernetes.adoc
+++ b/docs/src/main/asciidoc/stork-kubernetes.adoc
@@ -3,21 +3,14 @@ This guide is maintained in the main Quarkus repository
 and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
-= Getting Started with SmallRye Stork
+= Using Stork with Kubernetes
 :extension-status: preview
 
 include::./attributes.adoc[]
 
-The essence of distributed systems resides in the interaction between services.
-In modern architecture, you often have multiple instances of your service to share the load or improve the resilience by redundancy.
-But how do you select the best instance of your service?
-That's where https://smallrye.io/smallrye-stork[SmallRye Stork] helps.
-Stork is going to choose the most appropriate instance.
-It offers:
+This guide explains how to use Stork with Kubernetes for service discovery and load balancing.
 
-* Extensible service discovery mechanisms
-* Built-in support for Consul and Kubernetes
-* Customizable client load-balancing strategies
+If you are new to Stork, please read the xref:stork.adoc[Stork Getting Started Guide].
 
 include::{includes}/extension-status.adoc[]
 

--- a/docs/src/main/asciidoc/stork-reference.adoc
+++ b/docs/src/main/asciidoc/stork-reference.adoc
@@ -4,11 +4,14 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Stork Reference Guide
+:extension-status: preview
 
 include::./attributes.adoc[]
 
 This guide is the companion from the xref:stork.adoc[Stork Getting Started Guide].
 It explains the configuration and usage of SmallRye Stork integration in Quarkus.
+
+include::{includes}/extension-status.adoc[]
 
 == Supported clients
 
@@ -55,6 +58,8 @@ quarkus.stork.my-service.service-discovery.k8s-namespace=my-namespace
 
 Stork looks for the Kubernetes Service with the given name (`my-service` in the previous example) in the specified namespace.
 Instead of using the Kubernetes Service IP directly and let Kubernetes handle the selection and balancing, Stork inspects the service and retrieves the list of pods providing the service. Then, it can select the instance.
+
+For a full example of using Stork with Kubernetes, please read the xref:stork-kubernetes.adoc[Using Stork with Kubernetes guide].
 
 == Implementing a custom service discovery
 


### PR DESCRIPTION
Some minor enhancement to the Stork guide and cross linking.

The title and introduction section of the Stork with Kubernetes was the same as the Getting Started one which is disturbing.

I also think the title of the Stork guide on the guide page should be updated to "Getting Started with Stock" or even better "Service discovery and Load Balancing with Stork" but I don't remember where to modify the title.
![image](https://user-images.githubusercontent.com/1819009/176906432-1ea939e8-a369-494e-9e6e-632f756cf77b.png)
