### PR TITLE
Add support for custom HTTP trace operation names to telemetry spans

### DIFF
--- a/integration-tests/opentelemetry/pom.xml
+++ b/integration-tests/opentelemetry/pom.xml
@@ -35,6 +35,12 @@
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
 
+        <!-- Vertx WebClient -->
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+        </dependency>
+
         <!-- Needed for InMemorySpanExporter to verify captured traces -->
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/PingPongResource.java
+++ b/integration-tests/opentelemetry/src/main/java/io/quarkus/it/opentelemetry/PingPongResource.java
@@ -6,11 +6,20 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.core.http.HttpClient;
+import io.vertx.mutiny.core.http.HttpClientRequest;
+import io.vertx.mutiny.core.http.HttpClientResponse;
 
 @Singleton
 @Path("/client")
@@ -31,6 +40,12 @@ public class PingPongResource {
     @RestClient
     PingPongRestClient pingRestClient;
 
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = "test.url")
+    String testUrl;
+
     @GET
     @Path("pong/{message}")
     public String pong(@PathParam("message") String message) {
@@ -49,4 +64,21 @@ public class PingPongResource {
     public Uni<String> asyncPing(@PathParam("message") String message) {
         return pingRestClient.asyncPingpong(message);
     }
+
+    @GET
+    @Path("async-ping-named/{message}")
+    public Uni<String> asyncPingNamed(@PathParam("message") String message) {
+        HttpClient httpClient = vertx.createHttpClient();
+        RequestOptions options = new RequestOptions()
+                .setMethod(HttpMethod.GET)
+                .setAbsoluteURI(testUrl + "/client/pong/" + message)
+                .setHeaders(MultiMap.caseInsensitiveMultiMap())
+                .setTraceOperation("Async Ping");
+        return httpClient.request(options)
+                .flatMap(HttpClientRequest::send)
+                .flatMap(HttpClientResponse::body)
+                .map(Buffer::toString)
+                .onItemOrFailure().call(httpClient::close);
+    }
+
 }

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -753,6 +753,27 @@ public class OpenTelemetryTestCase {
         Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
     }
 
+    @Test
+    void testCustomSpanNames() {
+        resetExporter();
+
+        given()
+                .contentType("application/json")
+                .when().get("/client/async-ping-named/one")
+                .then()
+                .statusCode(200)
+                .body(containsString("one"));
+
+        Awaitility.await().atMost(Duration.ofMinutes(2)).until(() -> getSpans().size() > 2);
+        Map<String, Object> spanData = getSpans().get(1);
+        Assertions.assertNotNull(spanData);
+        Assertions.assertNotNull(spanData.get("spanId"));
+
+        verifyResource(spanData);
+
+        Assertions.assertEquals("Async Ping", spanData.get("name"));
+    }
+
     /**
      * From bug #26149
      * NPE was thrown when HTTP version was not supported with OpenTelemetry


### PR DESCRIPTION
Vertx `WebClient` & `HttpClient` allow specifying a custom trace operation name. This uses a custom span name extractor to pass this trace operation name on as the span name.