### PR TITLE
Exposing getIfPresent in the CaffeineCache

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -597,6 +597,36 @@ public class CacheKeysService {
 }
 ----
 
+=== Retrieving a value if a key is present from a `CaffeineCache`
+
+The cache value from a specific `CaffeineCache` can be retrieved as an `Uni` as shown below.
+If the given key is contained in the cache, the returned `Uni` will emit the value to which the specified key is mapped to.
+Otherwise, the `Uni` will emit the `null` value.
+
+[source,java]
+----
+package org.acme.cache;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CaffeineCache;
+
+import java.util.Set;
+
+@ApplicationScoped
+public class CacheKeysService {
+
+    @CacheName("my-cache")
+    Cache cache;
+
+    public Uni<Object> getIfPresent(Object key) {
+        return cache.as(CaffeineCache.class).getIfPresent(key);
+    }
+}
+----
+
 == Configuring the underlying caching provider
 
 This extension uses https://github.com/ben-manes/caffeine[Caffeine] as its underlying caching provider.

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -599,9 +599,9 @@ public class CacheKeysService {
 
 === Retrieving a value if a key is present from a `CaffeineCache`
 
-The cache value from a specific `CaffeineCache` can be retrieved as an `Uni` as shown below.
-If the given key is contained in the cache, the returned `Uni` will emit the value to which the specified key is mapped to.
-Otherwise, the `Uni` will emit the `null` value.
+The cache value from a specific `CaffeineCache` can be retrieved if present as shown below.
+If the given key is contained in the cache, the returned `CompletableFuture` contains (existing or computed) future value to which the specified key is mapped to.
+Otherwise, the method with return the `null` value.
 
 [source,java]
 ----
@@ -613,7 +613,7 @@ import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheName;
 import io.quarkus.cache.CaffeineCache;
 
-import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 @ApplicationScoped
 public class CacheKeysService {
@@ -621,7 +621,7 @@ public class CacheKeysService {
     @CacheName("my-cache")
     Cache cache;
 
-    public Uni<Object> getIfPresent(Object key) {
+    public CompletableFuture<Object> getIfPresent(Object key) {
         return cache.as(CaffeineCache.class).getIfPresent(key);
     }
 }

--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -600,8 +600,9 @@ public class CacheKeysService {
 === Retrieving a value if a key is present from a `CaffeineCache`
 
 The cache value from a specific `CaffeineCache` can be retrieved if present as shown below.
-If the given key is contained in the cache, the returned `CompletableFuture` contains (existing or computed) future value to which the specified key is mapped to.
-Otherwise, the method with return the `null` value.
+If the given key is contained in the cache, the method will return the `CompletableFuture` the specified key is mapped to.
+That `CompletableFuture` may be computing or may already be completed.
+Otherwise, the method will return `null`.
 
 [source,java]
 ----

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
@@ -163,6 +163,24 @@ public class ProgrammaticApiTest {
     }
 
     @Test
+    public void testCacheNullValue() throws Exception {
+        // with custom key
+        Object key = new Object();
+
+        try {
+            // when null is cached
+            cache.get(key, (k) -> null).await().indefinitely();
+
+            // assert
+            assertKeySetContains(key);
+            assertGetIfPresent(key, null);
+        } finally {
+            // invalidate to remove side effects in other tests
+            cache.invalidate(key).await().indefinitely();
+        }
+    }
+
+    @Test
     public void testExceptionInValueLoader() throws Exception {
         // with custom key and exception
         Object key = new Object();

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
@@ -22,11 +22,11 @@ public interface CaffeineCache extends Cache {
      * enabled.
      *
      * @param key key whose associated value is to be returned
-     * @return the current (existing or computed) future value to which the specified key is mapped,
-     *         or {@code null} if this cache contains no mapping for the key
+     * @return the future value to which the specified key is mapped, or {@code null} if this cache
+     *         does not contain a mapping for the key
      * @throws NullPointerException if the specified key is null
      * @see com.github.benmanes.caffeine.cache.AsyncCache#getIfPresent(Object)
      */
     @Nullable
-    <K, V> CompletableFuture<V> getIfPresent(K key);
+    <V> CompletableFuture<V> getIfPresent(Object key);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
@@ -3,8 +3,6 @@ package io.quarkus.cache;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import io.smallrye.common.constraint.Nullable;
-
 public interface CaffeineCache extends Cache {
 
     /**
@@ -27,6 +25,5 @@ public interface CaffeineCache extends Cache {
      * @throws NullPointerException if the specified key is null
      * @see com.github.benmanes.caffeine.cache.AsyncCache#getIfPresent(Object)
      */
-    @Nullable
     <V> CompletableFuture<V> getIfPresent(Object key);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
@@ -1,8 +1,9 @@
 package io.quarkus.cache;
 
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
-import io.smallrye.mutiny.Uni;
+import io.smallrye.common.constraint.Nullable;
 
 public interface CaffeineCache extends Cache {
 
@@ -15,14 +16,17 @@ public interface CaffeineCache extends Cache {
     Set<Object> keySet();
 
     /**
-     * Returns an {@link Uni} emitting the value for the given key, if the key is contained in this cache. If the key does not
-     * exist in the cache, returned {@link Uni} will emit <code>null</code>.
+     * Returns the future associated with {@code key} in this cache, or {@code null} if there is no
+     * cached future for {@code key}. This method is delegating to the
+     * {@link com.github.benmanes.caffeine.cache.AsyncCache#getIfPresent(Object)}, while recording the cache stats if they are
+     * enabled.
      *
      * @param key key whose associated value is to be returned
-     *
-     * @return Uni emitting the value to which the specified key is mapped, or emitting <code>null</code> if this cache contains
-     *         no mapping for the key
+     * @return the current (existing or computed) future value to which the specified key is mapped,
+     *         or {@code null} if this cache contains no mapping for the key
      * @throws NullPointerException if the specified key is null
+     * @see com.github.benmanes.caffeine.cache.AsyncCache#getIfPresent(Object)
      */
-    <K, V> Uni<V> getIfPresent(K key);
+    @Nullable
+    <K, V> CompletableFuture<V> getIfPresent(K key);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
@@ -2,6 +2,8 @@ package io.quarkus.cache;
 
 import java.util.Set;
 
+import io.smallrye.mutiny.Uni;
+
 public interface CaffeineCache extends Cache {
 
     /**
@@ -11,4 +13,16 @@ public interface CaffeineCache extends Cache {
      * @return a set view of the keys contained in this cache
      */
     Set<Object> keySet();
+
+    /**
+     * Returns an {@link Uni} emitting the value for the given key, if the key is contained in this cache. If the key does not
+     * exist in the cache, returned {@link Uni} will emit <code>null</code>.
+     *
+     * @param key key whose associated value is to be returned
+     *
+     * @return Uni emitting the value to which the specified key is mapped, or emitting <code>null</code> if this cache contains
+     *         no mapping for the key
+     * @throws NullPointerException if the specified key is null
+     */
+    <K, V> Uni<V> getIfPresent(K key);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -104,11 +104,14 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
 
             // cast, but still throw the CacheException in case it fails
             return unwrapCacheValueOrThrowable(existingCacheValue)
-                    .thenApply(value -> {
-                        try {
-                            return (V) value;
-                        } catch (ClassCastException e) {
-                            throw new CacheException("An existing cached value type does not match the requested type", e);
+                    .thenApply(new Function<>() {
+                        @Override
+                        public Object apply(Object value) {
+                            try {
+                                return (V) value;
+                            } catch (ClassCastException e) {
+                                throw new CacheException("An existing cached value type does not match the requested type", e);
+                            }
                         }
                     });
 

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -106,7 +106,7 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
             return unwrapCacheValueOrThrowable(existingCacheValue)
                     .thenApply(new Function<>() {
                         @Override
-                        public Object apply(Object value) {
+                        public V apply(Object value) {
                             try {
                                 return (V) value;
                             } catch (ClassCastException e) {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -90,17 +90,17 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
     }
 
     @Override
-    public <K, V> Uni<V> getIfPresent(K key) {
+    public <K, V> CompletableFuture<V> getIfPresent(K key) {
         Objects.requireNonNull(key, NULL_KEYS_NOT_SUPPORTED_MSG);
         CompletableFuture<Object> caffeineValue = getFromCaffeineIfPresent(key);
 
-        // emit null if key is not in cache
+        // if null return
         if (null == caffeineValue) {
-            return Uni.createFrom().nullItem();
+            return null;
         }
 
-        // otherwise cast and emit the value
-        return Uni.createFrom().completionStage(() -> cast(caffeineValue));
+        // otherwise cast and return
+        return caffeineValue.thenApply(this::cast);
     }
 
     /**


### PR DESCRIPTION
Fixes #26730.

Implemented the exposure of the `getIfPresent` from the `CaffeineCache`, as described in the #26730. 

As this is my first PR, I tried to follow which test(s) should be updated by looking at references to the `CaffeineCache#keySet()` and the only test actually testing this method is `ProgrammaticApiTest`.. Not sure if this is enough, but as I was missing a test case for the exception thrown in the value loader, I added that..

Also tried to extend the docs..

I am available for any suggestion and proposal for improvement..