### PR TITLE
Jakarta - Adjust workflow tuning via environment variable

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -116,7 +116,7 @@ jobs:
     steps:
       - name: Skip non-compilable modules for jakarta-rewrite branch
         run: |
-          echo "COMMON_MAVEN_ARGS=${COMMON_MAVEN_ARGS} -pl '"'!'":quarkus-integration-test-infinispan-client' -pl '"'!'":quarkus-integration-test-kafka-avro'" >> $GITHUB_ENV
+          echo "EXCLUDE_JAKARTA_INCOMPATIBLE_MODULES=-pl "'!'":quarkus-integration-test-infinispan-client -pl "'!'":quarkus-integration-test-kafka-avro" >> $GITHUB_ENV
         if: github.ref_name == 'jakarta-rewrite'
 
       - uses: actions/checkout@v2
@@ -155,7 +155,7 @@ jobs:
         run: ./jakarta/prepare.sh
       - name: Build
         run: |
-          ./mvnw -T1C $COMMON_MAVEN_ARGS -DskipTests -DskipITs -Dinvoker.skip -Dno-format -Dtcks clean install
+          ./mvnw -T1C $COMMON_MAVEN_ARGS $EXCLUDE_JAKARTA_INCOMPATIBLE_MODULES -DskipTests -DskipITs -Dinvoker.skip -Dno-format -Dtcks clean install
       - name: Verify extension dependencies
         shell: bash
         run: ./update-extension-dependencies.sh $COMMON_MAVEN_ARGS
@@ -186,7 +186,7 @@ jobs:
         id: get-gib-impacted
         # mvnw just for creating gib-impacted.log ("validate" should not waste much time if not incremental at all, e.g. on main)
         run: |
-          ./mvnw -q -T1C $COMMON_MAVEN_ARGS -Dtcks -Dquickly-ci ${{ steps.get-gib-args.outputs.gib_args }} -Dgib.logImpactedTo=gib-impacted.log validate
+          ./mvnw -q -T1C $COMMON_MAVEN_ARGS $EXCLUDE_JAKARTA_INCOMPATIBLE_MODULES -Dtcks -Dquickly-ci ${{ steps.get-gib-args.outputs.gib_args }} -Dgib.logImpactedTo=gib-impacted.log validate
           if [ -f gib-impacted.log ]
           then
             # TODO: for now, we don't run TCKs and for the jakarta-rewrite branch


### PR DESCRIPTION
Hard to find a quoting that actually works on GitHub with the weird
stuff they are doing to set environment variables via a file.

@famod after this is in, I will need your help. I have the GIB build failing for the `jakarta-rewrite` branch. I tried to remove `-q` here but the build says nothing except build success but apparently it exits with a `1` status anyway and I have no idea what's going on:
https://github.com/quarkusio/quarkus/runs/7247993104?check_suite_focus=true
Note: this particular build already includes this fix. I also tried to remove `$EXCLUDE_JAKARTA_INCOMPATIBLE_MODULES` from the GIB command line but to no avail.

The `jakarta-rewrite` branch will be pushed tonight and after that, you can push whatever you want to `jakarta-rewrite` to test the workflow, just know that it's force pushed every night with the new state.