### PR TITLE
Make use of @ConfigProperties on producer methods consistent with Spring Boot

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ConfigPropertiesBuildStep.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/configproperties/ConfigPropertiesBuildStep.java
@@ -175,7 +175,8 @@ public class ConfigPropertiesBuildStep {
                 boolean needsValidation = classConfigPropertiesUtil.addProducerMethodForClassConfigProperties(
                         Thread.currentThread().getContextClassLoader(), classInfo,
                         configPropertiesMetadata.getPrefix(), configPropertiesMetadata.getNamingStrategy(),
-                        configPropertiesMetadata.isFailOnMismatchingMember(), configPropertiesMetadata.isNeedsQualifier());
+                        configPropertiesMetadata.isFailOnMismatchingMember(), configPropertiesMetadata.isNeedsQualifier(),
+                        configPropertiesMetadata.getInstanceFactory());
                 if (needsValidation) {
                     configClassesThatNeedValidation.add(classInfo.name());
                 }

--- a/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesProcessor.java
+++ b/extensions/spring-boot-properties/deployment/src/main/java/io/quarkus/spring/boot/properties/deployment/ConfigurationPropertiesProcessor.java
@@ -1,22 +1,42 @@
 package io.quarkus.spring.boot.properties.deployment;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.config.ConfigProperties;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.ArcConfig;
 import io.quarkus.arc.deployment.configproperties.ConfigPropertiesMetadataBuildItem;
