### PR TITLE
Disable dev services for default connection in Named*MongoClientConfigTest

### DIFF
--- a/extensions/mongodb-client/deployment/src/test/resources/application-named-mongoclient.properties
+++ b/extensions/mongodb-client/deployment/src/test/resources/application-named-mongoclient.properties
@@ -1,2 +1,5 @@
+# disable dev services explicitly for default connection
+quarkus.mongodb.devservices.enabled=false
+
 quarkus.mongodb.cluster1.connection-string=mongodb://127.0.0.1:27018
 quarkus.mongodb.cluster2.connection-string=mongodb://127.0.0.1:27019


### PR DESCRIPTION
We don't want to start a Docker container in these tests.