### PR TITLE
Bump mermaid-js to 9.1.1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -136,7 +136,7 @@
         <webjar.jquery.version>3.6.0</webjar.jquery.version>
         <webjar.codemirror.version>5.62.2</webjar.codemirror.version>
         <!-- we don't add mermaid as a dependency as it brings a ton of things we don't use -->
-        <webjar.mermaid.version>8.9.1</webjar.mermaid.version>
+        <webjar.mermaid.version>9.1.1</webjar.mermaid.version>
         <webjar.d3js.version>6.6.0</webjar.d3js.version>
 
         <!-- revapi API check -->


### PR DESCRIPTION
Simple version bump.

Please note despite "major version bump" the doc is quite clear:

> Some few GitGraphs based on the alpha version might break with the update. This is the reason for the major version number update.

We don't seem to use gitGraph are all.