### PR TITLE
RestEasy Reactive: Keep target when handling failed authorization check

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SecurityExceptionMapperWithResourceInfoTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customexceptions/SecurityExceptionMapperWithResourceInfoTest.java
@@ -1,0 +1,57 @@
+package io.quarkus.resteasy.reactive.server.test.customexceptions;
+
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import javax.annotation.security.DenyAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SecurityExceptionMapperWithResourceInfoTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Resource.class);
+                }
+            });
+
+    @Test
+    void test() {
+        RestAssured.get("/test/denied")
+                .then().statusCode(403).body(is(Resource.class.getName()));
+    }
+
+    @Path("test")
+    public static class Resource {
+        @GET
+        @Path("denied")
+        @Produces("text/plain")
+        @DenyAll
+        public String denied() {
+            return "denied";
+        }
+
+        @ServerExceptionMapper(SecurityException.class)
+        Response handle(SecurityException t, ResourceInfo resourceInfo) {
+            return Response.status(403).entity(resourceInfo.getResourceClass().getName()).build();
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
@@ -111,7 +111,7 @@ public class EagerSecurityHandler implements ServerRestHandler {
 
                         @Override
                         public void onFailure(Throwable failure) {
-                            requestContext.resume(failure);
+                            requestContext.resume(failure, true);
                         }
                     });
         }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -51,8 +51,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     }
 
     public synchronized void resume(Throwable throwable) {
-        handleException(throwable);
-        resume((Executor) null);
+        resume(throwable, false);
     }
 
     public synchronized void resume(Throwable throwable, boolean keepTarget) {
@@ -303,13 +302,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
      * a response result and switch to the abort chain
      */
     public void handleException(Throwable t) {
-        if (abortHandlerChainStarted) {
-            handleUnrecoverableError(unwrapException(t));
-        } else {
-            this.throwable = unwrapException(t);
-            abortHandlerChainStarted = true;
-            restart(abortHandlerChain);
-        }
+        handleException(t, false);
     }
 
     public void handleException(Throwable t, boolean keepSameTarget) {


### PR DESCRIPTION
So that exception mappers can access the target-specific `ResourceInfo` properties, the handling of the exceptions during the authorization checks must keep the target when switching to the abort chain.