### PR TITLE
Qute - fix origin of an expression used as a section param

### DIFF
--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionBlock.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionBlock.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -180,9 +179,9 @@ public final class SectionBlock implements WithOrigin, ErrorInitializer {
         }
     }
 
-    static SectionBlock.Builder builder(String id, Function<String, Expression> expressionFunc,
+    static SectionBlock.Builder builder(String id, Parser parser,
             ErrorInitializer errorInitializer) {
-        return new Builder(id, expressionFunc, errorInitializer).setLabel(id);
+        return new Builder(id, parser, errorInitializer).setLabel(id);
     }
 
     static class Builder implements BlockInfo {
@@ -193,14 +192,13 @@ public final class SectionBlock implements WithOrigin, ErrorInitializer {
         private Map<String, String> parameters;
         private final List<TemplateNode> nodes;
         private Map<String, Expression> expressions;
-        private final Function<String, Expression> expressionFun;
+        private final Parser parser;
         private final ErrorInitializer errorInitializer;
 
-        public Builder(String id, Function<String, Expression> expressionFun,
-                ErrorInitializer errorInitializer) {
+        public Builder(String id, Parser parser, ErrorInitializer errorInitializer) {
             this.id = id;
             this.nodes = new ArrayList<>();
-            this.expressionFun = expressionFun;
+            this.parser = parser;
             this.errorInitializer = errorInitializer;
         }
 
@@ -229,7 +227,7 @@ public final class SectionBlock implements WithOrigin, ErrorInitializer {
 
         @Override
         public Expression addExpression(String param, String value) {
-            Expression expression = expressionFun.apply(value);
+            Expression expression = parser.createSectionBlockExpression(this, value);
             if (expressions == null) {
                 expressions = new LinkedHashMap<>();
             }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionHelperFactory.java
@@ -140,6 +140,8 @@ public interface SectionHelperFactory<T extends SectionHelper> {
          * Parse and register an expression for the specified parameter.
          * <p>
          * A registered expression contributes to the {@link Template#getExpressions()}, i.e. can be validated at build time.
+         * <p>
+         * The origin of the returned expression is the origin of the containing block.
          *
          * @param param
          * @param value

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/SectionNode.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import org.jboss.logging.Logger;
 
@@ -18,9 +17,9 @@ class SectionNode implements TemplateNode {
 
     private static final Logger LOG = Logger.getLogger("io.quarkus.qute.nodeResolve");
 
-    static Builder builder(String helperName, Origin origin, Function<String, Expression> expressionFun,
+    static Builder builder(String helperName, Origin origin, Parser parser,
             ErrorInitializer errorFun) {
-        return new Builder(helperName, origin, expressionFun, errorFun);
+        return new Builder(helperName, origin, parser, errorFun);
     }
 
     final String name;
@@ -110,15 +109,14 @@ class SectionNode implements TemplateNode {
         private EngineImpl engine;
         private final ErrorInitializer errorInitializer;
 
-        Builder(String helperName, Origin origin, Function<String, Expression> expressionFun,
-                ErrorInitializer errorInitializer) {
+        Builder(String helperName, Origin origin, Parser parser, ErrorInitializer errorInitializer) {
             this.helperName = helperName;
             this.origin = origin;
             this.blocks = new ArrayList<>();
             this.errorInitializer = errorInitializer;
             // The main block is always present
             addBlock(SectionBlock
-                    .builder(SectionHelperFactory.MAIN_BLOCK_NAME, expressionFun, errorInitializer)
+                    .builder(SectionHelperFactory.MAIN_BLOCK_NAME, parser, errorInitializer)
                     .setOrigin(origin));
         }
 

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/IfSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/IfSectionTest.java
@@ -240,6 +240,25 @@ public class IfSectionTest {
                         .data("user", "Stef", "target", new Target(ContentStatus.NEW)).render());
     }
 
+    @Test
+    public void testParameterOrigin() {
+        Engine engine = Engine.builder().addDefaults().build();
+        Template template = engine.parse("  {#if item.price > 1}{/if}");
+        List<Expression> expressions = template.getExpressions();
+        assertEquals(2, expressions.size());
+        for (Expression expression : expressions) {
+            if (expression.isLiteral()) {
+                assertEquals(1, expression.getLiteralValue().getNow(false));
+                assertEquals(1, expression.getOrigin().getLine());
+                assertEquals(3, expression.getOrigin().getLineCharacterStart());
+            } else {
+                assertEquals("item.price", expression.toOriginalString());
+                assertEquals(1, expression.getOrigin().getLine());
+                assertEquals(3, expression.getOrigin().getLineCharacterStart());
+            }
+        }
+    }
+
     public static class Target {
 
         public ContentStatus status;

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/ParserTest.java
@@ -157,7 +157,7 @@ public class ParserTest {
                 + "{/}");
         Origin fooItemsOrigin = find(template.getExpressions(), "foo.items").getOrigin();
         assertEquals(6, fooItemsOrigin.getLine());
-        assertEquals(14, fooItemsOrigin.getLineCharacterStart());
+        assertEquals(1, fooItemsOrigin.getLineCharacterStart());
         assertEquals(24, fooItemsOrigin.getLineCharacterEnd());
         Origin itemNameOrigin = find(template.getExpressions(), "item.name").getOrigin();
         assertEquals(8, itemNameOrigin.getLine());

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/SetSectionTest.java
@@ -2,6 +2,7 @@ package io.quarkus.qute;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class SetSectionTest {
@@ -39,6 +40,25 @@ public class SetSectionTest {
         assertEquals("2", engine.parse("{#let foo?=1}{foo}{/let}").data("foo", 2).render());
         assertEquals("true::1::no", engine.parse("{#set foo?=true bar=1 baz?='yes'}{foo}::{bar}::{baz}{/set}")
                 .data("bar", "42", "baz", "no").render());
+    }
+
+    @Test
+    public void testParameterOrigin() {
+        Engine engine = Engine.builder().addDefaults().build();
+        Template template = engine.parse("  {#let item=1 foo=bar}{/let}");
+        List<Expression> expressions = template.getExpressions();
+        assertEquals(2, expressions.size());
+        for (Expression expression : expressions) {
+            if (expression.isLiteral()) {
+                assertEquals(1, expression.getLiteralValue().getNow(false));
+                assertEquals(1, expression.getOrigin().getLine());
+                assertEquals(3, expression.getOrigin().getLineCharacterStart());
+            } else {
+                assertEquals("bar", expression.toOriginalString());
+                assertEquals(1, expression.getOrigin().getLine());
+                assertEquals(3, expression.getOrigin().getLineCharacterStart());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
- there is no easy way to reliably identify the column of an expression
used as a section param, therefore, we'll report the column of the
containing section/block for the moment
- related to #26479