### PR TITLE
Fix testing guide's example for Testcontainers

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1317,6 +1317,9 @@ public class CustomResource implements QuarkusTestResourceLifecycleManager, DevS
         // apply the network to the container
         containerNetworkId.ifPresent(container::withNetworkMode);
 
+        // start container before retrieving its URL or other properties
+        container.start();
+
         String jdbcUrl = container.getJdbcUrl();
         if (containerNetworkId.isPresent()) {
             // Replace hostname + port in the provided JDBC URL with the hostname of the Docker container


### PR DESCRIPTION
If container.start() is missing, it will fail with "java.lang.IllegalStateException: Mapped port can only be obtained
after the container is started", or can get a NPE at a later phase of execution, if no call to retrieving port info is
made

Fixes #26573