### PR TITLE
Resolve Sec. Identity in Reactive routes when Proactive Auth disabled

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -124,7 +124,8 @@ when authentication is complete and the identity is available.
 
 NOTE: It's still possible to access the `SecurityIdentity` synchronously with `public SecurityIdentity getIdentity()`
 in the xref:resteasy-reactive.adoc[RESTEasy Reactive] from endpoints annotated with `@RolesAllowed`, `@Authenticated`,
-or with respective configuration authorization checks as authentication has already happened.
+or with respective configuration authorization checks as authentication has already happened. The same is also valid
+for the xref:reactive-routes.adoc[Reactive routes] if a route response is synchronous.
 
 === How to customize authentication exception responses
 

--- a/extensions/reactive-routes/deployment/pom.xml
+++ b/extensions/reactive-routes/deployment/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security-test-utils</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/AnnotatedRouteHandlerBuildItem.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/AnnotatedRouteHandlerBuildItem.java
@@ -17,14 +17,18 @@ public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
     private final MethodInfo method;
     private final boolean blocking;
     private final HttpCompression compression;
+    /**
+     * If true, always attempt to authenticate user right before the body handler is run
+     */
+    private final boolean alwaysAuthenticateRoute;
 
     public AnnotatedRouteHandlerBuildItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> routes,
             AnnotationInstance routeBase) {
-        this(bean, method, routes, routeBase, false, HttpCompression.UNDEFINED);
+        this(bean, method, routes, routeBase, false, HttpCompression.UNDEFINED, false);
     }
 
     public AnnotatedRouteHandlerBuildItem(BeanInfo bean, MethodInfo method, List<AnnotationInstance> routes,
-            AnnotationInstance routeBase, boolean blocking, HttpCompression compression) {
+            AnnotationInstance routeBase, boolean blocking, HttpCompression compression, boolean alwaysAuthenticateRoute) {
         super();
         this.bean = bean;
         this.routes = routes;
@@ -32,6 +36,7 @@ public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
         this.method = method;
         this.blocking = blocking;
         this.compression = compression;
+        this.alwaysAuthenticateRoute = alwaysAuthenticateRoute;
     }
 
     public BeanInfo getBean() {
@@ -52,6 +57,10 @@ public final class AnnotatedRouteHandlerBuildItem extends MultiBuildItem {
 
     public boolean isBlocking() {
         return blocking;
+    }
+
+    public boolean shouldAlwaysAuthenticateRoute() {
+        return alwaysAuthenticateRoute;
     }
 
     public HttpCompression getCompression() {

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/LazyAuthRouteTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/LazyAuthRouteTest.java
@@ -1,0 +1,100 @@
+package io.quarkus.vertx.web;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.runtime.SecurityIdentityAssociation;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.ext.web.RoutingContext;
+
+public class LazyAuthRouteTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"), "application.properties")
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, HelloWorldBean.class));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("admin", "admin", "admin")
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testAuthZInPlace() {
+        given().auth().basic("user", "user").when().get("/hello-ra").then().statusCode(403);
+    }
+
+    @Test
+    public void testRolesAllowedVoidMethod() {
+        given().auth().basic("admin", "admin").when().get("/hello-ra").then().statusCode(200).body(is("Hello admin"));
+    }
+
+    @Test
+    public void testRolesAllowedDirectResponse() {
+        given().auth().basic("admin", "admin").when().get("/hello-ra-direct").then().statusCode(200).body(is("Hello admin"));
+    }
+
+    @Test
+    public void testAuthenticated() {
+        given().auth().basic("user", "user").when().get("/hello-auth").then().statusCode(200);
+    }
+
+    @Test
+    public void testDenyAll() {
+        given().auth().basic("user", "user").when().get("/hello-deny").then().statusCode(403);
+    }
+
+    public static final class HelloWorldBean {
+
+        @Inject
+        SecurityIdentityAssociation securityIdentityAssociation;
+
+        @Authenticated
+        @Route(path = "/hello-auth", methods = Route.HttpMethod.GET)
+        public void greetingsAuth(RoutingContext rc) {
+            respond(rc);
+        }
+
+        @RolesAllowed("admin")
+        @Route(path = "/hello-ra", methods = Route.HttpMethod.GET)
+        public void greetingsRA(RoutingContext rc) {
+            respond(rc);
+        }
+
+        @RolesAllowed("admin")
+        @Route(path = "/hello-ra-direct", methods = Route.HttpMethod.GET)
+        public String greetingsRADirect() {
+            return hello();
+        }
+
+        @DenyAll
+        @Route(path = "/hello-deny", methods = Route.HttpMethod.GET)
+        public String greetingsDeny() {
+            return hello();
+        }
+
+        private void respond(RoutingContext rc) {
+            rc.response().end(hello());
+        }
+
+        private String hello() {
+            return "Hello " + securityIdentityAssociation.getIdentity().getPrincipal().getName();
+        }
+    }
+
+}


### PR DESCRIPTION
Fix #23547 for Reactive routes (follow up to #26457)

When proactive authentication was disabled and `@RollesAllowed`, `@Authenticated`, or `@DenyAll` was used in non-blocking (e.g. method wasn't annotated with `@Blocking`) context and route method response type was not uni/multi/completionstage, then `BlockingOperationNotAllowedException` was thrown as `SecurityConstrainer` called a blocking operation `getIdentity` on IO thread. Such a cases are detected now in a build time and later the handler that triggers authentication is added right before body handler (if not authenticated already).