### PR TITLE
ArtifactCoords API adjustment

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BootstrapFromOriginalJarTestBase.java
@@ -112,7 +112,7 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
                 for (Dependency moduleDep : moduleDeps) {
                     parentPom.getModules().add(moduleDep.getArtifactId());
                     final String moduleVersion = moduleDep.getVersion() == null
-                            ? managedVersions.get(ArtifactKey.gact(moduleDep.getGroupId(), moduleDep.getArtifactId(),
+                            ? managedVersions.get(ArtifactKey.of(moduleDep.getGroupId(), moduleDep.getArtifactId(),
                                     moduleDep.getClassifier(), moduleDep.getType()))
                             : moduleDep.getVersion();
                     Model modulePom = ModelUtils.readModel(resolver
@@ -216,7 +216,7 @@ public abstract class BootstrapFromOriginalJarTestBase extends PackageAppTestBas
         final List<Dependency> managed = appPom.getDependencyManagement() == null ? List.of()
                 : appPom.getDependencyManagement().getDependencies();
         for (Dependency d : managed) {
-            managedVersions.put(ArtifactKey.gact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType()),
+            managedVersions.put(ArtifactKey.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType()),
                     d.getVersion());
             if (d.getType().equals(ArtifactCoords.TYPE_POM) && d.getScope().equals("import")) {
                 collectManagedDeps(ModelUtils

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1059,7 +1059,7 @@ public class DevMojo extends AbstractMojo {
             addProject(builder, appModel.getAppArtifact(), true);
             appModel.getApplicationModule().getBuildFiles().forEach(p -> builder.watchedBuildFile(p));
             builder.localArtifact(
-                    ArtifactKey.gact(project.getGroupId(), project.getArtifactId(), null, ArtifactCoords.TYPE_JAR));
+                    ArtifactKey.of(project.getGroupId(), project.getArtifactId(), null, ArtifactCoords.TYPE_JAR));
         } else {
             for (ResolvedDependency project : DependenciesFilter.getReloadableModules(appModel)) {
                 addProject(builder, project, project == appModel.getAppArtifact());
@@ -1090,7 +1090,7 @@ public class DevMojo extends AbstractMojo {
         for (Artifact appDep : project.getArtifacts()) {
             // only add the artifact if it's present in the dev mode context
             // we need this to avoid having jars on the classpath multiple times
-            ArtifactKey key = ArtifactKey.gact(appDep.getGroupId(), appDep.getArtifactId(),
+            ArtifactKey key = ArtifactKey.of(appDep.getGroupId(), appDep.getArtifactId(),
                     appDep.getClassifier(), appDep.getArtifactHandler().getExtension());
             if (!builder.isLocal(key) && configuredParentFirst.contains(key)) {
                 builder.classpathEntry(appDep.getFile());

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactCoords.java
@@ -14,6 +14,14 @@ public interface ArtifactCoords {
         return new GACTV(groupId, artifactId, null, TYPE_JAR, version);
     }
 
+    static ArtifactCoords jar(String groupId, String artifactId, String classifier, String version) {
+        return new GACTV(groupId, artifactId, classifier, TYPE_JAR, version);
+    }
+
+    static ArtifactCoords of(String groupId, String artifactId, String classifier, String type, String version) {
+        return new GACTV(groupId, artifactId, classifier, type, version);
+    }
+
     String TYPE_JAR = "jar";
     String TYPE_POM = "pom";
     String DEFAULT_CLASSIFIER = "";

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
@@ -149,7 +149,7 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
     }
 
     public ArtifactKey getKey() {
-        return ArtifactKey.gact(groupId, artifactId, classifier, type);
+        return ArtifactKey.of(groupId, artifactId, classifier, type);
     }
 
     public String toGACTVString() {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactKey.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactKey.java
@@ -6,14 +6,49 @@ public interface ArtifactKey {
         return GACT.fromString(s);
     }
 
+    static ArtifactKey of(String groupId, String artifactId, String classifier, String type) {
+        return new GACT(groupId, artifactId, classifier, type);
+    }
+
+    /**
+     * Creates an artifact key that consists of an artifact's groupId and artifactId.
+     * The classifier and type will be left empty.
+     *
+     * @param groupId artifact groupId
+     * @param artifactId artifact id
+     * @return artifact key that consists of an artifact's groupId and artifactId
+     */
     static ArtifactKey ga(String groupId, String artifactId) {
         return new GACT(groupId, artifactId);
     }
 
+    /**
+     * @deprecated
+     *
+     *             Creates an artifact key that consists of groupId:artifactId:classifer and a {@code null} type.
+     *
+     * @param groupId artifact groupId
+     * @param artifactId artifact id
+     * @param classifier artifact classifier
+     * @return artifact key
+     */
+    @Deprecated(forRemoval = true)
     static ArtifactKey gac(String groupId, String artifactId, String classifier) {
         return new GACT(groupId, artifactId, classifier);
     }
 
+    /**
+     * @deprecated in favor of {@link ArtifactKey#of(String, String, String, String)}
+     *
+     *             Creates an artifact key for a given groupId:artifactId:classifier:type
+     *
+     * @param groupId artifact groupId
+     * @param artifactId artifact id
+     * @param classifier artifact classifier
+     * @param type artifact type
+     * @return artifact key
+     */
+    @Deprecated(forRemoval = true)
     static ArtifactKey gact(String groupId, String artifactId, String classifier, String type) {
         return new GACT(groupId, artifactId, classifier, type);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
@@ -101,7 +101,7 @@ public class GACTV implements ArtifactCoords, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(artifactId, classifier, groupId, type, version);
+        return Objects.hash(groupId, artifactId, classifier, type, version);
     }
 
     @Override

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -640,7 +640,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                             deps = getMetadataNode(extObject).putArray("extension-dependencies");
                             extensionDeps.set(deps);
                         }
-                        deps.add(ArtifactKey.gact(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
+                        deps.add(ArtifactKey.of(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
                                 .toGacString());
                     }
                 }
@@ -692,7 +692,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final ArtifactKey rootDeploymentGact = getDeploymentCoords().getKey();
         final RootNode rootDeployment = new RootNode(rootDeploymentGact, 2);
         final Artifact artifact = project.getArtifact();
-        final Node rootRuntime = rootDeployment.newChild(ArtifactKey.gact(artifact.getGroupId(), artifact.getArtifactId(),
+        final Node rootRuntime = rootDeployment.newChild(ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
                 artifact.getClassifier(), artifact.getType()), 1);
 
         rootDeployment.expectedDeploymentNodes.put(rootDeployment.gact, rootDeployment);

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/util/DependencyUtils.java
@@ -17,7 +17,7 @@ import org.eclipse.aether.graph.DependencyNode;
 public class DependencyUtils {
 
     public static ArtifactKey getKey(Artifact artifact) {
-        return ArtifactKey.gact(artifact.getGroupId(), artifact.getArtifactId(),
+        return ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
                 artifact.getClassifier(), artifact.getExtension());
     }
 

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -654,7 +654,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
                             deps = getMetadataNode(extObject).putArray("extension-dependencies");
                             extensionDeps.set(deps);
                         }
-                        deps.add(ArtifactKey.gact(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
+                        deps.add(ArtifactKey.of(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension())
                                 .toGacString());
                     }
                 }
@@ -706,7 +706,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         final ArtifactKey rootDeploymentGact = getDeploymentCoords().getKey();
         final RootNode rootDeployment = new RootNode(rootDeploymentGact, 2);
         final Artifact artifact = project.getArtifact();
-        final Node rootRuntime = rootDeployment.newChild(ArtifactKey.gact(artifact.getGroupId(), artifact.getArtifactId(),
+        final Node rootRuntime = rootDeployment.newChild(ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
                 artifact.getClassifier(), artifact.getType()), 1);
 
         rootDeployment.expectedDeploymentNodes.put(rootDeployment.gact, rootDeployment);

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/util/PlatformArtifacts.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/util/PlatformArtifacts.java
@@ -43,6 +43,13 @@ public class PlatformArtifacts {
                 : coords;
     }
 
+    public static io.quarkus.maven.dependency.ArtifactCoords ensureBomArtifact(
+            io.quarkus.maven.dependency.ArtifactCoords coords) {
+        return isCatalogArtifactId(coords.getArtifactId())
+                ? getBomArtifactForCatalog(coords)
+                : coords;
+    }
+
     public static ArtifactCoords getBomArtifactForCatalog(ArtifactCoords coords) {
         return new ArtifactCoords(coords.getGroupId(),
                 coords.getArtifactId().substring(0,
@@ -50,4 +57,11 @@ public class PlatformArtifacts {
                 null, "pom", coords.getVersion());
     }
 
+    public static io.quarkus.maven.dependency.ArtifactCoords getBomArtifactForCatalog(
+            io.quarkus.maven.dependency.ArtifactCoords coords) {
+        return new ArtifactCoords(coords.getGroupId(),
+                coords.getArtifactId().substring(0,
+                        coords.getArtifactId().length() - Constants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()),
+                null, "pom", coords.getVersion());
+    }
 }


### PR DESCRIPTION
This change is unifying the hashCode() calculation between `io.quarkus.maven.ArtifactCoords` and `io.quarkus.maven.dependency.GACTV`. Both classes implement `io.quarkus.maven.dependency.ArtifactCoords` which should replace the API in the `io.quarkus.maven` package in the near future.