### PR TITLE
Add "default-codestart" in platform catalog metadata

### DIFF
--- a/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
+++ b/devtools/bom-descriptor-json/src/main/resources/catalog-overrides.json
@@ -139,6 +139,7 @@
   ],
   "metadata":{
     "project": {
+      "default-codestart": "resteasy-reactive",
       "properties": {
         "doc-root": "https://quarkus.io",
         "rest-assured-version": "${rest-assured.version}",


### PR DESCRIPTION
This is just anticipation and does nothing for now.
It will allow to delete the workaround logic which get the default codestart manually in the devtools code.