### PR TITLE
Use EPOCH timestamp as a file modification timestamp when adding libs docker layer 

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -217,4 +217,19 @@ public class JibConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean useCurrentTimestamp;
+
+    /**
+     * Whether to set the modification time (last modified time) of the files put by Jib in the image to the actual
+     * build time. Otherwise, the modification time will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC).
+     *
+     * If the modification time is constant (flag is set to false so Unix epoch is used) across two consecutive builds,
+     * the docker layer sha256 digest will be different only if the actual files added by Jib to the docker layer were
+     * changed. More exactly, having 2 consecutive builds will generate different docker layers only if the actual
+     * content of the files within the docker layer was changed.
+     *
+     * If the current timestamp is used the sha256 digest of the docker layer will always be different even if the
+     * content of the files didn't change.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useCurrentTimestampFileModification;
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -219,9 +219,9 @@ public class JibConfig {
     public boolean useCurrentTimestamp;
 
     /**
-     * Whether to set the modification time (last modified time) of lib files in the image put by Jib to the actual
-     * build time. Otherwise, the the modification time will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC).
+     * Whether to set the modification time (last modified time) of the files put by Jib in the image to the actual
+     * build time. Otherwise, the modification time will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC).
      */
     @ConfigItem(defaultValue = "true")
-    public boolean useCurrentTimestampLib;
+    public boolean useCurrentTimestampFileModification;
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -217,4 +217,11 @@ public class JibConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean useCurrentTimestamp;
+
+    /**
+     * Whether to set the modification time (last modified time) of lib files in the image put by Jib to the actual
+     * build time. Otherwise, the the modification time will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC).
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean useCurrentTimestampLib;
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibConfig.java
@@ -221,6 +221,14 @@ public class JibConfig {
     /**
      * Whether to set the modification time (last modified time) of the files put by Jib in the image to the actual
      * build time. Otherwise, the modification time will be set to the Unix epoch (00:00:00, January 1st, 1970 in UTC).
+     *
+     * If the modification time is constant (flag is set to false so Unix epoch is used) across two consecutive builds,
+     * the docker layer sha256 digest will be different only if the actual files added by Jib to the docker layer were
+     * changed. More exactly, having 2 consecutive builds will generate different docker layers only if the actual
+     * content of the files within the docker layer was changed.
+     *
+     * If the current timestamp is used the sha256 digest of the docker layer will always be different even if the
+     * content of the files didn't change.
      */
     @ConfigItem(defaultValue = "true")
     public boolean useCurrentTimestampFileModification;

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -492,9 +492,9 @@ public class JibProcessor {
                 AbsoluteUnixPath libsMainPath = workDirInContainer.resolve(JarResultBuildStep.LIB)
                         .resolve(JarResultBuildStep.MAIN);
                 addLayer(jibContainerBuilder, nonFastChangingLibPaths, libsMainPath, "fast-jar-normal-libs",
-                        isMutableJar, now);
+                        isMutableJar, Instant.EPOCH);
                 addLayer(jibContainerBuilder, new ArrayList<>(fastChangingLibPaths), libsMainPath, "fast-jar-changing-libs",
-                        isMutableJar, now);
+                        isMutableJar, Instant.EPOCH);
             }
 
             if (appCDSResult.isPresent()) {

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -492,9 +492,9 @@ public class JibProcessor {
                 AbsoluteUnixPath libsMainPath = workDirInContainer.resolve(JarResultBuildStep.LIB)
                         .resolve(JarResultBuildStep.MAIN);
                 addLayer(jibContainerBuilder, nonFastChangingLibPaths, libsMainPath, "fast-jar-normal-libs",
-                        isMutableJar,modificationTime );
+                        isMutableJar, modificationTime);
                 addLayer(jibContainerBuilder, new ArrayList<>(fastChangingLibPaths), libsMainPath, "fast-jar-changing-libs",
-                        isMutableJar, modificationTime );
+                        isMutableJar, modificationTime);
             }
 
             if (appCDSResult.isPresent()) {
@@ -558,7 +558,7 @@ public class JibProcessor {
                     .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
 
             if (jibConfig.useCurrentTimestamp) {
-                jibContainerBuilder.setCreationTime(modificationTime);
+                jibContainerBuilder.setCreationTime(Instant.now());
             }
 
             for (int port : jibConfig.ports) {

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -489,12 +489,13 @@ public class JibProcessor {
                             "fast-jar-deployment-libs", true, now);
                 }
 
+                Instant libModificationTime = jibConfig.useCurrentTimestampLib ? now : Instant.EPOCH;
                 AbsoluteUnixPath libsMainPath = workDirInContainer.resolve(JarResultBuildStep.LIB)
                         .resolve(JarResultBuildStep.MAIN);
                 addLayer(jibContainerBuilder, nonFastChangingLibPaths, libsMainPath, "fast-jar-normal-libs",
-                        isMutableJar, Instant.EPOCH);
+                        isMutableJar, libModificationTime);
                 addLayer(jibContainerBuilder, new ArrayList<>(fastChangingLibPaths), libsMainPath, "fast-jar-changing-libs",
-                        isMutableJar, Instant.EPOCH);
+                        isMutableJar, libModificationTime);
             }
 
             if (appCDSResult.isPresent()) {

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -444,7 +444,8 @@ public class JibProcessor {
         }
 
         try {
-            Instant modificationTime = jibConfig.useCurrentTimestampFileModification ? Instant.now() : Instant.EPOCH;
+			Instant now = Instant.now();
+			Instant modificationTime = jibConfig.useCurrentTimestampFileModification ? now : Instant.EPOCH;
 
             JibContainerBuilder jibContainerBuilder = Jib
                     .from(toRegistryImage(ImageReference.parse(baseJvmImage), jibConfig.baseRegistryUsername,
@@ -558,7 +559,7 @@ public class JibProcessor {
                     .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
 
             if (jibConfig.useCurrentTimestamp) {
-                jibContainerBuilder.setCreationTime(Instant.now());
+				jibContainerBuilder.setCreationTime(now);
             }
 
             for (int port : jibConfig.ports) {

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -444,8 +444,8 @@ public class JibProcessor {
         }
 
         try {
-			Instant now = Instant.now();
-			Instant modificationTime = jibConfig.useCurrentTimestampFileModification ? now : Instant.EPOCH;
+            Instant now = Instant.now();
+            Instant modificationTime = jibConfig.useCurrentTimestampFileModification ? now : Instant.EPOCH;
 
             JibContainerBuilder jibContainerBuilder = Jib
                     .from(toRegistryImage(ImageReference.parse(baseJvmImage), jibConfig.baseRegistryUsername,
@@ -559,7 +559,7 @@ public class JibProcessor {
                     .setLabels(allLabels(jibConfig, containerImageConfig, containerImageLabels));
 
             if (jibConfig.useCurrentTimestamp) {
-				jibContainerBuilder.setCreationTime(now);
+                jibContainerBuilder.setCreationTime(now);
             }
 
             for (int port : jibConfig.ports) {


### PR DESCRIPTION
Use Instant.EPOCH when adding libsMainPath layers so if the content of the files do not change the layer digest doesn't change either

Fixes: [26734](https://github.com/quarkusio/quarkus/issues/26734) 
