### PR TITLE
Locally configured OIDC paths should override the discovered ones

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -914,6 +914,20 @@ quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect
 quarkus.oidc.end-session-path=/protocol/openid-connect/logout
 ----
 
+Sometimes your OpenId Connect provider supports a metadata discovery but does not return all the endpoint URLs required for the authorization code flow to complete or for the application to support the additional functions such as a user logout. In such cases you can simply configure a missing endpoint URL locally:
+
+[source, properties]
+----
+# Metadata is auto-discovered but it does not return an end-session endpoint URL
+
+quarkus.oidc.auth-server-url=http://localhost:8180/oidcprovider/account
+
+# Configure the end-session URL locally, it can be an absolute or relative (to 'quarkus.oidc.auth-server-url') address
+quarkus.oidc.end-session-path=logout
+----
+
+Exactly the same configuration can be used to override a discovered endpoint URL if that URL does not work for the local Quarkus endpoint and a more specific value is required. For example, one can imagine that in the above example, a provider which supports both global and application specific end-session endpoints returns a global end-session URL such as `http://localhost:8180/oidcprovider/account/global-logout` which will logout the user from all the applications this user is currently logged in, while the current application only wants to get this user logged out from this application, therefore, `quarkus.oidc.end-session-path=logout` is used to override the global end-session URL.
+
 === Token Propagation
 Please see xref:security-openid-connect-client-reference.adoc#token-propagation[Token Propagation] section about the Authorization Code Flow access token propagation to the downstream services.
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcConfigurationMetadata.java
@@ -47,26 +47,26 @@ public class OidcConfigurationMetadata {
         this(wellKnownConfig, null);
     }
 
-    public OidcConfigurationMetadata(JsonObject wellKnownConfig, OidcConfigurationMetadata fallbackConfig) {
+    public OidcConfigurationMetadata(JsonObject wellKnownConfig, OidcConfigurationMetadata localMetadataConfig) {
         this.tokenUri = getMetadataValue(wellKnownConfig, TOKEN_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.tokenUri);
+                localMetadataConfig == null ? null : localMetadataConfig.tokenUri);
         this.introspectionUri = getMetadataValue(wellKnownConfig, INTROSPECTION_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.introspectionUri);
+                localMetadataConfig == null ? null : localMetadataConfig.introspectionUri);
         this.authorizationUri = getMetadataValue(wellKnownConfig, AUTHORIZATION_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.authorizationUri);
+                localMetadataConfig == null ? null : localMetadataConfig.authorizationUri);
         this.jsonWebKeySetUri = getMetadataValue(wellKnownConfig, JWKS_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.jsonWebKeySetUri);
+                localMetadataConfig == null ? null : localMetadataConfig.jsonWebKeySetUri);
         this.userInfoUri = getMetadataValue(wellKnownConfig, USERINFO_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.userInfoUri);
+                localMetadataConfig == null ? null : localMetadataConfig.userInfoUri);
         this.endSessionUri = getMetadataValue(wellKnownConfig, END_SESSION_ENDPOINT,
-                fallbackConfig == null ? null : fallbackConfig.endSessionUri);
-        this.issuer = getMetadataValue(wellKnownConfig, ISSUER, fallbackConfig == null ? null : fallbackConfig.issuer);
+                localMetadataConfig == null ? null : localMetadataConfig.endSessionUri);
+        this.issuer = getMetadataValue(wellKnownConfig, ISSUER,
+                localMetadataConfig == null ? null : localMetadataConfig.issuer);
         this.json = wellKnownConfig;
     }
 
