### PR TITLE
Rename misspelled OIDC DevUI 'webClienTimeout' to 'webClientTimeout'

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/DevUiConfig.java
@@ -71,6 +71,6 @@ public class DevUiConfig {
      * Use this property to configure how long an HTTP client used by Dev UI handlers will wait for a response when requesting
      * tokens from OpenId Connect Provider and sending them to the service endpoint.
      */
-    @ConfigItem
-    public Optional<Duration> webClienTimeout;
+    @ConfigItem(defaultValue = "4S")
+    public Duration webClientTimeout;
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/OidcDevConsoleProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.deployment.devservices;
 
-import java.time.Duration;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -104,12 +103,12 @@ public class OidcDevConsoleProcessor extends AbstractDevConsoleProcessor {
                     metadata != null ? metadata.getString("end_session_endpoint") : null,
                     metadata != null ? metadata.containsKey("introspection_endpoint") : false);
 
-            Duration webClientTimeout = oidcConfig.devui.webClienTimeout.isPresent() ? oidcConfig.devui.webClienTimeout.get()
-                    : Duration.ofSeconds(4);
             produceDevConsoleRouteItems(devConsoleRoute,
-                    new OidcTestServiceHandler(vertxInstance, webClientTimeout),
-                    new OidcAuthorizationCodePostHandler(vertxInstance, webClientTimeout, oidcConfig.devui.grantOptions),
-                    new OidcPasswordClientCredHandler(vertxInstance, webClientTimeout, oidcConfig.devui.grantOptions));
+                    new OidcTestServiceHandler(vertxInstance, oidcConfig.devui.webClientTimeout),
+                    new OidcAuthorizationCodePostHandler(vertxInstance, oidcConfig.devui.webClientTimeout,
+                            oidcConfig.devui.grantOptions),
+                    new OidcPasswordClientCredHandler(vertxInstance, oidcConfig.devui.webClientTimeout,
+                            oidcConfig.devui.grantOptions));
         }
     }
 

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/DevServicesConfig.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.deployment.devservices.keycloak;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -185,17 +184,6 @@ public class DevServicesConfig {
      */
     @ConfigItem
     public OptionalInt port;
-
-    /**
-     * The WebClient timeout.
-     * Use this property to configure how long an HTTP client will wait for a response when requesting
-     * tokens from Keycloak and sending them to the service endpoint.
-     *
-     * @deprecated Use {@link DevUiConfig#webClienTimeout}.
-     */
-    @ConfigItem(defaultValue = "4S")
-    @Deprecated
-    public Duration webClienTimeout;
 
     @Override
     public boolean equals(Object o) {

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevConsoleProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.oidc.deployment.devservices.keycloak;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
@@ -60,13 +59,13 @@ public class KeycloakDevConsoleProcessor extends AbstractDevConsoleProcessor {
         if (configProps.isPresent() && configProps.get().getConfig().containsKey("keycloak.url")) {
             @SuppressWarnings("unchecked")
             Map<String, String> users = (Map<String, String>) configProps.get().getProperties().get("oidc.users");
-            Duration webClientTimeout = oidcConfig.devui.webClienTimeout.isPresent() ? oidcConfig.devui.webClienTimeout.get()
-                    : KeycloakDevServicesProcessor.capturedDevServicesConfiguration.webClienTimeout;
             produceDevConsoleRouteItems(devConsoleRoute,
-                    new OidcTestServiceHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout),
-                    new OidcAuthorizationCodePostHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout,
+                    new OidcTestServiceHandler(KeycloakDevServicesProcessor.vertxInstance, oidcConfig.devui.webClientTimeout),
+                    new OidcAuthorizationCodePostHandler(KeycloakDevServicesProcessor.vertxInstance,
+                            oidcConfig.devui.webClientTimeout,
                             oidcConfig.devui.grantOptions),
-                    new OidcPasswordClientCredHandler(KeycloakDevServicesProcessor.vertxInstance, webClientTimeout, users,
+                    new OidcPasswordClientCredHandler(KeycloakDevServicesProcessor.vertxInstance,
+                            oidcConfig.devui.webClientTimeout, users,
                             oidcConfig.devui.grantOptions));
         }
     }


### PR DESCRIPTION
Fixes #26648.

This PR fixes a typo in OIDC DevUI `webClienTimeout` and also removed a deprecated and also misspelled `webClienTimeout`.
I'm not sure this PR should be marked with a `release/breaking-change` label as I can't imagine users actually using these mistyped properties which are also the build time only properties affecting Dev UI only, but I've added it just in case