### PR TITLE
RESTEasy Reactive - prevent repeating of standard security checks

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -143,6 +143,7 @@ import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveInitialiser;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRecorder;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveRuntimeRecorder;
 import io.quarkus.resteasy.reactive.server.runtime.ResteasyReactiveServerRuntimeConfig;
+import io.quarkus.resteasy.reactive.server.runtime.StandardSecurityCheckInterceptor;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationCompletionExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationFailedExceptionMapper;
 import io.quarkus.resteasy.reactive.server.runtime.exceptionmappers.AuthenticationRedirectExceptionMapper;
@@ -1129,6 +1130,17 @@ public class ResteasyReactiveProcessor {
             }
         }
 
+    }
+
+    @BuildStep
+    void registerSecurityInterceptors(Capabilities capabilities,
+            BuildProducer<AdditionalBeanBuildItem> beans) {
+        if (capabilities.isPresent(Capability.SECURITY)) {
+            // Register interceptors for standard security annotations to prevent repeated security checks
+            beans.produce(new AdditionalBeanBuildItem(StandardSecurityCheckInterceptor.RolesAllowedInterceptor.class,
+                    StandardSecurityCheckInterceptor.AuthenticatedInterceptor.class,
+                    StandardSecurityCheckInterceptor.PermitAllInterceptor.class));
+        }
     }
 
     private <T> T consumeStandardSecurityAnnotations(MethodInfo methodInfo, ClassInfo classInfo, IndexView index,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedJaxRsTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedJaxRsTestCase.java
@@ -29,10 +29,9 @@ public class RolesAllowedJaxRsTestCase {
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(RolesAllowedResource.class, UserResource.class, RolesAllowedBlockingResource.class,
-                            SerializationEntity.class, SerializationRolesResource.class,
-                            TestIdentityProvider.class,
-                            TestIdentityController.class,
-                            UnsecuredSubResource.class));
+                            SerializationEntity.class, SerializationRolesResource.class, TestIdentityProvider.class,
+                            TestIdentityController.class, UnsecuredSubResource.class, RolesAllowedService.class,
+                            RolesAllowedServiceResource.class));
 
     @BeforeAll
     public static void setupUsers() {
@@ -59,6 +58,14 @@ public class RolesAllowedJaxRsTestCase {
         RestAssured.given().auth().basic("admin", "admin").get("/user").then().body(is(""));
         RestAssured.given().auth().basic("user", "user").get("/user").then().body(is(""));
         RestAssured.given().auth().preemptive().basic("user", "user").get("/user").then().body(is("user"));
+    }
+
+    @Test
+    public void testNestedRolesAllowed() {
+        // there are 2 different checks in place: user & admin on resource, admin on service
+        RestAssured.given().auth().basic("admin", "admin").get("/roles-service/hello").then().statusCode(200)
+                .body(is(RolesAllowedService.SERVICE_HELLO));
+        RestAssured.given().auth().basic("user", "user").get("/roles-service/hello").then().statusCode(403);
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedService.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedService.java
@@ -1,0 +1,16 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RolesAllowedService {
+
+    public static final String SERVICE_HELLO = "Hello from Service!";
+
+    @RolesAllowed("admin")
+    public String hello() {
+        return SERVICE_HELLO;
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/RolesAllowedServiceResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/roles-service")
+public class RolesAllowedServiceResource {
+
+    @Inject
+    RolesAllowedService rolesAllowedService;
+
+    @Path("/hello")
+    @RolesAllowed({ "user", "admin" })
+    @GET
+    public String getServiceHello() {
+        return rolesAllowedService.hello();
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/StandardSecurityCheckInterceptor.java
@@ -1,0 +1,80 @@
+package io.quarkus.resteasy.reactive.server.runtime;
+
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.EXECUTED;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_HANDLER;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.Priority;
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.spi.runtime.AuthorizationController;
+import io.quarkus.security.spi.runtime.MethodDescription;
+
+/**
+ * Security checks for RBAC annotations on endpoints are done by
+ * the {@link io.quarkus.resteasy.reactive.server.runtime.security.EagerSecurityHandler},
+ * this interceptor propagates the information to the SecurityHandler to prevent repeated checks. The {@link DenyAll}
+ * security check is performed just once.
+ */
+public abstract class StandardSecurityCheckInterceptor {
+
+    public static final String STANDARD_SECURITY_CHECK_INTERCEPTOR = StandardSecurityCheckInterceptor.class.getName();
+
+    @Inject
+    AuthorizationController controller;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        if (controller.isAuthorizationEnabled() && CurrentRequestManager.get() != null
+                && alreadyDoneByEagerSecurityHandler(
+                        CurrentRequestManager.get().getProperty(STANDARD_SECURITY_CHECK_INTERCEPTOR), ic.getMethod())) {
+            ic.getContextData().put(SECURITY_HANDLER, EXECUTED);
+        }
+        return ic.proceed();
+    }
+
+    private boolean alreadyDoneByEagerSecurityHandler(Object methodWithFinishedChecks, Method method) {
+        // compare methods: EagerSecurityHandler only intercept endpoints, we still want SecurityHandler run for CDI beans
+        return methodWithFinishedChecks != null && MethodDescription.ofMethod(method).equals(methodWithFinishedChecks);
+    }
+
+    /**
+     * Prevent the SecurityHandler from performing {@link RolesAllowed} security checks
+     */
+    @Interceptor
+    @RolesAllowed("")
+    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    public static final class RolesAllowedInterceptor extends StandardSecurityCheckInterceptor {
+
+    }
+
+    /**
+     * Prevent the SecurityHandler from performing {@link javax.annotation.security.PermitAll} security checks
+     */
+    @Interceptor
+    @PermitAll
+    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    public static final class PermitAllInterceptor extends StandardSecurityCheckInterceptor {
+
+    }
+
+    /**
+     * Prevent the SecurityHandler from performing {@link Authenticated} security checks
+     */
+    @Interceptor
+    @Authenticated
+    @Priority(Interceptor.Priority.PLATFORM_BEFORE)
+    public static final class AuthenticatedInterceptor extends StandardSecurityCheckInterceptor {
+
+    }
+}

--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/SecurityHandlerConstants.java
@@ -1,0 +1,15 @@
+package io.quarkus.security.spi.runtime;
+
+public class SecurityHandlerConstants {
+
+    /**
+     * Invocation context data key used by the SecurityHandler to save a security checks state
+     */
+    public static final String SECURITY_HANDLER = "io.quarkus.security.securityHandler";
+
+    /**
+     * The SecurityHandler keep a state of security checks in the Invocation context data to prevent repeated checks.
+     * `executed` means the check has already been done.
+     */
+    public static final String EXECUTED = "executed";
+}

--- a/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityHandler.java
+++ b/extensions/security/runtime/src/main/java/io/quarkus/security/runtime/interceptor/SecurityHandler.java
@@ -1,5 +1,8 @@
 package io.quarkus.security.runtime.interceptor;
 
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.EXECUTED;
+import static io.quarkus.security.spi.runtime.SecurityHandlerConstants.SECURITY_HANDLER;
+
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -15,9 +18,6 @@ import io.smallrye.mutiny.Uni;
  */
 @Singleton
 public class SecurityHandler {
-
-    private static final String HANDLER_NAME = SecurityHandler.class.getName();
-    private static final String EXECUTED = "executed";
 
     @Inject
     SecurityConstrainer constrainer;
@@ -49,7 +49,7 @@ public class SecurityHandler {
     }
 
     private boolean alreadyHandled(InvocationContext ic) {
-        return ic.getContextData().put(HANDLER_NAME, EXECUTED) != null;
+        return ic.getContextData().put(SECURITY_HANDLER, EXECUTED) != null;
     }
 
     private static class UniContinuation implements Function<Object, Uni<?>> {


### PR DESCRIPTION
fix: #26536

`EagerSecurityHandler` performs standard security checks for endpoints annotated with an RBAC annotation and the same checks are later done by `SecurityHandler`. We still need interceptors to run for CDI beans and gRPC. This PR prevents repeating of security checks by propagating the information that check is done to `SecurityHandler` via invocation context.