### PR TITLE
Reorder Resteasy Reactive client handlers so preClientSendHandler is always first

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/HandlerChain.java
@@ -51,11 +51,11 @@ class HandlerChain {
         }
         List<ClientRestHandler> result = new ArrayList<>(
                 (preClientSendHandler != null ? 4 : 3) + requestFilters.size() + responseFilters.size());
-        for (int i = 0; i < requestFilters.size(); i++) {
-            result.add(new ClientRequestFilterRestHandler(requestFilters.get(i)));
-        }
         if (preClientSendHandler != null) {
             result.add(preClientSendHandler);
+        }
+        for (int i = 0; i < requestFilters.size(); i++) {
+            result.add(new ClientRequestFilterRestHandler(requestFilters.get(i)));
         }
         result.add(clientSendHandler);
         result.add(clientSetResponseEntityRestHandler);

--- a/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/test/java/org/jboss/resteasy/reactive/client/impl/HandlerChainTest.java
@@ -1,0 +1,44 @@
+package org.jboss.resteasy.reactive.client.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseFilter;
+import org.jboss.resteasy.reactive.client.api.LoggingScope;
+import org.jboss.resteasy.reactive.client.logging.DefaultClientLogger;
+import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
+import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
+import org.junit.jupiter.api.Test;
+
+public class HandlerChainTest {
+
+    @Test
+    public void preSendHandlerIsAlwaysFirst() throws Exception {
+
+        var chain = new HandlerChain(true, LoggingScope.NONE, Collections.emptyMap(), new DefaultClientLogger());
+
+        ClientRestHandler preHandler = ctx -> {
+        };
+        chain.setPreClientSendHandler(preHandler);
+
+        var config = new ConfigurationImpl(RuntimeType.CLIENT);
+        ClientRequestFilter testReqFilter = ctx -> {
+        };
+        config.register(testReqFilter);
+        ClientResponseFilter testResFilter = (reqCtx, resCtx) -> {
+        };
+        config.register(testResFilter);
+
+        var handlers = chain.createHandlerChain(config);
+
+        // Ensure req & res filters and pre-send handler are all included
+        assertTrue(handlers.length > 3);
+
+        // Ensure pre-send is the very first
+        assertEquals(handlers[0], preHandler);
+    }
+
+}


### PR DESCRIPTION
Presumably the `preClientSendHandler` was added to support observability/telemetry but it has not been working.

The `preClientSendHandler` was previosuly ordered _after_ the request filters but the telemetry is reported using a filter (e.g. `OpenTelemetryClientFilter`). Given that setup the  client’s route template was not set on the context until after the telemeetry was reported.

This simply rearranges the `preClientSendHandler` to run first, before any other handlers, including filters. Which makes the route template available to everybody and fixes the telemetry reporting.