### PR TITLE
Fix OidcClient duplicating the client_id for the public client

### DIFF
--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -109,7 +109,7 @@ public class OidcClientImpl implements OidcClient {
                         body.add(OidcConstants.CLIENT_ASSERTION, jwt);
                     }
                 } else if (!OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
-                    body.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
+                    body = copyMultiMap(body).set(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
                 }
                 if (!additionalGrantParameters.isEmpty()) {
                     body = copyMultiMap(body);

--- a/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
+++ b/integration-tests/oidc-client-wiremock/src/main/java/io/quarkus/it/keycloak/FrontendResource.java
@@ -63,4 +63,11 @@ public class FrontendResource {
         return clients.getClient("refresh").refreshTokens(refreshToken)
                 .onItem().transform(t -> t.getAccessToken());
     }
+
+    @GET
+    @Path("password-grant-public-client")
+    @Produces("text/plain")
+    public Uni<String> passwordGrantPublicClient() {
+        return clients.getClient("password-grant-public-client").getTokens().onItem().transform(t -> t.getAccessToken());
+    }
 }

--- a/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-client-wiremock/src/main/resources/application.properties
@@ -7,6 +7,12 @@ quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=alice
 quarkus.oidc-client.grant-options.password.password=alice
 
+quarkus.oidc-client.password-grant-public-client.token-path=${keycloak.url}/tokens_public_client
+quarkus.oidc-client.password-grant-public-client.client-id=quarkus-app
+quarkus.oidc-client.password-grant-public-client.grant.type=password
+quarkus.oidc-client.password-grant-public-client.grant-options.password.username=alice
+quarkus.oidc-client.password-grant-public-client.grant-options.password.password=alice
+
 quarkus.oidc-client.non-standard-response.token-path=${keycloak.url}/non-standard-tokens
 quarkus.oidc-client.non-standard-response.client-id=quarkus-app
 quarkus.oidc-client.non-standard-response.credentials.secret=secret

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/KeycloakRealmResourceManager.java
@@ -35,6 +35,13 @@ public class KeycloakRealmResourceManager implements QuarkusTestResourceLifecycl
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                         .withBody(
                                 "{\"access_token\":\"access_token_1\", \"expires_in\":4, \"refresh_token\":\"refresh_token_1\"}")));
+        server.stubFor(WireMock.post("/tokens_public_client")
+                .withRequestBody(matching("grant_type=password&username=alice&password=alice&client_id=quarkus-app"))
+                .willReturn(WireMock
+                        .aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                        .withBody(
+                                "{\"access_token\":\"access_token_public_client\", \"expires_in\":20}")));
         server.stubFor(WireMock.post("/non-standard-tokens")
                 .withHeader("X-Custom", matching("XCustomHeaderValue"))
                 .withRequestBody(matching("grant_type=password&username=alice&password=alice&extra_param=extra_param_value"))

--- a/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
+++ b/integration-tests/oidc-client-wiremock/src/test/java/io/quarkus/it/keycloak/OidcClientTest.java
@@ -77,6 +77,18 @@ public class OidcClientTest {
     }
 
     @Test
+    public void testEchoTokensPasswordGrantPublicClient() {
+        RestAssured.when().get("/frontend/password-grant-public-client")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_public_client"));
+        RestAssured.when().get("/frontend/password-grant-public-client")
+                .then()
+                .statusCode(200)
+                .body(equalTo("access_token_public_client"));
+    }
+
+    @Test
     public void testEchoTokensNonStandardResponse() {
         RestAssured.when().get("/frontend/echoTokenNonStandardResponse")
                 .then()


### PR DESCRIPTION
Fixes #26619.

`OidcClient` has a cached `MultiMap` which keeps some properties which are reused across multiple token requests (ex, it has a client id and secret set if the client post authentication is required, and scopes) - but if the public client is used to request a token then the same client id is added to the same `MultiMap`. 

So this PR does a minor update, copies the map to have a request specific map if the client is public (as it does in other cases) and it fixes the problem, the test has been added.