### PR TITLE
Avoid AppArtifact API

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CurrentClassState.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CurrentClassState.java
@@ -3,7 +3,7 @@ package io.quarkus.deployment.dev;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.maven.dependency.ArtifactKey;
 
 public class CurrentClassState {
 
@@ -19,15 +19,15 @@ public class CurrentClassState {
 
     public static class CurrentModuleState {
 
-        private final AppArtifactKey module;
+        private final ArtifactKey module;
         private final Map<String, String> fileToHash;
 
-        public CurrentModuleState(AppArtifactKey module, Map<String, String> fileToHash) {
+        public CurrentModuleState(ArtifactKey module, Map<String, String> fileToHash) {
             this.module = module;
             this.fileToHash = fileToHash;
         }
 
-        public AppArtifactKey getModule() {
+        public ArtifactKey getModule() {
             return module;
         }
 

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerWithInvalidExtensionTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/TracerWithInvalidExtensionTest.java
@@ -1,12 +1,13 @@
 package io.quarkus.opentelemetry.deployment;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.test.QuarkusProdModeTest;
 
@@ -14,9 +15,7 @@ public class TracerWithInvalidExtensionTest {
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .withEmptyApplication()
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-opentracing", "999-SNAPSHOT")))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-opentracing", Version.getVersion())))
             .setExpectedException(ConfigurationException.class);
 
     @Test

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractEntity;
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractItem;
@@ -19,6 +18,7 @@ import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyLis
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.Item;
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsRepository;
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsResource;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 import io.restassured.RestAssured;
 
@@ -36,9 +36,9 @@ class OpenApiIntegrationTest {
                     .addAsResource("application.properties")
                     .addAsResource("import.sql"))
             .setForcedDependencies(List.of(
-                    new AppArtifact("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion())))
+                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion())))
             .setRun(true);
 
     @Test

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
 import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.AbstractEntity;
 import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.AbstractItem;
@@ -19,6 +18,7 @@ import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.Emp
 import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.Item;
 import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.ItemsRepository;
 import io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository.ItemsResource;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 import io.restassured.RestAssured;
 
@@ -36,9 +36,9 @@ class OpenApiIntegrationTest {
                     .addAsResource("application.properties")
                     .addAsResource("import.sql"))
             .setForcedDependencies(List.of(
-                    new AppArtifact("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-reactive-pg-client-deployment", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion())))
+                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-reactive-pg-client-deployment", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion())))
             .setRun(true);
 
     @Test

--- a/extensions/resteasy-classic/resteasy-links/deployment/src/test/java/io/quarkus/resteasy/links/deployment/HalLinksWithJacksonTest.java
+++ b/extensions/resteasy-classic/resteasy-links/deployment/src/test/java/io/quarkus/resteasy/links/deployment/HalLinksWithJacksonTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.resteasy.links.deployment;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class HalLinksWithJacksonTest extends AbstractHalLinksTest {
@@ -13,10 +13,9 @@ public class HalLinksWithJacksonTest extends AbstractHalLinksTest {
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-resteasy-jackson", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-hal", Version.getVersion())))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-resteasy-jackson", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))
             .setLogFileName("app.log")
             .setRun(true);
 }

--- a/extensions/resteasy-classic/resteasy-links/deployment/src/test/java/io/quarkus/resteasy/links/deployment/HalLinksWithJsonbTest.java
+++ b/extensions/resteasy-classic/resteasy-links/deployment/src/test/java/io/quarkus/resteasy/links/deployment/HalLinksWithJsonbTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.resteasy.links.deployment;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class HalLinksWithJsonbTest extends AbstractHalLinksTest {
@@ -13,10 +13,9 @@ public class HalLinksWithJsonbTest extends AbstractHalLinksTest {
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-resteasy-jsonb", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-hal", Version.getVersion())))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-resteasy-jsonb", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))
             .setRun(true);
 
 }

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/asyncio/AsyncIOUndertowTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/asyncio/AsyncIOUndertowTest.java
@@ -1,13 +1,13 @@
 package io.quarkus.resteasy.test.asyncio;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -18,8 +18,7 @@ public class AsyncIOUndertowTest {
             .withApplicationRoot((jar) -> jar
                     .addClasses(AsyncIOResource.class))
             .withConfigurationResource("application-asyncio.properties")
-            .setForcedDependencies(
-                    Arrays.asList(new AppArtifact("io.quarkus", "quarkus-undertow", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-undertow", Version.getVersion())));
 
     @Test
     public void testAsyncIODoesNotBlock() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJacksonTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJacksonTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.resteasy.reactive.links.deployment;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class HalLinksWithJacksonTest extends AbstractHalLinksTest {
@@ -13,9 +13,8 @@ public class HalLinksWithJacksonTest extends AbstractHalLinksTest {
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-resteasy-reactive-jackson", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-hal", Version.getVersion())))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jackson", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))
             .setRun(true);
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJsonbTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/HalLinksWithJsonbTest.java
@@ -1,11 +1,11 @@
 package io.quarkus.resteasy.reactive.links.deployment;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class HalLinksWithJsonbTest extends AbstractHalLinksTest {
@@ -13,10 +13,9 @@ public class HalLinksWithJsonbTest extends AbstractHalLinksTest {
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(AbstractEntity.class, TestRecord.class, TestResource.class))
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-resteasy-reactive-jsonb", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-hal", Version.getVersion())))
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-hal", Version.getVersion())))
             .setRun(true);
 
 }