-    private static String getMetadataValue(JsonObject wellKnownConfig, String propertyName, String fallbackValue) {
-        String value = wellKnownConfig.getString(propertyName);
-        return value != null ? value : fallbackValue;
+    private static String getMetadataValue(JsonObject wellKnownConfig, String propertyName, String localValue) {
+        return localValue != null ? localValue : wellKnownConfig.getString(propertyName);
     }
 
     public String getTokenUri() {

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -24,20 +24,14 @@ quarkus.oidc.code-flow-encrypted-id-token-jwk.auth-server-url=${keycloak.url}/re
 quarkus.oidc.code-flow-encrypted-id-token-jwk.client-id=quarkus-web-app
 quarkus.oidc.code-flow-encrypted-id-token-jwk.credentials.secret=secret
 quarkus.oidc.code-flow-encrypted-id-token-jwk.application-type=web-app
-quarkus.oidc.code-flow-encrypted-id-token-jwk.discovery-enabled=false
-quarkus.oidc.code-flow-encrypted-id-token-jwk.authorization-path=/
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token-path=${keycloak.url}/realms/quarkus/encrypted-id-token
-quarkus.oidc.code-flow-encrypted-id-token-jwk.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
 quarkus.oidc.code-flow-encrypted-id-token-jwk.token.decryption-key-location=privateKey.jwk
 
 quarkus.oidc.code-flow-encrypted-id-token-pem.auth-server-url=${keycloak.url}/realms/quarkus/
 quarkus.oidc.code-flow-encrypted-id-token-pem.client-id=quarkus-web-app
 quarkus.oidc.code-flow-encrypted-id-token-pem.credentials.secret=secret
 quarkus.oidc.code-flow-encrypted-id-token-pem.application-type=web-app
-quarkus.oidc.code-flow-encrypted-id-token-pem.discovery-enabled=false
-quarkus.oidc.code-flow-encrypted-id-token-pem.authorization-path=/
-quarkus.oidc.code-flow-encrypted-id-token-pem.token-path=${keycloak.url}/realms/quarkus/encrypted-id-token
-quarkus.oidc.code-flow-encrypted-id-token-pem.jwks-path=${keycloak.url}/realms/quarkus/protocol/openid-connect/certs
+quarkus.oidc.code-flow-encrypted-id-token-pem.token-path=encrypted-id-token
 quarkus.oidc.code-flow-encrypted-id-token-pem.token.decryption-key-location=privateKey.pem
 
 quarkus.oidc.code-flow-form-post.auth-server-url=${keycloak.url}/realms/quarkus-form-post/

--- a/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
+++ b/test-framework/oidc-server/src/main/java/io/quarkus/test/oidc/server/OidcWiremockTestResource.java
@@ -273,8 +273,8 @@ public class OidcWiremockTestResource implements QuarkusTestResourceLifecycleMan
     public static String getEncryptedIdToken(String userName, Set<String> groups) {
         return Jwt.preferredUserName(userName)
                 .groups(groups)
-                .issuer("quarkus.test.oidc.token.issuer")
-                .audience("quarkus.test.oidc.token.audience")
+                .issuer(TOKEN_ISSUER)
+                .audience(TOKEN_AUDIENCE)
                 .subject("123456")
                 .jws()
                 .keyId("1")


### PR DESCRIPTION
This is also related to https://github.com/quarkusio/quarkus/discussions/22806.

This PR simplifies the OIDC `web-app` configuration significantly when the auto-discovery works but only a specific URL has to be customized, you can see it from the test update. 
If the OIDC provider returns a list of various URLs, and one needs to override one of them (as in the updated tests), a rather awkward way to achieve it is to disable the discovery, and then set at least 2 other URLs (in the test cases these are `authorization` and `jwks` paths, but there could be at least 2 more for the introspection and the logout) which one needs to find out from the metadata first, and finally override a specific URL (in the test it is a `token` path) and it is obviously not exactly a user friendly mechanism, even though it allows to handle such cases.

Until now the locally configured URLs have only been used as a fallback in case of the discovery working but returning an non complete list of URLs, as far as I recall, Steph asked for that for the same reason, to avoid disabling the discovery and manually setting all the required URLs.

I had to fix `OidcWiremockTestResource` as the encrypted test tokens were created with the wrong issuer/audience values, those values were in fact the names of the properties which can be used to customize what `OidcWiremockTestResource` uses when creating the tokens. The reason it worked before was because the test which was relying on those tokens had the discovery disabled, therefore `OidcWiremockTestResource` discovery endpoint returning a different issuer was not requested, so the endpoint was not requesting a specific issuer match.