### PR TITLE
Fix CustomDirective for smallrye-graphql

### DIFF
--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -75,6 +75,7 @@ import io.smallrye.graphql.cdi.producer.GraphQLProducer;
 import io.smallrye.graphql.schema.Annotations;
 import io.smallrye.graphql.schema.SchemaBuilder;
 import io.smallrye.graphql.schema.model.Argument;
+import io.smallrye.graphql.schema.model.DirectiveType;
 import io.smallrye.graphql.schema.model.Field;
 import io.smallrye.graphql.schema.model.Group;
 import io.smallrye.graphql.schema.model.InputType;
@@ -403,6 +404,7 @@ public class SmallRyeGraphQLProcessor {
         classes.addAll(getTypeClassNames(schema.getTypes().values()));
         classes.addAll(getInputClassNames(schema.getInputs().values()));
         classes.addAll(getInterfaceClassNames(schema.getInterfaces().values()));
+        classes.addAll(getDirectiveTypeClassNames(schema.getDirectiveTypes()));
 
         return classes.toArray(String[]::new);
     }
@@ -456,6 +458,16 @@ public class SmallRyeGraphQLProcessor {
         for (Type complexGraphQLType : complexGraphQLTypes) {
             classes.add(complexGraphQLType.getClassName());
             classes.addAll(getFieldClassNames(complexGraphQLType.getFields()));
+        }
+        return classes;
+    }
+
+    private Set<String> getDirectiveTypeClassNames(Collection<DirectiveType> complexGraphQLDirectiveTypes) {
+        Set<String> classes = new HashSet<>();
+        for (DirectiveType complexGraphQLDirectiveType : complexGraphQLDirectiveTypes) {
+            if (complexGraphQLDirectiveType.getClassName() != null) {
+                classes.add(complexGraphQLDirectiveType.getClassName());
+            }
         }
         return classes;
     }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CustomDirective.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/CustomDirective.java
@@ -1,0 +1,18 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.NonNull;
+
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.DirectiveLocation;
+
+@Directive(on = { DirectiveLocation.OBJECT, DirectiveLocation.INTERFACE, DirectiveLocation.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+@Description("test-description")
+public @interface CustomDirective {
+    @NonNull
+    String[] fields();
+}

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/GraphQLTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.smallrye.graphql.deployment;
 
-import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.MEDIATYPE_JSON;
-
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +28,7 @@ public class GraphQLTest extends AbstractGraphQLTest {
     static QuarkusUnitTest test = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(TestResource.class, TestPojo.class, TestRandom.class, TestGenericsPojo.class,
-                            BusinessException.class)
+                            CustomDirective.class, BusinessException.class)
                     .addAsResource(new StringAsset(getPropertyAsString(configuration())), "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 
@@ -51,6 +49,8 @@ public class GraphQLTest extends AbstractGraphQLTest {
         Assertions.assertTrue(body.contains("type TestGenericsPojo_String {"));
         Assertions.assertTrue(body.contains("enum SomeEnum {"));
         Assertions.assertTrue(body.contains("enum Number {"));
+        Assertions.assertTrue(body.contains("type TestPojo @customDirective(fields : [\"test-pojo\"])"));
+        Assertions.assertTrue(body.contains("message: String @customDirective(fields : [\"message\"])"));
     }
 
     @Test
@@ -253,6 +253,7 @@ public class GraphQLTest extends AbstractGraphQLTest {
     private static Map<String, String> configuration() {
         Map<String, String> m = new HashMap<>();
         m.put("quarkus.smallrye-graphql.events.enabled", "true");
+        m.put("quarkus.smallrye-graphql.schema-include-directives", "true");
         return m;
     }
 }

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/HotReloadTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/HotReloadTest.java
@@ -23,7 +23,7 @@ public class HotReloadTest extends AbstractGraphQLTest {
     final static QuarkusDevModeTest TEST = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(TestResource.class, TestPojo.class, TestRandom.class, TestGenericsPojo.class,
-                            BusinessException.class)
+                            CustomDirective.class, BusinessException.class)
                     .addAsResource(new StringAsset(getPropertyAsString()), "application.properties")
                     .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
 

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestPojo.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/TestPojo.java
@@ -6,7 +6,9 @@ import java.util.List;
 /**
  * Just a test pojo
  */
+@CustomDirective(fields = "test-pojo")
 public class TestPojo {
+    @CustomDirective(fields = "message")
     private String message;
     private List<String> list = Arrays.asList("a", "b", "c");
 


### PR DESCRIPTION
Fix for #20802.
@jmartisk fixed the UnsupportedOperationException in io.smallrye.graphql.schema.model.DirectiveType, so there was only a small change needed.

With the bean validation directives, there already seems to be a directive there without a class name, which causes problems.
```
DirectiveType(, name='constraint', description='Indicates a Bean Validation constraint', ...
```
@jmartisk Could you have a look at the changes in extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java if this is ok?