### PR TITLE
Set service account name only to the generated deployment

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesCommonHelper.java
@@ -183,7 +183,7 @@ public class KubernetesCommonHelper {
 
         //Handle RBAC
         if (!roleBindings.isEmpty()) {
-            result.add(new DecoratorBuildItem(target, new ApplyServiceAccountNameDecorator(name)));
+            result.add(new DecoratorBuildItem(target, new ApplyServiceAccountNameDecorator(name, name)));
             result.add(new DecoratorBuildItem(target, new AddServiceAccountResourceDecorator(name)));
             roles.forEach(r -> result.add(new DecoratorBuildItem(target, new AddRoleResourceDecorator(name, r))));
             roleBindings.forEach(rb -> {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndExistingResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndExistingResourcesTest.java
@@ -51,7 +51,12 @@ public class WithKubernetesClientAndExistingResourcesTest {
 
         assertThat(kubernetesList).filteredOn(h -> "Deployment".equals(h.getKind())).allSatisfy(h -> {
             Deployment deployment = (Deployment) h;
-            assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName()).isEqualTo(APPLICATION_NAME);
+            String serviceAccountName = deployment.getSpec().getTemplate().getSpec().getServiceAccountName();
+            if (h.getMetadata().getName().equals(APPLICATION_NAME)) {
+                assertThat(serviceAccountName).isEqualTo(APPLICATION_NAME);
+            } else {
+                assertThat(serviceAccountName).isNull();
+            }
         });
 
         assertThat(kubernetesList).filteredOn(h -> "ServiceAccount".equals(h.getKind())).singleElement().satisfies(h -> {


### PR DESCRIPTION
This change is related to this comment: https://github.com/quarkusio/quarkus/pull/25750#issuecomment-1172592901

I'm not sure if applying the service account name was the original purpose, so I will let @iocanel to decide on these changes. 