### PR TITLE
Turn parent first, runner parent first and lesser priority artifacts into dependency flags

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestSupport.java
@@ -198,8 +198,10 @@ public class TestSupport implements TestController {
                     //we always want to propagate parent first
                     //so it is consistent. Some modules may not have quarkus dependencies
                     //so they won't load junit parent first without this
-                    for (var i : curatedApplication.getApplicationModel().getParentFirst()) {
-                        builder.addParentFirstArtifact(i);
+                    for (var i : curatedApplication.getApplicationModel().getDependencies()) {
+                        if (i.isClassLoaderParentFirst()) {
+                            builder.addParentFirstArtifact(i.getKey());
+                        }
                     }
                     var testCuratedApplication = builder // we want to re-discover the local dependencies with test scope
                             .build()

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -83,6 +83,7 @@ import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathVisit;
@@ -817,8 +818,12 @@ public class JarResultBuildStep {
      */
     private Set<ArtifactKey> getParentFirstKeys(CurateOutcomeBuildItem curateOutcomeBuildItem,
             ClassLoadingConfig classLoadingConfig) {
-        final Set<ArtifactKey> parentFirstKeys = new HashSet<>(
-                curateOutcomeBuildItem.getApplicationModel().getRunnerParentFirst());
+        final Set<ArtifactKey> parentFirstKeys = new HashSet<>();
+        curateOutcomeBuildItem.getApplicationModel().getDependencies().forEach(d -> {
+            if (d.isFlagSet(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST)) {
+                parentFirstKeys.add(d.getKey());
+            }
+        });
         classLoadingConfig.parentFirstArtifacts.ifPresent(
                 parentFirstArtifacts -> {
                     for (String artifact : parentFirstArtifacts) {

--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -385,7 +385,6 @@ public class QuarkusDev extends QuarkusTask {
                 .setApplicationModel(appModel)
                 .setApplicationRoot(PathsCollection.from(resourceDirs))
                 .setMode(QuarkusBootstrap.Mode.DEV)
-                .addParentFirstArtifacts(appModel.getParentFirst())
                 .build().getParentFirstArtifacts();
 
         for (io.quarkus.maven.dependency.ResolvedDependency artifact : appModel.getDependencies()) {

--- a/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
+++ b/devtools/gradle/gradle-model/src/main/java/io/quarkus/gradle/dependency/ConditionalDependenciesEnabler.java
@@ -190,12 +190,12 @@ public class ConditionalDependenciesEnabler {
 
     private boolean exists(Dependency dependency) {
         return existingArtifacts
-                .contains(ArtifactKey.gact(dependency.getGroup(), dependency.getName(), null, ArtifactCoords.TYPE_JAR));
+                .contains(ArtifactKey.of(dependency.getGroup(), dependency.getName(), null, ArtifactCoords.TYPE_JAR));
     }
 
     public boolean exists(ExtensionDependency dependency) {
         return existingArtifacts
-                .contains(ArtifactKey.gact(dependency.getGroup(), dependency.getName(), null, ArtifactCoords.TYPE_JAR));
+                .contains(ArtifactKey.of(dependency.getGroup(), dependency.getName(), null, ArtifactCoords.TYPE_JAR));
     }
 
     private static GACT getFeatureKey(ModuleVersionIdentifier version) {
@@ -207,6 +207,6 @@ public class ConditionalDependenciesEnabler {
     }
 
     private static ArtifactKey getKey(ResolvedArtifact a) {
-        return ArtifactKey.gact(a.getModuleVersion().getId().getGroup(), a.getName(), a.getClassifier(), a.getType());
+        return ArtifactKey.of(a.getModuleVersion().getId().getGroup(), a.getName(), a.getClassifier(), a.getType());
     }
 }

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1084,7 +1084,6 @@ public class DevMojo extends AbstractMojo {
                 .setApplicationModel(appModel)
                 .setApplicationRoot(PathsCollection.from(resourceDirs))
                 .setMode(QuarkusBootstrap.Mode.DEV)
-                .addParentFirstArtifacts(appModel.getParentFirst())
                 .build().getParentFirstArtifacts();
 
         for (Artifact appDep : project.getArtifacts()) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/AppModel.java
@@ -26,6 +26,11 @@ import org.jboss.logging.Logger;
 @Deprecated
 public class AppModel implements ApplicationModel, Serializable {
 
+    public static final String PARENT_FIRST_ARTIFACTS = "parent-first-artifacts";
+    public static final String RUNNER_PARENT_FIRST_ARTIFACTS = "runner-parent-first-artifacts";
+    public static final String EXCLUDED_ARTIFACTS = "excluded-artifacts";
+    public static final String LESSER_PRIORITY_ARTIFACTS = "lesser-priority-artifacts";
+
     private static final long serialVersionUID = 6728602422991848950L;
 
     private static final Logger log = Logger.getLogger(AppModel.class);

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/model/ApplicationModel.java
@@ -14,11 +14,6 @@ import java.util.stream.Collectors;
 
 public interface ApplicationModel {
 
-    String PARENT_FIRST_ARTIFACTS = "parent-first-artifacts";
-    String RUNNER_PARENT_FIRST_ARTIFACTS = "runner-parent-first-artifacts";
-    String EXCLUDED_ARTIFACTS = "excluded-artifacts";
-    String LESSER_PRIORITY_ARTIFACTS = "lesser-priority-artifacts";
-
     ResolvedDependency getAppArtifact();
 
     Collection<ResolvedDependency> getDependencies();

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/BootstrapUtils.java
@@ -10,6 +10,7 @@ import io.quarkus.bootstrap.model.CapabilityContract;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.resolver.AppModelResolverException;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.GACT;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import java.io.File;
@@ -75,14 +76,16 @@ public class BootstrapUtils {
             a.setPaths(d.getResolvedPaths() == null ? PathsCollection.of()
                     : PathsCollection.from(d.getResolvedPaths()));
             builder.addDependency(new AppDependency(a, d.getScope(), d.getFlags()));
+            if (d.isFlagSet(DependencyFlags.CLASSLOADER_LESSER_PRIORITY)) {
+                builder.addLesserPriorityArtifact(a.getKey());
+            }
+            if (d.isClassLoaderParentFirst()) {
+                builder.addParentFirstArtifact(a.getKey());
+            }
+            if (d.isFlagSet(DependencyFlags.CLASSLOADER_RUNNER_PARENT_FIRST)) {
+                builder.addRunnerParentFirstArtifact(a.getKey());
+            }
         });
-        appModel.getLowerPriorityArtifacts().forEach(k -> builder.addLesserPriorityArtifact(
-                new AppArtifactKey(k.getGroupId(), k.getArtifactId(), k.getClassifier(), k.getType())));
-        appModel.getParentFirst().forEach(k -> builder
-                .addParentFirstArtifact(new AppArtifactKey(k.getGroupId(), k.getArtifactId(), k.getClassifier(), k.getType())));
-        appModel.getRunnerParentFirst().forEach(k -> builder.addRunnerParentFirstArtifact(
-                new AppArtifactKey(k.getGroupId(), k.getArtifactId(), k.getClassifier(), k.getType())));
-
         appModel.getReloadableWorkspaceDependencies().forEach(k -> builder.addLocalProjectArtifact(
                 new AppArtifactKey(k.getGroupId(), k.getArtifactId(), k.getClassifier(), k.getType())));
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
@@ -4,7 +4,7 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
 
     String groupId;
     String artifactId;
-    String classifier = "";
+    String classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
     String type = GACTV.TYPE_JAR;
     String version;
     String scope = "compile";

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
@@ -46,6 +46,10 @@ public interface Dependency extends ArtifactCoords {
         return isFlagSet(DependencyFlags.RELOADABLE) && isWorkspaceModule();
     }
 
+    default boolean isClassLoaderParentFirst() {
+        return isFlagSet(DependencyFlags.CLASSLOADER_PARENT_FIRST);
+    }
+
     default boolean isFlagSet(int flag) {
         return (getFlags() & flag) > 0;
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/DependencyFlags.java
@@ -3,17 +3,20 @@ package io.quarkus.maven.dependency;
 public interface DependencyFlags {
 
     /* @formatter:off */
-    public static final int OPTIONAL =                             0b00000001;
-    public static final int DIRECT =                               0b00000010;
-    public static final int RUNTIME_CP =                           0b00000100;
-    public static final int DEPLOYMENT_CP =                        0b00001000;
-    public static final int RUNTIME_EXTENSION_ARTIFACT =           0b00010000;
-    public static final int WORKSPACE_MODULE =                     0b00100000;
-    public static final int RELOADABLE =                           0b01000000;
+    public static final int OPTIONAL =                             0b00000000001;
+    public static final int DIRECT =                               0b00000000010;
+    public static final int RUNTIME_CP =                           0b00000000100;
+    public static final int DEPLOYMENT_CP =                        0b00000001000;
+    public static final int RUNTIME_EXTENSION_ARTIFACT =           0b00000010000;
+    public static final int WORKSPACE_MODULE =                     0b00000100000;
+    public static final int RELOADABLE =                           0b00001000000;
     // A top-level runtime extension artifact is either a direct
     // dependency or a first extension dependency on the branch
     // navigating from the root to leaves
-    public static final int TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT = 0b10000000;
+    public static final int TOP_LEVEL_RUNTIME_EXTENSION_ARTIFACT = 0b00010000000;
+    public static final int CLASSLOADER_PARENT_FIRST             = 0b00100000000;
+    public static final int CLASSLOADER_RUNNER_PARENT_FIRST      = 0b01000000000;
+    public static final int CLASSLOADER_LESSER_PRIORITY          = 0b10000000000;
     /* @formatter:on */
 
 }

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/ConfiguredClassLoading.java
@@ -88,7 +88,11 @@ public class ConfiguredClassLoading implements Serializable {
             }
 
             if (appModel != null) {
-                parentFirstArtifacts.addAll(appModel.getParentFirst());
+                appModel.getDependencies().forEach(d -> {
+                    if (d.isClassLoaderParentFirst()) {
+                        parentFirstArtifacts.add(d.getKey());
+                    }
+                });
 
                 if (mode == Mode.TEST) {
                     final WorkspaceModule module = appModel.getApplicationModule();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -9,6 +9,7 @@ import io.quarkus.bootstrap.model.AppModel;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.util.BootstrapUtils;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.OpenPathTree;
 import io.quarkus.paths.PathTree;
@@ -190,7 +191,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
             //we always load this from the parent if it is available, as this acts as a bridge between the running
             //app and the dev mode code
             builder.addParentFirstElement(element);
-        } else if (appModel.getLowerPriorityArtifacts().contains(key)) {
+        } else if (dep.isFlagSet(DependencyFlags.CLASSLOADER_LESSER_PRIORITY)) {
             builder.addLesserPriorityElement(element);
         }
         builder.addElement(element);


### PR DESCRIPTION
Refactoring to represent dependency classloading config options as DependencyFlags, instead of `Set<ArtifactKey>` in `ApplicationModel`.