### PR TITLE
Bump smallrye-open-api from 2.1.22 to 2.1.23

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-config.version>2.11.0</smallrye-config.version>
         <smallrye-health.version>3.2.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.5</smallrye-metrics.version>
-        <smallrye-open-api.version>2.1.22</smallrye-open-api.version>
+        <smallrye-open-api.version>2.1.23</smallrye-open-api.version>
         <smallrye-graphql.version>1.6.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.0</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.5.0</smallrye-fault-tolerance.version>


### PR DESCRIPTION
Fixes #26461
