### PR TITLE
Fix exit code 1 in CI step 'Get GIB impacted modules' on jakarta-rewrite branch

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -187,13 +187,13 @@ jobs:
         # mvnw just for creating gib-impacted.log ("validate" should not waste much time if not incremental at all, e.g. on main)
         run: |
           ./mvnw -q -T1C $COMMON_MAVEN_ARGS $EXCLUDE_JAKARTA_INCOMPATIBLE_MODULES -Dtcks -Dquickly-ci ${{ steps.get-gib-args.outputs.gib_args }} -Dgib.logImpactedTo=gib-impacted.log validate
-          if [ -f gib-impacted.log ]
+          if [ -s gib-impacted.log ]
           then
             # TODO: for now, we don't run TCKs and for the jakarta-rewrite branch
             # we filter them here so that it cascades to all the builds
             if [ "${GITHUB_REF_NAME}" == "jakarta-rewrite" ]
             then
-              GIB_IMPACTED=$(cat gib-impacted.log | grep -Pv '^(integration-tests/infinispan-client|integration-tests/kafka-avro)')
+              GIB_IMPACTED=$(sed -E '/^(integration-tests\/infinispan-client|integration-tests\/kafka-avro)/d' gib-impacted.log)
             else
               GIB_IMPACTED=$(cat gib-impacted.log)
             fi


### PR DESCRIPTION
Related to #26663

`gib-impacted.log` can be empty when GIB bailed out due to e.g.:
```
[INFO] gitflow-incremental-builder execution skipped: Changed path matches regex defined by skipIfPathMatches: .github/workflows/ci-actions-incremental.yml
```

This is a problem for that `grep` execution because it will return with exit code 1 when nothing matched.
Changing the `if` predicate `-f` to `-s` would be enough to fix that.

But `grep` will also return 1 if nothing is left, e.g. when _only_ `integration-tests/infinispan-client` and/or `integration-tests/kafka-avro` were changed.
Therefore I replaced `grep` with `sed` (which doesn't care whether or not the respective lines are present).