### PR TITLE
Update 'getting started' documentation for 'quarkus-maven-plugin' version following Quarkus example

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -113,7 +113,7 @@ In addition, you can see the `quarkus-maven-plugin` responsible of the packaging
         <plugin>
             <groupId>${quarkus.platform.group-id}</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus-plugin.version}</version>
+            <version>${quarkus.platform.version}</version>
             <extensions>true</extensions>
             <executions>
                 <execution>


### PR DESCRIPTION
Update 'getting started' documentation for 'quarkus-maven-plugin' version following Quarkus example : 
https://github.com/quarkusio/quarkus-quickstarts/blob/06852dcf5e46c76185ee20cf41e491c466531653/getting-started/pom.xml#L69