### PR TITLE
Implementation of devservices caches for infinispan-client extension

### DIFF
--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -162,11 +162,11 @@ public class InfinispanDevServiceProcessor {
             timeout.ifPresent(infinispanContainer::withStartupTimeout);
             infinispanContainer.start();
 
-            if (!devServicesConfig.cacheTemplates.isEmpty()) {
+            if (!devServicesConfig.caches.isEmpty()) {
                 ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
                 configurationBuilder.security().authentication().saslMechanism("DIGEST-MD5");
                 RemoteCacheManager remoteCacheManager = infinispanContainer.getRemoteCacheManager(configurationBuilder);
-                devServicesConfig.cacheTemplates.forEach((cacheName, templateName) -> remoteCacheManager.administration()
+                devServicesConfig.caches.forEach((cacheName, templateName) -> remoteCacheManager.administration()
                         .createCache(cacheName, Enum.valueOf(DefaultTemplate.class, templateName)));
             }
 

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
@@ -69,13 +69,13 @@ public class InfinispanDevServicesConfig {
      * <p>
      * To configure a cache, you would use one of the enum values from {@code org.infinispan.client.hotrod.DefaultTemplate}
      * <p>
-     * quarkus.infinispan-client.devservices.cache-templates.cache1=DIST_SYNC
-     * quarkus.infinispan-client.devservices.cache-templates.cache2=REPL_SYNC
+     * quarkus.infinispan-client.devservices.caches.cache1=DIST_SYNC
+     * quarkus.infinispan-client.devservices.caches.cache2=REPL_SYNC
      * <p>
      * If an invalid cache template is passed, the Infinispan server will throw an error when trying to start.
      */
     @ConfigItem
-    public Map<String, String> cacheTemplates;
+    public Map<String, String> caches;
 
     @Override
     public boolean equals(Object o) {
@@ -89,11 +89,11 @@ public class InfinispanDevServicesConfig {
                 Objects.equals(shared, that.shared) &&
                 Objects.equals(serviceName, that.serviceName) &&
                 Objects.equals(artifacts, this.artifacts) &&
-                Objects.equals(cacheTemplates, this.cacheTemplates);
+                Objects.equals(caches, this.caches);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, port, shared, serviceName, artifacts, cacheTemplates);
+        return Objects.hash(enabled, port, shared, serviceName, artifacts, caches);
     }
 }

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServicesConfig.java
@@ -1,9 +1,6 @@
 package io.quarkus.infinispan.client.deployment.devservices;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
+import java.util.*;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -67,6 +64,19 @@ public class InfinispanDevServicesConfig {
     @ConfigItem
     public Optional<List<String>> artifacts;
 
+    /**
+     * List of the caches to be created and their associated cache templates.
+     * <p>
+     * To configure a cache, you would use one of the enum values from {@code org.infinispan.client.hotrod.DefaultTemplate}
+     * <p>
+     * quarkus.infinispan-client.devservices.cache-templates.cache1=DIST_SYNC
+     * quarkus.infinispan-client.devservices.cache-templates.cache2=REPL_SYNC
+     * <p>
+     * If an invalid cache template is passed, the Infinispan server will throw an error when trying to start.
+     */
+    @ConfigItem
+    public Map<String, String> cacheTemplates;
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -78,11 +88,12 @@ public class InfinispanDevServicesConfig {
                 Objects.equals(port, that.port) &&
                 Objects.equals(shared, that.shared) &&
                 Objects.equals(serviceName, that.serviceName) &&
-                Objects.equals(artifacts, this.artifacts);
+                Objects.equals(artifacts, this.artifacts) &&
+                Objects.equals(cacheTemplates, this.cacheTemplates);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, port, shared, serviceName, artifacts);
+        return Objects.hash(enabled, port, shared, serviceName, artifacts, cacheTemplates);
     }
 }


### PR DESCRIPTION
When starting a devservices instance of Infinispan, there is a race condition in which the injection of the RemoteCache can happen prior any chance to creation of the caches, resulting in a null pointer on the remote cache instance. 

This implementation allows the user to create caches via devservices config.

Discussion reference: https://github.com/quarkusio/quarkus-quickstarts/issues/392#issuecomment-1186188991

Notes: 

- The `ConfigurationBuilder` passed to the `InfinispanContainer.getRemoteCache` method needed to be adjusted due to the defaulting of the security defaults of the sasl mechanism to "scram-sha-512" rather than to the expected "DIGEST-MD5". There may be a need to move this config to the actual `org.infinispan.server.test.core.InfinispanContainer` implementation located in the Infinispan project. TBH, I am not sure how the existing implementation works without this addition as it uses the default admin/password combo. 
- There are no tests associated with this pull request. I attempted to write some in the infinispan-client extension's integration test project, however the current tests do not use devservices, but rather rolls their own Infinispan server. @wburns 