### PR TITLE
Change the quarkus-kotlin extension status to stable

### DIFF
--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -5,14 +5,11 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using Kotlin
 
-:extension-status: preview
 include::./attributes.adoc[]
 
 https://kotlinlang.org/[Kotlin] is a very popular programming language that targets the JVM (amongst other environments). Kotlin has experienced a surge in popularity the last few years making it the most popular JVM language, except for Java of course.
 
 Quarkus provides first class support for using Kotlin as will be explained in this guide.
-
-include::{includes}/extension-status.adoc[]
 
 == Prerequisites
 

--- a/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   guide: "https://quarkus.io/guides/kotlin"
   categories:
   - "alt-languages"
-  status: "preview"
+  status: "stable"
   codestart:
     name: "kotlin"
     kind: "core"

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
   guide: "https://quarkus.io/guides/hibernate-orm-panache-kotlin"
   categories:
   - "data"
-  status: "experimental"
+  status: "stable"
   config:
   - "quarkus.datasource."
   - "quarkus.hibernate-orm."

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -14,7 +14,7 @@ metadata:
   categories:
   - "web"
   - "reactive"
-  status: "experimental"
+  status: "stable"
   codestart:
     name: "resteasy-reactive"
     languages:


### PR DESCRIPTION
Following the discussion https://groups.google.com/g/quarkus-dev/c/Yz3BriSfsf4/m/HVFLNfPtCAAJ?utm_medium=email&utm_source=footer

It doesn't seem like there are major issues to fix to earn the `stable` status for `quarkus-kotlin`. Any objections?