### PR TITLE
Docs: Add limitations for Basic Authentication

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -23,7 +23,29 @@ If the user name is `Alice` and the password is `secret`, the HTTP authorization
 ====
  
 The Basic Authentication mechanism does not provide confidentiality protection for the transmitted credentials. The credentials are merely encoded with Base64 when in transit and not encrypted or hashed in any way. Therefore, Basic Authentication is used with HTTPS to provide confidentiality.
- 
+
+Basic Authentication is a well-specified, simple challenge and response scheme that all web browsers and most web servers understand. However, there are a few limitations associated with Basic Authentication, which include:
+
+Credentials are sent as plain text::
++
+--
+It is required to use HTTPS with Basic Authentication to avoid exposing the credentials. However, if the load balancer terminates HTTPS, the risk of exposing credentials as plain text increases when a request is forwarded to Quarkus over HTTP.
+
+Also, in multi-hop deployments, the credentials can be exposed if HTTPS is used between the client and the first Quarkus endpoint only, and the credentials are propagated to the next Quarkus endpoint over HTTP.
+--
+
+Credentials are sent with each request::
++
+--
+In Basic Authentication, a username and password need to be sent with each request, which increases the risk of credentials being exposed.
+--
+
+Application complexity increases::
++
+--
+The Quarkus application needs to ensure itself that usernames, passwords, and roles are managed securely, which increases the application complexity.
+--
+
 [[enabling-basic-auth]]
 === Enabling Basic Authentication
  


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/QDOCS-29

Added limitations for Basic Authentication in "security-built-in-authentication.adoc" file. 

Doc preview: http://file.pnq.redhat.com/~hmanwani/QDOCS-29-main 