### PR TITLE
Extend Redis cursors to consume items individually 

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashScanCursor.java
@@ -5,4 +5,11 @@ import java.util.Map;
 import io.quarkus.redis.datasource.Cursor;
 
 public interface HashScanCursor<K, V> extends Cursor<Map<K, V>> {
+    /**
+     * Returns an {@code Iterable} providing each entry from the hash individually.
+     * Unlike {@link #next()} which provides the entries by batch, this method returns them one by one.
+     *
+     * @return the iterable
+     */
+    Iterable<Map.Entry<K, V>> toIterable();
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashScanCursor.java
@@ -3,6 +3,16 @@ package io.quarkus.redis.datasource.hash;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.ReactiveCursor;
+import io.smallrye.mutiny.Multi;
 
 public interface ReactiveHashScanCursor<K, V> extends ReactiveCursor<Map<K, V>> {
+
+    /**
+     * Produces a {@code Multi} emitting each entry from hash individually.
+     * Unlike {@link #next()} which provides the entries by batch, this method returns them one by one.
+     *
+     * @return the multi
+     */
+    Multi<Map.Entry<K, V>> toMulti();
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyCommands.java
@@ -5,8 +5,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
-import io.quarkus.redis.datasource.Cursor;
-
 /**
  * Allows executing commands manipulating keys.
  * See <a href="https://redis.io/commands/?group=generic">the generic command list</a> for further information about these
@@ -405,7 +403,7 @@ public interface KeyCommands<K> {
      *
      * @return the cursor.
      **/
-    Cursor<Set<K>> scan();
+    KeyScanCursor<K> scan();
 
     /**
      * Execute the command <a href="https://redis.io/commands/scan">SCAN</a>.
@@ -416,7 +414,7 @@ public interface KeyCommands<K> {
      * @param args the extra arguments
      * @return the cursor.
      **/
-    Cursor<Set<K>> scan(KeyScanArgs args);
+    KeyScanCursor<K> scan(KeyScanArgs args);
 
     /**
      * Execute the command <a href="https://redis.io/commands/touch">TOUCH</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyScanCursor.java
@@ -1,0 +1,15 @@
+package io.quarkus.redis.datasource.keys;
+
+import java.util.Set;
+
+import io.quarkus.redis.datasource.Cursor;
+
+public interface KeyScanCursor<K> extends Cursor<Set<K>> {
+    /**
+     * Returns an {@code Iterable} providing the keys individually.
+     * Unlike {@link #next()} which provides the keys by batch, this method returns them one by one.
+     *
+     * @return the iterable
+     */
+    Iterable<K> toIterable();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyCommands.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
-import io.quarkus.redis.datasource.ReactiveCursor;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -406,7 +405,7 @@ public interface ReactiveKeyCommands<K> {
      *
      * @return the cursor.
      **/
-    ReactiveCursor<Set<K>> scan();
+    ReactiveKeyScanCursor<K> scan();
 
     /**
      * Execute the command <a href="https://redis.io/commands/scan">SCAN</a>.
@@ -417,7 +416,7 @@ public interface ReactiveKeyCommands<K> {
      * @param args the extra arguments
      * @return the cursor.
      **/
-    ReactiveCursor<Set<K>> scan(KeyScanArgs args);
+    ReactiveKeyScanCursor<K> scan(KeyScanArgs args);
 
     /**
      * Execute the command <a href="https://redis.io/commands/touch">TOUCH</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyScanCursor.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.datasource.keys;
+
+import java.util.Set;
+
+import io.quarkus.redis.datasource.ReactiveCursor;
+import io.smallrye.mutiny.Multi;
+
+public interface ReactiveKeyScanCursor<K> extends ReactiveCursor<Set<K>> {
+
+    /**
+     * Produces a {@code Multi} emitting each key individually.
+     * Unlike {@link #next()} which provides the keys by batch, this method returns them one by one.
+     *
+     * @return the multi
+     */
+    Multi<K> toMulti();
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveSScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveSScanCursor.java
@@ -3,7 +3,16 @@ package io.quarkus.redis.datasource.set;
 import java.util.List;
 
 import io.quarkus.redis.datasource.ReactiveCursor;
+import io.smallrye.mutiny.Multi;
 
 public interface ReactiveSScanCursor<V> extends ReactiveCursor<List<V>> {
+
+    /**
+     * Returns an {@code Multi} providing each member of the set individually.
+     * Unlike {@link #next()} which provides the members by batch, this method returns them one by one.
+     *
+     * @return the multi
+     */
+    Multi<V> toMulti();
 
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/SScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/SScanCursor.java
@@ -5,4 +5,12 @@ import java.util.List;
 import io.quarkus.redis.datasource.Cursor;
 
 public interface SScanCursor<V> extends Cursor<List<V>> {
+
+    /**
+     * Returns an {@code Iterable} providing each member of the set individually.
+     * Unlike {@link #next()} which provides the members by batch, this method returns them one by one.
+     *
+     * @return the iterable
+     */
+    Iterable<V> toIterable();
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveZScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveZScanCursor.java
@@ -3,7 +3,16 @@ package io.quarkus.redis.datasource.sortedset;
 import java.util.List;
 
 import io.quarkus.redis.datasource.ReactiveCursor;
+import io.smallrye.mutiny.Multi;
 
 public interface ReactiveZScanCursor<V> extends ReactiveCursor<List<ScoredValue<V>>> {
+
+    /**
+     * Produces a {@code Multi} emitting each member from the sorted set individually.
+     * Unlike {@link #next()} which provides the members by batch, this method returns them one by one.
+     *
+     * @return the multi
+     */
+    Multi<ScoredValue<V>> toMulti();
 
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZScanCursor.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ZScanCursor.java
@@ -5,4 +5,12 @@ import java.util.List;
 import io.quarkus.redis.datasource.Cursor;
 
 public interface ZScanCursor<V> extends Cursor<List<ScoredValue<V>>> {
+
+    /**
+     * Returns an {@code Iterable} providing each member of the sorted set individually.
+     * Unlike {@link #next()} which provides the members by batch, this method returns them one by one.
+     *
+     * @return the iterable
+     */
+    Iterable<ScoredValue<V>> toIterable();
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ReactiveRedisClientImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/client/ReactiveRedisClientImpl.java
@@ -4,7 +4,11 @@ import java.util.List;
 
 import io.quarkus.redis.client.reactive.ReactiveRedisClient;
 import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.*;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.mutiny.redis.client.Request;
+import io.vertx.mutiny.redis.client.Response;
 
 class ReactiveRedisClientImpl implements ReactiveRedisClient {
     private final RedisAPI redisAPI;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractKeyCommands.java
@@ -11,15 +11,11 @@ import static io.vertx.mutiny.redis.client.Command.PEXPIRETIME;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
-import io.quarkus.redis.datasource.ReactiveCursor;
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
-import io.quarkus.redis.datasource.keys.KeyScanArgs;
 import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 import io.smallrye.mutiny.Uni;
@@ -257,15 +253,6 @@ class AbstractKeyCommands<K> extends AbstractRedisCommands {
                     }
                     return t;
                 });
-    }
-
-    ReactiveCursor<Set<K>> scan() {
-        return new ScanReactiveCursorImpl<>(redis, marshaller, typeOfKey, Collections.emptyList());
-    }
-
-    ReactiveCursor<Set<K>> scan(KeyScanArgs args) {
-        nonNull(args, "args");
-        return new ScanReactiveCursorImpl<>(redis, marshaller, typeOfKey, args.toArgs());
     }
 
     Uni<Response> _touch(K... keys) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingKeyCommandsImpl.java
@@ -3,13 +3,12 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 
-import io.quarkus.redis.datasource.Cursor;
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.KeyCommands;
 import io.quarkus.redis.datasource.keys.KeyScanArgs;
+import io.quarkus.redis.datasource.keys.KeyScanCursor;
 import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 
@@ -210,12 +209,12 @@ public class BlockingKeyCommandsImpl<K> implements KeyCommands<K> {
     }
 
     @Override
-    public Cursor<Set<K>> scan() {
+    public KeyScanCursor<K> scan() {
         return new ScanBlockingCursorImpl<>(reactive.scan(), timeout);
     }
 
     @Override
-    public Cursor<Set<K>> scan(KeyScanArgs args) {
+    public KeyScanCursor<K> scan(KeyScanArgs args) {
         return new ScanBlockingCursorImpl<>(reactive.scan(args), timeout);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HashScanBlockingCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/HashScanBlockingCursorImpl.java
@@ -27,6 +27,11 @@ public class HashScanBlockingCursorImpl<K, V> implements HashScanCursor<K, V> {
     }
 
     @Override
+    public Iterable<Map.Entry<K, V>> toIterable() {
+        return reactive.toMulti().subscribe().asIterable();
+    }
+
+    @Override
     public long cursorId() {
         return reactive.cursorId();
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
@@ -6,13 +6,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
-import io.quarkus.redis.datasource.ReactiveCursor;
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.KeyScanArgs;
 import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
+import io.quarkus.redis.datasource.keys.ReactiveKeyScanCursor;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
@@ -198,12 +197,12 @@ public class ReactiveKeyCommandsImpl<K> extends AbstractKeyCommands<K> implement
     }
 
     @Override
-    public ReactiveCursor<Set<K>> scan() {
+    public ReactiveKeyScanCursor<K> scan() {
         return new ScanReactiveCursorImpl<>(redis, marshaller, typeOfKey, Collections.emptyList());
     }
 
     @Override
-    public ReactiveCursor<Set<K>> scan(KeyScanArgs args) {
+    public ReactiveKeyScanCursor<K> scan(KeyScanArgs args) {
         nonNull(args, "args");
         return new ScanReactiveCursorImpl<>(redis, marshaller, typeOfKey, args.toArgs());
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanBlockingCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/SScanBlockingCursorImpl.java
@@ -30,4 +30,9 @@ public class SScanBlockingCursorImpl<V> implements SScanCursor<V> {
     public long cursorId() {
         return reactive.cursorId();
     }
+
+    @Override
+    public Iterable<V> toIterable() {
+        return reactive.toMulti().subscribe().asIterable();
+    }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanBlockingCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ScanBlockingCursorImpl.java
@@ -3,15 +3,15 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.util.Set;
 
-import io.quarkus.redis.datasource.Cursor;
-import io.quarkus.redis.datasource.ReactiveCursor;
+import io.quarkus.redis.datasource.keys.KeyScanCursor;
+import io.quarkus.redis.datasource.keys.ReactiveKeyScanCursor;
 
-public class ScanBlockingCursorImpl<K, V> implements Cursor<Set<K>> {
+public class ScanBlockingCursorImpl<K> implements KeyScanCursor<K> {
 
-    private final ReactiveCursor<Set<K>> reactive;
+    private final ReactiveKeyScanCursor<K> reactive;
     private final Duration timeout;
 
-    public ScanBlockingCursorImpl(ReactiveCursor<Set<K>> reactive, Duration timeout) {
+    public ScanBlockingCursorImpl(ReactiveKeyScanCursor<K> reactive, Duration timeout) {
         this.timeout = timeout;
         this.reactive = reactive;
     }
@@ -29,5 +29,10 @@ public class ScanBlockingCursorImpl<K, V> implements Cursor<Set<K>> {
     @Override
     public long cursorId() {
         return reactive.cursorId();
+    }
+
+    @Override
+    public Iterable<K> toIterable() {
+        return reactive.toMulti().subscribe().asIterable();
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanBlockingCursorImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ZScanBlockingCursorImpl.java
@@ -31,4 +31,9 @@ public class ZScanBlockingCursorImpl<V> implements ZScanCursor<V> {
     public long cursorId() {
         return reactive.cursorId();
     }
+
+    @Override
+    public Iterable<ScoredValue<V>> toIterable() {
+        return reactive.toMulti().subscribe().asIterable();
+    }
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -201,6 +201,32 @@ public class SetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void sscanEmpty() {
+        SScanCursor<Person> cursor = sets.sscan(key);
+
+        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
+
+        List<Person> list = cursor.next();
+
+        assertThat(cursor.cursorId()).isEqualTo(0);
+        assertThat(cursor.hasNext()).isFalse();
+        assertThat(list).isEmpty();
+    }
+
+    @Test
+    void sscanEmptyAsIterable() {
+        SScanCursor<Person> cursor = sets.sscan(key);
+
+        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
+
+        Iterable<Person> iterable = cursor.toIterable();
+        assertThat(iterable).isEmpty();
+        assertThat(cursor.hasNext()).isFalse();
+    }
+
+    @Test
     void sscanWithCursorAndArgs() {
         sets.sadd(key, person1);
         SScanCursor<Person> cursor = sets.sscan(key, new ScanArgs().count(3));
@@ -226,6 +252,22 @@ public class SetCommandsTest extends DatasourceTestBase {
         SScanCursor<String> cursor = set.sscan(key, new ScanArgs().count(5));
         while (cursor.hasNext()) {
             check.addAll(cursor.next());
+        }
+
+        assertThat(check).containsExactlyInAnyOrderElementsOf(expect);
+    }
+
+    @Test
+    void sscanMultipleAsITerable() {
+        Set<String> expect = new HashSet<>();
+        Set<String> check = new HashSet<>();
+        SetCommands<String, String> set = ds.set(String.class, String.class);
+        populateMany(expect, set);
+
+        SScanCursor<String> cursor = set.sscan(key, new ScanArgs().count(5));
+        Iterable<String> iterable = cursor.toIterable();
+        for (String s : iterable) {
+            check.add(s);
         }
 
         assertThat(check).containsExactlyInAnyOrderElementsOf(expect);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
@@ -627,6 +627,28 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void zsscanEmpty() {
+        ZScanCursor<Place> cursor = setOfPlaces.zscan(key);
+        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
+        List<ScoredValue<Place>> values = cursor.next();
+        assertThat(cursor.cursorId()).isEqualTo(0);
+        assertThat(cursor.hasNext()).isFalse();
+        assertThat(values).isEmpty();
+    }
+
+    @Test
+    void zsscanEmptyAsIterable() {
+        ZScanCursor<Place> cursor = setOfPlaces.zscan(key);
+        assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
+        assertThat(cursor.hasNext()).isTrue();
+        Iterable<ScoredValue<Place>> iterable = cursor.toIterable();
+        assertThat(iterable).isEmpty();
+        assertThat(cursor.cursorId()).isEqualTo(0);
+        assertThat(cursor.hasNext()).isFalse();
+    }
+
+    @Test
     void zsscanWithCursorAndArgs() {
         setOfPlaces.zadd(key, 1.0, Place.crussol);
         setOfPlaces.zadd(key, 2.0, Place.grignan);
@@ -651,6 +673,23 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
         List<ScoredValue<String>> values = new ArrayList<>();
         while (cursor.hasNext()) {
             values.addAll(cursor.next());
+        }
+        assertThat(cursor.cursorId()).isEqualTo(0L);
+        assertThat(cursor.hasNext()).isFalse();
+        assertThat(values).hasSize(100);
+    }
+
+    @Test
+    void zscanMultipleAsITerable() {
+        populateManyStringEntries();
+
+        ZScanCursor<String> cursor = setOfStrings.zscan(key, new ScanArgs().count(5));
+        assertThat(cursor).isNotNull();
+        assertThat(cursor.hasNext()).isTrue();
+
+        List<ScoredValue<String>> values = new ArrayList<>();
+        for (ScoredValue<String> scoredValue : cursor.toIterable()) {
+            values.add(scoredValue);
         }
         assertThat(cursor.cursorId()).isEqualTo(0L);
         assertThat(cursor.hasNext()).isFalse();


### PR DESCRIPTION
The Redis commands return batches, but the developers usually want to iterate over the items individually.
This commit adds the methods to iterate (using a Multi or an Iterable) over the items.
