### PR TITLE
Rewrite BuildTimeRunTime and RunTime Defaults ConfigSource

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java
@@ -89,18 +89,10 @@ public final class RunTimeConfigurationGenerator {
     public static final String CONFIG_CLASS_NAME = "io.quarkus.runtime.generated.Config";
     static final String BSDVCS_CLASS_NAME = "io.quarkus.runtime.generated.BootstrapDefaultValuesConfigSource";
     static final String RTDVCS_CLASS_NAME = "io.quarkus.runtime.generated.RunTimeDefaultValuesConfigSource";
-    static final String BTRTDVCS_CLASS_NAME = "io.quarkus.runtime.generated.BuildTimeRunTimeDefaultValuesConfigSource";
 
     // member descriptors
-
-    static final MethodDescriptor BTRTDVCS_NEW = MethodDescriptor.ofConstructor(BTRTDVCS_CLASS_NAME);
-
     public static final FieldDescriptor C_INSTANCE = FieldDescriptor.of(CONFIG_CLASS_NAME, "INSTANCE",
             CONFIG_CLASS_NAME);
-    static final FieldDescriptor C_BUILD_TIME_CONFIG_SOURCE = FieldDescriptor.of(CONFIG_CLASS_NAME, "buildTimeConfigSource",
-            ConfigSource.class);
-    static final FieldDescriptor C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE = FieldDescriptor.of(CONFIG_CLASS_NAME,
-            "buildTimeRunTimeDefaultsConfigSource", ConfigSource.class);
     public static final MethodDescriptor C_CREATE_BOOTSTRAP_CONFIG = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME,
             "createBootstrapConfig", CONFIG_CLASS_NAME);
     public static final MethodDescriptor C_ENSURE_INITIALIZED = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME,
@@ -115,9 +107,6 @@ public final class RunTimeConfigurationGenerator {
             void.class);
     public static final MethodDescriptor C_READ_CONFIG = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME, "readConfig", void.class,
             List.class);
