### PR TITLE
Use grpc instead of grpc-server for the Kubernetes port name

### DIFF
--- a/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
+++ b/extensions/grpc/deployment/src/main/java/io/quarkus/grpc/deployment/GrpcServerProcessor.java
@@ -466,7 +466,7 @@ public class GrpcServerProcessor {
         if (!bindables.isEmpty()) {
             int port = ConfigProvider.getConfig().getOptionalValue("quarkus.grpc.server.port", Integer.class)
                     .orElse(9000);
-            return new KubernetesPortBuildItem(port, GRPC_SERVER);
+            return new KubernetesPortBuildItem(port, "grpc");
         }
         return null;
     }


### PR DESCRIPTION
Originally reported [here](https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Configure.20grpc-server.20port.20name/near/289568076) 