### PR TITLE
Make otel spans for RR clients more spec compliant

### DIFF
--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/RestClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/RestClientOpenTelemetryTest.java
@@ -71,7 +71,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = spans.get(1);
         assertEquals(CLIENT, client.getKind());
-        assertEquals("/hello", client.getName());
+        assertEquals("HTTP GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello", client.getAttributes().get(HTTP_URL));
@@ -89,7 +89,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = spans.get(1);
         assertEquals(CLIENT, client.getKind());
-        assertEquals("/hello", client.getName());
+        assertEquals("HTTP GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello?query=1", client.getAttributes().get(HTTP_URL));
@@ -109,7 +109,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = spans.get(1);
         assertEquals(CLIENT, client.getKind());
-        assertEquals("/hello", client.getName());
+        assertEquals("HTTP GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello?query=1", client.getAttributes().get(HTTP_URL));
@@ -136,7 +136,7 @@ public class RestClientOpenTelemetryTest {
 
         SpanData client = spans.get(1);
         assertEquals(CLIENT, client.getKind());
-        assertEquals("/hello/{path}", client.getName());
+        assertEquals("HTTP GET", client.getName());
         assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
         assertEquals(uri.toString() + "hello/another", client.getAttributes().get(HTTP_URL));

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveClientTest.java
@@ -68,7 +68,7 @@ public class OpenTelemetryReactiveClientTest {
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) server.get("attributes")).get(HTTP_METHOD.getKey()));
 
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("/reactive", client.get("name"));
+        assertEquals("HTTP GET", client.get("name"));
 
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.GET.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));
@@ -102,7 +102,7 @@ public class OpenTelemetryReactiveClientTest {
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) server.get("attributes")).get(HTTP_METHOD.getKey()));
 
         assertEquals(SpanKind.CLIENT.toString(), client.get("kind"));
-        assertEquals("/reactive", client.get("name"));
+        assertEquals("HTTP POST", client.get("name"));
 
         assertEquals(HTTP_OK, ((Map<?, ?>) client.get("attributes")).get(HTTP_STATUS_CODE.getKey()));
         assertEquals(HttpMethod.POST.name(), ((Map<?, ?>) client.get("attributes")).get(HTTP_METHOD.getKey()));

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -542,12 +542,12 @@ public class OpenTelemetryTestCase {
                 Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
                 Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
             } else if (spanData.get("kind").equals(SpanKind.CLIENT.toString())
-                    && spanData.get("name").equals("/client/pong/{message}")) {
+                    && spanData.get("name").equals("HTTP GET")) {
                 clientFound = true;
                 // Client span
                 verifyResource(spanData);
 
-                Assertions.assertEquals("/client/pong/{message}", spanData.get("name"));
+                Assertions.assertEquals("HTTP GET", spanData.get("name"));
                 Assertions.assertEquals(SpanKind.CLIENT.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
 
@@ -655,12 +655,12 @@ public class OpenTelemetryTestCase {
                 Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
                 Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
             } else if (spanData.get("kind").equals(SpanKind.CLIENT.toString())
-                    && spanData.get("name").equals("/client/pong/{message}")) {
+                    && spanData.get("name").equals("HTTP GET")) {
                 clientFound = true;
                 // Client span
                 verifyResource(spanData);
 
-                Assertions.assertEquals("/client/pong/{message}", spanData.get("name"));
+                Assertions.assertEquals("HTTP GET", spanData.get("name"));
                 Assertions.assertEquals(SpanKind.CLIENT.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));
 

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/BasicTest.java
@@ -154,10 +154,10 @@ public class BasicTest {
                 Assertions.assertNotNull(spanData.get("attr_http.client_ip"));
                 Assertions.assertNotNull(spanData.get("attr_http.user_agent"));
             } else if (spanData.get("kind").equals(SpanKind.CLIENT.toString())
-                    && spanData.get("name").equals("/hello")) {
+                    && spanData.get("name").equals("HTTP POST")) {
                 clientFound = true;
                 // Client span
-                Assertions.assertEquals("/hello", spanData.get("name"));
+                Assertions.assertEquals("HTTP POST", spanData.get("name"));
 
                 Assertions.assertEquals(SpanKind.CLIENT.toString(), spanData.get("kind"));
                 Assertions.assertTrue((Boolean) spanData.get("ended"));


### PR DESCRIPTION
The OpenTelementry [Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.10.0/specification/trace/semantic_conventions/http.md#name) is pretty clear about not using the URI as the default span name due to its high cardinality.

> Instrumentation MUST NOT default to using URI path as span name…

Previously that's exactly what the span name extractor was doing. 

Understanding that there are a number of issues and PRs related to reducing the cardinality of the client span names. After working in a live environment with telemetry enabled I've made some changes to make the span names compliant and easier to disambiguate in UIs like Jaeger.

1. This new format never uses the raw URI, as dictated by the spec.
2. The format always starts with `HTTP` followed by the method, when available.
3. If the route template is available it is appended last.

Examples:

    HTTP
    HTTP GET
    HTTP GET /test


Always prepending the `HTTP <method>` disambiguates the client and server spans (which might share the same exact route template) in the UI. In the example below you can see how the edge service uses a client to call the data service. The client and server have the exact same route template but with the prefixing it easily distinguishable.

<img width="353" alt="Screen Shot 2022-07-12 at 9 11 06 PM" src="https://user-images.githubusercontent.com/787655/178649000-0d8993ca-b82a-471e-a59d-ca2ec84f035f.png">


This example might seem a little redundant since it's in the hierarchical format but we find it much easier to read. Also, in other flat formats the client and server are quite clear without drilling down.