### PR TITLE
Move REST codestarts to be catalog dependant (RESTEasy/Reactive, Spring Web)

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/base/README.tpl.qute.md
@@ -1,0 +1,1 @@
+{#include readme-header /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,0 +1,1 @@
+{#include index-entry path=resource.path/}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/codestart.yml
@@ -1,0 +1,19 @@
+name: resteasy-codestart
+ref: resteasy
+type: code
+tags: extension-codestart
+metadata:
+  title: RESTEasy JAX-RS
+  description: Easily start your RESTful Web Services
+  related-guide-section: https://quarkus.io/guides/getting-started#the-jax-rs-resources
+language:
+  base:
+    data:
+      resource:
+        class-name: GreetingResource
+        path: "/hello"
+        response: "Hello RESTEasy"
+    dependencies:
+      - io.quarkus:quarkus-resteasy
+    test-dependencies:
+      - io.rest-assured:rest-assured

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("{resource.path}")
+public class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "{resource.response}";
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class {resource.class-name}IT extends {resource.class-name}Test {
+    // Execute the same tests but in packaged mode.
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class {resource.class-name}Test {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(is("{resource.response}"));
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
@@ -1,0 +1,14 @@
+package org.acme
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT : {resource.class-name}Test()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
@@ -1,0 +1,12 @@
+package org.acme
+
+import javax.ws.rs.\{GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(Array[String](MediaType.TEXT_PLAIN))
+    def hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT extends {resource.class-name}Test

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    def testHelloEndpoint() = {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/README.tpl.qute.md
@@ -1,0 +1,1 @@
+{#include readme-header /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,0 +1,1 @@
+{#include index-entry path=resource.path/}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/codestart.yml
@@ -1,0 +1,19 @@
+name: resteasy-reactive-codestart
+ref: resteasy-reactive
+type: code
+tags: extension-codestart
+metadata:
+  title: RESTEasy Reactive
+  description: Easily start your Reactive RESTful Web Services
+  related-guide-section: https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources
+language:
+  base:
+    data:
+      resource:
+        class-name: GreetingResource
+        path: "/hello"
+        response: "Hello from RESTEasy Reactive"
+    dependencies:
+      - io.quarkus:quarkus-resteasy-reactive
+    test-dependencies:
+      - io.rest-assured:rest-assured

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("{resource.path}")
+public class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "{resource.response}";
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class {resource.class-name}IT extends {resource.class-name}Test {
+    // Execute the same tests but in packaged mode.
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class {resource.class-name}Test {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(is("{resource.response}"));
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
@@ -1,0 +1,14 @@
+package org.acme
+
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    fun hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT : {resource.class-name}Test()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
@@ -1,0 +1,12 @@
+package org.acme
+
+import javax.ws.rs.\{GET, Path, Produces}
+import javax.ws.rs.core.MediaType
+
+@Path("{resource.path}")
+class {resource.class-name} {
+
+    @GET
+    @Produces(Array[String](MediaType.TEXT_PLAIN))
+    def hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT extends {resource.class-name}Test

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    def testHelloEndpoint() = {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/base/README.tpl.qute.md
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/base/README.tpl.qute.md
@@ -1,0 +1,1 @@
+{#include readme-header /}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/base/src/main/resources/META-INF/resources/index.entry.qute.html
@@ -1,0 +1,1 @@
+{#include index-entry path=resource.path/}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/codestart.yml
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/codestart.yml
@@ -1,0 +1,21 @@
+name: spring-web-codestart
+ref: spring-web
+type: code
+tags: extension-codestart
+metadata:
+  title: Spring Web
+  description: Spring, the Quarkus way! Start your RESTful Web Services with a Spring Controller.
+  related-guide-section: https://quarkus.io/guides/spring-web#greetingcontroller
+language:
+  base:
+    data:
+      resource:
+        class-name: GreetingController
+        path: "/greeting"
+        response: "Hello Spring"
+      package-name: org.acme
+    dependencies:
+      - io.quarkus:quarkus-spring-web
+      - io.quarkus:quarkus-resteasy-reactive-jackson
+    test-dependencies:
+      - io.rest-assured:rest-assured

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/main/java/org/acme/{resource.class-name}.tpl.qute.java
@@ -1,0 +1,15 @@
+package org.acme;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("{resource.path}")
+public class {resource.class-name} {
+
+    @GetMapping
+    public String hello() {
+        return "{resource.response}";
+    }
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/native-test/java/org/acme/{resource.class-name}IT.tpl.qute.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class {resource.class-name}IT extends {resource.class-name}Test {
+    // Execute the same tests but in packaged mode.
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/java/src/test/java/org/acme/{resource.class-name}Test.tpl.qute.java
@@ -1,0 +1,21 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class {resource.class-name}Test {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(is("{resource.response}"));
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/main/kotlin/org/acme/{resource.class-name}.tpl.qute.kt
@@ -1,0 +1,14 @@
+package org.acme
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("{resource.path}")
+class {resource.class-name} {
+
+    @GetMapping
+    fun hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/native-test/kotlin/org/acme/{resource.class-name}IT.tpl.qute.kt
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT : {resource.class-name}Test()

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/kotlin/src/test/kotlin/org/acme/{resource.class-name}Test.tpl.qute.kt
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    fun testHelloEndpoint() {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/main/scala/org/acme/{resource.class-name}.tpl.qute.scala
@@ -1,0 +1,12 @@
+package org.acme;
+
+import org.springframework.web.bind.annotation.\{GetMapping, RequestMapping, RestController}
+
+
+@RestController
+@RequestMapping(Array[String]("{resource.path}"))
+class {resource.class-name} {
+
+    @GetMapping
+    def hello() = "{resource.response}"
+}

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/native-test/scala/org/acme/{resource.class-name}IT.tpl.qute.scala
@@ -1,0 +1,6 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+@QuarkusIntegrationTest
+class {resource.class-name}IT extends {resource.class-name}Test

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/spring-web-codestart/scala/src/test/scala/org/acme/{resource.class-name}Test.tpl.qute.scala
@@ -1,0 +1,20 @@
+package org.acme
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class {resource.class-name}Test {
+
+    @Test
+    def testHelloEndpoint() = {
+        given()
+          .`when`().get("{resource.path}")
+          .then()
+             .statusCode(200)
+             .body(`is`("{resource.response}"))
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/CodestartResourceLoadersBuilder.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/CodestartResourceLoadersBuilder.java
@@ -99,16 +99,18 @@ public final class CodestartResourceLoadersBuilder {
             Collection<String> extraCodestartsArtifactCoords,
             ExtensionCatalog catalog,
             MavenArtifactResolver mvn) {
+
         final Map<String, Artifact> codestartsArtifacts = new LinkedHashMap<>();
 
+        // The latest inserted in the Map will have priority over the previous (in case of codestarts name conflicts)
         if (catalog != null) {
             // Load codestarts from each extensions codestart artifacts
             for (Extension e : catalog.getExtensions()) {
-                final String artifactCoords = getCodestartArtifact(e);
-                if (artifactCoords == null || codestartsArtifacts.containsKey(artifactCoords)) {
+                final String coords = getCodestartArtifact(e);
+                if (coords == null || codestartsArtifacts.containsKey(coords)) {
                     continue;
                 }
-                codestartsArtifacts.put(artifactCoords, DependencyUtils.toArtifact(artifactCoords));
+                codestartsArtifacts.put(coords, DependencyUtils.toArtifact(coords));
             }
         }
 
@@ -120,17 +122,22 @@ public final class CodestartResourceLoadersBuilder {
         if (catalog != null) {
             // Load codestarts from catalog codestart artifacts
             final List<String> catalogCodestartArtifacts = getCodestartArtifacts(catalog);
-            for (String artifactCoords : catalogCodestartArtifacts) {
-                if (codestartsArtifacts.containsKey(artifactCoords)) {
-                    continue;
+            for (String coords : catalogCodestartArtifacts) {
+                if (codestartsArtifacts.containsKey(coords)) {
+                    // Make sure it overrides the previous codestarts
+                    codestartsArtifacts.remove(coords);
                 }
-                codestartsArtifacts.put(artifactCoords, DependencyUtils.toArtifact(artifactCoords));
+                codestartsArtifacts.put(coords, DependencyUtils.toArtifact(coords));
             }
         }
 
         // Load codestarts from the given artifacts
-        for (String codestartArtifactCoords : extraCodestartsArtifactCoords) {
-            codestartsArtifacts.put(codestartArtifactCoords, DependencyUtils.toArtifact(codestartArtifactCoords));
+        for (String coords : extraCodestartsArtifactCoords) {
+            if (codestartsArtifacts.containsKey(coords)) {
+                // Make sure it overrides the previous codestarts
+                codestartsArtifacts.remove(coords);
+            }
+            codestartsArtifacts.put(coords, DependencyUtils.toArtifact(coords));
         }
 
         final List<ResourceLoader> codestartResourceLoaders = new ArrayList<>(codestartsArtifacts.size());


### PR DESCRIPTION
We keep them (duplicated) in the base for a few versions to keep backward compat.