### PR TITLE
Add TestPrincipalProducer

### DIFF
--- a/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
+++ b/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/RootResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.resteasy.elytron;
 
+import java.security.Principal;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -21,6 +22,8 @@ import io.quarkus.security.identity.SecurityIdentity;
 public class RootResource {
     @Inject
     SecurityIdentity identity;
+    @Inject
+    Principal principal;
 
     @POST
     @Consumes(MediaType.TEXT_PLAIN)
@@ -54,7 +57,7 @@ public class RootResource {
     @Path("/user")
     @RolesAllowed("user")
     public String user(@Context SecurityContext sec) {
-        return sec.getUserPrincipal().getName();
+        return sec.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":" + principal.getName();
     }
 
     @GET

--- a/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/TestSecurityTestCase.java
+++ b/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/TestSecurityTestCase.java
@@ -80,7 +80,7 @@ class TestSecurityTestCase {
                 .get("/user")
                 .then()
                 .statusCode(200)
-                .body(is("testUser"));
+                .body(is("testUser:testUser:testUser"));
     }
 
     @Test

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import java.security.Principal;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -33,6 +34,9 @@ public class ProtectedResource {
     SecurityIdentity identity;
 
     @Inject
+    Principal principal;
+
+    @Inject
     OidcConfigurationMetadata configMetadata;
 
     @Inject
@@ -63,13 +67,15 @@ public class ProtectedResource {
     @GET
     @Path("test-security")
     public String testSecurity() {
-        return securityContext.getUserPrincipal().getName();
+        return securityContext.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":"
+                + principal.getName();
     }
 
     @GET
     @Path("test-security-oidc")
     public String testSecurityJwt() {
-        return idToken.getName() + ":" + idToken.getGroups().iterator().next()
+        return idToken.getName() + ":" + identity.getPrincipal().getName() + ":" + principal.getName()
+                + ":" + idToken.getGroups().iterator().next()
                 + ":" + idToken.getClaim("email")
                 + ":" + userInfo.getString("sub")
                 + ":" + configMetadata.get("audience");

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -21,7 +21,7 @@ public class TestSecurityLazyAuthTest {
     @TestSecurity(user = "user1", roles = "viewer")
     public void testWithDummyUser() {
         RestAssured.when().get("test-security").then()
-                .body(is("user1"));
+                .body(is("user1:user1:user1"));
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestSecurityLazyAuthTest {
     })
     public void testJwtWithDummyUser() {
         RestAssured.when().get("test-security-oidc").then()
-                .body(is("userOidc:viewer:user@gmail.com:subject:aud"));
+                .body(is("userOidc:userOidc:userOidc:viewer:user@gmail.com:subject:aud"));
     }
 
 }

--- a/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/main/java/io/quarkus/it/keycloak/ProtectedJwtResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.it.keycloak;
 
+import java.security.Principal;
+
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -22,6 +24,9 @@ public class ProtectedJwtResource {
     SecurityIdentity identity;
 
     @Inject
+    Principal principal;
+
+    @Inject
     JsonWebToken accessToken;
 
     @Context
@@ -31,7 +36,8 @@ public class ProtectedJwtResource {
     @Path("test-security")
     @RolesAllowed("viewer")
     public String testSecurity() {
-        return securityContext.getUserPrincipal().getName();
+        return securityContext.getUserPrincipal().getName() + ":" + identity.getPrincipal().getName() + ":"
+                + principal.getName();
     }
 
     @POST
@@ -46,7 +52,7 @@ public class ProtectedJwtResource {
     @Path("test-security-jwt")
     @RolesAllowed("viewer")
     public String testSecurityJwt() {
-        return accessToken.getName() + ":" + accessToken.getGroups().iterator().next()
-                + ":" + accessToken.getClaim("email");
+        return accessToken.getName() + ":" + identity.getPrincipal().getName() + ":" + principal.getName()
+                + ":" + accessToken.getGroups().iterator().next() + ":" + accessToken.getClaim("email");
     }
 }

--- a/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
+++ b/integration-tests/smallrye-jwt-token-propagation/src/test/java/io/quarkus/it/keycloak/TestSecurityLazyAuthTest.java
@@ -20,7 +20,7 @@ public class TestSecurityLazyAuthTest {
     @TestSecurity(user = "user1", roles = "viewer")
     public void testWithDummyUser() {
         RestAssured.when().get("test-security").then()
-                .body(is("user1"));
+                .body(is("user1:user1:user1"));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class TestSecurityLazyAuthTest {
     })
     public void testJwtGetWithDummyUser() {
         RestAssured.when().get("test-security-jwt").then()
-                .body(is("userJwt:viewer:user@gmail.com"));
+                .body(is("userJwt:userJwt:userJwt:viewer:user@gmail.com"));
     }
 
 }

--- a/test-framework/security/src/main/java/io/quarkus/test/security/TestPrincipalProducer.java
+++ b/test-framework/security/src/main/java/io/quarkus/test/security/TestPrincipalProducer.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.security;
+
+import java.security.Principal;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+@Alternative
+@Priority(Interceptor.Priority.LIBRARY_AFTER)
+@ApplicationScoped
+public class TestPrincipalProducer {
+
+    @Inject
+    SecurityIdentity testIdentity;
+
+    @Produces
+    @RequestScoped
+    public Principal getTestIdentity() {
+        return testIdentity.getPrincipal();
+    }
+}


### PR DESCRIPTION
Related to #26765.

While @kucharzyk has managed to get it working with the correct dependencies, `integration-tests/elytron-resteasy` shows the problem - injected `SecurityIdentity` will return a correctly initialized `Principal` while a directly injected `Principal` is anonymous.
I think it is to do with `SecurityIdentityAssociation`'s not returning an identity principal directly - but I'm not going to try to change that code as it works for the prod case. But adding a test principal producer fixes it, and I've also updated `smallrye-jwt` and `oidc` tests to verify it is not interfering.