### PR TITLE
Add config option for native to produce JSON output

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -25,6 +25,7 @@ public final class GraalVM {
         static final Version VERSION_21_3_0 = new Version("GraalVM 21.3.0", "21.3.0", Distribution.ORACLE);
         static final Version VERSION_21_3_2 = new Version("GraalVM 21.3.2", "21.3.2", Distribution.ORACLE);
         static final Version VERSION_22_0_0_2 = new Version("GraalVM 22.0.0.2", "22.0.0.2", Distribution.ORACLE);
+        static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
 
         public static final Version VERSION_22_1_0 = new Version("GraalVM 22.1.0", "22.1.0", Distribution.ORACLE);
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -711,6 +711,15 @@ public class NativeImageBuildStep {
                     }
                 }
 
+                // only available in GraalVM 22.3.0 and better.
+                if (graalVMVersion.compareTo(GraalVM.Version.VERSION_22_3_0) >= 0) {
+                    // For build time information
+                    nativeImageArgs.add("-H:+CollectImageBuildStatistics");
+                    nativeImageArgs.add("-H:ImageBuildStatisticsFile=" + nativeImageName + "-timing-stats.json");
+                    // For getting the build output stats as a JSON file
+                    nativeImageArgs.add("-H:BuildOutputJSONFile=" + nativeImageName + "-build-output-stats.json");
+                }
+
                 /*
                  * Any parameters following this call are forced over the user provided parameters in
                  * quarkus.native.additional-build-args. So if you need a parameter to be overridable through


### PR DESCRIPTION
Latest GraalVM master (release 22.3.0 in October) has new
options so as to produce a JSON file listing relevant build
output metrics in that JSON file. In addition, there are options
to get some timing information (e.g. total time to build an image)
and get that written to a JSON file as well.

Enable those options by default for a native build and on GraalVM
22.3.0 and better.