### PR TITLE
Rename quarkus.hibernate-search-orm.enabled to quarkus.hibernate-search-orm.active and repurpose quarkus.hibernate-search-orm.enabled to disable Hibernate Search at build time

### DIFF
--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -16,6 +16,7 @@ import io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem;
 import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingRecorder;
 import io.quarkus.hibernate.search.orm.coordination.outboxpolling.runtime.HibernateSearchOutboxPollingRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
+import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchEnabled;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationStaticConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit;
@@ -24,11 +25,7 @@ class HibernateSearchOutboxPollingProcessor {
 
     private static final String HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING = "Hibernate Search ORM - Coordination - Outbox polling";
 
-    @BuildStep
-    void registerIndexedClasses() {
-    }
-
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     void registerInternalModel(BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel) {
@@ -41,7 +38,7 @@ class HibernateSearchOutboxPollingProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(HibernateSearchOutboxPollingRecorder recorder,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
@@ -59,7 +56,7 @@ class HibernateSearchOutboxPollingProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setRuntimeConfig(HibernateSearchOutboxPollingRecorder recorder,
             HibernateSearchOutboxPollingRuntimeConfig runtimeConfig,

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
@@ -25,7 +25,7 @@ import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElas
 public class HibernateSearchElasticsearchCdiProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     void generateSearchBeans(HibernateSearchElasticsearchRecorder recorder,
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
@@ -67,7 +67,7 @@ public class HibernateSearchElasticsearchCdiProcessor {
         return configurator.done();
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     void registerAnnotations(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations) {
         // add the @SearchExtension class

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -156,11 +156,11 @@ class HibernateSearchElasticsearchProcessor {
         if (indexedAnnotationsForPU.isEmpty()) {
             // we don't have any indexed entity, we can disable Hibernate Search
             staticIntegrations.produce(new HibernateOrmIntegrationStaticConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
-                    persistenceUnitName).setInitListener(recorder.createDisabledStaticInitListener()));
+                    persistenceUnitName).setInitListener(recorder.createStaticInitInactiveListener()));
             // we need a runtime listener even when Hibernate Search is disabled,
             // just to let Hibernate Search boot up until the point where it checks whether it's enabled or not
             runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
-                    persistenceUnitName).setInitListener(recorder.createDisabledRuntimeInitListener()));
+                    persistenceUnitName).setInitListener(recorder.createRuntimeInitInactiveListener()));
             return;
         }
 

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -74,11 +74,13 @@ class HibernateSearchElasticsearchProcessor {
 
     HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig;
 
+    // Note this is necessary even if Hibernate Search is disabled
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     NativeImageFeatureBuildItem nativeImageFeature() {
         return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
     }
 
+    // Note this is necessary even if Hibernate Search is disabled
     @BuildStep
     void setupLogFilters(BuildProducer<LogCleanupFilterBuildItem> filters) {
         // if the category changes, please also update DisableLoggingFeature in the runtime module
@@ -86,7 +88,33 @@ class HibernateSearchElasticsearchProcessor {
                 "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateSearchPreIntegrationService", "HSEARCH000034"));
     }
 
-    @BuildStep
+    @BuildStep(onlyIfNot = HibernateSearchEnabled.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    public void disableHibernateSearchStaticInit(HibernateSearchElasticsearchRecorder recorder,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
+            BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticIntegrations) {
+        for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
+            String puName = puDescriptor.getPersistenceUnitName();
+            staticIntegrations.produce(new HibernateOrmIntegrationStaticConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
+                    puName).setInitListener(recorder.createStaticInitInactiveListener()));
+        }
+    }
+
+    @BuildStep(onlyIfNot = HibernateSearchEnabled.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void disableHibernateSearchRuntimeInit(HibernateSearchElasticsearchRecorder recorder,
+            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
+            BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations) {
+        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
+            String puName = puDescriptor.getPersistenceUnitName();
+            runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
+                    puName).setInitListener(recorder.createRuntimeInitInactiveListener()));
+        }
+    }
+
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(ExecutionTime.STATIC_INIT)
     public void build(HibernateSearchElasticsearchRecorder recorder,
             CombinedIndexBuildItem combinedIndexBuildItem,
@@ -160,7 +188,8 @@ class HibernateSearchElasticsearchProcessor {
             // we need a runtime listener even when Hibernate Search is disabled,
             // just to let Hibernate Search boot up until the point where it checks whether it's enabled or not
             runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
-                    persistenceUnitName).setInitListener(recorder.createRuntimeInitInactiveListener()));
+                    persistenceUnitName)
+                    .setInitListener(recorder.createRuntimeInitInactiveListener()));
             return;
         }
 
