### PR TITLE
Rename DependecyGraph to DependencyGraph in extensions/arc/deployment

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/ArcDevConsoleProcessor.java
@@ -18,7 +18,7 @@ import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.CompletedApplicationClassPredicateBuildItem;
 import io.quarkus.arc.deployment.CustomScopeAnnotationsBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
-import io.quarkus.arc.deployment.devconsole.DependecyGraph.Link;
+import io.quarkus.arc.deployment.devconsole.DependencyGraph.Link;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.BeanDeploymentValidator;
 import io.quarkus.arc.processor.BeanDeploymentValidator.ValidationContext;
@@ -153,7 +153,7 @@ public class ArcDevConsoleProcessor {
         return false;
     }
 
-    DependecyGraph buildDependencyGraph(BeanInfo bean, ValidationContext validationContext, BeanResolver resolver,
+    DependencyGraph buildDependencyGraph(BeanInfo bean, ValidationContext validationContext, BeanResolver resolver,
             DevBeanInfos devBeanInfos) {
         Set<DevBeanInfo> nodes = new HashSet<>();
         Collection<BeanInfo> beans = validationContext.get(BuildExtension.Key.BEANS);
@@ -162,7 +162,7 @@ public class ArcDevConsoleProcessor {
                 .collect(Collectors.groupingBy(BeanInfo::getDeclaringBean));
         addNodesDependencies(bean, nodes, links, bean, devBeanInfos);
         addNodesDependents(bean, nodes, links, bean, beans, declaringToProducers, resolver, devBeanInfos);
-        return new DependecyGraph(nodes, links);
+        return new DependencyGraph(nodes, links);
     }
 
     void addNodesDependencies(BeanInfo root, Set<DevBeanInfo> nodes, Set<Link> links, BeanInfo bean,

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DependencyGraph.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DependencyGraph.java
@@ -3,12 +3,12 @@ package io.quarkus.arc.deployment.devconsole;
 import java.util.Objects;
 import java.util.Set;
 
-public class DependecyGraph {
+public class DependencyGraph {
 
     public final Set<DevBeanInfo> nodes;
     public final Set<Link> links;
 
-    public DependecyGraph(Set<DevBeanInfo> nodes, Set<Link> links) {
+    public DependencyGraph(Set<DevBeanInfo> nodes, Set<Link> links) {
         this.nodes = nodes;
         this.links = links;
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DevBeanInfos.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DevBeanInfos.java
@@ -15,7 +15,7 @@ public class DevBeanInfos {
     private final List<DevInterceptorInfo> removedInterceptors;
     private final List<DevDecoratorInfo> decorators;
     private final List<DevDecoratorInfo> removedDecorators;
-    private final Map<String, DependecyGraph> dependencyGraphs;
+    private final Map<String, DependencyGraph> dependencyGraphs;
 
     public DevBeanInfos() {
         beans = new ArrayList<>();
@@ -74,7 +74,7 @@ public class DevBeanInfos {
         return null;
     }
 
-    public DependecyGraph getDependencyGraph(String beanId) {
+    public DependencyGraph getDependencyGraph(String beanId) {
         return dependencyGraphs.get(beanId);
     }
 
@@ -110,7 +110,7 @@ public class DevBeanInfos {
         removedDecorators.add(decorator);
     }
 
-    void addDependencyGraph(String beanId, DependecyGraph graph) {
+    void addDependencyGraph(String beanId, DependencyGraph graph) {
         dependencyGraphs.put(beanId, graph);
     }
 


### PR DESCRIPTION
Maybe the creator of this class, @mkouba, should do the review because I do not know if the rename has impacts outside the quarkusio/quarkus project.