-    static final FieldDescriptor C_SPECIFIED_RUN_TIME_CONFIG_SOURCE = FieldDescriptor.of(CONFIG_CLASS_NAME,
-            "specifiedRunTimeConfigSource",
-            ConfigSource.class);
     static final FieldDescriptor C_UNKNOWN = FieldDescriptor.of(CONFIG_CLASS_NAME, "unknown", List.class);
     static final FieldDescriptor C_UNKNOWN_RUNTIME = FieldDescriptor.of(CONFIG_CLASS_NAME, "unknownRuntime", List.class);
     static final MethodDescriptor C_REPORT_UNKNOWN = MethodDescriptor.ofMethod(CONFIG_CLASS_NAME, "reportUnknown", void.class,
@@ -191,15 +180,8 @@ public final class RunTimeConfigurationGenerator {
     static final MethodDescriptor RCSP_NEW = MethodDescriptor.ofConstructor(RuntimeConfigSourceProvider.class, String.class);
     static final MethodDescriptor RCSF_NEW = MethodDescriptor.ofConstructor(RuntimeConfigSourceFactory.class, String.class);
 
-    static final MethodDescriptor CS_GET_VALUE = MethodDescriptor.ofMethod(ConfigSource.class, "getValue", String.class,
-            String.class);
-
     static final MethodDescriptor AL_NEW = MethodDescriptor.ofConstructor(ArrayList.class);
     static final MethodDescriptor AL_ADD = MethodDescriptor.ofMethod(ArrayList.class, "add", boolean.class, Object.class);
-
-    static final MethodDescriptor HM_NEW = MethodDescriptor.ofConstructor(HashMap.class);
-    static final MethodDescriptor HM_PUT = MethodDescriptor.ofMethod(HashMap.class, "put", Object.class, Object.class,
-            Object.class);
 
     static final MethodDescriptor ITRA_ITERATOR = MethodDescriptor.ofMethod(Iterable.class, "iterator", Iterator.class);
 
@@ -300,8 +282,8 @@ public final class RunTimeConfigurationGenerator {
         final List<RootDefinition> roots;
         final Map<String, String> allBuildTimeValues;
         // default values given in the build configuration
-        final Map<String, String> specifiedRunTimeDefaultValues;
-        final Map<String, String> buildTimeRunTimeVisibleValues;
+        final Map<String, String> runTimeDefaultValues;
+        final Map<String, String> buildTimeRunTimeValues;
         final Map<Container, MethodDescriptor> enclosingMemberMethods = new HashMap<>();
         final Map<Class<?>, MethodDescriptor> groupInitMethods = new HashMap<>();
         final Map<Class<?>, FieldDescriptor> configRootsByType = new HashMap<>();
@@ -342,10 +324,10 @@ public final class RunTimeConfigurationGenerator {
             final BuildTimeConfigurationReader.ReadResult buildTimeReadResult = builder.buildTimeReadResult;
             buildTimeConfigResult = Assert.checkNotNullParam("buildTimeReadResult", buildTimeReadResult);
             allBuildTimeValues = Assert.checkNotNullParam("allBuildTimeValues", buildTimeReadResult.getAllBuildTimeValues());
-            specifiedRunTimeDefaultValues = Assert.checkNotNullParam("specifiedRunTimeDefaultValues",
-                    buildTimeReadResult.getSpecifiedRunTimeDefaultValues());
-            buildTimeRunTimeVisibleValues = Assert.checkNotNullParam("buildTimeRunTimeVisibleValues",
-                    buildTimeReadResult.getBuildTimeRunTimeVisibleValues());
+            runTimeDefaultValues = Assert.checkNotNullParam("runTimeDefaultValues",
+                    buildTimeReadResult.getRunTimeDefaultValues());
+            buildTimeRunTimeValues = Assert.checkNotNullParam("buildTimeRunTimeValues",
+                    buildTimeReadResult.getBuildTimeRunTimeValues());
             classOutput = Assert.checkNotNullParam("classOutput", builder.getClassOutput());
             roots = Assert.checkNotNullParam("builder.roots", builder.getBuildTimeReadResult().getAllRoots());
             additionalTypes = Assert.checkNotNullParam("additionalTypes", builder.getAdditionalTypes());
@@ -388,28 +370,9 @@ public final class RunTimeConfigurationGenerator {
             clinit.invokeStaticMethod(PM_SET_RUNTIME_DEFAULT_PROFILE, clinit.load(ProfileManager.getActiveProfile()));
             clinitNameBuilder = clinit.newInstance(SB_NEW);
 
-            // create the map for build time config source
-            final ResultHandle buildTimeValues = clinit.newInstance(HM_NEW);
-            for (Map.Entry<String, String> entry : buildTimeRunTimeVisibleValues.entrySet()) {
-                clinit.invokeVirtualMethod(HM_PUT, buildTimeValues, clinit.load(entry.getKey()), clinit.load(entry.getValue()));
-            }
-
             // static field containing the instance of the class - is set when createBootstrapConfig is run
             cc.getFieldCreator(C_INSTANCE)
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_VOLATILE);
-
-            // the build time config source field, to feed into the run time config
-            cc.getFieldCreator(C_BUILD_TIME_CONFIG_SOURCE)
-                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
-            final ResultHandle buildTimeConfigSource = clinit.newInstance(PCS_NEW, buildTimeValues,
-                    clinit.load("Build time config"), clinit.load(Integer.MAX_VALUE));
-            clinit.writeStaticField(C_BUILD_TIME_CONFIG_SOURCE, buildTimeConfigSource);
-
-            // the build time run time visible default values config source
-            cc.getFieldCreator(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE)
-                    .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
-            final ResultHandle buildTimeRunTimeDefaultValuesConfigSource = clinit.newInstance(BTRTDVCS_NEW);
-            clinit.writeStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE, buildTimeRunTimeDefaultValuesConfigSource);
 
             // the bootstrap default values config source
             if (!buildTimeReadResult.isBootstrapRootsEmpty()) {
@@ -423,37 +386,10 @@ public final class RunTimeConfigurationGenerator {
                     .setModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL);
             clinit.writeStaticField(C_RUN_TIME_DEFAULTS_CONFIG_SOURCE, clinit.newInstance(RTDVCS_NEW));
 
-            // create the map for run time specified values config source
-            final ResultHandle specifiedRunTimeValues = clinit.newInstance(HM_NEW);
-            if (!liveReloadPossible) {
-                //we don't need these in devmode
-                //including it would just cache the first values
-                //but these can already just be read directly, as we are in the same JVM
-                for (Map.Entry<String, String> entry : specifiedRunTimeDefaultValues.entrySet()) {
-                    clinit.invokeVirtualMethod(HM_PUT, specifiedRunTimeValues, clinit.load(entry.getKey()),
-                            clinit.load(entry.getValue()));
-                }
-            }
-
-            final ResultHandle specifiedRunTimeSource = clinit.newInstance(PCS_NEW, specifiedRunTimeValues,
-                    clinit.load("Specified default values"), clinit.load(Integer.MIN_VALUE + 100));
-
-            cc.getFieldCreator(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE)
-                    .setModifiers(Opcodes.ACC_STATIC | (liveReloadPossible ? Opcodes.ACC_VOLATILE : Opcodes.ACC_FINAL));
-            clinit.writeStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE, specifiedRunTimeSource);
-
             // the build time config, which is for user use only (not used by us other than for loading converters)
             final ResultHandle buildTimeBuilder = clinit.invokeStaticMethod(CU_CONFIG_BUILDER_WITH_ADD_DISCOVERED,
                     clinit.load(true), clinit.load(false), clinit.load(launchMode));
-            final ResultHandle array = clinit.newArray(ConfigSource[].class, 3);
-            // build time values (recorded visible for runtime)
-            clinit.writeArrayValue(array, 0, buildTimeConfigSource);
-            // build time runtime defaults for Config Roots
-            clinit.writeArrayValue(array, 1, buildTimeRunTimeDefaultValuesConfigSource);
-            // runtime default values (recorded during build time)
-            clinit.writeArrayValue(array, 2, clinit.readStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE));
 
-            clinit.invokeVirtualMethod(SRCB_WITH_SOURCES, buildTimeBuilder, array);
             // add safe static sources
             for (String runtimeConfigSource : staticConfigSources) {
                 clinit.invokeStaticMethod(CU_ADD_SOURCE_PROVIDER, buildTimeBuilder,
@@ -519,25 +455,9 @@ public final class RunTimeConfigurationGenerator {
             // at run time (when we're ready) we update the factory and then release the build time config
             installConfiguration(clinitConfig, clinit);
             if (liveReloadPossible) {
-                final ResultHandle buildTimeRunTimeDefaultValuesConfigSource = reinit
-                        .readStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE);
-                // create the map for build time config source
-                final ResultHandle buildTimeValues = reinit.newInstance(HM_NEW);
-                for (Map.Entry<String, String> entry : buildTimeRunTimeVisibleValues.entrySet()) {
-                    reinit.invokeVirtualMethod(HM_PUT, buildTimeValues, reinit.load(entry.getKey()),
-                            reinit.load(entry.getValue()));
-                }
-                final ResultHandle buildTimeConfigSource = reinit.newInstance(PCS_NEW, buildTimeValues,
-                        reinit.load("Build time config = Reloaded"), reinit.load(Integer.MAX_VALUE));
                 // the build time config, which is for user use only (not used by us other than for loading converters)
                 final ResultHandle buildTimeBuilder = reinit.invokeStaticMethod(CU_CONFIG_BUILDER, reinit.load(true),
                         reinit.load(launchMode));
-                final ResultHandle array = reinit.newArray(ConfigSource[].class, 2);
-                // build time values
-                reinit.writeArrayValue(array, 0, buildTimeConfigSource);
-                // build time defaults
-                reinit.writeArrayValue(array, 1, buildTimeRunTimeDefaultValuesConfigSource);
-                reinit.invokeVirtualMethod(SRCB_WITH_SOURCES, buildTimeBuilder, array);
                 // add safe static sources
                 for (String runtimeConfigSource : staticConfigSources) {
                     reinit.invokeStaticMethod(CU_ADD_SOURCE_PROVIDER, buildTimeBuilder,
@@ -620,18 +540,9 @@ public final class RunTimeConfigurationGenerator {
             // add in the custom sources that bootstrap config needs
             ResultHandle bootstrapConfigSourcesArray = null;
             if (bootstrapConfigSetupNeeded()) {
-                bootstrapConfigSourcesArray = readBootstrapConfig.newArray(ConfigSource[].class, 4);
-                // build time config (expanded values)
-                readBootstrapConfig.writeArrayValue(bootstrapConfigSourcesArray, 0,
-                        readBootstrapConfig.readStaticField(C_BUILD_TIME_CONFIG_SOURCE));
-                // specified run time config default values
-                readBootstrapConfig.writeArrayValue(bootstrapConfigSourcesArray, 1,
-                        readBootstrapConfig.readStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE));
-                // build time run time visible default config source
-                readBootstrapConfig.writeArrayValue(bootstrapConfigSourcesArray, 2,
-                        readBootstrapConfig.readStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE));
+                bootstrapConfigSourcesArray = readBootstrapConfig.newArray(ConfigSource[].class, 1);
                 // bootstrap config default values
-                readBootstrapConfig.writeArrayValue(bootstrapConfigSourcesArray, 3,
+                readBootstrapConfig.writeArrayValue(bootstrapConfigSourcesArray, 0,
                         readBootstrapConfig.readStaticField(C_BOOTSTRAP_DEFAULTS_CONFIG_SOURCE));
 
                 // add bootstrap safe static sources
@@ -670,21 +581,13 @@ public final class RunTimeConfigurationGenerator {
 
             // add in our custom sources
             final ResultHandle runtimeConfigSourcesArray = readConfig.newArray(ConfigSource[].class,
-                    bootstrapConfigSetupNeeded() ? 5 : 4);
-            // build time config (expanded values)
-            readConfig.writeArrayValue(runtimeConfigSourcesArray, 0, readConfig.readStaticField(C_BUILD_TIME_CONFIG_SOURCE));
-            // specified run time config default values
-            readConfig.writeArrayValue(runtimeConfigSourcesArray, 1,
-                    readConfig.readStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE));
+                    bootstrapConfigSetupNeeded() ? 2 : 1);
             // run time config default values
-            readConfig.writeArrayValue(runtimeConfigSourcesArray, 2,
+            readConfig.writeArrayValue(runtimeConfigSourcesArray, 0,
                     readConfig.readStaticField(C_RUN_TIME_DEFAULTS_CONFIG_SOURCE));
-            // build time run time visible default config source
-            readConfig.writeArrayValue(runtimeConfigSourcesArray, 3,
-                    readConfig.readStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE));
             if (bootstrapConfigSetupNeeded()) {
                 // bootstrap config default values
-                readConfig.writeArrayValue(runtimeConfigSourcesArray, 4,
+                readConfig.writeArrayValue(runtimeConfigSourcesArray, 1,
                         readConfig.readStaticField(C_BOOTSTRAP_DEFAULTS_CONFIG_SOURCE));
             }
 
@@ -955,9 +858,6 @@ public final class RunTimeConfigurationGenerator {
 
             // generate run time default values config source class
             generateDefaultValuesConfigSourceClass(runTimePatternMap, RTDVCS_CLASS_NAME);
-
-            // generate build time run time visible default values config source class
-            generateDefaultValuesConfigSourceClass(buildTimeRunTimePatternMap, BTRTDVCS_CLASS_NAME);
         }
 
         private void configSweepLoop(MethodDescriptor parserBody, MethodCreator method, ResultHandle config,
@@ -1741,6 +1641,7 @@ public final class RunTimeConfigurationGenerator {
             mc.setModifiers(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC);
 
             ResultHandle unknownProperty = mc.getMethodParam(0);
+            ResultHandle unknown = mc.getMethodParam(1);
 
             // Ignore all build property names. This is to ignore any properties mapped with @ConfigMapping, because
             // these do not fall into the ignore ConfigPattern.
@@ -1751,24 +1652,14 @@ public final class RunTimeConfigurationGenerator {
                 mc.ifTrue(equalsResult).trueBranch().returnValue(null);
             }
 
-            ResultHandle unknown = mc.getMethodParam(1);
-
-            // Ignore recorded properties. If properties are present here, it means that they were recorded at build
-            // time as being mapped in a @ConfigMapping
-            ResultHandle buildTimeRunTimeSource = mc.readStaticField(C_BUILD_TIME_CONFIG_SOURCE);
-            ResultHandle buildTimeRunTimeValue = mc.invokeInterfaceMethod(CS_GET_VALUE, buildTimeRunTimeSource,
-                    unknownProperty);
-            mc.ifNotNull(buildTimeRunTimeValue).trueBranch().returnValue(null);
-
-            ResultHandle buildTimeRunTimeDefaultsSource = mc.readStaticField(C_BUILD_TIME_RUN_TIME_DEFAULTS_CONFIG_SOURCE);
-            ResultHandle buildTimeRunTimeDefaultValue = mc.invokeInterfaceMethod(CS_GET_VALUE, buildTimeRunTimeDefaultsSource,
-                    unknownProperty);
-            mc.ifNotNull(buildTimeRunTimeDefaultValue).trueBranch().returnValue(null);
-
-            ResultHandle runtimeSpecifiedSource = mc.readStaticField(C_SPECIFIED_RUN_TIME_CONFIG_SOURCE);
-            ResultHandle runtimeSpecifiedValue = mc.invokeInterfaceMethod(CS_GET_VALUE, runtimeSpecifiedSource,
-                    unknownProperty);
-            mc.ifNotNull(runtimeSpecifiedValue).trueBranch().returnValue(null);
+            // Ignore recorded runtime property names. This is to ignore any properties mapped with @ConfigMapping, because
+            // these do not fall into the ignore ConfigPattern.
+            for (String buildTimeProperty : runTimeDefaultValues.keySet()) {
+                ResultHandle equalsResult = mc.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(Object.class, "equals", boolean.class, Object.class), unknownProperty,
+                        mc.load(buildTimeProperty));
+                mc.ifTrue(equalsResult).trueBranch().returnValue(null);
+            }
 
             // Add the property as unknown only if all checks fail
             mc.invokeVirtualMethod(AL_ADD, unknown, unknownProperty);

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/ConfigGenerationBuildStep.java
@@ -3,6 +3,7 @@ package io.quarkus.deployment.steps;
 import static io.quarkus.deployment.configuration.ConfigMappingUtils.processExtensionConfigMapping;
 import static io.quarkus.deployment.steps.ConfigBuildSteps.SERVICES_PREFIX;
 import static io.quarkus.deployment.util.ServiceUtil.classNamesNamedIn;
+import static io.quarkus.runtime.configuration.ConfigUtils.QUARKUS_BUILD_TIME_RUNTIME_PROPERTIES;
 import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_LOCATIONS;
 import static java.util.stream.Collectors.toList;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 
@@ -59,18 +61,16 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.deployment.configuration.RunTimeConfigurationGenerator;
-import io.quarkus.deployment.configuration.definition.ClassDefinition;
-import io.quarkus.deployment.configuration.definition.RootDefinition;
-import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.quarkus.runtime.configuration.ConfigDiagnostic;
 import io.quarkus.runtime.configuration.ConfigRecorder;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.configuration.QuarkusConfigValue;
 import io.quarkus.runtime.configuration.RuntimeOverrideConfigSource;
 import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
 import io.smallrye.config.ConfigSourceFactory;
@@ -88,18 +88,45 @@ public class ConfigGenerationBuildStep {
     }
 
     @BuildStep
-    GeneratedResourceBuildItem runtimeDefaultsConfig(List<RunTimeConfigurationDefaultBuildItem> runTimeDefaults,
-            BuildProducer<NativeImageResourceBuildItem> nativeImageResourceBuildItemBuildProducer)
-            throws IOException {
-        Properties p = new Properties();
-        for (var e : runTimeDefaults) {
-            p.setProperty(e.getKey(), e.getValue());
+    void buildTimeRunTimeConfig(
+            ConfigurationBuildItem configItem,
+            BuildProducer<GeneratedResourceBuildItem> generatedResource,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResource) throws Exception {
+
+        Map<String, String> buildTimeRunTimeValues = configItem.getReadResult().getBuildTimeRunTimeValues();
+        Properties properties = new Properties();
+        for (Map.Entry<String, String> entry : buildTimeRunTimeValues.entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
         }
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        p.store(out, null);
-        nativeImageResourceBuildItemBuildProducer
-                .produce(new NativeImageResourceBuildItem(ConfigUtils.QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES));
-        return new GeneratedResourceBuildItem(ConfigUtils.QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES, out.toByteArray());
+        properties.store(out, null);
+        generatedResource.produce(new GeneratedResourceBuildItem(QUARKUS_BUILD_TIME_RUNTIME_PROPERTIES, out.toByteArray()));
+        nativeImageResource.produce(new NativeImageResourceBuildItem(QUARKUS_BUILD_TIME_RUNTIME_PROPERTIES));
+    }
+
+    @BuildStep
+    void runtimeDefaultsConfig(
+            ConfigurationBuildItem configItem,
+            List<RunTimeConfigurationDefaultBuildItem> runTimeDefaults,
+            BuildProducer<GeneratedResourceBuildItem> generatedResource,
+            BuildProducer<NativeImageResourceBuildItem> nativeImageResource) throws IOException {
+
+        Properties properties = new Properties();
+        for (RunTimeConfigurationDefaultBuildItem e : runTimeDefaults) {
+            properties.setProperty(e.getKey(), e.getValue());
+        }
+
+        Map<String, String> runTimeDefaultValues = configItem.getReadResult().getRunTimeDefaultValues();
+        for (Map.Entry<String, String> entry : runTimeDefaultValues.entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        properties.store(out, null);
+        generatedResource.produce(
+                new GeneratedResourceBuildItem(ConfigUtils.QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES, out.toByteArray()));
+        nativeImageResource.produce(new NativeImageResourceBuildItem(ConfigUtils.QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES));
     }
 
     @BuildStep
@@ -231,8 +258,14 @@ public class ConfigGenerationBuildStep {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void checkForBuildTimeConfigChange(
-            ConfigRecorder recorder, ConfigurationBuildItem configItem, LoggingSetupBuildItem loggingSetupBuildItem,
+            RecorderContext recorderContext,
+            ConfigRecorder recorder,
+            ConfigurationBuildItem configItem,
             List<SuppressNonRuntimeConfigChangedWarningBuildItem> suppressNonRuntimeConfigChangedWarningItems) {
+
+        recorderContext.registerSubstitution(io.smallrye.config.ConfigValue.class, QuarkusConfigValue.class,
+                QuarkusConfigValue.Substitution.class);
+
         BuildTimeConfigurationReader.ReadResult readResult = configItem.getReadResult();
         Config config = ConfigProvider.getConfig();
 
@@ -241,15 +274,22 @@ public class ConfigGenerationBuildStep {
             excludedConfigKeys.add(item.getConfigKey());
         }
 
-        Map<String, String> values = new HashMap<>();
-        for (RootDefinition root : readResult.getAllRoots()) {
-            if (root.getConfigPhase() == ConfigPhase.BUILD_AND_RUN_TIME_FIXED ||
-                    root.getConfigPhase() == ConfigPhase.BUILD_TIME) {
+        Map<String, ConfigValue> values = new HashMap<>();
 
-                Iterable<ClassDefinition.ClassMember> members = root.getMembers();
-                handleMembers(config, values, members, root.getName() + ".", excludedConfigKeys);
+        for (final Map.Entry<String, String> entry : readResult.getAllBuildTimeValues().entrySet()) {
+            if (excludedConfigKeys.contains(entry.getKey())) {
+                continue;
             }
+            values.putIfAbsent(entry.getKey(), config.getConfigValue(entry.getKey()));
         }
+
+        for (Map.Entry<String, String> entry : readResult.getBuildTimeRunTimeValues().entrySet()) {
+            if (excludedConfigKeys.contains(entry.getKey())) {
+                continue;
+            }
+            values.put(entry.getKey(), config.getConfigValue(entry.getKey()));
+        }
+
         recorder.handleConfigChange(values);
     }
 
@@ -306,28 +346,6 @@ public class ConfigGenerationBuildStep {
     private String appendProfileToFilename(String path, String activeProfile) {
         String pathWithoutExtension = FilenameUtils.removeExtension(path);
         return String.format("%s-%s.%s", pathWithoutExtension, activeProfile, FilenameUtils.getExtension(path));
-    }
-
-    private void handleMembers(Config config, Map<String, String> values, Iterable<ClassDefinition.ClassMember> members,
-            String prefix, Set<String> excludedConfigKeys) {
-        for (ClassDefinition.ClassMember member : members) {
-            if (member instanceof ClassDefinition.ItemMember) {
-                ClassDefinition.ItemMember itemMember = (ClassDefinition.ItemMember) member;
-                String propertyName = prefix + member.getPropertyName();
-                if (excludedConfigKeys.contains(propertyName)) {
-                    continue;
-                }
-                Optional<String> val = config.getOptionalValue(propertyName, String.class);
-                if (val.isPresent()) {
-                    values.put(propertyName, val.get());
-                } else {
-                    values.put(propertyName, itemMember.getDefaultValue());
-                }
-            } else if (member instanceof ClassDefinition.GroupMember) {
-                handleMembers(config, values, ((ClassDefinition.GroupMember) member).getGroupDefinition().getMembers(),
-                        prefix + member.getDescriptor().getName() + ".", excludedConfigKeys);
-            }
-        }
     }
 
     private static Set<String> discoverService(

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigRecorder.java
@@ -3,15 +3,16 @@ package io.quarkus.runtime.configuration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigurationRuntimeConfig.BuildTimeMismatchAtRuntime;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
 
 @Recorder
 public class ConfigRecorder {
@@ -24,25 +25,30 @@ public class ConfigRecorder {
         this.configurationConfig = configurationConfig;
     }
 
-    public void handleConfigChange(Map<String, String> buildTimeConfig) {
-        Config configProvider = ConfigProvider.getConfig();
-        List<String> mismatches = null;
-        for (Map.Entry<String, String> entry : buildTimeConfig.entrySet()) {
-            Optional<String> val = configProvider.getOptionalValue(entry.getKey(), String.class);
-            if (val.isPresent()) {
-                if (!val.get().equals(entry.getValue())) {
-                    if (mismatches == null) {
-                        mismatches = new ArrayList<>();
-                    }
-                    mismatches.add(" - " + entry.getKey() + " is set to '" + val.get()
-                            + "' but it is build time fixed to '" + entry.getValue() + "'. Did you change the property "
-                            + entry.getKey() + " after building the application?");
-                }
+    public void handleConfigChange(Map<String, ConfigValue> buildTimeRuntimeValues) {
+        SmallRyeConfigBuilder configBuilder = ConfigUtils.emptyConfigBuilder();
+        for (ConfigSource configSource : ConfigProvider.getConfig().getConfigSources()) {
+            if ("BuildTime RunTime Fixed".equals(configSource.getName())) {
+                continue;
+            }
+            configBuilder.withSources(configSource);
+        }
+        SmallRyeConfig config = configBuilder.build();
+
+        List<String> mismatches = new ArrayList<>();
+        for (Map.Entry<String, ConfigValue> entry : buildTimeRuntimeValues.entrySet()) {
+            ConfigValue currentValue = config.getConfigValue(entry.getKey());
+            if (currentValue.getValue() != null && !entry.getValue().getValue().equals(currentValue.getValue())
+                    && entry.getValue().getSourceOrdinal() < currentValue.getSourceOrdinal()) {
+                mismatches.add(
+                        " - " + entry.getKey() + " is set to '" + currentValue.getValue()
+                                + "' but it is build time fixed to '"
+                                + entry.getValue().getValue() + "'. Did you change the property " + entry.getKey()
+                                + " after building the application?");
             }
         }
-        if (mismatches != null && !mismatches.isEmpty()) {
-            final String msg = "Build time property cannot be changed at runtime:\n"
-                    + mismatches.stream().collect(Collectors.joining("\n"));
+        if (!mismatches.isEmpty()) {
+            final String msg = "Build time property cannot be changed at runtime:\n" + String.join("\n", mismatches);
             switch (configurationConfig.buildTimeMismatchAtRuntime) {
                 case fail:
                     throw new IllegalStateException(msg);
@@ -53,7 +59,6 @@ public class ConfigRecorder {
                     throw new IllegalStateException("Unexpected " + BuildTimeMismatchAtRuntime.class.getName() + ": "
                             + configurationConfig.buildTimeMismatchAtRuntime);
             }
-
         }
     }
 }

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -7,19 +7,18 @@ import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE_PARENT;
 import static io.smallrye.config.SmallRyeConfigBuilder.META_INF_MICROPROFILE_CONFIG_PROPERTIES;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -39,9 +38,10 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.DotEnvConfigSourceProvider;
 import io.smallrye.config.EnvConfigSource;
 import io.smallrye.config.FallbackConfigSourceInterceptor;
+import io.smallrye.config.KeyMap;
+import io.smallrye.config.KeyMapBackedConfigSource;
 import io.smallrye.config.Priorities;
 import io.smallrye.config.ProfileConfigSourceInterceptor;
-import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -57,6 +57,7 @@ public final class ConfigUtils {
      * The name of the property associated with a random UUID generated at launch time.
      */
     static final String UUID_KEY = "quarkus.uuid";
+    public static final String QUARKUS_BUILD_TIME_RUNTIME_PROPERTIES = "quarkus-build-time-runtime.properties";
     public static final String QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES = "quarkus-runtime-config-defaults.properties";
 
     private ConfigUtils() {
@@ -113,7 +114,9 @@ public final class ConfigUtils {
             builder.withDefaultValue(UUID_KEY, UUID.randomUUID().toString());
             builder.withSources(new DotEnvConfigSourceProvider());
             builder.withSources(
-                    new PropertiesConfigSource(loadRuntimeDefaultValues(), "Runtime Defaults", Integer.MIN_VALUE + 50));
+                    new DefaultsConfigSource(loadBuildTimeRunTimeValues(), "BuildTime RunTime Fixed", Integer.MAX_VALUE));
+            builder.withSources(
+                    new DefaultsConfigSource(loadRunTimeDefaultValues(), "RunTime Defaults", Integer.MIN_VALUE + 100));
         } else {
             List<ConfigSource> sources = new ArrayList<>();
             sources.addAll(classPathSources(META_INF_MICROPROFILE_CONFIG_PROPERTIES, classLoader));
@@ -226,21 +229,20 @@ public final class ConfigUtils {
         builder.withSources(provider.getConfigSourceFactory(Thread.currentThread().getContextClassLoader()));
     }
 
-    public static Map<String, String> loadRuntimeDefaultValues() {
-        Map<String, String> values = new HashMap<>();
-        try (InputStream in = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES)) {
-            if (in == null) {
-                return values;
-            }
-            Properties p = new Properties();
-            p.load(in);
-            for (String k : p.stringPropertyNames()) {
-                if (!values.containsKey(k)) {
-                    values.put(k, p.getProperty(k));
-                }
-            }
-            return values;
+    public static Map<String, String> loadBuildTimeRunTimeValues() {
+        try {
+            URL resource = Thread.currentThread().getContextClassLoader().getResource(QUARKUS_BUILD_TIME_RUNTIME_PROPERTIES);
+            return resource != null ? ConfigSourceUtil.urlToMap(resource) : Collections.emptyMap();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Map<String, String> loadRunTimeDefaultValues() {
+        try {
+            URL resource = Thread.currentThread().getContextClassLoader()
+                    .getResource(QUARKUS_RUNTIME_CONFIG_DEFAULTS_PROPERTIES);
+            return resource != null ? ConfigSourceUtil.urlToMap(resource) : Collections.emptyMap();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -375,6 +377,46 @@ public final class ConfigUtils {
         @Override
         public Set<String> getPropertyNames() {
             return Collections.emptySet();
+        }
+    }
+
+    static class DefaultsConfigSource extends KeyMapBackedConfigSource {
+        private final KeyMap<String> wildcards;
+        private final Set<String> propertyNames;
+
+        public DefaultsConfigSource(final Map<String, String> properties, final String name, final int ordinal) {
+            super(name, ordinal, propertiesToKeyMap(properties));
+            this.wildcards = new KeyMap<>();
+            this.propertyNames = new HashSet<>();
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                if (entry.getKey().contains("*")) {
+                    this.wildcards.findOrAdd(entry.getKey()).putRootValue(entry.getValue());
+                } else {
+                    this.propertyNames.add(entry.getKey());
+                }
+            }
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return propertyNames;
+        }
+
+        @Override
+        public String getValue(final String propertyName) {
+            String value = super.getValue(propertyName);
+            return value == null ? wildcards.findRootValue(propertyName) : value;
+        }
+
+        private static KeyMap<String> propertiesToKeyMap(final Map<String, String> properties) {
+            KeyMap<String> keyMap = new KeyMap<>();
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                if (entry.getKey().contains("*")) {
+                    continue;
+                }
+                keyMap.findOrAdd(entry.getKey()).putRootValue(entry.getValue());
+            }
+            return keyMap;
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigValue.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/QuarkusConfigValue.java
@@ -1,0 +1,117 @@
+package io.quarkus.runtime.configuration;
+
+import io.quarkus.runtime.ObjectSubstitution;
+import io.smallrye.config.ConfigValue;
+
+public class QuarkusConfigValue {
+    private String name;
+    private String value;
+    private String rawValue;
+    private String profile;
+    private String configSourceName;
+    private int configSourceOrdinal;
+    private int configSourcePosition;
+    private int lineNumber;
+
+    public String getName() {
+        return name;
+    }
+
+    public QuarkusConfigValue setName(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public QuarkusConfigValue setValue(final String value) {
+        this.value = value;
+        return this;
+    }
+
+    public String getRawValue() {
+        return rawValue;
+    }
+
+    public QuarkusConfigValue setRawValue(final String rawValue) {
+        this.rawValue = rawValue;
+        return this;
+    }
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public QuarkusConfigValue setProfile(final String profile) {
+        this.profile = profile;
+        return this;
+    }
+
+    public String getConfigSourceName() {
+        return configSourceName;
+    }
+
+    public QuarkusConfigValue setConfigSourceName(final String configSourceName) {
+        this.configSourceName = configSourceName;
+        return this;
+    }
+
+    public int getConfigSourceOrdinal() {
+        return configSourceOrdinal;
+    }
+
+    public QuarkusConfigValue setConfigSourceOrdinal(final int configSourceOrdinal) {
+        this.configSourceOrdinal = configSourceOrdinal;
+        return this;
+    }
+
+    public int getConfigSourcePosition() {
+        return configSourcePosition;
+    }
+
+    public QuarkusConfigValue setConfigSourcePosition(final int configSourcePosition) {
+        this.configSourcePosition = configSourcePosition;
+        return this;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public QuarkusConfigValue setLineNumber(final int lineNumber) {
+        this.lineNumber = lineNumber;
+        return this;
+    }
+
+    public static final class Substitution implements ObjectSubstitution<ConfigValue, QuarkusConfigValue> {
+        @Override
+        public QuarkusConfigValue serialize(final ConfigValue obj) {
+            QuarkusConfigValue configValue = new QuarkusConfigValue();
+            configValue.setName(obj.getName());
+            configValue.setValue(obj.getValue());
+            configValue.setRawValue(obj.getRawValue());
+            configValue.setProfile(obj.getProfile());
+            configValue.setConfigSourceName(obj.getConfigSourceName());
+            configValue.setConfigSourceOrdinal(obj.getConfigSourceOrdinal());
+            configValue.setConfigSourcePosition(obj.getConfigSourcePosition());
+            configValue.setLineNumber(obj.getLineNumber());
+            return configValue;
+        }
+
+        @Override
+        public ConfigValue deserialize(final QuarkusConfigValue obj) {
+            return ConfigValue.builder()
+                    .withName(obj.getName())
+                    .withValue(obj.getValue())
+                    .withRawValue(obj.getRawValue())
+                    .withProfile(obj.getProfile())
+                    .withConfigSourceName(obj.getConfigSourceName())
+                    .withConfigSourceOrdinal(obj.getConfigSourceOrdinal())
+                    .withConfigSourcePosition(obj.getConfigSourcePosition())
+                    .withLineNumber(obj.getLineNumber())
+                    .build();
+        }
+    }
+}

--- a/extensions/picocli/deployment/src/test/java/io/quarkus/picocli/deployment/AvailableConfigSourcesTest.java
+++ b/extensions/picocli/deployment/src/test/java/io/quarkus/picocli/deployment/AvailableConfigSourcesTest.java
@@ -27,7 +27,7 @@ public class AvailableConfigSourcesTest {
     void sources() {
         ConfigValue value = config.getConfigValue("my.prop");
         assertEquals("1234", value.getValue());
-        assertEquals("PropertiesConfigSource[source=Specified default values]", value.getConfigSourceName());
+        assertEquals("RunTime Defaults", value.getConfigSourceName());
 
         for (final ConfigSource configSource : config.getConfigSources()) {
             if (configSource.getName().contains("application.properties")) {

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientOverrideRuntimeConfigTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientOverrideRuntimeConfigTest.java
@@ -40,7 +40,7 @@ public class RestClientOverrideRuntimeConfigTest {
     void overrideConfig() {
         // Build time property recording
         Optional<ConfigSource> specifiedDefaultValues = config
-                .getConfigSource("PropertiesConfigSource[source=Specified default values]");
+                .getConfigSource("RunTime Defaults");
         assertTrue(specifiedDefaultValues.isPresent());
         assertTrue(specifiedDefaultValues.get().getPropertyNames()
                 .contains("io.quarkus.restclient.configuration.EchoClient/mp-rest/url"));

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientRunTimeConfigSource.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/RestClientRunTimeConfigSource.java
@@ -41,7 +41,7 @@ public class RestClientRunTimeConfigSource extends MapBackedConfigSource {
 
     private static boolean isRuntime() {
         for (ConfigSource configSource : ConfigProvider.getConfig().getConfigSources()) {
-            if (configSource.getName().equals("PropertiesConfigSource[source=Specified default values]")) {
+            if (configSource.getName().equals("RunTime Defaults")) {
                 return true;
             }
         }

--- a/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
+++ b/integration-tests/test-extension/extension/deployment/src/main/java/io/quarkus/extest/deployment/TestProcessor.java
@@ -335,7 +335,7 @@ public final class TestProcessor {
             TestMappingBuildTime testMappingBuildTime,
             TestMappingBuildTimeRunTime testMappingBuildTimeRunTime) {
         Map<String, String> buildTimeValues = configItem.getReadResult().getAllBuildTimeValues();
-        Map<String, String> buildTimeRunTimeValues = configItem.getReadResult().getBuildTimeRunTimeVisibleValues();
+        Map<String, String> buildTimeRunTimeValues = configItem.getReadResult().getBuildTimeRunTimeValues();
 
         if (!testMappingBuildTime.value().equals("value")
                 || !buildTimeValues.getOrDefault("quarkus.mapping.bt.value", "").equals("value")) {

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/BuildTimeRunTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/BuildTimeRunTimeConfigTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.config;
+
+import static org.hamcrest.core.Is.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.deployment.util.FileUtil;
+import io.quarkus.runtime.ApplicationConfig;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.runtime.TlsConfig;
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.smallrye.config.SmallRyeConfig;
+import io.vertx.ext.web.Router;
+
+public class BuildTimeRunTimeConfigTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest TEST = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> {
+                try {
+                    String props = new String(FileUtil.readFileContents(
+                            BuildTimeRunTimeConfigTest.class.getClassLoader().getResourceAsStream("application.properties")),
+                            StandardCharsets.UTF_8);
+
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(DevBean.class)
+                            .addAsResource(new StringAsset(props + "\nquarkus.application.name=my-app\n"),
+                                    "application.properties");
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).setLogRecordPredicate(logRecord -> !logRecord.getMessage().contains("but it is build time fixed to"));
+
+    @Test
+    void buildTimeRunTimeConfig() {
+        // A combination of QuarkusUnitTest and QuarkusProdModeTest tests ordering may mess with the port leaving it in
+        // 8081 and QuarkusDevModeTest does not changes to the right port.
+        RestAssured.port = -1;
+
+        RestAssured.when().get("/application").then()
+                .statusCode(200)
+                .body(is("my-app"));
+
+        RestAssured.when().get("/tls").then()
+                .statusCode(200)
+                .body(is("false"));
+
+        RestAssured.when().get("/source/quarkus.application.name").then()
+                .statusCode(200)
+                .body(is("BuildTime RunTime Fixed"));
+
+        RestAssured.when().get("/source/quarkus.tls.trust-all").then()
+                .statusCode(200)
+                .body(is("BuildTime RunTime Fixed"));
+
+        TEST.modifyResourceFile("application.properties", s -> s + "\n" +
+                "quarkus.application.name=modified-app\n" +
+                "quarkus.tls.trust-all=true\n");
+
+        RestAssured.when().get("/application").then()
+                .statusCode(200)
+                .body(is("modified-app"));
+
+        RestAssured.when().get("/tls").then()
+                .statusCode(200)
+                .body(is("true"));
+
+        RestAssured.when().get("/source/quarkus.application.name").then()
+                .statusCode(200)
+                .body(is("BuildTime RunTime Fixed"));
+
+        RestAssured.when().get("/source/quarkus.tls.trust-all").then()
+                .statusCode(200)
+                .body(is("BuildTime RunTime Fixed"));
+    }
+
+    @ApplicationScoped
+    public static class DevBean {
+        @Inject
+        Router router;
+        @Inject
+        SmallRyeConfig config;
+        @Inject
+        ApplicationConfig applicationConfig;
+        @Inject
+        TlsConfig tlsConfig;
+
+        public void register(@Observes StartupEvent ev) {
+            router.get("/application").handler(rc -> rc.response().end(applicationConfig.name.get()));
+            router.get("/tls").handler(rc -> rc.response().end(tlsConfig.trustAll + ""));
+            router.get("/source/:name")
+                    .handler(rc -> rc.response().end(config.getConfigValue(rc.pathParam("name")).getConfigSourceName()));
+        }
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RenameConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/config/RenameConfigTest.java
@@ -52,7 +52,7 @@ public class RenameConfigTest {
         assertEquals("old-default", renameConfig.withDefault);
 
         // Make sure we only record the actual properties in the sources (and not renamed properties)
-        Optional<ConfigSource> configSource = config.getConfigSource("PropertiesConfigSource[source=Build time config]");
+        Optional<ConfigSource> configSource = config.getConfigSource("BuildTime RunTime Fixed");
         assertTrue(configSource.isPresent());
         ConfigSource buildTimeRunTimeDefaults = configSource.get();
 

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/ConfiguredBeanTest.java
@@ -3,7 +3,6 @@ package io.quarkus.extest;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -320,7 +319,7 @@ public class ConfiguredBeanTest {
 
         ConfigValue value = config.getConfigValue("quarkus.btrt.all-values.long-primitive");
         Assertions.assertEquals("1234567891", value.getValue());
-        Assertions.assertEquals("PropertiesConfigSource[source=Build time config]", value.getConfigSourceName());
+        Assertions.assertEquals("BuildTime RunTime Fixed", value.getConfigSourceName());
         Assertions.assertEquals(Integer.MAX_VALUE, value.getConfigSourceOrdinal());
     }
 
@@ -333,7 +332,7 @@ public class ConfiguredBeanTest {
 
     @Test
     public void testConfigDefaultValuesSourceOrdinal() {
-        Optional<ConfigSource> source = config.getConfigSource("PropertiesConfigSource[source=Specified default values]");
+        Optional<ConfigSource> source = config.getConfigSource("RunTime Defaults");
         assertTrue(source.isPresent());
         ConfigSource defaultValues = source.get();
         assertEquals(Integer.MIN_VALUE + 100, defaultValues.getOrdinal());
@@ -355,7 +354,7 @@ public class ConfiguredBeanTest {
 
     @Test
     public void testProfileDefaultValuesSource() {
-        Optional<ConfigSource> source = config.getConfigSource("PropertiesConfigSource[source=Specified default values]");
+        Optional<ConfigSource> source = config.getConfigSource("RunTime Defaults");
         assertTrue(source.isPresent());
         ConfigSource defaultValues = source.get();
 
@@ -388,15 +387,9 @@ public class ConfiguredBeanTest {
         assertEquals("5678", anotherPrefixConfig.prop);
         assertEquals("5678", anotherPrefixConfig.map.get("prop"));
 
-        ConfigSource defaultValues = null;
-        for (ConfigSource configSource : config.getConfigSources()) {
-            if (configSource.getName().contains("PropertiesConfigSource[source=Specified default values]")) {
-                defaultValues = configSource;
-                break;
-            }
-        }
-        assertNotNull(defaultValues);
+        Optional<ConfigSource> runTimeDefaults = config.getConfigSource("RunTime Defaults");
+        assertTrue(runTimeDefaults.isPresent());
         // java.version should not be recorded
-        assertFalse(defaultValues.getPropertyNames().contains("java.version"));
+        assertFalse(runTimeDefaults.get().getPropertyNames().contains("java.version"));
     }
 }

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/OverrideBuildTimeConfigTest.java
@@ -1,0 +1,25 @@
+package io.quarkus.extest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OverrideBuildTimeConfigTest {
+    @RegisterExtension
+    static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
+            .setRuntimeProperties(Map.of("quarkus.tls.trust-all", "true"))
+            .setRun(true);
+
+    @Test
+    void overrideBuildTimeConfigTest() {
+        assertTrue(TEST.getStartupConsoleOutput()
+                .contains(
+                        "- quarkus.tls.trust-all is set to 'true' but it is build time fixed to 'false'. Did you " +
+                                "change the property quarkus.tls.trust-all after building the application?"));
+    }
+}

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/RuntimeDefaultsTest.java
@@ -29,16 +29,14 @@ public class RuntimeDefaultsTest {
 
     @Test
     void doNotRecordEnvRuntimeDefaults() {
-        Optional<ConfigSource> defaultValues = config
-                .getConfigSource("PropertiesConfigSource[source=Specified default values]");
+        Optional<ConfigSource> defaultValues = config.getConfigSource("RunTime Defaults");
         assertTrue(defaultValues.isPresent());
         assertEquals("properties", defaultValues.get().getValue("bt.do.not.record"));
     }
 
     @Test
     void doNotRecordActiveUnprofiledPropertiesDefaults() {
-        Optional<ConfigSource> defaultValues = config
-                .getConfigSource("PropertiesConfigSource[source=Specified default values]");
+        Optional<ConfigSource> defaultValues = config.getConfigSource("RunTime Defaults");
         assertTrue(defaultValues.isPresent());
         assertEquals("properties", config.getRawValue("bt.profile.record"));
         assertEquals("properties", defaultValues.get().getValue("%test.bt.profile.record"));

--- a/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
+++ b/integration-tests/test-extension/extension/deployment/src/test/java/io/quarkus/extest/UnknownConfigTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -27,7 +28,8 @@ public class UnknownConfigTest {
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
             .assertLogRecords(logRecords -> {
                 Set<String> properties = logRecords.stream().flatMap(
-                        logRecord -> Stream.of(logRecord.getParameters())).map(Object::toString).collect(Collectors.toSet());
+                        logRecord -> Stream.of(Optional.ofNullable(logRecord.getParameters()).orElse(new Object[0])))
+                        .map(Object::toString).collect(Collectors.toSet());
                 assertTrue(properties.contains("quarkus.unknown.prop"));
                 assertFalse(properties.contains("quarkus.build.unknown.prop"));
             });


### PR DESCRIPTION
- Fixes #26156
- Fixes #23680
- Fixes #25857

Currently, there are a few issues with the BuildTimeRunTime values and the RunTime Default values:
- The source and values are generated directly in the Config class. In Dev mode the sources are not regenerated, meaning that lookups or injections to ConfigRoot classes keep the old values. This is not an issue in most cases because these configurations are used during build time in the extensions. Still, users can observe different values (or if somewhere in the code, we look up the property directly). The case of `quarkus.tls.trust-all` which is marked build-time, but it can be changed during runtime.
- https://github.com/quarkusio/quarkus/pull/20932 changed the BuildTime and RunTime values source to have the max original value. This prevented override of such configurations. This was not very visible because these configurations are primarily used in build time in the extensions, but users can observe different values.
- Defaults values for BuildTime and RunTime could still be overridden since the source is set with a low ordinal.
- The report of such values being overridden was inaccurate due to all of the above.

Changes in the PR:
- The BuildTime and RunTime values and the RunTime Default values are now written to an external resource. This fixes the issue with reloading values in DEV mode.
- The BuildTime and RunTime default values are now merged with the recorded user values.
- The source gets max priority to disallow overring values. This prevents users from seeing different values if they look up a configuration directly or inject a ConfigRoot class.
- The recorded RunTime Default values are now merged with the Build Item RunTime Default values 
- Checking for overrides warnings takes into account the source of the configuration

A few extra considerations:
- We now instantiate the source twice (for static and runtime). There are other cases where we double instance sources. I think we can improve this generally by just reusing the builder from static to runtime.
- These sources are now a resource for the native image. We can probably still generate a class with all the values, but I wanted to keep the same code and behavior between dev and native.
- Due to being a single source now and the defaults being in higher priority, it should require fewer lookups to create the ConfigRoot classes.