### PR TITLE
RESTEasy Reactive - Perform eager security checks for JaxRS security

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -1030,16 +1030,26 @@ public class ResteasyReactiveProcessor {
         if (!capabilities.isPresent(Capability.SECURITY)) {
             return null;
         }
+
+        final boolean denyJaxRs = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.security.jaxrs.deny-unannotated-endpoints", Boolean.class).orElse(false);
+        final boolean hasDefaultJaxRsRolesAllowed = ConfigProvider.getConfig()
+                .getOptionalValues("quarkus.security.jaxrs.default-roles-allowed", String.class).map(l -> !l.isEmpty())
+                .orElse(false);
         var index = indexBuildItem.getComputingIndex();
         return new MethodScannerBuildItem(new MethodScanner() {
             @Override
             public List<HandlerChainCustomizer> scan(MethodInfo method, ClassInfo actualEndpointClass,
                     Map<String, Object> methodContext) {
-                return Objects.requireNonNullElse(
-                        consumeStandardSecurityAnnotations(method, actualEndpointClass, index,
-                                (c) -> Collections.singletonList(
-                                        EagerSecurityHandler.Customizer.newInstance(httpBuildTimeConfig.auth.proactive))),
-                        Collections.emptyList());
+                List<HandlerChainCustomizer> securityHandlerList = consumeStandardSecurityAnnotations(method,
+                        actualEndpointClass, index,
+                        (c) -> Collections.singletonList(
+                                EagerSecurityHandler.Customizer.newInstance(httpBuildTimeConfig.auth.proactive)));
+                if (securityHandlerList == null && (denyJaxRs || hasDefaultJaxRsRolesAllowed)) {
+                    securityHandlerList = Collections
+                            .singletonList(EagerSecurityHandler.Customizer.newInstance(httpBuildTimeConfig.auth.proactive));
+                }
+                return Objects.requireNonNullElse(securityHandlerList, Collections.emptyList());
             }
         });
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DefaultRolesAllowedJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DefaultRolesAllowedJaxRsTest.java
@@ -43,6 +43,18 @@ public class DefaultRolesAllowedJaxRsTest {
     }
 
     @Test
+    public void shouldDenyUnannotatedNonBlocking() {
+        String path = "/unsecured/defaultSecurityNonBlocking";
+        assertStatus(path, 200, 403, 401);
+    }
+
+    @Test
+    public void shouldPermitPermitAllMethodNonBlocking() {
+        String path = "/permitAll/defaultSecurityNonBlocking";
+        assertStatus(path, 200, 200, 200);
+    }
+
+    @Test
     public void shouldPermitPermitAllMethod() {
         assertStatus("/unsecured/permitAll", 200, 200, 200);
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
@@ -40,6 +40,18 @@ public class DenyAllJaxRsTest {
     }
 
     @Test
+    public void shouldDenyUnannotatedNonBlocking() {
+        String path = "/unsecured/defaultSecurityNonBlocking";
+        assertStatus(path, 403, 401);
+    }
+
+    @Test
+    public void shouldPermitPermitAllMethodNonBlocking() {
+        String path = "/permitAll/defaultSecurityNonBlocking";
+        assertStatus(path, 200, 200);
+    }
+
+    @Test
     public void shouldDenyDenyAllMethod() {
         String path = "/unsecured/denyAll";
         assertStatus(path, 403, 401);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermitAllResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/PermitAllResource.java
@@ -4,6 +4,8 @@ import javax.annotation.security.PermitAll;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import io.smallrye.common.annotation.NonBlocking;
+
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
@@ -14,6 +16,13 @@ public class PermitAllResource {
     @GET
     public String defaultSecurity() {
         return "defaultSecurity";
+    }
+
+    @NonBlocking
+    @Path("/defaultSecurityNonBlocking")
+    @GET
+    public String defaultSecurityNonBlocking() {
+        return "defaultSecurityNonBlocking";
     }
 
     @Path("/sub")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/UnsecuredResource.java
@@ -5,6 +5,8 @@ import javax.annotation.security.PermitAll;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import io.smallrye.common.annotation.NonBlocking;
+
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
  */
@@ -14,6 +16,13 @@ public class UnsecuredResource {
     @GET
     public String defaultSecurity() {
         return "defaultSecurity";
+    }
+
+    @NonBlocking
+    @Path("/defaultSecurityNonBlocking")
+    @GET
+    public String defaultSecurityNonBlocking() {
+        return "defaultSecurityNonBlocking";
     }
 
     @Path("/permitAll")

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/security/EagerSecurityHandler.java
@@ -127,7 +127,7 @@ public class EagerSecurityHandler implements ServerRestHandler {
 
     public static abstract class Customizer implements HandlerChainCustomizer {
 
-        public static Customizer newInstance(boolean isProactiveAuthEnabled) {
+        public static HandlerChainCustomizer newInstance(boolean isProactiveAuthEnabled) {
             return isProactiveAuthEnabled ? new ProactiveAuthEnabledCustomizer() : new ProactiveAuthDisabledCustomizer();
         }
 


### PR DESCRIPTION
fix: #26553

Same issue as with #23547, security checks with disabled proactive security on the IO thread performed by `SecurityConstrainer` leads to an exception as identity is accessed in a synchronous manner. Now these checks are performed eagerly in RR so by the time checks are performed by `SecurityConstrainer`, user is already authenticated - same situation as with RBAC annotations.