--- a/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
+++ b/extensions/webjars-locator/deployment/src/test/java/io/quarkus/webjar/locator/test/WebJarLocatorTest.java
@@ -2,13 +2,13 @@ package io.quarkus.webjar.locator.test;
 
 import static org.hamcrest.core.Is.is;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
@@ -20,8 +20,9 @@ public class WebJarLocatorTest extends WebJarLocatorTestSupport {
             .withApplicationRoot((jar) -> jar
                     .addAsResource(new StringAsset("<html>Hello!<html>"), META_INF_RESOURCES + "/index.html")
                     .addAsResource(new StringAsset("Test"), META_INF_RESOURCES + "/some/path/test.txt"))
-            .setForcedDependencies(Arrays.asList(new AppArtifact("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
-                    new AppArtifact("org.webjars", "momentjs", MOMENTJS_VERSION)));
+            .setForcedDependencies(List.of(
+                    Dependency.of("org.webjars", "jquery-ui", JQUERY_UI_VERSION),
+                    Dependency.of("org.webjars", "momentjs", MOMENTJS_VERSION)));
 
     @Test
     public void test() {

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
@@ -1,6 +1,5 @@
 package io.quarkus.bootstrap.resolver.maven.workspace;
 
-import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
@@ -218,8 +217,8 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
         if (findArtifact(artifact) == null) {
             return Collections.emptyList();
         }
-        lastFindVersionsKey = new AppArtifactKey(artifact.getGroupId(), artifact.getArtifactId());
-        return lastFindVersions = Collections.singletonList(artifact.getVersion());
+        lastFindVersionsKey = ArtifactKey.ga(artifact.getGroupId(), artifact.getArtifactId());
+        return lastFindVersions = List.of(artifact.getVersion());
     }
 
     public String getResolvedVersion() {

--- a/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/MultipleContainerImageExtensionTest.java
+++ b/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/MultipleContainerImageExtensionTest.java
@@ -7,8 +7,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class MultipleContainerImageExtensionTest {
@@ -21,8 +21,8 @@ public class MultipleContainerImageExtensionTest {
             .setExpectedException(IllegalStateException.class)
             .setForcedDependencies(
                     Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-container-image-jib", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
+                            Dependency.of("io.quarkus", "quarkus-container-image-jib", Version.getVersion()),
+                            Dependency.of("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
 
     @Test
     public void testBuildShouldFail() {

--- a/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/SingleContainerImageExtensionTest.java
+++ b/integration-tests/container-image/quarkus-standard-way/src/test/java/io/quarkus/it/container/image/SingleContainerImageExtensionTest.java
@@ -2,13 +2,13 @@ package io.quarkus.it.container.image;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -20,9 +20,7 @@ public class SingleContainerImageExtensionTest {
             .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
             .setApplicationName("single-container-image")
             .setApplicationVersion("0.1-SNAPSHOT")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way-kafka/src/test/java/io/quarkus/it/kubernetes/kafka/BasicMinikubeTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way-kafka/src/test/java/io/quarkus/it/kubernetes/kafka/BasicMinikubeTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class BasicMinikubeTest {
             .setApplicationName("minikube-with-defaults")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("basic-minikube.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-minikube", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-minikube", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,9 +28,7 @@ public class KnativeWithHealthTest {
             .setApplicationName("knative-health")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("knative-with-health.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithImagePullSecretTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithImagePullSecretTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -16,8 +15,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -31,8 +30,7 @@ public class KnativeWithImagePullSecretTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("knative-with-image-pull-secret.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithSecretConfigTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithSecretConfigTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.knative.serving.v1.Service;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,9 @@ public class KnativeWithSecretConfigTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("knative-with-secret-config.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-kubernetes-config", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-config", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesAndMinikubeWithApplicationPropertiesTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,7 @@ public class KubernetesAndMinikubeWithApplicationPropertiesTest {
             .setApplicationName("kubernetes-and-minikube")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-and-minikube-with-application.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-minikube", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-minikube", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesConfigWithSecretsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.rbac.PolicyRule;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,7 @@ public class KubernetesConfigWithSecretsTest {
             .setApplicationName("kubernetes-config-with-secrets")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-config-with-secrets.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-kubernetes-config", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes-config", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesInitContainersTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesInitContainersTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class KubernetesInitContainersTest {
             .setApplicationName("kubernetes-with-init-containers")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-init-containers.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesServiceMappingTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,8 +29,7 @@ public class KubernetesServiceMappingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-service-mapping.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoMongoBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoMongoBindingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,11 +27,10 @@ public class KubernetesWithAutoMongoBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-auto-mongo-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-mongodb-client", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-mongodb-client", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoMysqlBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoMysqlBindingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,12 +27,11 @@ public class KubernetesWithAutoMysqlBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-auto-mysql-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-jdbc-mysql", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-datasource", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-jdbc-mysql", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-datasource", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoPostgresBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithAutoPostgresBindingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,12 +27,11 @@ public class KubernetesWithAutoPostgresBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-auto-postgres-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-jdbc-postgresql", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-datasource", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-jdbc-postgresql", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-datasource", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithGitlabLikeImageTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithGitlabLikeImageTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,9 +26,8 @@ public class KubernetesWithGitlabLikeImageTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-gitlab-like-image.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthAndJibTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,10 +28,9 @@ public class KubernetesWithHealthAndJibTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-health-and-jib.properties")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -17,8 +16,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -34,9 +33,8 @@ public class KubernetesWithHealthTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-health.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,8 +28,7 @@ public class KubernetesWithIngressTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-ingress.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitContainerResourceLimitsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInitContainerResourceLimitsTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,8 +28,7 @@ public class KubernetesWithInitContainerResourceLimitsTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-init-container-resource-limits.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInputStatefulSetResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithInputStatefulSetResourcesTest.java
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
 import io.quarkus.kubernetes.spi.CustomProjectRootBuildItem;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -33,8 +33,7 @@ public class KubernetesWithInputStatefulSetResourcesTest {
             .setLogFileName("k8s.log")
             .addCustomResourceEntry(Path.of("src", "main", "kubernetes", "kubernetes.yml"),
                     "manifests/custom-deployment/kubernetes-with-stateful.yml")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())))
             .addBuildChainCustomizerEntries(
                     new QuarkusProdModeTest.BuildChainCustomizerEntry(
                             KubernetesWithCustomResourcesTest.CustomProjectRootBuildItemProducerProdMode.class,

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomAbsoluteTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomAbsoluteTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -32,9 +31,8 @@ public class KubernetesWithMetricsCustomAbsoluteTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-metrics-custom-absolute.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomRelativeTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsCustomRelativeTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -32,9 +31,7 @@ public class KubernetesWithMetricsCustomRelativeTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-metrics-custom-relative.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsNoAnnotationsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsNoAnnotationsTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -32,9 +31,8 @@ public class KubernetesWithMetricsNoAnnotationsTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-metrics-no-annotations.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMetricsTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -31,10 +31,9 @@ public class KubernetesWithMetricsTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("kubernetes-with-metrics.properties")
-            .setForcedDependencies(
-                    List.of(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-smallrye-metrics", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMicrometerTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithMicrometerTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -31,9 +30,8 @@ public class KubernetesWithMicrometerTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setRun(true)
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithPvcVolumesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithPvcVolumesTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,7 @@ public class KubernetesWithPvcVolumesTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-pvc-volumes.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithQuarkusAppNameTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,10 +26,9 @@ public class KubernetesWithQuarkusAppNameTest {
             .setApplicationName("kubernetes-with-quarkus-app-name")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-quarkus-app-name.properties")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-container-image-s2i", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-s2i", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRbacAndNamespaceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRbacAndNamespaceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,8 +16,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -32,8 +31,9 @@ public class KubernetesWithRbacAndNamespaceTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-rbac-and-namespace.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithRootAndHealthTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,9 +26,7 @@ public class KubernetesWithRootAndHealthTest {
             .setApplicationName("root-and-health")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-root-and-health.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSemiAutoPostgresBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSemiAutoPostgresBindingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,12 +27,11 @@ public class KubernetesWithSemiAutoPostgresBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-semi-auto-postgres-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-jdbc-postgresql", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-datasource", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-jdbc-postgresql", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-datasource", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithServiceBindingTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,9 +28,9 @@ public class KubernetesWithServiceBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-service-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndJibTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,9 +26,8 @@ public class KubernetesWithSidecarAndJibTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-sidecar-and-jib.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-container-image-jib", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndProbesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSidecarAndProbesTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -16,8 +15,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -31,8 +30,7 @@ public class KubernetesWithSidecarAndProbesTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-sidecar-and-probes.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSpecifiedContainerNameTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithSpecifiedContainerNameTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -16,8 +15,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.openshift.api.model.DeploymentTriggerPolicy;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,10 +29,9 @@ public class KubernetesWithSpecifiedContainerNameTest {
             .setApplicationName("kubernetes-with-specified-container-name")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("kubernetes-with-specified-container-name.properties")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-container-image-s2i", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-s2i", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithStatefulSetResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithStatefulSetResourceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,8 +29,7 @@ public class KubernetesWithStatefulSetResourceTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource(APP_NAME + ".properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithApplicationPropertiesTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,8 +28,7 @@ public class MinikubeWithApplicationPropertiesTest {
             .setApplicationName("minikube-with-application-properties")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("minikube-with-application.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-minikube", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-minikube", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithDefaultsTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,7 @@ public class MinikubeWithDefaultsTest {
             .setApplicationName("minikube-with-defaults")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("minikube-with-defaults.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-minikube", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-minikube", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithMixedStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/MinikubeWithMixedStyleEnvTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.EnvFromSource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,8 +26,7 @@ public class MinikubeWithMixedStyleEnvTest {
             .setApplicationName("minikube-with-mixed-style-env")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("minikube-with-mixed-style-env.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-minikube", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-minikube", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithAppConfigMapTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithAppConfigMapTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.AbstractObjectAssert;
@@ -16,8 +15,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,8 +29,7 @@ public class OpenshiftWithAppConfigMapTest {
             .setApplicationName("openshift-with-app-config-map")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-app-config-map.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithAppSecretTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithAppSecretTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.AbstractObjectAssert;
@@ -16,8 +15,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,8 +29,7 @@ public class OpenshiftWithAppSecretTest {
             .setApplicationName("openshift-with-app-secret")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-app-secret.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDeploymentResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDeploymentResourceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -39,8 +38,7 @@ public class OpenshiftWithDeploymentResourceTest {
             .overrideConfigKey("quarkus.openshift.replicas", "3")
             .overrideConfigKey("quarkus.container-image.group", "testme")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerBuildStrategyTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerBuildStrategyTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class OpenshiftWithDockerBuildStrategyTest {
             .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
             .setApplicationName("openshift-s2i").setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-docker-build-strategy.properties")
-            .setForcedDependencies(Collections
-                    .singletonList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -31,9 +30,7 @@ public class OpenshiftWithHealthTest {
             .setRun(true)
             .setLogFileName("k8s.log")
             .withConfigurationResource("openshift-with-health.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-smallrye-health", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmAdditionalArgumentsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmAdditionalArgumentsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class OpenshiftWithJvmAdditionalArgumentsTest {
             .setApplicationName("openshift-with-jvm-additional-arguments")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-jvm-additional-arguments.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));;
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));;
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmArgumentsTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithJvmArgumentsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class OpenshiftWithJvmArgumentsTest {
             .setApplicationName("openshift-with-jvm-arguments")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-jvm-arguments.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));;
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));;
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLegacySidecarAndS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLegacySidecarAndS2iTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.AbstractObjectAssert;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,8 +26,7 @@ public class OpenshiftWithLegacySidecarAndS2iTest {
             .setApplicationName("openshift-sidecar-test")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-legacy-sidecar-and-s2i.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerAndDeploymentResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerAndDeploymentResourceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -36,8 +35,9 @@ public class OpenshiftWithLocalDockerAndDeploymentResourceTest {
             .overrideConfigKey("quarkus.container-image.builder", "docker")
             .overrideConfigKey("quarkus.container-image.group", "testme")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithLocalDockerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -15,8 +14,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -38,8 +37,9 @@ public class OpenshiftWithLocalDockerTest {
             .overrideConfigKey("quarkus.container-image.builder", "docker")
             .overrideConfigKey("quarkus.container-image.group", "testme")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(Arrays.asList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion()),
-                    new AppArtifact("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-container-image-docker", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRemoteDebugTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRemoteDebugTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -28,8 +27,7 @@ public class OpenshiftWithRemoteDebugTest {
             .setApplicationName("openshift-with-debug")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-debug.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithS2iTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.AbstractObjectAssert;
@@ -17,8 +16,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -31,8 +30,7 @@ public class OpenshiftWithS2iTest {
             .setApplicationName("openshift-s2i")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-s2i.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithServiceBindingTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithServiceBindingTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,8 +13,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.dekorate.servicebinding.model.ServiceBinding;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -29,9 +28,9 @@ public class OpenshiftWithServiceBindingTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-service-binding.properties")
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Arrays.asList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion()),
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
+            .setForcedDependencies(List.of(
+                    Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-kubernetes-service-binding", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithSidecarAndS2iTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithSidecarAndS2iTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.AbstractObjectAssert;
@@ -13,8 +12,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -27,8 +26,7 @@ public class OpenshiftWithSidecarAndS2iTest {
             .setApplicationName("openshift-sidecar-test")
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource("openshift-with-sidecar-and-s2i.properties")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithStatefulSetResourceTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithStatefulSetResourceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -26,8 +25,7 @@ public class OpenshiftWithStatefulSetResourceTest {
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class)).setApplicationName(APP_NAME)
             .setApplicationVersion("0.1-SNAPSHOT").withConfigurationResource(APP_NAME + ".properties").setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithUberJarTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithUberJarTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.assertj.core.api.Condition;
@@ -16,8 +15,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -30,8 +29,7 @@ public class OpenshiftWithUberJarTest {
             .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
             .setApplicationName("openshift-uberjar").setApplicationVersion("0.1-SNAPSHOT").setRun(true)
             .setLogFileName("k8s.log").withConfigurationResource("openshift-with-uberjar.properties")
-            .setForcedDependencies(
-                    Collections.singletonList(new AppArtifact("io.quarkus", "quarkus-openshift", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndExistingResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndExistingResourcesTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
 import io.quarkus.kubernetes.spi.CustomProjectRootBuildItem;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -30,8 +30,7 @@ public class WithKubernetesClientAndExistingResourcesTest {
             .withConfigurationResource("kubernetes-with-" + APPLICATION_NAME + ".properties")
             .addCustomResourceEntry(Path.of("src", "main", "kubernetes", "kubernetes.yml"),
                     "manifests/kubernetes-with-" + APPLICATION_NAME + "/kubernetes.yml")
-            .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())))
             .addBuildChainCustomizerEntries(
                     new QuarkusProdModeTest.BuildChainCustomizerEntry(
                             KubernetesWithCustomResourcesTest.CustomProjectRootBuildItemProducerProdMode.class,

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndRbacDisabledTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientAndRbacDisabledTest.java
@@ -4,15 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -29,9 +28,7 @@ public class WithKubernetesClientAndRbacDisabledTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .withConfigurationResource(APPLICATION_NAME + ".properties")
             .setRun(true)
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/WithKubernetesClientTest.java
@@ -6,15 +6,14 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.quarkus.bootstrap.model.AppArtifact;
 import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.LogFile;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
@@ -29,9 +28,7 @@ public class WithKubernetesClientTest {
             .setApplicationVersion("0.1-SNAPSHOT")
             .setRun(true)
             .setLogFileName("k8s.log")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            new AppArtifact("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes-client", Version.getVersion())));
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/GeneratedResourceBuildItemTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/GeneratedResourceBuildItemTest.java
@@ -8,14 +8,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.test.QuarkusProdModeTest;
 
@@ -31,10 +30,9 @@ class GeneratedResourceBuildItemTest {
             .setRun(true)
             .setExpectExit(true)
             .overrideConfigKey("quarkus.package.type", "uber-jar")
-            .setForcedDependencies(
-                    Arrays.asList(
-                            new AppArtifact("org.apache.cxf", "cxf-rt-bindings-xml", "3.4.3"),
-                            new AppArtifact("org.apache.cxf", "cxf-rt-bindings-soap", "3.4.3")));
+            .setForcedDependencies(List.of(
+                    Dependency.of("org.apache.cxf", "cxf-rt-bindings-xml", "3.4.3"),
+                    Dependency.of("org.apache.cxf", "cxf-rt-bindings-soap", "3.4.3")));
 
     @Test
     public void testXMLResourceWasMerged() throws IOException {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/UberJarIgnoredResourceBuildItemTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/UberJarIgnoredResourceBuildItemTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.test.QuarkusProdModeTest;
 
@@ -26,10 +26,9 @@ class UberJarIgnoredResourceBuildItemTest {
             .setRun(true)
             .setExpectExit(true)
             .overrideConfigKey("quarkus.package.type", "uber-jar")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            // META-INF/cxf/cxf.fixml should be present in the cxf-rt-transports-http and cxf-core JARs
-                            new AppArtifact("org.apache.cxf", "cxf-rt-transports-http", "3.4.3")));
+            .setForcedDependencies(List.of(
+                    // META-INF/cxf/cxf.fixml should be present in the cxf-rt-transports-http and cxf-core JARs
+                    Dependency.of("org.apache.cxf", "cxf-rt-transports-http", "3.4.3")));
 
     @Test
     public void testResourceWasIgnored() throws IOException {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/UberJarMergedResourceBuildItemTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/deployment/pkg/builditem/UberJarMergedResourceBuildItemTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.test.QuarkusProdModeTest;
 
@@ -30,10 +30,9 @@ class UberJarMergedResourceBuildItemTest {
             .setRun(true)
             .setExpectExit(true)
             .overrideConfigKey("quarkus.package.type", "uber-jar")
-            .setForcedDependencies(
-                    Collections.singletonList(
-                            // META-INF/cxf/bus-extensions.txt should be present in the cxf-rt-transports-http and cxf-core JARs
-                            new AppArtifact("org.apache.cxf", "cxf-rt-transports-http", "3.4.3")));
+            .setForcedDependencies(List.of(
+                    // META-INF/cxf/bus-extensions.txt should be present in the cxf-rt-transports-http and cxf-core JARs
+                    Dependency.of("org.apache.cxf", "cxf-rt-transports-http", "3.4.3")));
 
     @Test
     public void testResourceWasMerged() throws IOException {


### PR DESCRIPTION
There is no functional change in this PR. It simply replaces `AppArtifact*` API with the corresponding `io.quarkus.maven.dependency.*` API. They implement the same interfaces. `AppArtifact*` is simply not the implementation we want to keep going forward.