### PR TITLE
Auto-rerun failing tests once via surefire/failsafe

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -167,6 +167,10 @@
         <enforce-test-deps-scope.skip>${enforcer.skip}</enforce-test-deps-scope.skip>
 
         <surefire.argLine.additional></surefire.argLine.additional>
+        <!-- https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html -->
+        <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
+        <failsafe.rerunFailingTestsCount>1</failsafe.rerunFailingTestsCount>
+
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
To reduce the number of failing builds that only fail because of flakes.
https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html

This is probably a bit controversial:
- real failures just fail again, possibly wasting time (no big deal, IMO)
- some tests might not be reentrant (but the good news is that if the second run fails it's the first failure that's reported in the xml report)

If this is merged, it might be a good idea to enhance the bot to collect flakiness data so that flakes don't go unnoticed entirely.