### PR TITLE
Bootstrap option to enable workspace module parent hierarchy initialization

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/DefaultWorkspaceModule.java
@@ -109,6 +109,12 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
         }
 
         @Override
+        public Builder setParent(WorkspaceModule parent) {
+            DefaultWorkspaceModule.this.parent = parent;
+            return this;
+        }
+
+        @Override
         public WorkspaceModule build() {
             final DefaultWorkspaceModule module = DefaultWorkspaceModule.this;
             if (module.id == null) {
@@ -176,6 +182,11 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
         public Collection<String> getAdditionalTestClasspathElements() {
             return DefaultWorkspaceModule.this.additionalTestClasspathElements;
         }
+
+        @Override
+        public WorkspaceModule getParent() {
+            return parent;
+        }
     }
 
     private WorkspaceModuleId id;
@@ -187,6 +198,7 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
     private List<Dependency> directDeps;
     private Collection<String> testClasspathDependencyExclusions = List.of();
     private Collection<String> additionalTestClasspathElements = List.of();
+    private WorkspaceModule parent;
 
     private DefaultWorkspaceModule() {
     }
@@ -268,6 +280,11 @@ public class DefaultWorkspaceModule implements WorkspaceModule, Serializable {
     @Override
     public Collection<String> getAdditionalTestClasspathElements() {
         return additionalTestClasspathElements;
+    }
+
+    @Override
+    public WorkspaceModule getParent() {
+        return parent;
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/WorkspaceModule.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/workspace/WorkspaceModule.java
@@ -59,6 +59,8 @@ public interface WorkspaceModule {
 
     Collection<String> getAdditionalTestClasspathElements();
 
+    WorkspaceModule getParent();
+
     Mutable mutable();
 
     interface Mutable extends WorkspaceModule {
@@ -84,6 +86,8 @@ public interface WorkspaceModule {
         Mutable setTestClasspathDependencyExclusions(Collection<String> excludes);
 
         Mutable setAdditionalTestClasspathElements(Collection<String> elements);
+
+        Mutable setParent(WorkspaceModule parent);
 
         WorkspaceModule build();
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
@@ -17,7 +17,7 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
 
     public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version) {
         super(groupId, artifactId, classifier, type, version);
-        this.scope = "compile";
+        this.scope = SCOPE_COMPILE;
         flags = 0;
     }
 
@@ -29,7 +29,7 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
     }
 
     public ArtifactDependency(ArtifactCoords coords, int... flags) {
-        this(coords, "compile", flags);
+        this(coords, SCOPE_COMPILE, flags);
     }
 
     public ArtifactDependency(ArtifactCoords coords, String scope, int... flags) {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
@@ -2,6 +2,9 @@ package io.quarkus.maven.dependency;
 
 public interface Dependency extends ArtifactCoords {
 
+    String SCOPE_COMPILE = "compile";
+    String SCOPE_IMPORT = "import";
+
     public static Dependency of(String groupId, String artifactId) {
         return new ArtifactDependency(groupId, artifactId, null, ArtifactCoords.TYPE_JAR, null);
     }
@@ -11,7 +14,7 @@ public interface Dependency extends ArtifactCoords {
     }
 
     public static Dependency pomImport(String groupId, String artifactId, String version) {
-        return new ArtifactDependency(groupId, artifactId, null, ArtifactCoords.TYPE_POM, version, "import", false);
+        return new ArtifactDependency(groupId, artifactId, null, ArtifactCoords.TYPE_POM, version, SCOPE_IMPORT, false);
     }
 
     String getScope();

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangDevModeLauncherImpl.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/jbang/JBangDevModeLauncherImpl.java
@@ -8,7 +8,6 @@ import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedArtifactDependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
@@ -100,7 +99,7 @@ public class JBangDevModeLauncherImpl implements Closeable {
                     .setMode(QuarkusBootstrap.Mode.DEV)
                     .setTargetDirectory(targetClasses)
                     .setAppArtifact(appArtifact)
-                    .setManagingProject(new GACTV("io.quarkus", "quarkus-bom", "", "pom", getQuarkusVersion()))
+                    .setManagingProject(ArtifactCoords.pom("io.quarkus", "quarkus-bom", getQuarkusVersion()))
                     .setForcedDependencies(deps.entrySet().stream().map(s -> {
                         String[] parts = s.getKey().split(":");
                         Dependency artifact;

--- a/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
+++ b/independent-projects/bootstrap/core/src/test/java/io/quarkus/bootstrap/resolver/TsArtifact.java
@@ -48,6 +48,14 @@ public class TsArtifact {
         return new TsArtifact(DEFAULT_GROUP_ID, artifactId, EMPTY, TYPE_JAR, version);
     }
 
+    public static TsArtifact pom(String artifactId) {
+        return new TsArtifact(DEFAULT_GROUP_ID, artifactId, EMPTY, TYPE_POM, DEFAULT_VERSION);
+    }
+
+    public static TsArtifact pom(String artifactId, String version) {
+        return new TsArtifact(DEFAULT_GROUP_ID, artifactId, EMPTY, TYPE_POM, version);
+    }
+
     public static TsArtifact pom(String groupId, String artifactId, String version) {
         return new TsArtifact(groupId, artifactId, EMPTY, TYPE_POM, version);
     }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/BootstrapAppModelResolver.java
@@ -41,6 +41,7 @@ import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
 import org.eclipse.aether.version.Version;
 
@@ -202,7 +203,7 @@ public class BootstrapAppModelResolver implements AppModelResolver {
 
         final Map<ArtifactKey, Dependency> managedMap = new HashMap<>();
         for (io.quarkus.maven.dependency.Dependency d : module.getDirectDependencyConstraints()) {
-            if (d.getScope().equals("import")) {
+            if (io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT.equals(d.getScope())) {
                 mvn.resolveDescriptor(toAetherArtifact(d)).getManagedDependencies()
                         .forEach(dep -> managedMap.putIfAbsent(getKey(dep.getArtifact()), dep));
             } else {
@@ -289,9 +290,9 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             return Set.of();
         }
         if (devmode) {
-            return Set.of("test");
+            return Set.of(JavaScopes.TEST);
         }
-        return Set.of("provided", "test");
+        return Set.of(JavaScopes.PROVIDED, JavaScopes.TEST);
     }
 
     private ApplicationModel buildAppModel(ResolvedDependency appArtifact, CollectRequest collectRtDepsRequest,
@@ -335,7 +336,8 @@ public class BootstrapAppModelResolver implements AppModelResolver {
         }
 
         final WorkspaceModule resolvedModule = mvn.getProjectModuleResolver() == null ? null
-                : mvn.getProjectModuleResolver().getProjectModule(appArtifact.getGroupId(), appArtifact.getArtifactId());
+                : mvn.getProjectModuleResolver().getProjectModule(appArtifact.getGroupId(), appArtifact.getArtifactId(),
+                        appArtifact.getVersion());
         if (resolvedArtifact != null && resolvedModule == null) {
             return resolvedArtifact;
         }
@@ -523,5 +525,4 @@ public class BootstrapAppModelResolver implements AppModelResolver {
             throw new BootstrapMavenException("Failed to read descriptor of " + artifact, e);
         }
     }
-
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/ApplicationDependencyTreeResolver.java
@@ -355,7 +355,7 @@ public class ApplicationDependencyTreeResolver {
                 WorkspaceModule module = null;
                 if (resolver.getProjectModuleResolver() != null) {
                     module = resolver.getProjectModuleResolver().getProjectModule(artifact.getGroupId(),
-                            artifact.getArtifactId());
+                            artifact.getArtifactId(), artifact.getVersion());
                 }
                 dep = toAppArtifact(artifact, module)
                         .setRuntimeCp()

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
@@ -30,6 +30,7 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     protected Path rootProjectDir;
     protected boolean preferPomsFromWorkspace;
     protected Boolean effectiveModelBuilder;
+    protected Boolean wsModuleParentHierarchy;
 
     /**
      * Local repository location
@@ -242,6 +243,22 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     @SuppressWarnings("unchecked")
     public T setEffectiveModelBuilder(boolean effectiveModelBuilder) {
         this.effectiveModelBuilder = effectiveModelBuilder;
+        return (T) this;
+    }
+
+    /**
+     * Whether to enable initialization of the parent hierarchy for discovered
+     * {@link io.quarkus.bootstrap.workspace.WorkspaceModule}s.
+     * Enabling complete POM hierarchy is useful for project info and update use-cases but not really for runtime be it test or
+     * dev modes.
+     * <p>
+     *
+     * @param wsModuleParentHierarchy whether to initialize parents for {@link io.quarkus.bootstrap.workspace.WorkspaceModule}
+     * @return this instance
+     */
+    @SuppressWarnings("unchecked")
+    public T setWorkspaceModuleParentHierarchy(boolean wsModuleParentHierarchy) {
+        this.wsModuleParentHierarchy = wsModuleParentHierarchy;
         return (T) this;
     }
 

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BuildDependencyGraphVisitor.java
@@ -145,7 +145,8 @@ public class BuildDependencyGraphVisitor {
             }
             WorkspaceModule module = null;
             if (resolver.getProjectModuleResolver() != null) {
-                module = resolver.getProjectModuleResolver().getProjectModule(artifact.getGroupId(), artifact.getArtifactId());
+                module = resolver.getProjectModuleResolver().getProjectModule(artifact.getGroupId(), artifact.getArtifactId(),
+                        artifact.getVersion());
                 if (module != null) {
                     flags |= DependencyFlags.WORKSPACE_MODULE;
                 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/LocalWorkspace.java
@@ -242,8 +242,8 @@ public class LocalWorkspace implements WorkspaceModelResolver, WorkspaceReader, 
     }
 
     @Override
-    public WorkspaceModule getProjectModule(ArtifactKey key) {
-        final LocalProject project = getProject(key);
-        return project == null ? null : project.toWorkspaceModule();
+    public WorkspaceModule getProjectModule(String groupId, String artifactId, String version) {
+        final LocalProject project = getProject(groupId, artifactId);
+        return project == null || !project.getVersion().equals(version) ? null : project.toWorkspaceModule(mvnCtx);
     }
 }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ProjectModuleResolver.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/workspace/ProjectModuleResolver.java
@@ -1,13 +1,8 @@
 package io.quarkus.bootstrap.resolver.maven.workspace;
 
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
-import io.quarkus.maven.dependency.ArtifactKey;
 
 public interface ProjectModuleResolver {
 
-    default WorkspaceModule getProjectModule(String groupId, String artifactId) {
-        return getProjectModule(ArtifactKey.ga(groupId, artifactId));
-    }
-
-    WorkspaceModule getProjectModule(ArtifactKey key);
+    WorkspaceModule getProjectModule(String groupId, String artifactId, String version);
 }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenBuildFile.java
@@ -55,7 +55,7 @@ public class MavenBuildFile extends BuildFile {
 
     @Override
     protected boolean importBom(ArtifactCoords coords) {
-        if (!"pom".equalsIgnoreCase(coords.getType())) {
+        if (!ArtifactCoords.TYPE_POM.equals(coords.getType())) {
             throw new IllegalArgumentException(coords + " is not a POM");
         }
         Model model = getModel();
@@ -63,7 +63,7 @@ public class MavenBuildFile extends BuildFile {
         d.setGroupId(coords.getGroupId());
         d.setArtifactId(coords.getArtifactId());
         d.setType(coords.getType());
-        d.setScope("import");
+        d.setScope(io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT);
         DependencyManagement dependencyManagement = model.getDependencyManagement();
         if (dependencyManagement == null) {
             dependencyManagement = new DependencyManagement();
@@ -93,8 +93,8 @@ public class MavenBuildFile extends BuildFile {
             d.setClassifier(coords.getClassifier());
         }
         d.setType(coords.getType());
-        if ("pom".equalsIgnoreCase(coords.getType())) {
-            d.setScope("import");
+        if (ArtifactCoords.TYPE_POM.equals(coords.getType())) {
+            d.setScope(io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT);
             DependencyManagement dependencyManagement = model.getDependencyManagement();
             if (dependencyManagement == null) {
                 dependencyManagement = new DependencyManagement();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/buildfile/MavenProjectBuildFile.java
@@ -212,7 +212,7 @@ public class MavenProjectBuildFile extends BuildFile {
 
     @Override
     protected boolean importBom(ArtifactCoords coords) {
-        if (!"pom".equalsIgnoreCase(coords.getType())) {
+        if (!ArtifactCoords.TYPE_POM.equals(coords.getType())) {
             throw new IllegalArgumentException(coords + " is not a POM");
         }
         final String depKey = depKey(coords.getGroupId(), coords.getArtifactId(), coords.getClassifier(), coords.getType());
@@ -222,14 +222,14 @@ public class MavenProjectBuildFile extends BuildFile {
                     coords.getArtifactId().equals(getProperty("quarkus.platform.artifact-id"))
                             ? "${quarkus.platform.artifact-id}"
                             : coords.getArtifactId(),
-                    "pom", "${quarkus.platform.version}");
+                    ArtifactCoords.TYPE_POM, "${quarkus.platform.version}");
         }
 
         final Dependency d = new Dependency();
         d.setGroupId(coords.getGroupId());
         d.setArtifactId(coords.getArtifactId());
         d.setType(coords.getType());
-        d.setScope("import");
+        d.setScope(io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT);
         d.setVersion(coords.getVersion());
         DependencyManagement dependencyManagement = model().getDependencyManagement();
         if (dependencyManagement == null) {
@@ -238,7 +238,7 @@ public class MavenProjectBuildFile extends BuildFile {
         }
         if (dependencyManagement.getDependencies()
                 .stream()
-                .filter(t -> t.getScope().equals("import"))
+                .filter(t -> t.getScope().equals(io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT))
                 .noneMatch(thisDep -> depKey.equals(resolveKey(thisDep)))) {
             dependencyManagement.addDependency(d);
             // the effective managed dependencies set may already include it
@@ -263,8 +263,8 @@ public class MavenProjectBuildFile extends BuildFile {
             d.setClassifier(coords.getClassifier());
         }
         d.setType(coords.getType());
-        if ("pom".equalsIgnoreCase(coords.getType())) {
-            d.setScope("import");
+        if (ArtifactCoords.TYPE_POM.equals(coords.getType())) {
+            d.setScope(io.quarkus.maven.dependency.Dependency.SCOPE_IMPORT);
             DependencyManagement dependencyManagement = model().getDependencyManagement();
             if (dependencyManagement == null) {
                 dependencyManagement = new DependencyManagement();

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/PomTransformer.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/maven/utilities/PomTransformer.java
@@ -1,5 +1,7 @@
 package io.quarkus.maven.utilities;
 
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -552,7 +554,7 @@ public class PomTransformer {
     public static class Gavtcs {
 
         public static Gavtcs importBom(String groupId, String artifactId, String version) {
-            return new Gavtcs(groupId, artifactId, version, "pom", null, "import");
+            return new Gavtcs(groupId, artifactId, version, ArtifactCoords.TYPE_POM, null, Dependency.SCOPE_IMPORT);
         }
 
         public static Gavtcs of(String rawGavtcs) {

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/builder/QuarkusModelBuilderTest.java
@@ -34,7 +34,7 @@ class QuarkusModelBuilderTest {
 
         assertNotNull(quarkusModel);
         assertNotNull(quarkusModel.getApplicationModule());
-        assertThat(quarkusModel.getWorkspaceModules()).isEmpty();
+        assertThat(quarkusModel.getWorkspaceModules().size()).isEqualTo(1);
 
         final ResolvedDependency appArtifact = quarkusModel.getAppArtifact();
         assertThat(appArtifact).isNotNull();
@@ -50,7 +50,7 @@ class QuarkusModelBuilderTest {
 
         assertNotNull(quarkusModel);
         assertNotNull(quarkusModel.getApplicationModule());
-        assertThat(quarkusModel.getWorkspaceModules()).isEmpty();
+        assertThat(quarkusModel.getWorkspaceModules().size()).isEqualTo(1);
 
         final ResolvedDependency appArtifact = quarkusModel.getAppArtifact();
         assertThat(appArtifact).isNotNull();
@@ -71,9 +71,10 @@ class QuarkusModelBuilderTest {
                 new File(projectDir, quarkusModel.getApplicationModule().getId().getArtifactId()), true);
 
         final Collection<WorkspaceModule> projectModules = quarkusModel.getWorkspaceModules();
-        assertEquals(projectModules.size(), 1);
+        assertEquals(projectModules.size(), 2);
         for (WorkspaceModule p : projectModules) {
-            assertProjectModule(p, new File(projectDir, p.getId().getArtifactId()), false);
+            assertProjectModule(p, new File(projectDir, p.getId().getArtifactId()),
+                    quarkusModel.getApplicationModule().getId().equals(p.getId()));
         }
 
         final ResolvedDependency appArtifact = quarkusModel.getAppArtifact();
@@ -104,9 +105,10 @@ class QuarkusModelBuilderTest {
                 new File(projectDir, quarkusModel.getApplicationModule().getId().getArtifactId()), true);
 
         final Collection<WorkspaceModule> projectModules = quarkusModel.getWorkspaceModules();
-        assertEquals(projectModules.size(), 1);
+        assertEquals(projectModules.size(), 2);
         for (WorkspaceModule p : projectModules) {
-            assertProjectModule(p, new File(projectDir, p.getId().getArtifactId()), false);
+            assertProjectModule(p, new File(projectDir, p.getId().getArtifactId()),
+                    quarkusModel.getApplicationModule().getId().equals(p.getId()));
         }
 
         final ResolvedDependency appArtifact = quarkusModel.getAppArtifact();


### PR DESCRIPTION
By default `ApplicationModel.getWorkspaceModules()` returns only modules for the JAR dependencies of an application. Which is enough for bootstrapping in dev and test modes.
For use-cases such as `quarkus:info` and `quarkus:update` though a complete parent POM hierarchy, including BOM modules present in the workspace, is necessary to be able to provide comprehensive information about the project. This PR introduces a Maven bootstrap config option that enables parent POM and BOM modules in the `ApplicationModel.getWorkspaceModules()`.