### PR TITLE
Fix JAX-RS snippet in hibernate-orm-panache.adoc

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -471,7 +471,7 @@ public class PersonResource {
 
     @GET
     @Path("/{id}")
-    public Person get(Long id) {
+    public Person get(@PathParam Long id) {
         return Person.findById(id);
     }
 
@@ -485,7 +485,7 @@ public class PersonResource {
     @PUT
     @Path("/{id}")
     @Transactional
-    public Person update(Long id, Person person) {
+    public Person update(@PathParam Long id, Person person) {
         Person entity = Person.findById(id);
         if(entity == null) {
             throw new NotFoundException();
@@ -500,7 +500,7 @@ public class PersonResource {
     @DELETE
     @Path("/{id}")
     @Transactional
-    public void delete(Long id) {
+    public void delete(@PathParam Long id) {
         Person entity = Person.findById(id);
         if(entity == null) {
             throw new NotFoundException();
@@ -510,7 +510,7 @@ public class PersonResource {
 
     @GET
     @Path("/search/{name}")
-    public Person search(String name) {
+    public Person search(@PathParam String name) {
         return Person.findByName(name);
     }
 


### PR DESCRIPTION
Needed `@PathParam` annotation was missing.

Aligning to other docs, make use of:
`org.jboss.resteasy.annotations.jaxrs.PathParam` 
(which do not require parameter value).

## Demonstrating why `@PathParam` is needed

Without:
![Screenshot 2022-07-16 at 07 48 52](https://user-images.githubusercontent.com/1699252/179342259-e4da4ae0-c702-4d31-b9c8-f883cdb90d76.png)

With:
![Screenshot 2022-07-16 at 07 49 31](https://user-images.githubusercontent.com/1699252/179342267-076088e5-c1a3-410e-b81b-ea09121eb100.png)

If you want to replicate locally, for your convenience: https://github.com/tarilabs/demo20220716

Hope this helps, even if it's just a very minor fix to a small snippet! 😅 