### PR TITLE
Use @All to inject ObjectMapperCustomizers

### DIFF
--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.TimeZone;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
@@ -17,6 +16,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 
@@ -26,7 +26,7 @@ public class ObjectMapperProducer {
     @DefaultBean
     @Singleton
     @Produces
-    public ObjectMapper objectMapper(Instance<ObjectMapperCustomizer> customizers,
+    public ObjectMapper objectMapper(@All List<ObjectMapperCustomizer> customizers,
             JacksonBuildTimeConfig jacksonBuildTimeConfig) {
         ObjectMapper objectMapper = new ObjectMapper();
         if (!jacksonBuildTimeConfig.failOnUnknownProperties) {
@@ -60,7 +60,7 @@ public class ObjectMapperProducer {
     }
 
     private List<ObjectMapperCustomizer> sortCustomizersInDescendingPriorityOrder(
-            Instance<ObjectMapperCustomizer> customizers) {
+            Iterable<ObjectMapperCustomizer> customizers) {
         List<ObjectMapperCustomizer> sortedCustomizers = new ArrayList<>();
         for (ObjectMapperCustomizer customizer : customizers) {
             sortedCustomizers.add(customizer);

--- a/extensions/jsonb/runtime/src/main/java/io/quarkus/jsonb/JsonbProducer.java
+++ b/extensions/jsonb/runtime/src/main/java/io/quarkus/jsonb/JsonbProducer.java
@@ -1,13 +1,15 @@
 package io.quarkus.jsonb;
 
+import java.util.List;
+
 import javax.enterprise.context.Dependent;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 
+import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 
 @Singleton
@@ -16,7 +18,7 @@ public class JsonbProducer {
     @Produces
     @Dependent //JsonbConfig is not thread safe so it must not be made singleton.
     @DefaultBean
-    public JsonbConfig jsonbConfig(Instance<JsonbConfigCustomizer> customizers) {
+    public JsonbConfig jsonbConfig(@All List<JsonbConfigCustomizer> customizers) {
         JsonbConfig jsonbConfig = new JsonbConfig();
         for (JsonbConfigCustomizer customizer : customizers) {
             customizer.customize(jsonbConfig);


### PR DESCRIPTION
This way, we are sure they are sorted by @Priority.
And they can still be sorted by #getPriority(), this hasn't changed.