### PR TITLE
Support @ActivateRequestContext on reactive methods

### DIFF
--- a/independent-projects/arc/pom.xml
+++ b/independent-projects/arc/pom.xml
@@ -50,6 +50,7 @@
         <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
         <version.gizmo>1.1.0.Final</version.gizmo>
         <version.jpa>2.2.3</version.jpa>
+        <version.mutiny>1.6.0</version.mutiny>
 
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
@@ -93,6 +94,12 @@
                 <groupId>io.quarkus.gizmo</groupId>
                 <artifactId>gizmo</artifactId>
                 <version>${version.gizmo}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.reactive</groupId>
+                <artifactId>mutiny</artifactId>
+                <version>${version.mutiny}</version>
             </dependency>
 
             <!-- JUnit 5 dependencies, imported as a BOM -->

--- a/independent-projects/arc/runtime/pom.xml
+++ b/independent-projects/arc/runtime/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
@@ -3,6 +3,8 @@ package io.quarkus.arc.impl;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.smallrye.mutiny.Uni;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import javax.annotation.Priority;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.interceptor.AroundInvoke;
@@ -20,7 +22,39 @@ public class ActivateRequestContextInterceptor {
             return invokeUni(ctx);
         }
 
+        if (ctx.getMethod().getReturnType().equals(CompletionStage.class)) {
+            return invokeStage(ctx);
+        }
+
         return invoke(ctx);
+    }
+
+    private CompletionStage<?> invokeStage(InvocationContext ctx) {
+        ManagedContext requestContext = Arc.container().requestContext();
+        if (requestContext.isActive()) {
+            return proceedWithStage(ctx);
+        }
+
+        return activate(requestContext)
+                .thenCompose(v -> proceedWithStage(ctx))
+                .whenComplete((r, t) -> requestContext.terminate());
+    }
+
+    private static CompletionStage<ManagedContext> activate(ManagedContext requestContext) {
+        try {
+            requestContext.activate();
+            return CompletableFuture.completedStage(requestContext);
+        } catch (Throwable t) {
+            return CompletableFuture.failedStage(t);
+        }
+    }
+
+    private CompletionStage<?> proceedWithStage(InvocationContext ctx) {
+        try {
+            return (CompletionStage<?>) ctx.proceed();
+        } catch (Throwable t) {
+            return CompletableFuture.failedStage(t);
+        }
     }
 
     private Uni<?> invokeUni(InvocationContext ctx) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
@@ -2,6 +2,7 @@ package io.quarkus.arc.impl;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
+import io.smallrye.mutiny.Uni;
 import javax.annotation.Priority;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.interceptor.AroundInvoke;
