### PR TITLE
Qute - Ignore classes defined in the unnamed package in `BeanArchives.index`

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -279,6 +279,10 @@ public final class BeanArchives {
             // Ignore primitives and arrays
             return false;
         }
+        if (isInUnnamedPackage(className)) {
+            LOGGER.debugf("Class %s is defined in an unnamed package; skipping indexing", className);
+            return false;
+        }
         try (InputStream stream = classLoader
                 .getResourceAsStream(className.replace('.', '/') + ".class")) {
             if (stream != null) {
@@ -291,5 +295,9 @@ public final class BeanArchives {
             LOGGER.warnf(e, "Failed to index %s: %s", className, e.getMessage());
         }
         return result;
+    }
+
+    private static boolean isInUnnamedPackage(String className) {
+        return !className.contains(".");
     }
 }

--- a/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanArchivesTest.java
+++ b/independent-projects/arc/processor/src/test/java/io/quarkus/arc/processor/BeanArchivesTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.arc.processor;
+
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BeanArchivesTest {
+
+    @Test
+    public void testIndex() {
+        final Indexer indexer = new Indexer();
+        Assertions.assertFalse(BeanArchives.index(indexer, "String"));
+        Assertions.assertTrue(BeanArchives.index(indexer, String.class.getName()));
+    }
+
+}


### PR DESCRIPTION
fixes: #26524

When `TypeInfos.create` is looking for a parameter declaration type, it checks a couple of options and fallbacks to a prefix `java.lang`.  The Qute reference guide contains an example of parameter declaration using only `{@String foo}` without `java.lang`, thus when user follows the example, he should not be warned. That is fixed by ignoring classes in the unnamed package.