### PR TITLE
Improve container image repository checks for some dev services

### DIFF
--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
@@ -29,6 +29,7 @@ public class ApicurioRegistryDevServicesBuildTimeConfig {
     /**
      * The Apicurio Registry image to use.
      * Note that only Apicurio Registry 2.x images are supported.
+     * Specifically, the image repository must end with {@code apicurio/apicurio-registry-mem}.
      */
     @ConfigItem(defaultValue = "quay.io/apicurio/apicurio-registry-mem:2.2.3.Final")
     public String imageName;

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -259,7 +259,7 @@ public class DevServicesApicurioRegistryProcessor {
                 withLabel(DEV_SERVICE_LABEL, serviceName);
             }
             withEnv("QUARKUS_PROFILE", "prod");
-            if (!dockerImageName.getRepository().equals("apicurio/apicurio-registry-mem")) {
+            if (!dockerImageName.getRepository().endsWith("apicurio/apicurio-registry-mem")) {
                 throw new IllegalArgumentException("Only apicurio/apicurio-registry-mem images are supported");
             }
         }

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesBuildTimeConfig.java
@@ -27,7 +27,8 @@ public class AmqpDevServicesBuildTimeConfig {
 
     /**
      * The image to use.
-     * Note that only {@code quay.io/artemiscloud/activemq-artemis-broker} images are supported.
+     * Note that only ActiveMQ Artemis images are supported.
+     * Specifically, the image repository must end with {@code artemiscloud/activemq-artemis-broker}.
      *
      * Check https://quay.io/repository/artemiscloud/activemq-artemis-broker to find the available versions.
      */

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -282,7 +282,7 @@ public class AmqpDevServicesProcessor {
             if (serviceName != null) { // Only adds the label in dev mode.
                 withLabel(DEV_SERVICE_LABEL, serviceName);
             }
-            if (dockerImageName.getRepository().equals("artemiscloud/activemq-artemis-broker")) {
+            if (dockerImageName.getRepository().endsWith("artemiscloud/activemq-artemis-broker")) {
                 waitingFor(Wait.forLogMessage(".*AMQ241004.*", 1)); // Artemis console available.
             } else {
                 throw new IllegalArgumentException("Only artemiscloud/activemq-artemis-broker images are supported");

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesBuildTimeConfig.java
@@ -122,6 +122,8 @@ public class RabbitMQDevServicesBuildTimeConfig {
 
     /**
      * The image to use.
+     * Note that only official RabbitMQ images are supported.
+     * Specifically, the image repository must end with {@code rabbitmq}.
      */
     @ConfigItem(defaultValue = "rabbitmq:3.9-management")
     public String imageName;

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -374,7 +374,7 @@ public class RabbitMQDevServicesProcessor {
             if (serviceName != null) { // Only adds the label in dev mode.
                 withLabel(DEV_SERVICE_LABEL, serviceName);
             }
-            if (!dockerImageName.getRepository().equals("rabbitmq")) {
+            if (!dockerImageName.getRepository().endsWith("rabbitmq")) {
                 throw new IllegalArgumentException("Only official rabbitmq images are supported");
             }
         }


### PR DESCRIPTION
This commit improves container image name checks for these dev services:

- Apicurio Registry
- ActiveMQ Artemis (AMQP)
- RabbitMQ

These dev services used to verify that the image repository is equal
to a hard-coded string. This commit changes that to verify that
the image repository _ends with_ the same hard-coded string, which
allows for repository namespacing in private container registries.

Fixes https://github.com/quarkusio/quarkus/issues/24308