### PR TITLE
Respect Maven defaultGoal in DevMojo

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -36,6 +36,7 @@ import org.aesh.readline.terminal.impl.ExecPty;
 import org.aesh.readline.terminal.impl.Pty;
 import org.aesh.terminal.Attributes;
 import org.aesh.terminal.utils.ANSI;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.BuildBase;
@@ -515,7 +516,13 @@ public class DevMojo extends AbstractMojo {
         String jandexGoalPhase = getGoalPhaseOrNull(ORG_JBOSS_JANDEX, JANDEX_MAVEN_PLUGIN, "jandex", "process-classes");
         boolean indexClassNeeded = jandexGoalPhase != null;
 
-        for (String goal : session.getGoals()) {
+        List<String> goals = session.getGoals();
+        // check for default goal(s) if none were specified explicitly,
+        // see also org.apache.maven.lifecycle.internal.DefaultLifecycleTaskSegmentCalculator
+        if (goals.isEmpty() && !StringUtils.isEmpty(project.getDefaultGoal())) {
+            goals = List.of(StringUtils.split(project.getDefaultGoal()));
+        }
+        for (String goal : goals) {
             if (goal.endsWith("quarkus:generate-code")) {
                 prepareNeeded = false;
             }


### PR DESCRIPTION
Stumbled upon this when I switched my `qdev`/`qtest` profiles from `<defaultGoal>quarkus:dev</default>` to `<defaultGoal>test-compile quarkus:dev</default>` to work around a strange ECJ (Eclipse compiler) issue and was still getting auto-invocations of all the plugins.

PS: The ECJ issue is another topic, but it seems like the auto-invocation via DevMode has a different config than the standard Maven one. Need to investigate later...