### PR TITLE
Fixed context path property in RESTEasy Reactive guide

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -134,7 +134,7 @@ public static class MyApplication extends Application {
 ----
 
 This will cause all rest endpoints to be resolve relative to `/api`, so the endpoint above with `@Path("rest")` would
-be accessible at `/api/rest/. You can also set the `quarkus.rest.path` build time property to set the root path if you
+be accessible at `/api/rest/`. You can also set the `quarkus.resteasy-reactive.path` build time property to set the root path if you
 don't want to use an annotation.
 
 === Declaring endpoints: HTTP methods

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/path/RestApplicationPathTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/path/RestApplicationPathTestCase.java
@@ -21,7 +21,7 @@ public class RestApplicationPathTestCase {
                     .addClasses(HelloResource.class, BarApp.class, BaseApplication.class));
 
     /**
-     * Using @ApplicationPath will overlay/replace `quarkus.rest.path`.
+     * Using @ApplicationPath will overlay/replace `quarkus.resteasy-reactive.path`.
      * Per spec:
      * <quote>
      * Identifies the application path that serves as the base URI for all resource


### PR DESCRIPTION
Minor formatting fix and replaced the legacy property.
Since the property is not mentioned on other pages it took more time than expected to find the correct name. Only if you know what exactly to search for you can find it on https://quarkus.io/guides/all-config