### PR TITLE
Qute - Type-safe validation for OR operator

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -386,7 +386,7 @@ public class MessageBundleProcessor {
     void validateMessageBundleMethodsInTemplates(TemplatesAnalysisBuildItem analysis,
             BeanArchiveIndexBuildItem beanArchiveIndex,
             List<TemplateExtensionMethodBuildItem> templateExtensionMethods,
-            List<TypeCheckExcludeBuildItem> excludes,
+            List<TypeCheckExcludeBuildItem> typeCheckExcludeBuildItems,
             List<MessageBundleBuildItem> messageBundles,
             List<MessageBundleMethodBuildItem> messageBundleMethods,
             List<TemplateExpressionMatchesBuildItem> expressionMatches,
@@ -528,10 +528,22 @@ public class MessageBundleProcessor {
                             for (Expression param : params) {
                                 if (param.hasTypeInfo()) {
                                     Map<String, Match> results = new HashMap<>();
+
+                                    final List<Predicate<TypeCheckExcludeBuildItem.TypeCheck>> excludes = new ArrayList<>();
+                                    // subset of excludes specific for extension methods
+                                    final List<Predicate<TypeCheckExcludeBuildItem.TypeCheck>> extensionMethodExcludes = new ArrayList<>();
+                                    for (TypeCheckExcludeBuildItem exclude : typeCheckExcludeBuildItems) {
+                                        excludes.add(exclude.getPredicate());
+                                        if (exclude.isExtensionMethodPredicate()) {
+                                            extensionMethodExcludes.add(exclude.getPredicate());
+                                        }
+                                    }
+
                                     QuteProcessor.validateNestedExpressions(config, exprEntry.getKey(), defaultBundleInterface,
                                             results, excludes, incorrectExpressions, expression, index,
                                             implicitClassToMembersUsed, templateIdToPathFun, generatedIdsToMatches,
-                                            checkedTemplate, lookupConfig, namedBeans, namespaceTemplateData,
+                                            extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
+                                            namespaceTemplateData,
                                             regularExtensionMethods, namespaceExtensionMethods, assignableCache);
                                     Match match = results.get(param.toOriginalString());
                                     if (match != null && !match.isEmpty() && !Types.isAssignableFrom(match.type(),

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -2,6 +2,7 @@ package io.quarkus.qute.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 import static io.quarkus.qute.Namespaces.isDataNamespace;
+import static io.quarkus.qute.ValueResolvers.OR;
 import static io.quarkus.qute.runtime.EngineProducer.CDI_NAMESPACE;
 import static io.quarkus.qute.runtime.EngineProducer.INJECT_NAMESPACE;
 import static java.util.function.Predicate.not;
@@ -136,6 +137,7 @@ import io.quarkus.qute.runtime.extensions.CollectionTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.ConfigTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.MapTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.NumberTemplateExtensions;
+import io.quarkus.qute.runtime.extensions.OrOperatorTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.StringTemplateExtensions;
 import io.quarkus.qute.runtime.extensions.TimeTemplateExtensions;
 import io.quarkus.runtime.util.StringUtil;
@@ -247,7 +249,7 @@ public class QuteProcessor {
                 .addBeanClasses(EngineProducer.class, TemplateProducer.class, ContentTypes.class, Template.class,
                         TemplateInstance.class, CollectionTemplateExtensions.class,
                         MapTemplateExtensions.class, NumberTemplateExtensions.class, ConfigTemplateExtensions.class,
-                        TimeTemplateExtensions.class, StringTemplateExtensions.class)
+                        TimeTemplateExtensions.class, StringTemplateExtensions.class, OrOperatorTemplateExtensions.class)
                 .build();
     }
 
@@ -782,7 +784,7 @@ public class QuteProcessor {
     void validateExpressions(TemplatesAnalysisBuildItem templatesAnalysis,
             BeanArchiveIndexBuildItem beanArchiveIndex,
             List<TemplateExtensionMethodBuildItem> templateExtensionMethods,
-            List<TypeCheckExcludeBuildItem> excludes,
+            List<TypeCheckExcludeBuildItem> typeCheckExcludeBuildItems,
             BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
             BuildProducer<ImplicitValueResolverBuildItem> implicitClasses,
             BuildProducer<TemplateExpressionMatchesBuildItem> expressionMatches,
@@ -842,9 +844,20 @@ public class QuteProcessor {
                 if (expression.isLiteral()) {
                     continue;
                 }
+
+                final List<Predicate<TypeCheck>> excludes = new ArrayList<>();
+                // subset of excludes specific for extension methods
+                final List<Predicate<TypeCheck>> extensionMethodExcludes = new ArrayList<>();
+                for (TypeCheckExcludeBuildItem exclude : typeCheckExcludeBuildItems) {
+                    excludes.add(exclude.getPredicate());
+                    if (exclude.isExtensionMethodPredicate()) {
+                        extensionMethodExcludes.add(exclude.getPredicate());
+                    }
+                }
+
                 Match match = validateNestedExpressions(config, templateAnalysis, null, new HashMap<>(), excludes,
                         incorrectExpressions, expression, index, implicitClassToMembersUsed, templateIdToPathFun,
-                        generatedIdsToMatches,
+                        generatedIdsToMatches, extensionMethodExcludes,
                         checkedTemplate, lookupConfig, namedBeans, namespaceTemplateData, regularExtensionMethods,
                         namespaceExtensionMethods, assignableCache);
                 generatedIdsToMatches.put(expression.getGeneratedId(), match);
@@ -955,11 +968,11 @@ public class QuteProcessor {
 
     static Match validateNestedExpressions(QuteConfig config, TemplateAnalysis templateAnalysis, ClassInfo rootClazz,
             Map<String, Match> results,
-            List<TypeCheckExcludeBuildItem> excludes, BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
+            List<Predicate<TypeCheck>> excludes, BuildProducer<IncorrectExpressionBuildItem> incorrectExpressions,
             Expression expression, IndexView index,
             Map<DotName, Set<String>> implicitClassToMembersUsed, Function<String, String> templateIdToPathFun,
-            Map<Integer, Match> generatedIdsToMatches, CheckedTemplateBuildItem checkedTemplate,
-            LookupConfig lookupConfig, Map<String, BeanInfo> namedBeans,
+            Map<Integer, Match> generatedIdsToMatches, List<Predicate<TypeCheck>> extensionMethodExcludes,
+            CheckedTemplateBuildItem checkedTemplate, LookupConfig lookupConfig, Map<String, BeanInfo> namedBeans,
             Map<String, TemplateDataBuildItem> namespaceTemplateData,
             List<TemplateExtensionMethodBuildItem> regularExtensionMethods,
             Map<String, List<TemplateExtensionMethodBuildItem>> namespaceExtensionMethods,
@@ -978,8 +991,8 @@ public class QuteProcessor {
                     if (!results.containsKey(param.toOriginalString())) {
                         validateNestedExpressions(config, templateAnalysis, null, results, excludes,
                                 incorrectExpressions, param, index, implicitClassToMembersUsed, templateIdToPathFun,
-                                generatedIdsToMatches, checkedTemplate, lookupConfig, namedBeans, namespaceTemplateData,
-                                regularExtensionMethods, namespaceExtensionMethods, assignableCache);
+                                generatedIdsToMatches, extensionMethodExcludes, checkedTemplate, lookupConfig, namedBeans,
+                                namespaceTemplateData, regularExtensionMethods, namespaceExtensionMethods, assignableCache);
                     }
                 }
             }
@@ -1224,29 +1237,24 @@ public class QuteProcessor {
                     }
                 }
 
+                Type type = null;
                 if (member == null) {
                     // Then try to find an extension method
                     extensionMethod = findTemplateExtensionMethod(info, match.type(), regularExtensionMethods, expression,
                             index, templateIdToPathFun, results, assignableCache);
                     if (extensionMethod != null) {
+                        type = resolveType(extensionMethod.getMethod(), match, index, extensionMethod, results, info);
+                        // Test whether the validation of extension method should be skipped
+                        if (skipValidation(extensionMethodExcludes, expression, match, info, type)) {
+                            break;
+                        }
                         member = extensionMethod.getMethod();
                     }
                 }
 
-                if (member == null) {
-                    // Test whether the validation should be skipped
-                    TypeCheck check = new TypeCheck(
-                            info.isProperty() ? info.asProperty().name : info.asVirtualMethod().name,
-                            match.clazz(),
-                            info.part.isVirtualMethod() ? info.part.asVirtualMethod().getParameters().size() : -1);
-                    if (isExcluded(check, excludes)) {
-                        LOGGER.debugf(
-                                "Expression part [%s] excluded from validation of [%s] against type [%s]",
-                                info.value,
-                                expression.toOriginalString(), match.type());
-                        match.clearValues();
-                        break;
-                    }
+                // Test whether the validation should be skipped
+                if (member == null && skipValidation(excludes, expression, match, info, match.type())) {
+                    break;
                 }
 
                 if (member == null) {
@@ -1256,7 +1264,9 @@ public class QuteProcessor {
                     match.clearValues();
                     break;
                 } else {
-                    Type type = resolveType(member, match, index, extensionMethod);
+                    if (type == null) {
+                        type = resolveType(member, match, index, extensionMethod, results, info);
+                    }
                     ClassInfo clazz = null;
                     if (type.kind() == Type.Kind.CLASS || type.kind() == Type.Kind.PARAMETERIZED_TYPE) {
                         clazz = index.getClassByName(type.name());
@@ -1279,6 +1289,23 @@ public class QuteProcessor {
             lookupConfig.nextPart();
         }
         return putResult(match, results, expression);
+    }
+
+    private static boolean skipValidation(List<Predicate<TypeCheck>> excludes, Expression expression, Match match, Info info,
+            Type type) {
+        TypeCheck check = new TypeCheck(
+                info.isProperty() ? info.asProperty().name : info.asVirtualMethod().name,
+                match.clazz(), type,
+                info.part.isVirtualMethod() ? info.part.asVirtualMethod().getParameters().size() : -1);
+        if (isExcluded(check, excludes)) {
+            LOGGER.debugf(
+                    "Expression part [%s] excluded from validation of [%s] against type [%s]",
+                    info.value,
+                    expression.toOriginalString(), match.type());
+            match.clearValues();
+            return true;
+        }
+        return false;
     }
 
     private static Match putResult(Match match, Map<String, Match> results, Expression expression) {
@@ -1880,6 +1907,14 @@ public class QuteProcessor {
             }
         }));
 
+        excludes.produce(new TypeCheckExcludeBuildItem(new Predicate<TypeCheck>() {
+            @Override
+            public boolean test(TypeCheck typeCheck) {
+                // OrOperatorTemplateExtensions should only be validated if we were able to resolve actual type
+                return OR.equals(typeCheck.name) && typeCheck.type != null && DotNames.OBJECT.equals(typeCheck.type.name());
+            }
+        }, true));
+
         if (config.typeCheckExcludes.isPresent()) {
             for (String exclude : config.typeCheckExcludes.get()) {
                 //
@@ -1952,7 +1987,7 @@ public class QuteProcessor {
     }
 
     private static Type resolveType(AnnotationTarget member, Match match, IndexView index,
-            TemplateExtensionMethodBuildItem extensionMethod) {
+            TemplateExtensionMethodBuildItem extensionMethod, Map<String, Match> results, Info info) {
         Type matchType;
         if (member.kind() == Kind.FIELD) {
             matchType = member.asField().type();
@@ -1998,6 +2033,33 @@ public class QuteProcessor {
                         }
                     }
                     if (extensionMatchBase != null && Types.containsTypeVariable(extensionMatchBase)) {
+
+                        // special handling for T methodName(T t, ...) without attribute annotations
+                        if (extensionMatchBase.kind() == Type.Kind.TYPE_VARIABLE && attributeAnnotations.isEmpty()
+                                && extensionMatchBase.name().equals(matchType.name()) && info.isVirtualMethod()) {
+
+                            // take into consideration other formal parameters of type T (f.e. T methodName(T t, T u))
+                            // keep it simple and skip parametrized types e.g. List<T>
+                            if (info.part.asVirtualMethod().getParameters() != null
+                                    && !info.part.asVirtualMethod().getParameters().isEmpty()) {
+                                final var paramExpressions = info.part.asVirtualMethod().getParameters();
+                                for (int i = 1; i < params.size() && (i - 1) < paramExpressions.size(); i++) {
+                                    // whether params.get(i) has same type as the extension base (e.g. T)
+                                    if (params.get(i).name().equals(extensionMatchBase.name())) {
+                                        final var paramMatch = results.get(paramExpressions.get(i - 1).toOriginalString());
+                                        // if all T params are not of exactly same type, we do not try to determine
+                                        // right superclass/interface as it's expensive
+                                        if (paramMatch != null && !match.type().equals(paramMatch.type())) {
+                                            return matchType;
+                                        }
+                                    }
+                                }
+                            }
+
+                            // obj.methodName(T t, ...) => 'obj' type equals T
+                            return match.type();
+                        }
+
                         declaringClassName = extensionMatchBase.name();
                     }
                 } else {
@@ -2838,9 +2900,9 @@ public class QuteProcessor {
         }
     }
 
-    private static boolean isExcluded(TypeCheck check, List<TypeCheckExcludeBuildItem> excludes) {
-        for (TypeCheckExcludeBuildItem exclude : excludes) {
-            if (exclude.getPredicate().test(check)) {
+    private static boolean isExcluded(TypeCheck check, List<Predicate<TypeCheck>> excludes) {
+        for (Predicate<TypeCheck> exclude : excludes) {
+            if (exclude.test(check)) {
                 return true;
             }
         }

--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeCheckExcludeBuildItem.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/TypeCheckExcludeBuildItem.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -16,13 +17,32 @@ import io.quarkus.builder.item.MultiBuildItem;
 public final class TypeCheckExcludeBuildItem extends MultiBuildItem {
 
     private final Predicate<TypeCheck> predicate;
+    private final boolean extensionMethodPredicate;
 
     public TypeCheckExcludeBuildItem(Predicate<TypeCheck> predicate) {
         this.predicate = Objects.requireNonNull(predicate);
+        this.extensionMethodPredicate = false;
+    }
+
+    public TypeCheckExcludeBuildItem(Predicate<TypeCheck> predicate, boolean extensionMethodPredicate) {
+        this.predicate = predicate;
+        this.extensionMethodPredicate = extensionMethodPredicate;
     }
 
     public Predicate<TypeCheck> getPredicate() {
         return predicate;
+    }
+
+    /**
+     * It might come handy to exclude {@link io.quarkus.qute.TemplateExtension} method from validation based on resolved
+     * return {@link Type} of the method. For example, type variables are hard to resolve in all situations and
+     * {@link #extensionMethodPredicate} allows you to skip validation on your conditions, as we do for
+     * {@link io.quarkus.qute.runtime.extensions.OrOperatorTemplateExtensions}.
+     *
+     * @return true if the predicate is used to exclude {@link io.quarkus.qute.TemplateExtension} method.
+     */
+    public boolean isExtensionMethodPredicate() {
+        return extensionMethodPredicate;
     }
 
     /**
@@ -48,10 +68,16 @@ public final class TypeCheckExcludeBuildItem extends MultiBuildItem {
          */
         public final int numberOfParameters;
 
-        public TypeCheck(String name, ClassInfo clazz, int parameters) {
+        /**
+         * The matching type.
+         */
+        public final Type type;
+
+        public TypeCheck(String name, ClassInfo clazz, Type type, int parameters) {
             this.name = Objects.requireNonNull(name, "Name must not be null");
             this.clazz = clazz;
             this.numberOfParameters = parameters;
+            this.type = type;
         }
 
         public boolean nameIn(String... values) {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Item.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Item.java
@@ -18,4 +18,5 @@ public class Item {
     public OtherItem[] getOtherItems() {
         return otherItems;
     }
+
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ItemWithName.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ItemWithName.java
@@ -1,0 +1,28 @@
+package io.quarkus.qute.deployment.typesafe;
+
+public class ItemWithName {
+    private final Name name;
+
+    public ItemWithName(Name name) {
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return 2;
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public static class Name {
+
+        public String toUpperCase() {
+            return OrOperatorTemplateExtensionTest.ITEM_NAME.toUpperCase();
+        }
+
+        public String pleaseMakeMyCaseUpper() {
+            return "UPPER CASE";
+        }
+    }
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionFailureTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.TemplateException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OrOperatorTemplateExtensionFailureTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Item.class, OtherItem.class, ItemWithName.class)
+                    .addAsResource(new StringAsset(
+                            "{@io.quarkus.qute.deployment.typesafe.Item item2}\n" +
+                                    "{#for item in item.otherItems}\n" +
+                                    "{@io.quarkus.qute.deployment.typesafe.Item item}\n" +
+                                    "  {data:item.name.or(item2.name).pleaseMakeMyCaseUpper}\n" +
+                                    "  {item.name.or(item2.name).pleaseMakeMyCaseUpper}\n" +
+                                    "{/for}\n"),
+                            "templates/item.html"))
+            .assertException(t -> {
+                Throwable e = t;
+                TemplateException te = null;
+                while (e != null) {
+                    if (e instanceof TemplateException) {
+                        te = (TemplateException) e;
+                        break;
+                    }
+                    e = e.getCause();
+                }
+                assertNotNull(te);
+                assertTrue(te.getMessage().contains(
+                        "{item.name.or(item2.name).pleaseMakeMyCaseUpper}: Property/method [pleaseMakeMyCaseUpper] not found on class [java.lang.String]"),
+                        te.getMessage());
+                // validation failure in data namespace
+                assertTrue(te.getMessage().contains(
+                        "{data:item.name.or(item2.name).pleaseMakeMyCaseUpper}: Property/method [pleaseMakeMyCaseUpper] not found on class [java.lang.String]"),
+                        te.getMessage());
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.qute.deployment.typesafe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qute.Template;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OrOperatorTemplateExtensionTest {
+
+    public static final String ITEM_NAME = "Test Name";
+    public static final String ITEM_WITH_NAME = "itemWithName";
+    public static final String ITEM = "item";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Item.class, OtherItem.class, ItemWithName.class, ItemWithName.Name.class)
+                    .addAsResource(new StringAsset(
+                            "{@io.quarkus.qute.deployment.typesafe.ItemWithName itemWithName}\n" +
+                                    "{@io.quarkus.qute.deployment.typesafe.Item item}\n" +
+                                    "{#for otherItem in item.otherItems}\n" +
+                                    "{missing.or(alsoMissing.or('item id is: ')).toLowerCase}" +
+                                    "{item.name.or(itemWithName.name).toUpperCase}" +
+                                    "{otherItem.id.or(itemWithName.id).longValue()}" +
+                                    "{/for}\n"),
+                            "templates/item.html"));
+
+    @Inject
+    Template item;
+
+    @Test
+    public void test() {
+        final String expected = "item id is: " + ITEM_NAME.toUpperCase();
+        final ItemWithName itemWithName = new ItemWithName(new ItemWithName.Name());
+
+        // id comes from OtherItem, name is String and toUpperCase is method from String
+        assertEquals(expected + OtherItem.ID,
+                item.data(ITEM, new Item(ITEM_NAME.toUpperCase(), new OtherItem()), ITEM_WITH_NAME, itemWithName).render()
+                        .trim());
+
+        // id comes from ItemWithName, name comes from ItemWithName.Name and toUpperCase is regular method
+        assertEquals(
+                expected + itemWithName.getId(),
+                item.data(ITEM, new Item(null, (OtherItem) null), ITEM_WITH_NAME, itemWithName).render().trim());
+    }
+
+}

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OtherItem.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OtherItem.java
@@ -2,4 +2,10 @@ package io.quarkus.qute.deployment.typesafe;
 
 public class OtherItem {
 
+    static final int ID = 1;
+
+    public Integer getId() {
+        return ID;
+    }
+
 }

--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/OrOperatorTemplateExtensions.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/extensions/OrOperatorTemplateExtensions.java
@@ -1,0 +1,21 @@
+package io.quarkus.qute.runtime.extensions;
+
+import java.util.Optional;
+
+import javax.enterprise.inject.Vetoed;
+
+import io.quarkus.qute.Results;
+import io.quarkus.qute.TemplateExtension;
+
+@Vetoed // Make sure no bean is created from this class
+@TemplateExtension
+public class OrOperatorTemplateExtensions {
+
+    static <T> T or(T value, T other) {
+        if (value == null || Results.isNotFound(value) || (value instanceof Optional && ((Optional<?>) value).isEmpty())) {
+            return other;
+        }
+        return value;
+    }
+
+}

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ValueResolvers.java
@@ -19,10 +19,9 @@ import java.util.function.Function;
 public final class ValueResolvers {
 
     static final String THIS = "this";
-
     static final String ELVIS = "?:";
-    static final String OR = "or";
     static final String COLON = ":";
+    public static final String OR = "or";
 
     public static ValueResolver rawResolver() {
         return new ValueResolver() {


### PR DESCRIPTION
closes: #25995

An expression with `or` operator is validated iff `or` operator is used when both sides has same data type (e.g. for expression `item.or(otherItem).methodName()`, both `otherItem` and `item` must have same data type) according to https://github.com/quarkusio/quarkus/issues/25995#issuecomment-1196479868.