+import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.spring.boot.properties.runtime.SpringBootConfigProperties;
 
 public class ConfigurationPropertiesProcessor {
 
     private static final DotName CONFIGURATION_PROPERTIES = DotName.createSimple(ConfigurationProperties.class.getName());
+    private static final DotName SPRING_BOOT_CONFIG_PROPERTIES = DotName
+            .createSimple(SpringBootConfigProperties.class.getName());
 
     @BuildStep
     public FeatureBuildItem registerFeature() {
@@ -25,31 +45,74 @@ public class ConfigurationPropertiesProcessor {
 
     @BuildStep
     public void produceConfigPropertiesMetadata(CombinedIndexBuildItem combinedIndex, ArcConfig arcConfig,
-            BuildProducer<ConfigPropertiesMetadataBuildItem> configPropertiesMetadataProducer) {
+            BuildProducer<ConfigPropertiesMetadataBuildItem> configPropertiesMetadataProducer,
+            BuildProducer<AnnotationsTransformerBuildItem> transformerProducer) {
+        IndexView index = combinedIndex.getIndex();
         ConfigProperties.NamingStrategy namingStrategy = arcConfig.configPropertiesDefaultNamingStrategy;
+        List<MethodInfo> onMethodInstances = new ArrayList<>();
+        List<ConfigPropertiesMetadataBuildItem> metadata = new ArrayList<>();
         for (AnnotationInstance annotation : combinedIndex.getIndex().getAnnotations(CONFIGURATION_PROPERTIES)) {
-            configPropertiesMetadataProducer.produce(
-                    createConfigPropertiesMetadata(annotation, combinedIndex.getIndex(), namingStrategy));
+            boolean ignoreMismatching = true;
+            AnnotationValue ignoreUnknownFieldsValue = annotation.value("ignoreUnknownFields");
+            if (ignoreUnknownFieldsValue != null) {
+                ignoreMismatching = ignoreUnknownFieldsValue.asBoolean();
+            }
+            switch (annotation.target().kind()) {
+                case CLASS:
+                    metadata.add(
+                            new ConfigPropertiesMetadataBuildItem(annotation.target().asClass(), getPrefix(annotation),
+                                    namingStrategy, !ignoreMismatching, false));
+                    break;
+                case METHOD:
+                    onMethodInstances.add(annotation.target().asMethod());
+                    metadata.add(new ConfigPropertiesMetadataBuildItem(
+                            index.getClassByName(annotation.target().asMethod().returnType().name()), getPrefix(annotation),
+                            namingStrategy, !ignoreMismatching, false, ArcInstanceFactory.INSTANCE));
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported annotation target kind " + annotation.target().kind().name());
+            }
         }
-    }
 
-    private ConfigPropertiesMetadataBuildItem createConfigPropertiesMetadata(AnnotationInstance annotation,
-            IndexView index, ConfigProperties.NamingStrategy namingStrategy) {
-        switch (annotation.target().kind()) {
-            case CLASS:
-                return createConfigPropertiesMetadataFromClass(annotation, namingStrategy);
-            case METHOD:
-                return createConfigPropertiesMetadataFromMethod(annotation, index, namingStrategy);
-            default:
-                throw new IllegalArgumentException(
-                        "Unsupported annotation target kind " + annotation.target().kind().name());
+        if (!onMethodInstances.isEmpty()) {
+            // the idea here is to transform the producer to add a special qualifier that will then be
+            // used by the generated code in order to obtain the instance of the class
+            transformerProducer.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+
+                @Override
+                public boolean appliesTo(AnnotationTarget.Kind kind) {
+                    return kind == AnnotationTarget.Kind.METHOD;
+                }
+
+                @Override
+                public void transform(TransformationContext transformationContext) {
+                    Collection<AnnotationInstance> instances = transformationContext.getAnnotations();
+                    boolean matches = false;
+                    for (AnnotationInstance instance : instances) {
+                        if (instance.target().kind() != AnnotationTarget.Kind.METHOD) {
+                            continue;
+                        }
+                        MethodInfo methodInfo = instance.target().asMethod();
+                        for (MethodInfo onMethodInstance : onMethodInstances) {
+                            if (onMethodInstance.equals(methodInfo)) {
+                                matches = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!matches) {
+                        return;
+                    }
+
+                    transformationContext.transform().add(SPRING_BOOT_CONFIG_PROPERTIES).done();
+                }
+            }));
         }
-    }
 
-    private ConfigPropertiesMetadataBuildItem createConfigPropertiesMetadataFromClass(AnnotationInstance annotation,
-            ConfigProperties.NamingStrategy namingStrategy) {
-        return new ConfigPropertiesMetadataBuildItem(annotation.target().asClass(), getPrefix(annotation),
-                namingStrategy, true, false);
+        for (ConfigPropertiesMetadataBuildItem bi : metadata) {
+            configPropertiesMetadataProducer.produce(bi);
+        }
     }
 
     private ConfigPropertiesMetadataBuildItem createConfigPropertiesMetadataFromMethod(AnnotationInstance annotation,
@@ -67,5 +130,29 @@ public class ConfigurationPropertiesProcessor {
         }
 
         return null;
+    }
+
+    private static class ArcInstanceFactory implements ConfigPropertiesMetadataBuildItem.InstanceFactory {
+
+        static final ArcInstanceFactory INSTANCE = new ArcInstanceFactory();
+
+        @Override
+        public ResultHandle apply(MethodCreator methodCreator, String configObjectClassName) {
+            // Arc.container().instance(configObjectClassName, SpringBootConfigProperties.Literal.class).get():
+            ResultHandle containerHandle = methodCreator
+                    .invokeStaticMethod(MethodDescriptor.ofMethod(Arc.class, "container", ArcContainer.class));
+            ResultHandle qualifiersHandle = methodCreator.newArray(Annotation.class, 1);
+            ResultHandle qualifierInstanceHandle = methodCreator.readStaticField(FieldDescriptor
+                    .of(SpringBootConfigProperties.Literal.class, "INSTANCE", SpringBootConfigProperties.Literal.class));
+            methodCreator.writeArrayValue(qualifiersHandle, 0, qualifierInstanceHandle);
+            ResultHandle instanceHandle = methodCreator.invokeInterfaceMethod(
+                    MethodDescriptor.ofMethod(ArcContainer.class, "instance", InstanceHandle.class, Class.class,
+                            Annotation[].class),
+                    containerHandle, methodCreator.loadClassFromTCCL(configObjectClassName),
+                    qualifiersHandle);
+            return methodCreator
+                    .invokeInterfaceMethod(MethodDescriptor.ofMethod(InstanceHandle.class, "get", Object.class),
+                            instanceHandle);
+        }
     }
 }

--- a/extensions/spring-boot-properties/runtime/pom.xml
+++ b/extensions/spring-boot-properties/runtime/pom.xml
@@ -39,6 +39,19 @@
                     </excludedArtifacts>
                 </configuration>
             </plugin>
+            <!--- @SpringBootConfigProperties needs to be part of the index -->
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/extensions/spring-boot-properties/runtime/src/main/java/io/quarkus/spring/boot/properties/runtime/SpringBootConfigProperties.java
+++ b/extensions/spring-boot-properties/runtime/src/main/java/io/quarkus/spring/boot/properties/runtime/SpringBootConfigProperties.java
@@ -1,0 +1,25 @@
+package io.quarkus.spring.boot.properties.runtime;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+/**
+ * This annotation is added as a qualifier to bean producer methods that produce @ConfigProperties beans
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SpringBootConfigProperties {
+
+    final class Literal extends AnnotationLiteral<SpringBootConfigProperties> implements SpringBootConfigProperties {
+
+        // used im generated code
+        @SuppressWarnings("unused")
+        public static final Literal INSTANCE = new Literal();
+
+        private static final long serialVersionUID = 1L;
+
+    }
+}

--- a/integration-tests/spring-boot-properties/pom.xml
+++ b/integration-tests/spring-boot-properties/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -54,6 +58,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-boot-properties-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/BeanProperties.java
+++ b/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/BeanProperties.java
@@ -2,9 +2,21 @@ package io.quarkus.it.spring.boot;
 
 public final class BeanProperties {
 
+    private final String finalValue;
+
+    int packagePrivateValue;
+
     private int value;
 
     private InnerClass innerClass;
+
+    public BeanProperties(String finalValue) {
+        this.finalValue = finalValue;
+    }
+
+    public String getFinalValue() {
+        return finalValue;
+    }
 
     public int getValue() {
         return value;

--- a/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/BeanPropertiesResource.java
+++ b/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/BeanPropertiesResource.java
@@ -16,6 +16,18 @@ public class BeanPropertiesResource {
         return properties.getValue();
     }
 
+    @Path("/finalValue")
+    @GET
+    public String getFinalValue() {
+        return properties.getFinalValue();
+    }
+
+    @Path("/packagePrivateValue")
+    @GET
+    public int getPackagePrivateValue() {
+        return properties.packagePrivateValue;
+    }
+
     @Path("/innerClass/value")
     @GET
     public String getInnerClassValue() {

--- a/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/SampleApplication.java
+++ b/integration-tests/spring-boot-properties/src/main/java/io/quarkus/it/spring/boot/SampleApplication.java
@@ -1,11 +1,17 @@
 package io.quarkus.it.spring.boot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class SampleApplication {
 
+    @Bean
     @ConfigurationProperties
     public BeanProperties beanProperties() {
-        return new BeanProperties();
+        BeanProperties result = new BeanProperties("final");
+        result.packagePrivateValue = 100;
+        return result;
     }
 }

--- a/integration-tests/spring-boot-properties/src/test/java/io/quarkus/it/spring/boot/BeanPropertiesTest.java
+++ b/integration-tests/spring-boot-properties/src/test/java/io/quarkus/it/spring/boot/BeanPropertiesTest.java
@@ -12,6 +12,20 @@ import io.quarkus.test.junit.QuarkusTest;
 class BeanPropertiesTest {
 
     @Test
+    void shouldHaveFinalValue() {
+        when().get("/bean/finalValue")
+                .then()
+                .body(is(equalTo("final")));
+    }
+
+    @Test
+    void shouldHavePackagePrivateValue() {
+        when().get("/bean/packagePrivateValue")
+                .then()
+                .body(is(equalTo("100")));
+    }
+
+    @Test
     void shouldHaveValue() {
         when().get("/bean/value")
                 .then()


### PR DESCRIPTION
Fixes: #26610

N.B: This is a breaking change because previously:

* We allowed the use of `@ConfigProperties` on non-producer methods
* We did not take into account the `ignoreUnknownFields` (which is `true` by default) and always failed when a field could not be written