### PR TITLE
Kafka dev service redpanda container failing with Text file busy

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedPandaKafkaContainer.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedPandaKafkaContainer.java
@@ -42,7 +42,8 @@ final class RedPandaKafkaContainer extends GenericContainer<RedPandaKafkaContain
         withCreateContainerCmdModifier(cmd -> {
             cmd.withEntrypoint("sh");
         });
-        withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; sleep 0.1; " +
+                STARTER_SCRIPT);
         waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1));
     }
 


### PR DESCRIPTION
Fixes #26603

The assumption is that a condition of a file existing [ -f blabla ] can be true while a file is being written on filesystem. Hence waiting one more sleep 0.1 before launching the redpanda.sh script.

Happy to hear my assumption is false. But then I do not know what else might have gone wrong in the racing condition I detailed in the issue.