### PR TITLE
Fix broken xrefs that use the doc-guides attribute

### DIFF
--- a/docs/src/main/asciidoc/_templates/attributes.adoc
+++ b/docs/src/main/asciidoc/_templates/attributes.adoc
@@ -3,7 +3,7 @@
 :idprefix:
 :idseparator: -
 :icons: font
-:doc-guides: ../
+:doc-guides: ..
 :doc-examples: ../_examples
 :imagesdir: ../../asciidoc/images
 :includes: ../includes


### PR DESCRIPTION
The following xref links, which are sourced in several doc contributor help topics in the _templates folder result in a 404 error:

- xref:{doc-guides}/doc-create-howto-tutorial.adoc[Tutorial: Create a How-To]
- xref:{doc-guides}/doc-concepts.adoc#howto-guide[Documentation concepts: How-to guides]
- xref:{doc-guides}/doc-reference.adoc[Quarkus documentation reference]

https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/_templates/%7Bdoc-guides%7D/doc-create-howto-tutorial.adoc

The {doc-guides} attribute incorrectly renders as **_templates/%7Bdoc-guides%7D/**

Steps to reproduce:

1. Open https://github.com/quarkusio/quarkus/blob/main/docs/src/main/asciidoc/_templates/template-howto.adoc.
2. Navigate to **Resources** and click on any of the following links:
![image](https://user-images.githubusercontent.com/92924207/180217307-1bd14ee7-5aae-4fca-8c2e-446b57ffffa3.png)