@@ -176,7 +205,7 @@ class HibernateSearchElasticsearchProcessor {
                         backendNamesForIndexedEntities, backendAndIndexNamesForSearchExtensions));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     void registerBeans(List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> searchEnabledPUs,
             BuildProducer<UnremovableBeanBuildItem> unremovableBean) {
         if (searchEnabledPUs.isEmpty()) {
@@ -189,7 +218,7 @@ class HibernateSearchElasticsearchProcessor {
                 ElasticsearchAnalysisConfigurer.class, IndexLayoutStrategy.class));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(RecorderContext recorderContext, HibernateSearchElasticsearchRecorder recorder,
             List<HibernateSearchIntegrationStaticConfiguredBuildItem> integrationStaticConfigBuildItems,
@@ -224,7 +253,7 @@ class HibernateSearchElasticsearchProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     void setRuntimeConfig(HibernateSearchElasticsearchRecorder recorder,
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
@@ -251,7 +280,7 @@ class HibernateSearchElasticsearchProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     public void processPersistenceUnitBuildTimeConfig(
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             ApplicationArchivesBuildItem applicationArchivesBuildItem,
@@ -358,7 +387,7 @@ class HibernateSearchElasticsearchProcessor {
         reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, reflectiveClasses));
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     DevservicesElasticsearchBuildItem devServices(HibernateSearchElasticsearchBuildTimeConfig buildTimeConfig) {
         if (buildTimeConfig.defaultPersistenceUnit != null && buildTimeConfig.defaultPersistenceUnit.defaultBackend != null
         // If the version is not set, the default backend is not in use.
@@ -376,7 +405,7 @@ class HibernateSearchElasticsearchProcessor {
         }
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class)
+    @BuildStep(onlyIf = HibernateSearchEnabled.class, onlyIfNot = IsNormal.class)
     void devServicesDropAndCreateAndDropByDefault(
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<DevServicesAdditionalConfigBuildItem> devServicesAdditionalConfigProducer) {

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchEnabled.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfig;
+
+/**
+ * Supplier that can be used to only run build steps
+ * if the Hibernate Search extension is enabled.
+ */
+public class HibernateSearchEnabled implements BooleanSupplier {
+
+    private final HibernateSearchElasticsearchBuildTimeConfig config;
+
+    HibernateSearchEnabled(HibernateSearchElasticsearchBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled;
+    }
+
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
@@ -14,12 +14,13 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRuntimeTemplateInfoBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
+import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchEnabled;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole.HibernateSearchDevConsoleRecorder;
 
 public class HibernateSearchElasticsearchDevConsoleProcessor {
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep(onlyIf = { HibernateSearchEnabled.class, IsDevelopment.class })
     @Record(RUNTIME_INIT)
     public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(HibernateSearchDevConsoleRecorder recorder,
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
@@ -32,7 +33,7 @@ public class HibernateSearchElasticsearchDevConsoleProcessor {
                 recorder.infoSupplier(runtimeConfig, persistenceUnitNames), this.getClass(), curateOutcomeBuildItem);
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = HibernateSearchEnabled.class)
     @Record(value = STATIC_INIT, optional = true)
     DevConsoleRouteBuildItem invokeEndpoint(HibernateSearchDevConsoleRecorder recorder) {
         return new DevConsoleRouteBuildItem("entity-types", "POST", recorder.indexEntity());

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
@@ -18,23 +18,23 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.test.QuarkusUnitTest;
 
-public class ConfigDisabledAndIndexedEntityTest {
+public class ConfigActiveFalseAndIndexedEntityTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedEntity.class))
             .withConfigurationResource("application.properties")
-            .overrideConfigKey("quarkus.hibernate-search-orm.enabled", "false");
+            .overrideConfigKey("quarkus.hibernate-search-orm.active", "false");
 
     @Inject
     SessionFactory sessionFactory;
 
     @Test
-    public void testDisabled() {
+    public void test() {
         assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "Cannot retrieve the SearchMapping: Hibernate Search was disabled through configuration properties");
+                        "Cannot retrieve the SearchMapping: Hibernate Search was deactivated through configuration properties");
 
         assertThatThrownBy(() -> Search.mapping(sessionFactory))
                 .isInstanceOf(SearchException.class)
@@ -43,7 +43,7 @@ public class ConfigDisabledAndIndexedEntityTest {
         assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties");
+                        "Cannot retrieve the SearchSession: Hibernate Search was deactivated through configuration properties");
 
         try (Session session = sessionFactory.openSession()) {
             assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
@@ -1,0 +1,63 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.inject.Inject;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.common.SearchException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigEnabledFalseAndActiveTrueTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedEntity.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-search-orm.enabled", "false")
+            .overrideConfigKey("quarkus.hibernate-search-orm.active", "true")
+            .assertException(throwable -> assertThat(throwable)
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContaining(
+                            "Hibernate Search activated explicitly, but Hibernate Search was disabled at build time",
+                            "If you want Hibernate Search to be active at runtime, you must set 'quarkus.hibernate-search-orm.enabled' to 'true' at build time",
+                            "If you don't want Hibernate Search to be active at runtime, you must leave 'quarkus.hibernate-search-orm.active' unset or set it to 'false'"));
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    public void test() {
+        assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "Cannot retrieve the SearchMapping: Hibernate Search was disabled through configuration properties");
+
+        assertThatThrownBy(() -> Search.mapping(sessionFactory))
+                .isInstanceOf(SearchException.class)
+                .hasMessageContaining("Hibernate Search was not initialized.");
+
+        assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties");
+
+        try (Session session = sessionFactory.openSession()) {
+            assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))
+                    .isInstanceOf(SearchException.class)
+                    .hasMessageContaining("Hibernate Search was not initialized.");
+        }
+    }
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndIndexedEntityTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.inject.Inject;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.common.SearchException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ConfigEnabledFalseAndIndexedEntityTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(IndexedEntity.class))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-search-orm.enabled", "false");
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Test
+    public void test() {
+        assertThat(Arc.container().instance(SearchMapping.class).get())
+                .isNull();
+
+        assertThatThrownBy(() -> Search.mapping(sessionFactory))
+                .isInstanceOf(SearchException.class)
+                .hasMessageContaining("Hibernate Search was not initialized.");
+
+        assertThat(Arc.container().instance(SearchSession.class).get())
+                .isNull();
+
+        try (Session session = sessionFactory.openSession()) {
+            assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))
+                    .isInstanceOf(SearchException.class)
+                    .hasMessageContaining("Hibernate Search was not initialized.");
+        }
+    }
+}

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -14,6 +14,18 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class HibernateSearchElasticsearchBuildTimeConfig {
 
     /**
+     * Whether Hibernate Search is enabled <strong>during the build</strong>.
+     *
+     * If Hibernate Search is disabled during the build, all processing related to Hibernate Search will be skipped,
+     * but it will not be possible to activate Hibernate Search at runtime:
+     * `quarkus.hibernate-search-orm.active` will default to `false` and setting it to `true` will lead to an error.
+     *
+     * @asciidoclet
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
      * Configuration for the default persistence unit.
      */
     @ConfigItem(name = ConfigItem.PARENT)

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -60,8 +60,8 @@ public class HibernateSearchElasticsearchRecorder {
                 backendAndIndexNamesForSearchExtensions, integrationStaticInitListeners);
     }
 
-    public HibernateOrmIntegrationStaticInitListener createDisabledStaticInitListener() {
-        return new HibernateSearchIntegrationDisabledListener();
+    public HibernateOrmIntegrationStaticInitListener createStaticInitInactiveListener() {
+        return new HibernateSearchIntegrationStaticInitInactiveListener();
     }
 
     public HibernateOrmIntegrationRuntimeInitListener createRuntimeInitListener(
@@ -74,8 +74,8 @@ public class HibernateSearchElasticsearchRecorder {
                 backendAndIndexNamesForSearchExtensions, integrationRuntimeInitListeners);
     }
 
-    public HibernateOrmIntegrationRuntimeInitListener createDisabledRuntimeInitListener() {
-        return new HibernateSearchIntegrationRuntimeInitDisabledListener();
+    public HibernateOrmIntegrationRuntimeInitListener createRuntimeInitInactiveListener() {
+        return new HibernateSearchIntegrationRuntimeInitInactiveListener();
     }
 
     public Supplier<SearchMapping> searchMappingSupplier(HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
@@ -85,9 +85,9 @@ public class HibernateSearchElasticsearchRecorder {
             public SearchMapping get() {
                 HibernateSearchElasticsearchRuntimeConfigPersistenceUnit config = runtimeConfig
                         .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
-                if (config != null && !config.enabled) {
+                if (config != null && !config.active) {
                     throw new IllegalStateException(
-                            "Cannot retrieve the SearchMapping: Hibernate Search was disabled through configuration properties");
+                            "Cannot retrieve the SearchMapping: Hibernate Search was deactivated through configuration properties");
                 }
                 SessionFactory sessionFactory;
                 if (isDefaultPersistenceUnit) {
@@ -108,9 +108,9 @@ public class HibernateSearchElasticsearchRecorder {
             public SearchSession get() {
                 HibernateSearchElasticsearchRuntimeConfigPersistenceUnit config = runtimeConfig
                         .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
-                if (config != null && !config.enabled) {
+                if (config != null && !config.active) {
                     throw new IllegalStateException(
-                            "Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties");
+                            "Cannot retrieve the SearchSession: Hibernate Search was deactivated through configuration properties");
                 }
                 Session session;
                 if (isDefaultPersistenceUnit) {
@@ -124,9 +124,9 @@ public class HibernateSearchElasticsearchRecorder {
         };
     }
 
-    private static final class HibernateSearchIntegrationDisabledListener
+    private static final class HibernateSearchIntegrationStaticInitInactiveListener
             implements HibernateOrmIntegrationStaticInitListener {
-        private HibernateSearchIntegrationDisabledListener() {
+        private HibernateSearchIntegrationStaticInitInactiveListener() {
         }
 
         @Override
@@ -260,10 +260,10 @@ public class HibernateSearchElasticsearchRecorder {
         }
     }
 
-    private static final class HibernateSearchIntegrationRuntimeInitDisabledListener
+    private static final class HibernateSearchIntegrationRuntimeInitInactiveListener
             implements HibernateOrmIntegrationRuntimeInitListener {
 
-        private HibernateSearchIntegrationRuntimeInitDisabledListener() {
+        private HibernateSearchIntegrationRuntimeInitInactiveListener() {
         }
 
         @Override
@@ -276,8 +276,8 @@ public class HibernateSearchElasticsearchRecorder {
         @Override
         public List<StandardServiceInitiator<?>> contributeServiceInitiators() {
             return List.of(
-                    // The service must be initiated even if Hibernate Search is disabled,
-                    // because it's also responsible for determining that Hibernate Search is disabled.
+                    // The service must be initiated even if Hibernate Search is not supposed to start,
+                    // because it's also responsible for determining that Hibernate Search should not start.
                     new HibernateSearchPreIntegrationService.Initiator());
         }
     }
@@ -303,7 +303,7 @@ public class HibernateSearchElasticsearchRecorder {
         @Override
         public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
             if (runtimeConfig != null) {
-                if (!runtimeConfig.enabled) {
+                if (!runtimeConfig.active) {
                     addConfig(propertyCollector, HibernateOrmMapperSettings.ENABLED, false);
                     // Do not process other properties: Hibernate Search is disabled anyway.
                     return;
@@ -436,8 +436,8 @@ public class HibernateSearchElasticsearchRecorder {
             return List.of(
                     // One of the purposes of this service is to provide configuration to Hibernate Search,
                     // so it absolutely must be updated with the runtime configuration.
-                    // The service must be initiated even if Hibernate Search is disabled,
-                    // because it's also responsible for determining that Hibernate Search is disabled.
+                    // The service must be initiated even if Hibernate Search is not supposed to start,
+                    // because it's also responsible for determining that Hibernate Search should not start.
                     new HibernateSearchPreIntegrationService.Initiator());
         }
     }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -41,6 +41,12 @@ public class HibernateSearchElasticsearchRuntimeConfig {
         return backendPropertyKey(persistenceUnitName, backendName, null, "version");
     }
 
+    public static String extensionPropertyKey(String radical) {
+        StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
+        keyBuilder.append(radical);
+        return keyBuilder.toString();
+    }
+
     public static String mapperPropertyKey(String persistenceUnitName, String radical) {
         StringBuilder keyBuilder = new StringBuilder("quarkus.hibernate-search-orm.");
         if (!PersistenceUnitUtil.isDefaultPersistenceUnit(persistenceUnitName)) {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -23,10 +23,13 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
 
     /**
-     * Whether Hibernate Search is enabled.
+     * Whether Hibernate Search should be active at runtime.
+     * <p>
+     * If Hibernate Search is not active, it won't index Hibernate ORM entities,
+     * and accessing the SearchMapping/SearchSession for search or other operation will not be possible.
      */
     @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    public boolean active;
 
     /**
      * Default backend

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -24,12 +24,17 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
 
     /**
      * Whether Hibernate Search should be active at runtime.
-     * <p>
+     *
      * If Hibernate Search is not active, it won't index Hibernate ORM entities,
      * and accessing the SearchMapping/SearchSession for search or other operation will not be possible.
+     *
+     * Note that if Hibernate Search is disabled (i.e. `quarkus.hibernate-search-orm.enabled` is set to `false`),
+     * it won't be active, and setting this property to `true` will fail.
+     *
+     * @asciidoclet
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean active;
+    @ConfigItem(defaultValueDocumentation = "`true` if Hibernate Search is enabled; `false` otherwise")
+    public Optional<Boolean> active;
 
     /**
      * Default backend

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
@@ -34,7 +34,7 @@ public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier
 
     @Override
     public IndexedPersistenceUnits get() {
-        if (!isEnabled()) {
+        if (!isActive()) {
             return new IndexedPersistenceUnits();
         }
         Map<String, SearchMapping> mappings = searchMapping(persistenceUnitNames);
@@ -52,8 +52,8 @@ public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier
                         }));
     }
 
-    private boolean isEnabled() {
-        return runtimeConfig.defaultPersistenceUnit.enabled;
+    private boolean isActive() {
+        return runtimeConfig.defaultPersistenceUnit.active;
     }
 
     public static Map<String, SearchMapping> searchMapping(Set<String> persistenceUnitNames) {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
@@ -53,7 +53,7 @@ public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier
     }
 
     private boolean isActive() {
-        return runtimeConfig.defaultPersistenceUnit.active;
+        return runtimeConfig.defaultPersistenceUnit.active.orElse(true);
     }
 
     public static Map<String, SearchMapping> searchMapping(Set<String> persistenceUnitNames) {

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateSearchActiveFalseTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateSearchActiveFalseTest.java
@@ -12,15 +12,15 @@ import io.restassured.RestAssured;
  * Note that this test cannot be placed under the relevant {@code -deployment} module because then the DEV UI processor would
  * not be able to locate the template resources correctly.
  */
-public class DevConsoleHibernateSearchDisabledTest {
+public class DevConsoleHibernateSearchActiveFalseTest {
 
     @RegisterExtension
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar.addAsResource(
                     new StringAsset("quarkus.datasource.db-kind=h2\n"
                             + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
-                            // Hibernate Search is disabled: the dev console should be empty.
-                            + "quarkus.hibernate-search-orm.enabled=false\n"
+                            // Hibernate Search is inactive: the dev console should be empty.
+                            + "quarkus.hibernate-search-orm.active=false\n"
                             + "quarkus.hibernate-search-orm.elasticsearch.version=7.10\n"),
                     "application.properties")
                     .addClasses(MyIndexedEntity.class));


### PR DESCRIPTION
The motivation is two-fold:

* I've been made aware that other extensions use `.enabled` to enable/disable an extension at *build time*, but Hibernate Search was using it to disable the extension at *runtime*. This PR restores consistency
* We still need something to disable Hibernate Search at runtime, because that's what was requested in the original use case. `.active` solves that.

~I'm not very enthusiastic about the name of the property `quarkus.hibernate-search-orm.started`, but that's the best I could come up with. I'm open to suggestions, keeping in mind that `quarkus.hibernate-search-orm.enabled` is not an option since it has a different purpose.~ => Renamed to `.active`, a bit better.

This is related to a conversation we had on the Quarkus mailing list: https://groups.google.com/g/quarkus-dev/c/rfWe_jrSzJY/m/u5282G-SEAAJ?utm_medium=email&utm_source=footer

For context, the conversation branched from there: https://groups.google.com/g/quarkus-dev/c/o8gtDJoV7VY/m/R9ub7DPqAgAJ?utm_medium=email&utm_source=footer

For the migration guide:

```
## `quarkus.hibernate-search-orm.enabled` was renamed to `quarkus.hibernate-search-orm.active`

If you were previously using the configuration property `quarkus.hibernate-search-orm.enabled` to enable/disable Hibernate Search at runtime (by setting the config in deployment configuration files, environment variables or commandline parameters), then you should use the configuration property `quarkus.hibernate-search-orm.active` instead.

`quarkus.hibernate-search-orm.enabled` is now aligned with Quarkus conventions and disables the extension at *build time*, which cannot be reverted at runtime.
```

Creating as draft because this PR is based on #26838 , which should be merged first.