### PR TITLE
Exclude OIDC server connection details from OIDCException

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -233,7 +233,8 @@ public class OidcRecorder {
 
     protected static OIDCException toOidcException(Throwable cause, String authServerUrl) {
         final String message = OidcCommonUtils.formatConnectionErrorMessage(authServerUrl);
-        return new OIDCException(message, cause);
+        LOG.debug(message);
+        return new OIDCException("OIDC Server is not available", cause);
     }
 
     protected static Uni<OidcProvider> createOidcProvider(OidcTenantConfig oidcConfig, TlsConfig tlsConfig, Vertx vertx) {


### PR DESCRIPTION
Related to #26314

This PR updates the OIDC code to avoid reporting the OIDC server connection details