### PR TITLE
Clear outer instances when init test state is called

### DIFF
--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.TestInfo;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
- * The purpose of this test is simply to ensure that {@link SimpleAnnotationCheckerBeforeEachCallback}
+ * The purpose of this test is simply to ensure that {@link TestContextCheckerBeforeEachCallback}
  * can read {@code @TestAnnotation} without issue.
  * Also checks that {@link SimpleAnnotationCheckerBeforeClassCallback} is executed properly
  */
@@ -69,7 +69,7 @@ public class QuarkusTestCallbacksTestCase {
     @TestAnnotation
     @Order(1)
     public void testTestMethodHasAnnotation() {
-        assertTrue(SimpleAnnotationCheckerBeforeEachCallback.testAnnotationChecked);
+        assertTrue(TestContextCheckerBeforeEachCallback.testAnnotationChecked);
     }
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedTestCase.java
@@ -59,6 +59,7 @@ public class QuarkusTestNestedTestCase {
         assertEquals(0, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
         assertEquals(0, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
         assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        assertEquals(0, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size(), "Found unexpected outer instances");
     }
 
     @Nested
@@ -94,6 +95,18 @@ public class QuarkusTestNestedTestCase {
         }
 
         @Test
+        @Order(3)
+        void testOuterInstancesInBeforeEach() {
+            assertEquals(1, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size());
+        }
+
+        @Test
+        @Order(4)
+        void testOuterInstancesInAfterEach() {
+            assertEquals(1, TestContextCheckerAfterEachCallback.OUTER_INSTANCES.size());
+        }
+
+        @Test
         void testInnerAndOuterValues() {
             assertEquals(EXPECTED_INNER_VALUE, innerValue);
             assertEquals(EXPECTED_OUTER_VALUE, outerValue);
@@ -122,7 +135,6 @@ public class QuarkusTestNestedTestCase {
             @Test
             @Order(1)
             void testOne() {
-                // assertEquals(1, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
                 assertEquals(1, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
             }
 
@@ -133,6 +145,24 @@ public class QuarkusTestNestedTestCase {
                 assertEquals(EXPECTED_INNER_VALUE, innerValue);
                 assertEquals(EXPECTED_OUTER_VALUE, outerValue);
                 assertEquals(EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE, secondLevelInnerValue);
+            }
+
+            @Test
+            @Order(3)
+            void testOuterInstancesInBeforeEach() {
+                assertEquals(2, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size());
+            }
+
+            @Test
+            @Order(4)
+            void testOuterInstancesInAfterEach() {
+                assertEquals(2, TestContextCheckerAfterEachCallback.OUTER_INSTANCES.size());
+            }
+
+            @Test
+            @Order(5)
+            void testOuterInstancesInAfterAll() {
+                assertEquals(1, TestContextCheckerAfterAllCallback.OUTER_INSTANCES.size());
             }
         }
     }
@@ -185,9 +215,9 @@ public class QuarkusTestNestedTestCase {
     @AfterAll
     static void afterAll() {
         assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
-        assertEquals(15, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(25, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
         assertEquals(4, COUNT_TEST.get(), "COUNT_TEST");
-        assertEquals(15, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(25, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
         assertEquals(0, COUNT_AFTER_ALL.getAndIncrement(), "COUNT_AFTER_ALL");
     }
 }

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerAfterAllCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerAfterAllCallback.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.main;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback;
+import io.quarkus.test.junit.callback.QuarkusTestContext;
+
+public class TestContextCheckerAfterAllCallback implements QuarkusTestAfterAllCallback {
+
+    public static final List<Object> OUTER_INSTANCES = new ArrayList<>();
+
+    @Override
+    public void afterAll(QuarkusTestContext context) {
+        OUTER_INSTANCES.clear();
+        OUTER_INSTANCES.addAll(context.getOuterInstances());
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerAfterEachCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerAfterEachCallback.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.main;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+public class TestContextCheckerAfterEachCallback implements QuarkusTestAfterEachCallback {
+
+    public static final List<Object> OUTER_INSTANCES = new ArrayList<>();
+
+    @Override
+    public void afterEach(QuarkusTestMethodContext context) {
+        OUTER_INSTANCES.clear();
+        OUTER_INSTANCES.addAll(context.getOuterInstances());
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
@@ -1,17 +1,23 @@
 package io.quarkus.it.main;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 
-public class SimpleAnnotationCheckerBeforeEachCallback implements QuarkusTestBeforeEachCallback {
+public class TestContextCheckerBeforeEachCallback implements QuarkusTestBeforeEachCallback {
 
+    public static final List<Object> OUTER_INSTANCES = new ArrayList<>();
     static boolean testAnnotationChecked;
 
     @Override
     public void beforeEach(QuarkusTestMethodContext context) {
-        // make sure that this comes into play only for the test we care about
+        OUTER_INSTANCES.clear();
+        OUTER_INSTANCES.addAll(context.getOuterInstances());
+
+        // continue only if this comes into play only for the test we care about
 
         Method testMethod = context.getTestMethod();
         if (!testMethod.getDeclaringClass().getName().endsWith("QuarkusTestCallbacksTestCase")) {

--- a/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback
+++ b/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback
@@ -1,0 +1,1 @@
+io.quarkus.it.main.TestContextCheckerAfterAllCallback

--- a/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
+++ b/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback
@@ -1,0 +1,1 @@
+io.quarkus.it.main.TestContextCheckerAfterEachCallback

--- a/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
+++ b/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback
@@ -1,1 +1,1 @@
-io.quarkus.it.main.SimpleAnnotationCheckerBeforeEachCallback
+io.quarkus.it.main.TestContextCheckerBeforeEachCallback

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -776,6 +776,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     outerInstances.add(outerInstance);
                 }
             } else {
+                outerInstances.clear();
                 actualTestInstance = runningQuarkusApplication.instance(actualTestClass);
             }
 


### PR DESCRIPTION
The init test state is called several times depending whether JUnit 5 is configured with the lifecycle method based or class based. 

Clearing out the outer instances every time the main class is initialized, ensure that the outer instances are always up to date.