@@ -15,17 +16,46 @@ public class ActivateRequestContextInterceptor {
 
     @AroundInvoke
     Object aroundInvoke(InvocationContext ctx) throws Exception {
-        ManagedContext requestContext = Arc.container().requestContext();
-        if (requestContext.isActive()) {
-            return ctx.proceed();
-        } else {
-            try {
-                requestContext.activate();
-                return ctx.proceed();
-            } finally {
-                requestContext.terminate();
+        if (ctx.getMethod().getReturnType().equals(Uni.class)) {
+            return invokeUni(ctx);
+        }
+
+        return invoke(ctx);
+    }
+
+    private Uni<?> invokeUni(InvocationContext ctx) {
+        return Uni.createFrom().deferred(() -> {
+            ManagedContext requestContext = Arc.container().requestContext();
+            if (requestContext.isActive()) {
+                return proceedWithUni(ctx);
             }
+
+            return Uni.createFrom().deferred(() -> {
+                requestContext.activate();
+                return proceedWithUni(ctx);
+            }).eventually(requestContext::terminate);
+        });
+    }
+
+    private Uni<?> proceedWithUni(InvocationContext ctx) {
+        try {
+            return (Uni<?>) ctx.proceed();
+        } catch (Throwable t) {
+            return Uni.createFrom().failure(t);
         }
     }
 
+    private Object invoke(InvocationContext ctx) throws Exception {
+        ManagedContext requestContext = Arc.container().requestContext();
+        if (requestContext.isActive()) {
+            return ctx.proceed();
+        }
+
+        try {
+            requestContext.activate();
+            return ctx.proceed();
+        } finally {
+            requestContext.terminate();
+        }
+    }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ActivateRequestContextInterceptor.java
@@ -19,19 +19,16 @@ public class ActivateRequestContextInterceptor {
 
     @AroundInvoke
     Object aroundInvoke(InvocationContext ctx) throws Exception {
-        if (ctx.getMethod().getReturnType().equals(Uni.class)) {
-            return invokeUni(ctx);
+        switch (ReactiveType.valueOf(ctx.getMethod())) {
+            case UNI:
+                return invokeUni(ctx);
+            case MULTI:
+                return invokeMulti(ctx);
+            case STAGE:
+                return invokeStage(ctx);
+            default:
+                return invoke(ctx);
         }
-
-        if (ctx.getMethod().getReturnType().equals(CompletionStage.class)) {
-            return invokeStage(ctx);
-        }
-
-        if (ctx.getMethod().getReturnType().equals(Multi.class)) {
-            return invokeMulti(ctx);
-        }
-
-        return invoke(ctx);
     }
 
     private CompletionStage<?> invokeStage(InvocationContext ctx) {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ReactiveType.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ReactiveType.java
@@ -1,0 +1,60 @@
+package io.quarkus.arc.impl;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A method reactive returned type.
+ */
+public enum ReactiveType {
+
+    /**
+     * The method returns a non recognised reactive type
+     */
+    NON_REACTIVE(false, null),
+
+    /**
+     * The method returns a {@link Uni}
+     */
+    UNI(true, Uni.class),
+
+    /**
+     * The method returns a {@link Multi}
+     */
+    MULTI(true, Multi.class),
+
+    /**
+     * The method returns a {@link CompletionStage}
+     */
+    STAGE(true, CompletionStage.class);
+
+    private final boolean reactive;
+    private final Class<?> type;
+
+    ReactiveType(boolean reactive, Class<?> type) {
+        this.reactive = reactive;
+        this.type = type;
+    }
+
+    boolean isReactive() {
+        return reactive;
+    }
+
+    public static ReactiveType valueOf(Method method) {
+        if (Void.class.equals(method.getReturnType())) {
+            return NON_REACTIVE;
+        }
+
+        for (ReactiveType reactiveType : ReactiveType.values()) {
+            if (Objects.nonNull(reactiveType.type)
+                    && reactiveType.type.isAssignableFrom(method.getReturnType())) {
+                return reactiveType;
+            }
+        }
+
+        return NON_REACTIVE;
+    }
+}

--- a/independent-projects/arc/runtime/src/test/java/io/quarkus/arc/impl/ReactiveTypeTest.java
+++ b/independent-projects/arc/runtime/src/test/java/io/quarkus/arc/impl/ReactiveTypeTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.arc.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.Test;
+
+public class ReactiveTypeTest {
+
+    @Test
+    public void testUni() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("uniCall");
+        assertEquals(ReactiveType.UNI, ReactiveType.valueOf(uniMethod));
+        assertTrue(ReactiveType.UNI.isReactive());
+    }
+
+    @Test
+    public void testMulti() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("multiCall");
+        assertEquals(ReactiveType.MULTI, ReactiveType.valueOf(uniMethod));
+        assertTrue(ReactiveType.MULTI.isReactive());
+    }
+
+    @Test
+    public void testStage() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("stageCall");
+        assertEquals(ReactiveType.STAGE, ReactiveType.valueOf(uniMethod));
+        assertTrue(ReactiveType.STAGE.isReactive());
+    }
+
+    @Test
+    public void testFuture() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("futureCall");
+        assertEquals(ReactiveType.STAGE, ReactiveType.valueOf(uniMethod));
+        assertTrue(ReactiveType.STAGE.isReactive());
+    }
+
+    @Test
+    public void testObject() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("objectCall");
+        assertEquals(ReactiveType.NON_REACTIVE, ReactiveType.valueOf(uniMethod));
+        assertFalse(ReactiveType.NON_REACTIVE.isReactive());
+    }
+
+    @Test
+    public void testVoid() throws Exception {
+        Method uniMethod = ReactiveInterface.class.getDeclaredMethod("voidCall");
+        assertEquals(ReactiveType.NON_REACTIVE, ReactiveType.valueOf(uniMethod));
+        assertFalse(ReactiveType.NON_REACTIVE.isReactive());
+    }
+
+    private static interface ReactiveInterface {
+        Uni<?> uniCall();
+
+        Multi<?> multiCall();
+
+        CompletionStage<?> stageCall();
+
+        CompletableFuture<?> futureCall();
+
+        Object objectCall();
+
+        void voidCall();
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/ActivateRequestContextInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/contexts/request/propagation/ActivateRequestContextInterceptorTest.java
@@ -1,0 +1,180 @@
+package io.quarkus.arc.test.contexts.request.propagation;
+
+import static io.quarkus.arc.test.contexts.request.propagation.ActivateRequestContextInterceptorTest.FakeSession.State.CLOSED;
+import static io.quarkus.arc.test.contexts.request.propagation.ActivateRequestContextInterceptorTest.FakeSession.State.INIT;
+import static io.quarkus.arc.test.contexts.request.propagation.ActivateRequestContextInterceptorTest.FakeSession.State.OPENED;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.arc.impl.ActivateRequestContextInterceptor;
+import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.contexts.request.propagation.ActivateRequestContextInterceptorTest.FakeSession.State;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Test the {@link ActivateRequestContextInterceptor} when {@link ActivateRequestContext} is applied to a method.
+ */
+public class ActivateRequestContextInterceptorTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(FakeSessionProducer.class, SessionClient.class);
+
+    InstanceHandle<SessionClient> clientHandler;
+
+    @BeforeEach
+    public void reset() {
+        FakeSession.state = INIT;
+        clientHandler = Arc.container().instance(SessionClient.class);
+    }
+
+    @AfterEach
+    public void terminate() {
+        clientHandler.close();
+        clientHandler.destroy();
+    }
+
+    @Test
+    public void testUni() throws Exception {
+        Assertions.assertEquals(INIT, FakeSession.getState());
+        FakeSession.State result = clientHandler.get().openUniSession().await().indefinitely();
+
+        // Closed in the dispose method
+        Assertions.assertEquals(CLOSED, FakeSession.getState());
+        Assertions.assertEquals(OPENED, result);
+    }
+
+    @Test
+    public void testMulti() throws Exception {
+        Assertions.assertEquals(INIT, FakeSession.getState());
+        FakeSession.State result = clientHandler.get().openMultiSession()
+                .toUni()
+                .await().indefinitely();
+
+        // Closed in the dispose method
+        Assertions.assertEquals(CLOSED, FakeSession.getState());
+        Assertions.assertEquals(OPENED, result);
+    }
+
+    @Test
+    public void testFuture() throws Exception {
+        Assertions.assertEquals(INIT, FakeSession.getState());
+        FakeSession.State result = clientHandler.get()
+                .openFutureSession().toCompletableFuture().join();
+
+        // Closed in the dispose method
+        Assertions.assertEquals(CLOSED, FakeSession.getState());
+        Assertions.assertEquals(OPENED, result);
+    }
+
+    @Test
+    public void testStage() throws Exception {
+        Assertions.assertEquals(INIT, FakeSession.getState());
+        FakeSession.State result = clientHandler.get().openStageSession()
+                .toCompletableFuture().join();
+
+        // Closed in the dispose method
+        Assertions.assertEquals(CLOSED, FakeSession.getState());
+        Assertions.assertEquals(OPENED, result);
+    }
+
+    @Test
+    public void testNonReactive() throws Exception {
+        Assertions.assertEquals(INIT, FakeSession.getState());
+        FakeSession.State result = clientHandler.get().openSession();
+
+        // Closed in the dispose method
+        Assertions.assertEquals(CLOSED, FakeSession.getState());
+        Assertions.assertEquals(OPENED, result);
+    }
+
+    @ApplicationScoped
+    static class SessionClient {
+        @Inject
+        FakeSession session;
+
+        @ActivateRequestContext
+        public Uni<State> openUniSession() {
+            return Uni.createFrom()
+                    .item(() -> session)
+                    .map(FakeSession::open);
+        }
+
+        @ActivateRequestContext
+        public Multi<State> openMultiSession() {
+            return Multi.createFrom()
+                    .item(() -> session)
+                    .map(FakeSession::open);
+        }
+
+        @ActivateRequestContext
+        public CompletionStage<State> openStageSession() {
+            return CompletableFuture
+                    .completedStage(session.open());
+        }
+
+        @ActivateRequestContext
+        public CompletableFuture<State> openFutureSession() {
+            return CompletableFuture
+                    .completedFuture(session.open());
+        }
+
+        @ActivateRequestContext
+        public State openSession() {
+            return session.open();
+        }
+    }
+
+    static class FakeSession {
+        enum State {
+            INIT,
+            OPENED,
+            CLOSED
+        };
+
+        public static State state = State.INIT;
+
+        public State open() {
+            state = State.OPENED;
+            return state;
+        }
+
+        public State close() {
+            state = State.CLOSED;
+            return state;
+        }
+
+        public static State getState() {
+            return state;
+        }
+    }
+
+    @Singleton
+    static class FakeSessionProducer {
+
+        @Produces
+        @RequestScoped
+        FakeSession produceSession() {
+            return new FakeSession();
+        }
+
+        void disposeSession(@Disposes FakeSession session) {
+            session.close();
+        }
+    }
+
+}


### PR DESCRIPTION
Fix #23739 

Support `@ActivateRequestContext` for methods returning a `Uni`