### PR TITLE
Support resolving platform catalog for any known stream

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/GACTV.java
@@ -39,7 +39,7 @@ public class GACTV implements ArtifactCoords, Serializable {
     protected GACTV(String[] parts) {
         groupId = parts[0];
         artifactId = parts[1];
-        classifier = parts[2];
+        classifier = parts[2] == null ? DEFAULT_CLASSIFIER : parts[2];
         type = parts[3] == null ? TYPE_JAR : parts[3];
         version = parts[4];
     }
@@ -54,17 +54,17 @@ public class GACTV implements ArtifactCoords, Serializable {
     }
 
     public GACTV(String groupId, String artifactId, String version) {
-        this(groupId, artifactId, "", TYPE_JAR, version);
+        this(groupId, artifactId, DEFAULT_CLASSIFIER, TYPE_JAR, version);
     }
 
     public GACTV(String groupId, String artifactId, String type, String version) {
-        this(groupId, artifactId, "", type, version);
+        this(groupId, artifactId, DEFAULT_CLASSIFIER, type, version);
     }
 
     public GACTV(String groupId, String artifactId, String classifier, String type, String version) {
         this.groupId = groupId;
         this.artifactId = artifactId;
-        this.classifier = classifier == null ? "" : classifier;
+        this.classifier = classifier == null ? DEFAULT_CLASSIFIER : classifier;
         this.type = type == null ? TYPE_JAR : type;
         this.version = version;
     }

--- a/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactCoords.java
+++ b/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactCoords.java
@@ -34,7 +34,7 @@ public class ArtifactCoords implements io.quarkus.maven.dependency.ArtifactCoord
     protected ArtifactCoords(String[] parts) {
         groupId = parts[0];
         artifactId = parts[1];
-        classifier = parts[2];
+        classifier = parts[2] == null ? DEFAULT_CLASSIFIER : parts[2];
         type = parts[3] == null ? TYPE_JAR : parts[3];
         version = parts[4];
     }
@@ -49,17 +49,17 @@ public class ArtifactCoords implements io.quarkus.maven.dependency.ArtifactCoord
     }
 
     public ArtifactCoords(String groupId, String artifactId, String version) {
-        this(groupId, artifactId, "", TYPE_JAR, version);
+        this(groupId, artifactId, DEFAULT_CLASSIFIER, TYPE_JAR, version);
     }
 
     public ArtifactCoords(String groupId, String artifactId, String type, String version) {
-        this(groupId, artifactId, "", type, version);
+        this(groupId, artifactId, DEFAULT_CLASSIFIER, type, version);
     }
 
     public ArtifactCoords(String groupId, String artifactId, String classifier, String type, String version) {
         this.groupId = groupId;
         this.artifactId = artifactId;
-        this.classifier = classifier == null ? "" : classifier;
+        this.classifier = classifier == null ? DEFAULT_CLASSIFIER : classifier;
         this.type = type == null ? TYPE_JAR : type;
         this.version = version;
     }

--- a/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
+++ b/independent-projects/tools/artifact-api/src/main/java/io/quarkus/maven/ArtifactKey.java
@@ -24,7 +24,7 @@ public class ArtifactKey implements io.quarkus.maven.dependency.ArtifactKey, Ser
             this.classifier = parts[2];
         }
         if (parts.length <= 3 || parts[3] == null) {
-            this.type = "jar";
+            this.type = ArtifactCoords.TYPE_JAR;
         } else {
             this.type = parts[3];
         }

--- a/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ArchivedStreamTest.java
+++ b/independent-projects/tools/devtools-testing/src/test/java/io/quarkus/devtools/project/create/ArchivedStreamTest.java
@@ -1,0 +1,61 @@
+package io.quarkus.devtools.project.create;
+
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.catalog.PlatformStreamCoords;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ArchivedStreamTest extends MultiplePlatformBomsTestBase {
+
+    private static final String PLATFORM_KEY = "io.test.platform";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        TestRegistryClientBuilder.newInstance()
+                //.debug()
+                .baseDir(configDir())
+                // registry
+                .newRegistry("registry.test.io")
+                // platform key
+                .newPlatform(PLATFORM_KEY)
+                .newStream("1.0")
+                // 1.0.4 release
+                .newRelease("1.1.1")
+                .quarkusVersion("1.1.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom").addExtension("ext-a").release()
+                .stream().platform()
+                .newArchivedStream("0.5")
+                .newArchivedRelease("0.5.1")
+                .quarkusVersion("0.5.1")
+                // default bom including quarkus-core + essential metadata
+                .addCoreMember().release()
+                // foo platform member
+                .newMember("acme-a-bom").addExtension("ext-a").release()
+                .registry()
+                .clientBuilder()
+                .build();
+
+        enableRegistryClient();
+    }
+
+    protected String getMainPlatformKey() {
+        return PLATFORM_KEY;
+    }
+
+    @Test
+    public void createUsingStream2_0() throws Exception {
+        final Path projectDir = newProjectDir("created-using-archive-stream-0.5");
+        createProject(projectDir, new PlatformStreamCoords(null, "0.5"), List.of("ext-a"));
+
+        assertModel(projectDir,
+                List.of(mainPlatformBom(), platformMemberBomCoords("acme-a-bom")),
+                List.of(new ArtifactCoords("io.test.platform", "ext-a", null)),
+                "0.5.1");
+    }
+}

--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/Constants.java
@@ -15,6 +15,8 @@ public interface Constants {
     String PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX = "-quarkus-platform-descriptor";
     String PLATFORM_PROPERTIES_ARTIFACT_ID_SUFFIX = "-quarkus-platform-properties";
 
+    String QUARKUS_VERSION_CLASSIFIER_ALL = "all";
+
     String JSON = "json";
 
     String LAST_UPDATED = "last-updated";


### PR DESCRIPTION
This change will allow `quarkus create -S 2.4` even if `2.4` isn't currently a recommended stream according to the registry.

Related PR for the registry https://github.com/quarkusio/registry.quarkus.io/pull/115