### PR TITLE
Allow setting working directory in gradle devmode task

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -279,7 +279,7 @@ public class QuarkusDev extends QuarkusTask {
             String outputFile = System.getProperty(IO_QUARKUS_DEVMODE_ARGS);
             if (outputFile == null) {
                 getProject().exec(action -> {
-                    action.commandLine(runner.args()).workingDir(QuarkusPluginExtension.getLastFile(getCompilationOutput()));
+                    action.commandLine(runner.args()).workingDir(getWorkingDirectory().get());
                     action.setStandardInput(System.in)
                             .setErrorOutput(System.out)
                             .setStandardOutput(System.out);


### PR DESCRIPTION
This branch uses the working dir property to run quarkus dev mode process

close #26586 