### PR TITLE
Fix tests lifecycle instance and methods annotated with AfterAll

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedPerClassLifecycleTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedPerClassLifecycleTestCase.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -27,7 +28,16 @@ public class QuarkusTestNestedPerClassLifecycleTestCase {
     private final AtomicInteger counter = new AtomicInteger(0);
 
     @BeforeAll
-    public void increment() {
+    public void incrementInBeforeAll() {
+        counter.incrementAndGet();
+    }
+
+    /**
+     * We're doing nothing with this code, but we want to keep it to verify the methods annotated
+     * with `@AfterAll` work for nested tests.
+     */
+    @AfterAll
+    public void incrementInAfterAll() {
         counter.incrementAndGet();
     }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -15,8 +15,10 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -121,7 +123,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     private static Class<?> actualTestClass;
     private static Object actualTestInstance;
     // needed for @Nested
-    private static List<Object> outerInstances = new ArrayList<>(1);
+    private static Deque<Object> outerInstances = new ArrayDeque<>(1);
     private static RunningQuarkusApplication runningQuarkusApplication;
     private static Pattern clonePattern;
     private static Throwable firstException; //if this is set then it will be thrown from the very first test that is run, the rest are aborted
@@ -561,7 +563,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
         Constructor<?> constructor = quarkusTestMethodContextClass.getConstructor(Object.class, List.class, Method.class);
         return new AbstractMap.SimpleEntry<>(quarkusTestMethodContextClass,
-                constructor.newInstance(actualTestInstance, outerInstances, actualTestMethod));
+                constructor.newInstance(actualTestInstance, new ArrayList<>(outerInstances), actualTestMethod));
     }
 
     private boolean isNativeOrIntegrationTest(Class<?> clazz) {
@@ -1078,7 +1080,9 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             }
         } finally {
             currentTestClassStack.pop();
-            outerInstances.clear();
+            if (!outerInstances.isEmpty()) {
+                actualTestInstance = outerInstances.pop();
+            }
         }
     }
 
@@ -1093,7 +1097,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         Class<?> quarkusTestContextClass = Class.forName(QuarkusTestContext.class.getName(), true,
                 runningQuarkusApplication.getClassLoader());
         Object quarkusTestContextInstance = quarkusTestContextClass.getConstructor(Object.class, List.class)
-                .newInstance(actualTestInstance, outerInstances);
+                .newInstance(actualTestInstance, new ArrayList<>(outerInstances));
 
         ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
         try {


### PR DESCRIPTION
The issue was not completely fixed in the commit https://github.com/quarkusio/quarkus/pull/25831/commits/b306d8a1f658f4ca04f7d7d7678be26fe29bb1a1. 

The problem was that we were clearing out all the outer instances and hence the current class was not matching with the current test instance.

Fix https://github.com/quarkusio/quarkus/issues/25812