### PR TITLE
Strip debug information from the native executable unconditionally

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildRunner.java
@@ -72,10 +72,9 @@ public abstract class NativeImageBuildRunner {
             if (objcopyExists) {
                 if (debugSymbolsEnabled) {
                     splitDebugSymbols(nativeImageName, resultingExecutableName);
-                } else {
-                    // Strip debug symbols regardless, because the underlying JDK might contain them
-                    objcopy("--strip-debug", resultingExecutableName);
                 }
+                // Strip debug symbols regardless, because the underlying JDK might contain them
+                objcopy("--strip-debug", resultingExecutableName);
             } else if (SystemUtils.IS_OS_LINUX) {
                 log.warn(
                         "objcopy executable not found in PATH. Debug symbols will therefore not be separated from the executable.");


### PR DESCRIPTION
PR #13963 mistakenly stopped stripping debug information from the native
executable when debug info generation is enabled resulting in both the
native executable and the corresponding `.debug` file containing the
debug information. Which also results in the native executable being
larger when `-Dquarkus.native.debug.enabled` is used:

```
$ du -hs quarkus-integration-test-main-999-SNAPSHOT-runner-nodebug
108M	quarkus-integration-test-main-999-SNAPSHOT-runner-nodebug

$ du -hs quarkus-integration-test-main-999-SNAPSHOT-runner-debug
182M	quarkus-integration-test-main-999-SNAPSHOT-runner-debug

$ du -hs quarkus-integration-test-main-999-SNAPSHOT-runner-debug.debug
75M	quarkus-integration-test-main-999-SNAPSHOT-runner-debug.debug
```

Inspecting `quarkus-integration-test-main-999-SNAPSHOT-runner-debug` and
`quarkus-integration-test-main-999-SNAPSHOT-runner-debug` with
`readelf --debug-dump=info` we observe that both files are containing
debug information while only the latter should contain them.