### PR TITLE
Update podman guide with latest instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,130 +1,132 @@
 # Contributing guide
 
-**Want to contribute? Great!** 
-We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
-This includes bug reports, fixes, documentation, examples... 
-But first, read this page (including the small print at the end).
+**Want to contribute? Great!**
+We try to make it easy, and all contributions, even the smaller ones, are more than welcome. This includes bug reports,
+fixes, documentation, examples... But first, read this page (including the small print at the end).
 
 * [Legal](#legal)
 * [Reporting an issue](#reporting-an-issue)
 * [Checking an issue is fixed in main](#checking-an-issue-is-fixed-in-main)
-  + [Using snapshots](#using-snapshots)
-  + [Building main](#building-main)
-  + [Updating the version](#updating-the-version)
+    + [Using snapshots](#using-snapshots)
+    + [Building main](#building-main)
+    + [Updating the version](#updating-the-version)
 * [Before you contribute](#before-you-contribute)
-  + [Code reviews](#code-reviews)
-  + [Coding Guidelines](#coding-guidelines)
-  + [Continuous Integration](#continuous-integration)
-  + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
+    + [Code reviews](#code-reviews)
+    + [Coding Guidelines](#coding-guidelines)
+    + [Continuous Integration](#continuous-integration)
+    + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
 * [Setup](#setup)
-  + [IDE Config and Code Style](#ide-config-and-code-style)
-    - [Eclipse Setup](#eclipse-setup)
-    - [IDEA Setup](#idea-setup)
-      * [How to work](#how-to-work)
-      * [`OutOfMemoryError` while importing](#-outofmemoryerror--while-importing)
-      * [`package sun.misc does not exist` while building](#-package-sunmisc-does-not-exist--while-building)
-      * [Formatting](#formatting)
-  + [Gitpod](#gitpod)
+    + [IDE Config and Code Style](#ide-config-and-code-style)
+        - [Eclipse Setup](#eclipse-setup)
+        - [IDEA Setup](#idea-setup)
+            * [How to work](#how-to-work)
+            * [`OutOfMemoryError` while importing](#-outofmemoryerror--while-importing)
+            * [`package sun.misc does not exist` while building](#-package-sunmisc-does-not-exist--while-building)
+            * [Formatting](#formatting)
+    + [Gitpod](#gitpod)
 * [Build](#build)
-  + [Workflow tips](#workflow-tips)
-    - [Building all modules of an extension](#building-all-modules-of-an-extension)
-    - [Building a single module of an extension](#building-a-single-module-of-an-extension)
-    - [Running a single test](#running-a-single-test)
-      * [Maven Invoker tests](#maven-invoker-tests)
-  + [Build with multiple threads](#build-with-multiple-threads)
-  + [Don't build any test modules](#don-t-build-any-test-modules)
-    - [Automatic incremental build](#automatic-incremental-build)
-      * [Special case `bom-descriptor-json`](#special-case--bom-descriptor-json-)
-      * [Usage by CI](#usage-by-ci)
+    + [Workflow tips](#workflow-tips)
+        - [Building all modules of an extension](#building-all-modules-of-an-extension)
+        - [Building a single module of an extension](#building-a-single-module-of-an-extension)
+        - [Running a single test](#running-a-single-test)
+            * [Maven Invoker tests](#maven-invoker-tests)
+    + [Build with multiple threads](#build-with-multiple-threads)
+    + [Don't build any test modules](#don-t-build-any-test-modules)
+        - [Automatic incremental build](#automatic-incremental-build)
+            * [Special case `bom-descriptor-json`](#special-case--bom-descriptor-json-)
+            * [Usage by CI](#usage-by-ci)
 * [Documentation](#documentation)
-  + [Building the documentation](#building-the-documentation)
-  + [Referencing a new guide in the index](#referencing-a-new-guide-in-the-index)
+    + [Building the documentation](#building-the-documentation)
+    + [Referencing a new guide in the index](#referencing-a-new-guide-in-the-index)
 * [Usage](#usage)
     - [With Maven](#with-maven)
     - [With Gradle](#with-gradle)
-  + [MicroProfile TCK's](#microprofile-tck-s)
-  + [Test Coverage](#test-coverage)
+
+    + [MicroProfile TCK's](#microprofile-tck-s)
+    + [Test Coverage](#test-coverage)
 * [Extensions](#extensions)
-  + [Descriptions](#descriptions)
-  + [Update dependencies to extensions](#update-dependencies-to-extensions)
+    + [Descriptions](#descriptions)
+    + [Update dependencies to extensions](#update-dependencies-to-extensions)
 * [The small print](#the-small-print)
 * [Frequently Asked Questions](#frequently-asked-questions)
 
-<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
-
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with
+markdown-toc</a></i></small>
 
 ## Legal
 
 All original contributions to Quarkus are licensed under the
-[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
-version 2.0 or later, or, if another license is specified as governing the file or directory being
-modified, such other license.
+[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0), version 2.0 or later, or, if another license is
+specified as governing the file or directory being modified, such other license.
 
-All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
-The DCO text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
+All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The DCO
+text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
 
 ## Reporting an issue
 
 This project uses GitHub issues to manage the issues. Open an issue directly in GitHub.
 
-If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
-Don't forget to indicate your Quarkus, Java, Maven/Gradle and GraalVM version. 
+If you believe you found a bug, and it's likely possible, please indicate a way to reproduce it, what you are seeing and
+what you would expect to see. Don't forget to indicate your Quarkus, Java, Maven/Gradle and GraalVM version.
 
 ## Checking an issue is fixed in main
 
-Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own application.
-Testing the `main` branch is easy and you have two options:
+Sometimes a bug has been fixed in the `main` branch of Quarkus and you want to confirm it is fixed for your own
+application. Testing the `main` branch is easy and you have two options:
 
 * either use the snapshots we publish daily on https://s01.oss.sonatype.org/content/repositories/snapshots
 * or build Quarkus all by yourself
 
-This is a quick summary to get you to quickly test main.
-If you are interested in having more details, refer to the [Build section](#build) and the [Usage section](#usage).
+This is a quick summary to get you to quickly test main. If you are interested in having more details, refer to
+the [Build section](#build) and the [Usage section](#usage).
 
 ### Using snapshots
 
 Snapshots are published daily, so you will have to wait for a snapshot containing the commits you are interested in.
 
-Then just add https://s01.oss.sonatype.org/content/repositories/snapshots as a Maven repository **and** a plugin repository in your settings xml:
+Then just add https://s01.oss.sonatype.org/content/repositories/snapshots as a Maven repository **and** a plugin
+repository in your settings xml:
 
 ```xml
+
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <profiles>
-    <profile>
-       <id>quarkus-snapshots</id>
-       <repositories>
-        <repository>
-          <id>quarkus-snapshots-repository</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <id>quarkus-snapshots-plugin-repository</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-          <releases>
-            <enabled>false</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
-  <activeProfiles>
-    <activeProfile>quarkus-snapshots</activeProfile>
-  </activeProfiles>
+    <profiles>
+        <profile>
+            <id>quarkus-snapshots</id>
+            <repositories>
+                <repository>
+                    <id>quarkus-snapshots-repository</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>quarkus-snapshots-plugin-repository</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>quarkus-snapshots</activeProfile>
+    </activeProfiles>
 </settings>
 ```
+
 You can check the last publication date here: https://s01.oss.sonatype.org/content/repositories/snapshots/io/quarkus/ .
 
 ### Building main
@@ -144,9 +146,12 @@ Wait for a bit and you're done.
 
 ### Updating the version
 
-When using the `main` branch, you need to use the group id `io.quarkus` instead of `io.quarkus.platform` for both the Quarkus BOM and the Quarkus Maven Plugin.
+When using the `main` branch, you need to use the group id `io.quarkus` instead of `io.quarkus.platform` for both the
+Quarkus BOM and the Quarkus Maven Plugin.
 
-In a standard Quarkus pom.xml set the `quarkus.platform.group-id`-property to `io.quarkus` and the `quarkus.platform.version`-property to `999-SNAPSHOT` to build your application against the locally installed main branch.
+In a standard Quarkus pom.xml set the `quarkus.platform.group-id`-property to `io.quarkus` and
+the `quarkus.platform.version`-property to `999-SNAPSHOT` to build your application against the locally installed main
+branch.
 
 You can now test your application.
 
@@ -167,28 +172,40 @@ We use this information to acknowledge your contributions in release announcemen
 
 ### Code reviews
 
-All submissions, including submissions by project members, need to be reviewed by at least one Quarkus committer before being merged.
+All submissions, including submissions by project members, need to be reviewed by at least one Quarkus committer before
+being merged.
 
-[GitHub Pull Request Review Process](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews) is followed for every pull request.
+[GitHub Pull Request Review Process](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews)
+is followed for every pull request.
 
 ### Coding Guidelines
 
- * We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/quarkusio/quarkus/graphs/contributors). For each major Quarkus release, we also publish the list of contributors in the announcement post.
- * Commits should be atomic and semantic. Please properly squash your pull requests before submitting them. Fixup commits can be used temporarily during the review process but things should be squashed at the end to have meaningful commits.
- We use merge commits so the GitHub Merge button cannot do that for us. If you don't know how to do that, just ask in your pull request, we will be happy to help!
+* We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project,
+  and we use the Git history to track authorship. GitHub also
+  has [this nice page with your contributions](https://github.com/quarkusio/quarkus/graphs/contributors). For each major
+  Quarkus release, we also publish the list of contributors in the announcement post.
+* Commits should be atomic and semantic. Please properly squash your pull requests before submitting them. Fixup commits
+  can be used temporarily during the review process but things should be squashed at the end to have meaningful commits.
+  We use merge commits so the GitHub Merge button cannot do that for us. If you don't know how to do that, just ask in
+  your pull request, we will be happy to help!
 
 ### Continuous Integration
 
-Because we are all humans, and to ensure Quarkus is stable for everyone, all changes must go through Quarkus continuous integration. Quarkus CI is based on GitHub Actions, which means that everyone has the ability to automatically execute CI in their forks as part of the process of making changes. We ask that all non-trivial changes go through this process, so that the contributor gets immediate feedback, while at the same time keeping our CI fast and healthy for everyone.
+Because we are all humans, and to ensure Quarkus is stable for everyone, all changes must go through Quarkus continuous
+integration. Quarkus CI is based on GitHub Actions, which means that everyone has the ability to automatically execute
+CI in their forks as part of the process of making changes. We ask that all non-trivial changes go through this process,
+so that the contributor gets immediate feedback, while at the same time keeping our CI fast and healthy for everyone.
 
-The process requires only one additional step to enable Actions on your fork (clicking the green button in the actions tab). [See the full video walkthrough](https://youtu.be/egqbx-Q-Cbg) for more details on how to do this.
+The process requires only one additional step to enable Actions on your fork (clicking the green button in the actions
+tab). [See the full video walkthrough](https://youtu.be/egqbx-Q-Cbg) for more details on how to do this.
 
-To keep the caching of non-Quarkus artifacts efficient (speeding up CI), you should occasionally sync the `main` branch of your fork with `main` of this repo (e.g. monthly).
+To keep the caching of non-Quarkus artifacts efficient (speeding up CI), you should occasionally sync the `main` branch
+of your fork with `main` of this repo (e.g. monthly).
 
 ### Tests and documentation are not optional
 
-Don't forget to include tests in your pull requests. 
-Also don't forget the documentation (reference documentation, javadoc...).
+Don't forget to include tests in your pull requests. Also don't forget the documentation (reference documentation,
+javadoc...).
 
 Be sure to test your pull request in:
 
@@ -198,31 +215,40 @@ Be sure to test your pull request in:
 ## Setup
 
 If you have not done so on this machine, you need to:
- 
+
 * Install Git and configure your GitHub access
 * Install Java SDK 11+ (OpenJDK recommended)
 * Install [GraalVM](https://quarkus.io/guides/building-native-image)
 * Install platform C developer tools:
     * Linux
-        * Make sure headers are available on your system (you'll hit 'Basic header file missing (<zlib.h>)' error if they aren't).
+        * Make sure headers are available on your system (you'll hit 'Basic header file missing (<zlib.h>)' error if
+          they aren't).
             * On Fedora `sudo dnf install zlib-devel`
             * Otherwise `sudo apt-get install libz-dev`
     * macOS
-        * `xcode-select --install` 
-* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux or `$location/JDK/GraalVM/Contents/Home` on macOS
+        * `xcode-select --install`
+* Set `GRAALVM_HOME` to your GraalVM Home directory e.g. `/opt/graalvm` on Linux
+  or `$location/JDK/GraalVM/Contents/Home` on macOS
 
-Docker is not strictly necessary: it is used to run the MariaDB and PostgreSQL tests which are not enabled by default. However, it is a recommended install if you plan to work on Quarkus JPA support:
+A container engine (such as [Docker](https://www.docker.com/) or [Podman](https://podman.io/)) is not strictly
+necessary: it is used to run the container-based tests which are not enabled by default.
 
-* Check [the installation guide](https://docs.docker.com/install/), and [the macOS installation guide](https://docs.docker.com/docker-for-mac/install/)
-* If you just install docker, be sure that your current user can run a container (no root required). 
-On Linux, check [the post-installation guide](https://docs.docker.com/install/linux/linux-postinstall/)
+It is a recommended install though when working on any extension that relies on dev services or container-based tests (
+Hibernate ORM, MongoDB, ...):
+
+* For Docker, check [the installation guide](https://docs.docker.com/install/),
+  and [the macOS installation guide](https://docs.docker.com/docker-for-mac/install/). If you just install docker, be
+  sure that your current user can run a container (no root required). On Linux,
+  check [the post-installation guide](https://docs.docker.com/install/linux/linux-postinstall/).
+* For Podman, some extra configuration will be required to get testcontainers working. See
+  the [Quarkus and Podman guide](https://quarkus.io/guides/podman) for setup instructions.
 
 ### IDE Config and Code Style
 
-Quarkus has a strictly enforced code style. Code formatting is done by the Eclipse code formatter, using the config files
-found in the `independent-projects/ide-config` directory. By default, when you run `./mvnw install`, the code will be formatted automatically.
-When submitting a pull request the CI build will fail if running the formatter results in any code changes, so it is
-recommended that you always run a full Maven build before submitting a pull request.
+Quarkus has a strictly enforced code style. Code formatting is done by the Eclipse code formatter, using the config
+files found in the `independent-projects/ide-config` directory. By default, when you run `./mvnw install`, the code will
+be formatted automatically. When submitting a pull request the CI build will fail if running the formatter results in
+any code changes, so it is recommended that you always run a full Maven build before submitting a pull request.
 
 If you want to run the formatting without doing a full build, you can run `./mvnw process-sources`.
 
@@ -237,32 +263,31 @@ Next navigate to _Java_ -> _Code Style_ -> _Organize Imports_. Click _Import_ an
 
 ##### How to work
 
-Quarkus is a large project and IDEA will have a hard time compiling the whole of it.
-Before you start coding, make sure to build the project using Maven from the commandline
-with `./mvnw -Dquickly`.
+Quarkus is a large project and IDEA will have a hard time compiling the whole of it. Before you start coding, make sure
+to build the project using Maven from the commandline with `./mvnw -Dquickly`.
 
 ##### `OutOfMemoryError` while importing
 
-After creating an IDEA project, the first import might fail with an `OutOfMemory` error,
-as the size of the project requires more memory than the IDEA default settings allow.
+After creating an IDEA project, the first import might fail with an `OutOfMemory` error, as the size of the project
+requires more memory than the IDEA default settings allow.
 
-**Note** In some IDEA versions the `OutOfMemory` error goes unreported. 
-So if no error is reported but IDEA is still failing to find symbols or the dependencies are wrong in the imported project, then importing might have failed due to an unreported `OutOfMemory` exception.
-One can further investigate this by inspecting the `org.jetbrains.idea.maven.server.RemoteMavenServer36` process (or processes) using `JConsole`.
+**Note** In some IDEA versions the `OutOfMemory` error goes unreported. So if no error is reported but IDEA is still
+failing to find symbols or the dependencies are wrong in the imported project, then importing might have failed due to
+an unreported `OutOfMemory` exception. One can further investigate this by inspecting
+the `org.jetbrains.idea.maven.server.RemoteMavenServer36` process (or processes) using `JConsole`.
 
-To fix that, open the _Preferences_ window (or _Settings_ depending on your edition),
-then navigate to _Build, Execution, Deployment_ > _Build Tools_ > _Maven_ > _Importing_.
-In _VM options for importer_, raise the heap to at least 2 GB; some people reported
-needing more, e.g. `-Xmx8g`.
+To fix that, open the _Preferences_ window (or _Settings_ depending on your edition), then navigate to _Build,
+Execution, Deployment_ > _Build Tools_ > _Maven_ > _Importing_. In _VM options for importer_, raise the heap to at least
+2 GB; some people reported needing more, e.g. `-Xmx8g`.
 
-In recent IDEA versions (e.g. 2020.3) this might not work because _VM options for importer_ get ignored when `.mvn/jdk.config` is present (see [IDEA-250160](https://youtrack.jetbrains.com/issue/IDEA-250160))
-it disregards the _VM options for importer_ settings.
-An alternative solution is to go to _Help_ > _Edit Custom Properties..._ and
-add the following line:
+In recent IDEA versions (e.g. 2020.3) this might not work because _VM options for importer_ get ignored
+when `.mvn/jdk.config` is present (see [IDEA-250160](https://youtrack.jetbrains.com/issue/IDEA-250160))
+it disregards the _VM options for importer_ settings. An alternative solution is to go to _Help_ > _Edit Custom
+Properties..._ and add the following line:
 
 `idea.maven.embedder.xmx=8g`
 
-After these configurations, you might need to run  _File_ -> _Invalidate Caches and Restart_ 
+After these configurations, you might need to run  _File_ -> _Invalidate Caches and Restart_
 and then trigger a `Reload all Maven projects`.
 
 ##### `package sun.misc does not exist` while building
@@ -278,23 +303,25 @@ and disable _Use '--release' option for cross compilation (java 9 and later)_.
 
 ##### Formatting
 
-Open the _Preferences_ window (or _Settings_ depending on your edition), navigate to _Plugins_ and install the [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter) from the Marketplace.
+Open the _Preferences_ window (or _Settings_ depending on your edition), navigate to _Plugins_ and install
+the [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter) from the
+Marketplace.
 
-Restart your IDE, open the *Preferences* (or *Settings*) window again and navigate to _Other Settings_ -> _Eclipse Code Formatter_.
+Restart your IDE, open the *Preferences* (or *Settings*) window again and navigate to _Other Settings_ -> _Eclipse Code
+Formatter_.
 
 Select _Use the Eclipse Code Formatter_, then change the _Eclipse Java Formatter Config File_ to point to the
-`eclipse-format.xml` file in the `independent-projects/ide-config` directory. Make sure the _Optimize Imports_ box is ticked, and
-select the `eclipse.importorder` file as the import order config file.
+`eclipse-format.xml` file in the `independent-projects/ide-config` directory. Make sure the _Optimize Imports_ box is
+ticked, and select the `eclipse.importorder` file as the import order config file.
 
 Next, disable wildcard imports:
 navigate to _Editor_ -> _Code Style_ -> _Java_ -> _Imports_
-and set _Class count to use import with '\*'_ to `999`.
-Do the same with _Names count to use static import with '\*'_.
+and set _Class count to use import with '\*'_ to `999`. Do the same with _Names count to use static import with '\*'_.
 
 ### Gitpod
 
-You can also use [Gitpod](https://gitpod.io) to contribute without installing anything on your computer. Click [here](https://gitpod.io/#https://github.com/quarkusio/quarkus/-/tree/main/) to start a workspace.
-
+You can also use [Gitpod](https://gitpod.io) to contribute without installing anything on your computer.
+Click [here](https://gitpod.io/#https://github.com/quarkusio/quarkus/-/tree/main/) to start a workspace.
 
 ## Build
 
@@ -302,7 +329,8 @@ You can also use [Gitpod](https://gitpod.io) to contribute without installing an
 * Navigate to the directory: `cd quarkus`
 * Set Maven heap to 4GB `export MAVEN_OPTS="-Xmx4g"`
 * Invoke `./mvnw -Dquickly` from the root directory
-* _Note: On Windows, it may be necessary to run the build from an elevated shell. If you experience a failed build with the error `"A required privilege is not held by the client"`, this should fix it._
+* _Note: On Windows, it may be necessary to run the build from an elevated shell. If you experience a failed build with
+  the error `"A required privilege is not held by the client"`, this should fix it._
 
 ```bash
 git clone https://github.com/quarkusio/quarkus.git
@@ -312,8 +340,9 @@ export MAVEN_OPTS="-Xmx4g"
 # Wait... success!
 ```
 
-This build skipped all the tests, native-image builds, documentation generation etc. and used the Maven goals `clean install` by default.
-For more details about `-Dquickly` have a look at the `quick-build` profile in `quarkus-parent` (root `pom.xml`).
+This build skipped all the tests, native-image builds, documentation generation etc. and used the Maven
+goals `clean install` by default. For more details about `-Dquickly` have a look at the `quick-build` profile
+in `quarkus-parent` (root `pom.xml`).
 
 When contributing to Quarkus, it is recommended to respect the following rules.
 
@@ -324,46 +353,51 @@ When you contribute to an extension, after having applied your changes, run:
 * `./mvnw -Dquickly` from the root directory to make sure you haven't broken anything obvious
 * `./mvnw -f extensions/<your-extension> clean install` to run a full build of your extension including the tests
 * `./mvnw -f integration-tests/<your-extension-its> clean install` to make sure ITs are still passing
-* `./mvnw -f integration-tests/<your-extension-its> clean install -Dnative` to test the native build (for small changes, it might not be useful, use your own judgement)
+* `./mvnw -f integration-tests/<your-extension-its> clean install -Dnative` to test the native build (for small changes,
+  it might not be useful, use your own judgement)
 
 **Contributing to a core artifact**
 
-Obviously, when you contribute to a core artifact of Quarkus, a change may impact any part of Quarkus.
-So the rule of thumb would be to run the full test suite locally but this is clearly impractical as it takes a lot of time/resources.
+Obviously, when you contribute to a core artifact of Quarkus, a change may impact any part of Quarkus. So the rule of
+thumb would be to run the full test suite locally but this is clearly impractical as it takes a lot of time/resources.
 
 Thus, it is recommended to use the following approach:
 
 * run `./mvnw -Dquickly` from the root directory to make sure you haven't broken anything obvious
-* run any build that might be useful to test the behavior you changed actually fixes the issue you had (might be an extension build, an integration test build...)
+* run any build that might be useful to test the behavior you changed actually fixes the issue you had (might be an
+  extension build, an integration test build...)
 * push your work to your own fork of Quarkus to trigger CI there
 * you can create a draft pull request to keep track of your work
-* wait until the build is green in your fork (use your own judgement if it's not fully green) before marking your pull request as ready for review (which will trigger Quarkus CI)
+* wait until the build is green in your fork (use your own judgement if it's not fully green) before marking your pull
+  request as ready for review (which will trigger Quarkus CI)
 
 ### Workflow tips
 
-Due to Quarkus being a large repository, having to rebuild the entire project every time a change is made isn't very productive. 
-The following Maven tips can vastly speed up development when working on a specific extension.
+Due to Quarkus being a large repository, having to rebuild the entire project every time a change is made isn't very
+productive. The following Maven tips can vastly speed up development when working on a specific extension.
 
 #### Building all modules of an extension
 
-Let's say you want to make changes to the `Jackson` extension. This extension contains the `deployment`, `runtime` and `spi` modules
-which can all be built by executing following command:
+Let's say you want to make changes to the `Jackson` extension. This extension contains the `deployment`, `runtime`
+and `spi` modules which can all be built by executing following command:
 
 ```
 ./mvnw install -f extensions/jackson/
 ```
 
-This command uses the path of the extension on the filesystem to identify it. Moreover, Maven will automatically build all modules in that path recursively.
+This command uses the path of the extension on the filesystem to identify it. Moreover, Maven will automatically build
+all modules in that path recursively.
 
 #### Building a single module of an extension
 
-Let's say you want to make changes to the `deployment` module of the Jackson extension. There are two ways to accomplish this task as shown by the following commands:
+Let's say you want to make changes to the `deployment` module of the Jackson extension. There are two ways to accomplish
+this task as shown by the following commands:
 
 ```
 ./mvnw install -f extensions/jackson/deployment
 ```
 
-or 
+or
 
 ```
 ./mvnw install --projects 'io.quarkus:quarkus-jackson-deployment'
@@ -373,8 +407,10 @@ In this command we use the groupId and artifactId of the module to identify it.
 
 #### Running a single test
 
-Often you need to run a single test from some Maven module. Say for example you want to run the `GreetingResourceTest` of the `resteasy-jackson` Quarkus integration test (which can be found [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/resteasy-jackson)).
-One way to accomplish this is by executing the following command:
+Often you need to run a single test from some Maven module. Say for example you want to run the `GreetingResourceTest`
+of the `resteasy-jackson` Quarkus integration test (which can be
+found [here](https://github.com/quarkusio/quarkus/blob/main/integration-tests/resteasy-jackson)). One way to accomplish
+this is by executing the following command:
 
 ```
 ./mvnw test -f integration-tests/resteasy-jackson/ -Dtest=GreetingResourceTest
@@ -382,8 +418,9 @@ One way to accomplish this is by executing the following command:
 
 ##### Maven Invoker tests
 
-For testing some scenarios, Quarkus uses the [Maven Invoker](https://maven.apache.org/shared/maven-invoker/) to run tests. For these cases, to run a single test, one needs to use the `invoker.test` property along with the name of the directory
-which houses the test project.
+For testing some scenarios, Quarkus uses the [Maven Invoker](https://maven.apache.org/shared/maven-invoker/) to run
+tests. For these cases, to run a single test, one needs to use the `invoker.test` property along with the name of the
+directory which houses the test project.
 
 For example, in order to only run the MySQL test project of the container-image tests, the Maven command would be:
 
@@ -391,12 +428,14 @@ For example, in order to only run the MySQL test project of the container-image 
 ./mvnw verify -f integration-tests/container-image/maven-invoker-way -Dinvoker.test=container-build-jib-with-mysql
 ```
 
-Note that we use the `verify` goal instead of the `test` goal because the Maven Invoker is usually bound to the integration-test phase. 
-Furthermore, depending on the actual test being invoked, more options maybe needed (for the specific integration test mentioned above, `-Dstart-containers` and `-Dtest-containers` are needed).
+Note that we use the `verify` goal instead of the `test` goal because the Maven Invoker is usually bound to the
+integration-test phase. Furthermore, depending on the actual test being invoked, more options maybe needed (for the
+specific integration test mentioned above, `-Dstart-containers` and `-Dtest-containers` are needed).
 
 ### Build with multiple threads
 
-The following standard Maven option can be used to build with multiple threads to speed things up (here 0.5 threads per CPU core):
+The following standard Maven option can be used to build with multiple threads to speed things up (here 0.5 threads per
+CPU core):
 
 ```
 ./mvnw install -T0.5C
@@ -416,35 +455,47 @@ This can come in handy when you are only interested in the actual "productive" a
 
 #### Automatic incremental build
 
-:information_source: This feature is currently in testing mode. You're invited to give it a go and please reach out via [Zulip](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev) or GitHub in case something doesn't work as expected or you have ideas to improve things.
+:information_source: This feature is currently in testing mode. You're invited to give it a go and please reach out
+via [Zulip](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev) or GitHub in case something doesn't work as
+expected or you have ideas to improve things.
 
-Instead of _manually_ specifying the modules to build as in the previous examples, you can tell [gitflow-incremental-builder (GIB)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder) to only build the modules that have been changed or depend on modules that have been changed (downstream).
-E.g.:
+Instead of _manually_ specifying the modules to build as in the previous examples, you can
+tell [gitflow-incremental-builder (GIB)](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder) to
+only build the modules that have been changed or depend on modules that have been changed (downstream). E.g.:
+
 ```
 ./mvnw install -Dincremental
 ```
-This will build all modules (and their downstream modules) that have been changed compared to your _local_ `main`, including untracked and uncommitted changes.
 
-If you just want to build the changes since the last commit on the current branch, you can switch off the branch comparison via `-Dgib.disableBranchComparison` (or short: `-Dgib.dbc`).
+This will build all modules (and their downstream modules) that have been changed compared to your _local_ `main`,
+including untracked and uncommitted changes.
 
-There are many more configuration options in GIB you can use to customize its behaviour: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#configuration
+If you just want to build the changes since the last commit on the current branch, you can switch off the branch
+comparison via `-Dgib.disableBranchComparison` (or short: `-Dgib.dbc`).
 
-Parallel builds (`-T...`) should work without problems but parallel test execution is not yet supported (in general, not a GIB limitation).
+There are many more configuration options in GIB you can use to customize its
+behaviour: https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#configuration
+
+Parallel builds (`-T...`) should work without problems but parallel test execution is not yet supported (in general, not
+a GIB limitation).
 
 ##### Special case `bom-descriptor-json`
 
-Without going too much into details (`devtools/bom-descriptor-json/pom.xml` has more info), you should build this module _without_ `-Dincremental` _if you changed any extension "metadata"_:
+Without going too much into details (`devtools/bom-descriptor-json/pom.xml` has more info), you should build this
+module _without_ `-Dincremental` _if you changed any extension "metadata"_:
 
 * Addition/renaming/removal of an extension
 * Any other changes to any `quarkus-extension.yaml`
 
 ##### Usage by CI
 
-The GitHub Actions based Quarkus CI is using GIB to reduce the average build time of pull request builds and builds of branches in your fork.
+The GitHub Actions based Quarkus CI is using GIB to reduce the average build time of pull request builds and builds of
+branches in your fork.
 
 CI is using a slightly different GIB config than locally:
 
-* [Special handling of "Explicitly selected projects"](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#explicitly-selected-projects) is deactivated
+* [Special handling of "Explicitly selected projects"](https://github.com/gitflow-incremental-builder/gitflow-incremental-builder#explicitly-selected-projects)
+  is deactivated
 * Untracked/uncommitted changes are not considered
 * Branch comparison is more complex due to distributed GitHub forks
 * Certain "critical" branches like `main` are not built incrementally
@@ -453,8 +504,10 @@ For more details see the `Get GIB arguments` step in `.github/workflows/ci-actio
 
 ## Documentation
 
-The documentation is hosted in the [`docs` module](https://github.com/quarkusio/quarkus/tree/main/docs) of the main Quarkus repository and is synced to the [Quarkus.io website](https://quarkus.io/guides/) at release time.
-The Asciidoc files can be found in the [`src/main/asciidoc` directory](https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc).
+The documentation is hosted in the [`docs` module](https://github.com/quarkusio/quarkus/tree/main/docs) of the main
+Quarkus repository and is synced to the [Quarkus.io website](https://quarkus.io/guides/) at release time. The Asciidoc
+files can be found in
+the [`src/main/asciidoc` directory](https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc).
 
 ### Building the documentation
 
@@ -466,7 +519,8 @@ First build the whole Quarkus repository with the documentation build enabled:
 ./mvnw -DquicklyDocs
 ```
 
-This will generate the configuration properties documentation includes in the root `target/asciidoc/generated/config/` directory and will avoid a lot of warnings when building the documentation module.
+This will generate the configuration properties documentation includes in the root `target/asciidoc/generated/config/`
+directory and will avoid a lot of warnings when building the documentation module.
 
 Then you can build the `docs` module specifically:
 
@@ -476,16 +530,22 @@ Then you can build the `docs` module specifically:
 
 You can check the output of the build in the `docs/target/generated-docs/` directory.
 
-You can build the documentation this way as many times as needed, just avoid doing a `./mvnw clean` at the root level because you would lose the configuration properties documentation includes.
+You can build the documentation this way as many times as needed, just avoid doing a `./mvnw clean` at the root level
+because you would lose the configuration properties documentation includes.
 
 ### Referencing a new guide in the index
 
-The [Guides index page](https://quarkus.io/guides/) visible on the website is generated from a YAML file named `guides-latest.yaml` present in the [Quarkus.io website repository](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/guides-latest.yaml).
-This particular file is for the latest stable version.
+The [Guides index page](https://quarkus.io/guides/) visible on the website is generated from a YAML file
+named `guides-latest.yaml` present in
+the [Quarkus.io website repository](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/guides-latest.yaml)
+. This particular file is for the latest stable version.
 
-When adding a new guide to the `main` version of Quarkus, you need to reference the guide in the [`main` guides index YAML file](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/guides-main.yaml).
+When adding a new guide to the `main` version of Quarkus, you need to reference the guide in
+the [`main` guides index YAML file](https://github.com/quarkusio/quarkusio.github.io/blob/develop/_data/guides-main.yaml)
+.
 
-This file will later be copied to become the new `guides-latest.yaml` file when the next major or minor version is released.
+This file will later be copied to become the new `guides-latest.yaml` file when the next major or minor version is
+released.
 
 ## Usage
 
@@ -534,7 +594,7 @@ pluginManagement {
     .
 }
 ```
- 
+
 *build.gradle*
 
 ```
@@ -546,38 +606,39 @@ repositories {
 
 ### MicroProfile TCK's
 
-Quarkus has a TCK module in `tcks` where all the MicroProfile TCK's are set up for you to run if you wish. These 
-include tests to areas like Config, JWT Authentication, Fault Tolerance, Health Checks, Metrics, OpenAPI, OpenTracing, 
-REST Client, Reactive Messaging and Context Propagation.
+Quarkus has a TCK module in `tcks` where all the MicroProfile TCK's are set up for you to run if you wish. These include
+tests to areas like Config, JWT Authentication, Fault Tolerance, Health Checks, Metrics, OpenAPI, OpenTracing, REST
+Client, Reactive Messaging and Context Propagation.
 
-The TCK module is not part of the main Maven reactor build, but you can enable it and run the TCK tests by activating 
-the Maven Profile `-Ptcks`. If your work is related to any of these areas, running the TCK's is highly recommended to 
+The TCK module is not part of the main Maven reactor build, but you can enable it and run the TCK tests by activating
+the Maven Profile `-Ptcks`. If your work is related to any of these areas, running the TCK's is highly recommended to
 make sure you are not breaking the project. The TCK's will also run on any Pull Request.
 
-You can either run all the TCK's or just a subset by executing `mvn verify` in the `tcks` module root or each of 
-the submodules. If you wish to run a particular test, you can use Maven `-Dtest=` property with the fully qualified 
-name of the test class and optionally the method name by using 
+You can either run all the TCK's or just a subset by executing `mvn verify` in the `tcks` module root or each of the
+submodules. If you wish to run a particular test, you can use Maven `-Dtest=` property with the fully qualified name of
+the test class and optionally the method name by using
 `mvn verify -Dtest=fully.qualified.test.class.name#methodName`.
 
 ### Test Coverage
 
-Quarkus uses Jacoco to generate test coverage. If you would like to generate the report run `mvn install -Ptest-coverage`,
-then change into the `coverage-report` directory and run `mvn package`. The code coverage report will be generated in
+Quarkus uses Jacoco to generate test coverage. If you would like to generate the report
+run `mvn install -Ptest-coverage`, then change into the `coverage-report` directory and run `mvn package`. The code
+coverage report will be generated in
 `target/site/jacoco/`.
 
-This currently does not work on Windows as it uses a shell script to copy all the classes and files into the code coverage
-module.
+This currently does not work on Windows as it uses a shell script to copy all the classes and files into the code
+coverage module.
 
-If you just need a report for a single module, run `mvn install jacoco:report -Ptest-coverage` in that module (or with `-f ...`).
+If you just need a report for a single module, run `mvn install jacoco:report -Ptest-coverage` in that module (or
+with `-f ...`).
 
 ## Extensions
 
 ### Descriptions
 
 Extensions descriptions (in the `runtime/pom.xml` description or in the YAML `quarkus-extension.yaml`)
-are used to describe the extension and are visible in https://code.quarkus.io.
-Try and pay attention to it.
-Here are a few recommendation guidelines:
+are used to describe the extension and are visible in https://code.quarkus.io. Try and pay attention to it. Here are a
+few recommendation guidelines:
 
 - keep it relatively short so that no hover is required to read it
 - describe the function over the technology
@@ -593,15 +654,18 @@ Bad examples and the corresponding good example:
 - "AWS Lambda" (use "Write AWS Lambda functions")
 - "Extension for building container images with Docker" (use "Build container images with Docker")
 - "PostgreSQL database connector" (use "Connect to the PostgreSQL database via JDBC")
-- "Asynchronous messaging for Reactive Streams" (use "Produce and consume messages and implement event driven and data streaming applications")
+- "Asynchronous messaging for Reactive Streams" (use "Produce and consume messages and implement event driven and data
+  streaming applications")
 
 ### Update dependencies to extensions
 
-When adding a new extension you should run `update-extension-dependencies.sh` so that special modules like `devtools/bom-descriptor-json`
-that are consuming this extension are built *after* the respective extension. Simply add to your commit the files that were changed by the script.
+When adding a new extension you should run `update-extension-dependencies.sh` so that special modules
+like `devtools/bom-descriptor-json`
+that are consuming this extension are built *after* the respective extension. Simply add to your commit the files that
+were changed by the script.
 
-When removing an extension make sure to also remove all dependencies to it from all `pom.xml`.
-It's easy to miss this as long as the extension artifact is still present in your local Maven repository.
+When removing an extension make sure to also remove all dependencies to it from all `pom.xml`. It's easy to miss this as
+long as the extension artifact is still present in your local Maven repository.
 
 ## The small print
 
@@ -613,9 +677,10 @@ This project is an open source project, please act responsibly, be nice, polite 
 
   Set Maven options to use more memory: `export MAVEN_OPTS="-Xmx4g"`.
 
-* IntelliJ fails to import Quarkus Maven project with `java.lang.OutOfMemoryError: GC overhead limit exceeded` 
+* IntelliJ fails to import Quarkus Maven project with `java.lang.OutOfMemoryError: GC overhead limit exceeded`
 
-  In IntelliJ IDEA if you see problems in the Maven view claiming `java.lang.OutOfMemoryError: GC overhead limit exceeded` that means the project import failed.
+  In IntelliJ IDEA if you see problems in the Maven view
+  claiming `java.lang.OutOfMemoryError: GC overhead limit exceeded` that means the project import failed.
 
   See section `IDEA Setup` as there are different possible solutions described.
 
@@ -630,23 +695,29 @@ This project is an open source project, please act responsibly, be nice, polite 
   [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.192 s - in io.quarkus.maven.it.GenerateConfigIT
   [INFO] Running io.quarkus.maven.it.DevMojoIT
   ```
-  DevMojoIT require a few minutes to run but anything more than that is not expected. Make sure that nothing is running on 8080.
+  DevMojoIT require a few minutes to run but anything more than that is not expected. Make sure that nothing is running
+  on 8080.
 
 * The native integration test for my extension didn't run in the CI
 
-  In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which are run in parallel.
-  This means that each new extension needs to be configured explicitly in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
+  In the interest of speeding up CI, the native build job `native-tests` have been split into multiple categories which
+  are run in parallel. This means that each new extension needs to be configured explicitly
+  in [`native-tests.json`](.github/native-tests.json) to have its integration tests run in native mode.
 
-* Build aborts complaining about missing (or superfluous) `minimal *-deployment dependencies` or `illegal runtime dependencies`
+* Build aborts complaining about missing (or superfluous) `minimal *-deployment dependencies`
+  or `illegal runtime dependencies`
 
-  To ensure a consistent build order, even when building in parallel (`./mvnw -T...`) or building incrementally/partially (`./mvnw -pl...`), the build enforces the presence of certain dependencies.
-  If those dependencies are not present, your local build will most likely use possibly outdated artifacts from you local repo and CI build might even fail not finding certain artifacts.
+  To ensure a consistent build order, even when building in parallel (`./mvnw -T...`) or building
+  incrementally/partially (`./mvnw -pl...`), the build enforces the presence of certain dependencies. If those
+  dependencies are not present, your local build will most likely use possibly outdated artifacts from you local repo
+  and CI build might even fail not finding certain artifacts.
 
   Just do what the failing enforcer rule is telling you, and you should be fine.
 
 * Build fails with multiple `This project has been banned from the build due to previous failures` messages
 
-  Just scroll up, there should be an error or warning somewhere. Failing enforcer rules are known to cause such effects and in this case there'll be something like:
+  Just scroll up, there should be an error or warning somewhere. Failing enforcer rules are known to cause such effects
+  and in this case there'll be something like:
   ```
   [WARNING] Rule 0: ... failed with message:
   ...

--- a/docs/src/main/asciidoc/podman.adoc
+++ b/docs/src/main/asciidoc/podman.adoc
@@ -6,72 +6,135 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Using Podman with Quarkus
 
 https://podman.io/[Podman] is a daemonless and rootless container engine for developing, managing, and running OCI Containers on your Linux system or other OS.
+If you're using Podman with Quarkus, some one-off setup is needed, but once it's done, you can take advantage of all the Quarkus features.
+
+== Installing Podman
+
+=== macOS
+
+Containers are really Linux.
+As such, Linux containers cannot run natively on macOS or Windows.
+Therefore, the containers must run in a Linux virtual machine (VM), and a Podman client interacts with that VM.
+A native hypervisor subsystem and virtualization software is used to run the Linux VM on the OS, and then containers are run within this VM.
+In Podman, this is known as the Podman machine, and it is built into the tool.
+
+macOS users can install Podman through https://brew.sh/[Homebrew].
+Once you have set up `brew`, you can use the `brew install` command to install Podman and `docker-compose`:
+
+[source,bash]
+----
+brew install podman
+brew install docker-compose
+podman machine init -v $HOME:$HOME
+sudo /opt/homebrew/Cellar/podman/4.0.3/bin/podman-mac-helper install
+podman machine set --rootful
+podman machine start
+alias docker='podman'
+----
+
+If you're using Podman 4.1 or higher, you don't need the `-v $HOME:$HOME` volume mount.
+
+If you're using Mac M1, an extra step is required to https://edofic.com/posts/2021-09-12-podman-m1-amd64[make AMD64 images work]:
+
+[source,bash]
+----
+podman machine ssh
+sudo -i
+rpm-ostree install qemu-user-static
+systemctl reboot
+----
+
+Once the virtual machine restarts, you should be good to run dev services.
+
+For more details, please see
+
+- the https://podman.io/getting-started/installation#macos[official Podman documentation]
+- article about https://www.redhat.com/sysadmin/replace-docker-podman-macos[running Podman on Mac]
+- https://xphyr.net/post/podman_on_osx/[another article], with good guidance on `--rootful` and mounting volumes
+- article about https://edofic.com/posts/2021-09-12-podman-m1-amd64[running AMD64 images with Podman on Mac M1]
+
+=== Windows
+
+Please see the https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md[Podman for Windows guide] for setup and usage instructions.
+
+Before starting the Podman machine, set it to prefer rootful container execution:
+
+[source,bash]
+----
+podman machine set --rootful
+----
+
+This action only needs to be done once.
+
+=== Linux
+
+The Podman package is available in several Linux distributions.
 Podman can be used the same way as Docker with the `podman-docker` package.
-
-== Installing Podman on Linux
-
-The Podman package is available in several Linux distributions. To install it for your OS, please refer to the  https://podman.io/getting-started/installation[Podman installation guide].
+To install it for your OS, please refer to the  https://podman.io/getting-started/installation[Podman installation guide].
 Below is the short installation instruction for popular Linux distributions:
 
-.Fedora
+==== Fedora
+
 [source,bash]
 ----
 sudo dnf install podman podman-docker docker-compose
 ----
-.Ubuntu (21.04 and later)
+
+==== Ubuntu (21.04 and later)
+
 [source,bash]
 ----
 sudo apt install podman podman-docker docker-compose
 ----
 
-=== After installation
+=== Setting DOCKER_HOST on Linux
 
-Podman is a daemonless container engine. Most Quarkus Dev Services and Testcontainers expect a running Docker daemon listening at a Unix socket.
-That's why the following steps are required.
-[source,bash]
+Podman supports two modes of operation: rootful, in which case the container runs as root on the host system, and rootless, where the container runs under a standard Unix user account.
+On Linux, the REST API Unix socket is, by default, restricted to only allow the root user to access it.
+This prevents someone from using a container to achieve a privilege escalation on the syetem.
+While these restrictions can be softened to allow a special group instead of just root, the recommended approach is to use rootless Podman on Linux.
+To use rootless Podman, you need to set a DOCKER_HOST environment variable to point to the user-specific socket.
+In both cases, you need to start the REST API by enabling the Podman socket service through systemd.
+
+[source]
 ----
-# Enable the podman socket with Docker REST API
+
+# Enable the podman socket with Docker REST API (only needs to be done once)
 systemctl --user enable podman.socket --now
-# Set the required envvars
+# Set the required environment variables (need to be run everytime or added to profile)
+
 export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
-export TESTCONTAINERS_RYUK_DISABLED=true
+
 ----
+
 For a detailed explanation, see this https://quarkus.io/blog/quarkus-devservices-testcontainers-podman/[blog article].
 
-To make changes permanent, add the exported environment variables to the "init" file from your shell. For example, the `bash` shell uses  the `~/.bashrc` file:
+== After installation
+
+=== Testcontainers privileges
+
+Edit `~/.testcontainers.properties` and add the following line
+
 [source,bash]
 ----
-echo "export DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock" >> ~/.bashrc
-echo "export TESTCONTAINERS_RYUK_DISABLED=true" >> ~/.bashrc
+ryuk.container.privileged=true
 ----
 
-=== Short names of images
+Alternatively, you can disable ryuk:
+
+[source]
+----
+export TESTCONTAINERS_RYUK_DISABLED=true #not recommended - see above!
+----
+
+This has the disadvantage of https://github.com/containers/podman/discussions/14238[disabling container cleanup], so you may find stale containers hanging around.
+This can be a problem if you're running automated tests.
+
+== Short names of images
 
 Testcontainers and Quarkus Dev Services also expect the container service they make requests against to be non-interactive.
 In case you have multiple registries configured in your Docker or Podman configuration, and when using short image names, Podman responds with a prompt asking which registry should be used to pull images.
 
-While we recommend you to avoid short names and always use fully specified names including the registry,
-Testcontainers unfortunately relies on short names internally for the time being.
-If you are using Testcontainers, either directly or through Dev Services,
-you need to disable this prompt by setting the `short-name-mode="disabled"` configuration property of Podman in `/etc/containers/registries.conf`.
+While we recommend you to avoid short names and always use fully specified names including the registry, Testcontainers unfortunately relies on short names internally for the time being.
+If you are using Testcontainers, either directly or through Dev Services, you need to disable this prompt by setting the `short-name-mode="disabled"` configuration property of Podman in `/etc/containers/registries.conf`.
 
-== Other operating systems
-
-Containers are really Linux. As such, Linux containers cannot run natively on macOS or Windows.
-Therefore, the containers must run in a Linux virtual machine (VM), and a Podman client interacts with that VM.
-So a native hypervisor subsystem and virtualization software is used to run the Linux VM on the OS, and then containers are run within this VM.
-
-.macOS
-macOS users can install Podman through https://brew.sh/[Homebrew]. Once you have set up `brew`, you can use the `brew install` command to install Podman and `docker-compose`:
-[source,bash]
-----
-brew install podman
-brew install docker-compose
-podman machine init
-podman machine start
-alias docker='podman'
-----
-For more details, please see the https://podman.io/getting-started/installation#macos[official Podman documentation] and this https://www.redhat.com/sysadmin/replace-docker-podman-macos[article].
-
-.Windows
-Please see the https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md[Podman for Windows guide] for setup and usage instructions.


### PR DESCRIPTION
Not everyone knows that podman works with Quarkus, so our guide should emphasise that it's possible. 

The podman guide isn't complete for Mac, especially Mac M1. It's missing some needed steps for cross-arch images, and docker sockets can be enabled in an easier way. More generally, the ryuk workaround to make podman work with testcontainers can be avoided with some testcontainers configuration, for all oses. 

Running a build with podman is hard, so I've linked to the podman guide from the contributing instructions.