### PR TITLE
Strip the scheme value from the OIDC proxy host

### DIFF
--- a/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
+++ b/extensions/keycloak-authorization/runtime/src/main/java/io/quarkus/keycloak/pep/runtime/KeycloakPolicyEnforcerRecorder.java
@@ -1,5 +1,6 @@
 package io.quarkus.keycloak.pep.runtime;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -90,8 +91,11 @@ public class KeycloakPolicyEnforcerRecorder {
         adapterConfig.setConnectionPoolSize(keycloakPolicyEnforcerConfig.connectionPoolSize);
 
         if (oidcConfig.proxy.host.isPresent()) {
-            adapterConfig.setProxyUrl(oidcConfig.proxy.host.get() + ":"
-                    + oidcConfig.proxy.port);
+            String host = oidcConfig.proxy.host.get();
+            if (!host.startsWith("http://") && !host.startsWith("https://")) {
+                host = URI.create(authServerUrl).getScheme() + "://" + host;
+            }
+            adapterConfig.setProxyUrl(host + ":" + oidcConfig.proxy.port);
         }
 
         PolicyEnforcerConfig enforcerConfig = getPolicyEnforcerConfig(keycloakPolicyEnforcerConfig,

--- a/extensions/oidc-common/runtime/pom.xml
+++ b/extensions/oidc-common/runtime/pom.xml
@@ -42,6 +42,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-build</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -228,7 +228,14 @@ public class OidcCommonUtils {
             return Optional.empty();
         }
         JsonObject jsonOptions = new JsonObject();
-        jsonOptions.put("host", proxyConfig.host.get());
+        // Vert.x Client currently does not expect a host having a scheme but keycloak-authorization expects scheme and host.
+        // Having a dedicated scheme property is probably better, but since it is property is not taken into account in Vertx Client
+        // it does not really make sense as it can send a misleading message that users can choose between `http` and `https`.
+        String host = URI.create(proxyConfig.host.get()).getHost();
+        if (host == null) {
+            host = proxyConfig.host.get();
+        }
+        jsonOptions.put("host", host);
         jsonOptions.put("port", proxyConfig.port);
         if (proxyConfig.username.isPresent()) {
             jsonOptions.put("username", proxyConfig.username.get());

--- a/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
+++ b/extensions/oidc-common/runtime/src/test/java/io/quarkus/oidc/common/runtime/OidcCommonUtilsTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.oidc.common.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.net.ProxyOptions;
+
+public class OidcCommonUtilsTest {
+
+    @Test
+    public void testProxyOptionsWithHostWithoutScheme() throws Exception {
+        OidcCommonConfig.Proxy config = new OidcCommonConfig.Proxy();
+        config.host = Optional.of("localhost");
+        config.port = 8080;
+        config.username = Optional.of("user");
+        config.password = Optional.of("password");
+
+        ProxyOptions options = OidcCommonUtils.toProxyOptions(config).get();
+        assertEquals("localhost", options.getHost());
+        assertEquals(8080, options.getPort());
+        assertEquals("user", options.getUsername());
+        assertEquals("password", options.getPassword());
+    }
+
+    @Test
+    public void testProxyOptionsWithHostWithScheme() throws Exception {
+        OidcCommonConfig.Proxy config = new OidcCommonConfig.Proxy();
+        config.host = Optional.of("http://localhost");
+        config.port = 8080;
+        config.username = Optional.of("user");
+        config.password = Optional.of("password");
+
+        assertEquals("http", URI.create(config.host.get()).getScheme());
+
+        ProxyOptions options = OidcCommonUtils.toProxyOptions(config).get();
+        assertEquals("localhost", options.getHost());
+        assertEquals(8080, options.getPort());
+        assertEquals("user", options.getUsername());
+        assertEquals("password", options.getPassword());
+    }
+}


### PR DESCRIPTION
Fixes #26577.

As described in #26577, Vertx (Mutiny) Web Client will fail if the proxy host is configured as `http://localhost` - I have confirmed it, `UnknownHostException` is reported - with `quarkus.oidc` using Mutiny `WebClient`. While `quarkus-keycloak-authorization` extending `quarkus-oidc` and sharing the same proxy configuration will fail unless the host is set as `http://localhost`.

So I've done a minor update which 1) strips the `scheme` from a proxy `host` value if the `scheme` is set as in  `http://localhost` in `OidcCommonUtils` which is used for creating `quarkus-oidc` and also `quarkus-oidc-client` and 2) adds `http://` to the host value if it is not already there when configuring `keycloak-authorization`.
At this moment of time it likely does not really make sense to introduce a `scheme` proxy option as it is not directly taken into account with `WebClient`.