### PR TITLE
Consistently consider quoted AND non-quoted versions of quarkus.datasource configuration properties

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
@@ -1,5 +1,8 @@
 package io.quarkus.deployment.builditem;
 
+import java.util.Collection;
+import java.util.List;
+
 import io.quarkus.builder.item.MultiBuildItem;
 
 /**
@@ -12,21 +15,40 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
 
-    private final String triggeringKey;
+    private final Collection<String> triggeringKeys;
     private final String key;
     private final String value;
     private final Runnable callbackWhenEnabled;
 
+    /**
+     * @deprecated Call
+     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(Collection, String, String, Runnable)}
+     *             instead.
+     */
+    @Deprecated
     public DevServicesAdditionalConfigBuildItem(String triggeringKey,
             String key, String value, Runnable callbackWhenEnabled) {
-        this.triggeringKey = triggeringKey;
+        this(List.of(triggeringKey), key, value, callbackWhenEnabled);
+    }
+
+    public DevServicesAdditionalConfigBuildItem(Collection<String> triggeringKeys,
+            String key, String value, Runnable callbackWhenEnabled) {
+        this.triggeringKeys = triggeringKeys;
         this.key = key;
         this.value = value;
         this.callbackWhenEnabled = callbackWhenEnabled;
     }
 
+    /**
+     * @deprecated Call {@link #getTriggeringKeys()} instead.
+     */
+    @Deprecated
     public String getTriggeringKey() {
-        return triggeringKey;
+        return getTriggeringKeys().iterator().next();
+    }
+
+    public Collection<String> getTriggeringKeys() {
+        return triggeringKeys;
     }
 
     public String getKey() {

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
@@ -68,7 +68,7 @@ class DevServicesConfigBuildStep {
         // On contrary to dev services config, "additional" config build items are
         // produced on each restart, so we don't want to remember them from one restart to the next.
         for (DevServicesAdditionalConfigBuildItem item : devServicesAdditionalConfigBuildItems) {
-            if (newProperties.containsKey(item.getTriggeringKey())) {
+            if (item.getTriggeringKeys().stream().anyMatch(newProperties::containsKey)) {
                 var callback = item.getCallbackWhenEnabled();
                 if (callback != null) {
                     callback.run(); // This generally involves logging

--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
@@ -25,6 +26,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.IntFunction;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
@@ -268,6 +270,48 @@ public final class ConfigUtils {
      */
     public static boolean isPropertyPresent(String propertyName) {
         return ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).isPropertyPresent(propertyName);
+    }
+
+    /**
+     * Checks if any of the given properties is present in the current Configuration.
+     * <p>
+     * Because the sources may not expose the property directly in {@link ConfigSource#getPropertyNames()}, we cannot
+     * reliably determine if the property is present in the properties list. The property needs to be retrieved to make
+     * sure it exists. Also, if the value is an expression, we want to ignore expansion, because this is not relevant
+     * for the check and the expansion value may not be available at this point.
+     * <p>
+     * It may be interesting to expose such API in SmallRyeConfig directly.
+     *
+     * @param propertyNames The configuration property names
+     * @return true if the property is present or false otherwise.
+     */
+    public static boolean isAnyPropertyPresent(Collection<String> propertyNames) {
+        for (String propertyName : propertyNames) {
+            if (isPropertyPresent(propertyName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the value of the first given property present in the current Configuration,
+     * or {@link Optional#empty()} if none of the properties is present.
+     *
+     * @param <T> The property type
+     * @param propertyNames The configuration property names
+     * @param propertyType The type that the resolved property value should be converted to
+     * @return true if the property is present or false otherwise.
+     */
+    public static <T> Optional<T> getFirstOptionalValue(List<String> propertyNames, Class<T> propertyType) {
+        Config config = ConfigProvider.getConfig();
+        for (String propertyName : propertyNames) {
+            Optional<T> value = config.getOptionalValue(propertyName, propertyType);
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DataSourceUtil.java
+++ b/extensions/datasource/common/src/main/java/io/quarkus/datasource/common/runtime/DataSourceUtil.java
@@ -1,6 +1,7 @@
 package io.quarkus.datasource.common.runtime;
 
 import java.util.Collection;
+import java.util.List;
 
 public final class DataSourceUtil {
 
@@ -12,6 +13,17 @@ public final class DataSourceUtil {
 
     public static boolean hasDefault(Collection<String> dataSourceNames) {
         return dataSourceNames.contains(DEFAULT_DATASOURCE_NAME);
+    }
+
+    public static List<String> dataSourcePropertyKeys(String datasourceName, String radical) {
+        if (datasourceName == null || DataSourceUtil.isDefault(datasourceName)) {
+            return List.of("quarkus.datasource." + radical);
+        } else {
+            // Two possible syntaxes: with or without quotes
+            return List.of(
+                    "quarkus.datasource.\"" + datasourceName + "\"." + radical,
+                    "quarkus.datasource." + datasourceName + "." + radical);
+        }
     }
 
     private DataSourceUtil() {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -273,22 +273,18 @@ public final class HibernateOrmProcessor {
                 .collect(HashSet::new, Collection::addAll, Collection::addAll);
 
         for (Entry<String, HibernateOrmConfigPersistenceUnit> entry : config.getAllPersistenceUnitConfigsAsMap().entrySet()) {
-            String propertyKeyIndicatingDataSourceConfigured;
             Optional<String> dataSourceName = entry.getValue().datasource;
-            if (dataSourceName.isEmpty()) {
-                propertyKeyIndicatingDataSourceConfigured = "quarkus.datasource.username";
-            } else {
-                propertyKeyIndicatingDataSourceConfigured = "quarkus.datasource." + dataSourceName.get() + ".username";
-            }
+            List<String> propertyKeysIndicatingDataSourceConfigured = DataSourceUtil
+                    .dataSourcePropertyKeys(dataSourceName.orElse(null), "username");
 
             if (!managedSources.contains(dataSourceName.orElse(DataSourceUtil.DEFAULT_DATASOURCE_NAME))) {
                 String databaseGenerationPropertyKey = HibernateOrmRuntimeConfig.puPropertyKey(entry.getKey(),
                         "database.generation");
-                if (!ConfigUtils.isPropertyPresent(propertyKeyIndicatingDataSourceConfigured)
+                if (!ConfigUtils.isAnyPropertyPresent(propertyKeysIndicatingDataSourceConfigured)
                         && !ConfigUtils.isPropertyPresent(databaseGenerationPropertyKey)) {
                     String forcedValue = "drop-and-create";
                     devServicesAdditionalConfigProducer
-                            .produce(new DevServicesAdditionalConfigBuildItem(propertyKeyIndicatingDataSourceConfigured,
+                            .produce(new DevServicesAdditionalConfigBuildItem(propertyKeysIndicatingDataSourceConfigured,
                                     databaseGenerationPropertyKey, forcedValue,
                                     () -> LOG.infof("Setting %s=%s to initialize Dev Services managed database",
                                             databaseGenerationPropertyKey, forcedValue)));

--- a/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceNamedWithUsernameTestCase.java
+++ b/extensions/jdbc/jdbc-postgresql/deployment/src/test/java/io/quarkus/jdbc/postgresql/deployment/DevServicesPostgresqlDatasourceNamedWithUsernameTestCase.java
@@ -1,0 +1,48 @@
+package io.quarkus.jdbc.postgresql.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.Connection;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DevServicesPostgresqlDatasourceNamedWithUsernameTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.datasource.\"DB2\".db-kind", "postgresql")
+            .overrideConfigKey("quarkus.datasource.\"DB2\".username", "foo")
+            .overrideConfigKey("quarkus.datasource.\"DB2\".password", "foo");
+
+    @Inject
+    @Named("DB2")
+    AgroalDataSource dataSource;
+
+    @Test
+    public void testDatasource() throws Exception {
+        AgroalConnectionPoolConfiguration configuration = null;
+
+        try {
+            configuration = dataSource.getConfiguration().connectionPoolConfiguration();
+        } catch (NullPointerException e) {
+            // we catch the NPE here as we have a proxycd and we can't test dataSource directly
+            fail("Datasource should not be null");
+        }
+        assertTrue(configuration.connectionFactoryConfiguration().jdbcUrl().contains("jdbc:postgresql:"));
+        assertEquals("foo", configuration.connectionFactoryConfiguration().principal().getName());
+
+        try (Connection connection = dataSource.getConnection()) {
+        }
+    }
+}


### PR DESCRIPTION
We were already taking both versions into account in `DevServicesDatasourceConfigurationHandlerBuildItem`, but not in every
other place.

Fixes #26507 