### PR TITLE
Include H2 in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -172,6 +172,7 @@ updates:
       - dependency-name: com.github.javaparser:javaparser-core
       - dependency-name: org.jboss.jdeparser:jdeparser
       - dependency-name: com.github.javaparser:javaparser-core
+      - dependency-name: com.h2database:h2
     ignore:
       # this one cannot be upgraded due to the usage of proxies in new versions
       # the proxy implements interfaces in a random order which causes issues


### PR DESCRIPTION
Now that we have upgraded to H2 2.x, it makes sense.