### PR TITLE
Dev UI - show binding env var for each config and sys. property in desc

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/config.html
@@ -485,7 +485,14 @@ function clearConfigFilter(){
                             {/if}
                         </td>
                         <td>
-                           {item.description.fmtJavadoc??}
+                            {#let description=item.description.fmtJavadoc??} {#if description}
+                            <p>{description}</p>
+                            {/} {/}
+                            {#if configsource.key.showEnvVarName}
+                            <div>
+                                <span>Environment variable: </span><code>{item.configValue.name.toEnvVar}</code>
+                            </div>
+                            {/}
                         </td>
                     </tr>
                     {/for}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigSourceName.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigSourceName.java
@@ -16,6 +16,10 @@ public class ConfigSourceName implements Comparable<ConfigSourceName> {
     private String displayName;
     private int ordinal;
     private boolean editable;
+    /**
+     * Show binding from environment variable for each config and system property
+     */
+    private boolean showEnvVarName;
 
     public ConfigSourceName() {
     }
@@ -28,6 +32,8 @@ public class ConfigSourceName implements Comparable<ConfigSourceName> {
         this.order = createOrder();
         this.displayName = createDisplayName();
         this.editable = createEditable();
+        // it doesn't make sense to convert environment variable to environment variable and show it
+        this.showEnvVarName = !name.equals(ENVIRONMENT_CONFIG_SOURCE);
     }
 
     public int getOrder() {
@@ -60,6 +66,14 @@ public class ConfigSourceName implements Comparable<ConfigSourceName> {
 
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public boolean isShowEnvVarName() {
+        return showEnvVarName;
+    }
+
+    public void setShowEnvVarName(boolean showEnvVarName) {
+        this.showEnvVarName = showEnvVarName;
     }
 
     public boolean isEditable() {


### PR DESCRIPTION
Follow up for #26408, 
Resolves #26408 for Dev UI

Appearance is similar to #26408; for Environment config source nothing was added as it doesn't make sense. I also added extra line between the description and the env var as table rows are styled differently here and it helps to readability.