### PR TITLE
Fix Quarkiverse template build and release

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B formatter:validate verify --file pom.xml
+        run: mvn -B formatter:validate clean install --file pom.xml

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Maven release ${{steps.metadata.outputs.current-version}}
         run: |
           git checkout -b release
-          mvn -B release:prepare -Prelease -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
+          mvn -B release:prepare -Prelease -DpreparationGoals="clean install" -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
           if ! git diff --quiet docs/modules/ROOT/pages/includes/attributes.adoc; then
             git add docs/modules/ROOT/pages/includes/attributes.adoc
             git commit -m "Update stable version for documentation"


### PR DESCRIPTION
Using only `verify` in mvn build and release won't let codestart tests pass.
Reason is that the tests are using the actual artifacts which should be installed in the local repo with `install`.

Note: `install` is the goal just after `verify`