### PR TITLE
Enhance OIDC Client to support the token revocation

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client-reference.adoc
@@ -495,6 +495,15 @@ If the access token needs to be refreshed but no refresh token is available then
 
 Please note that some OpenID Connect Providers will not return a refresh token in a `client_credentials` grant response. For example, starting from Keycloak 12 a refresh token will not be returned by default for `client_credentials`. The providers may also restrict a number of times a refresh token can be used.
 
+[[revoke-access-tokens]]
+=== Revoking Access Tokens
+
+If your OpenId Connect provider such as Keycloak supports a token revocation endpoint then `OidcClient#revokeAccessToken` can be used to revoke the current access token. The revocation endpoint URL will be discovered alongside the token request URI or can be configured with `quarkus.oidc-client.revoke-path`.
+
+You may want to have the access token revoked if using this token with a REST client fails with HTTP `401` or the access token has already been used for a long time and you'd like to refresh it.
+
+This can be achieved by requesting a token refresh using a refresh token. However, if the refresh token is not available then you can refresh it by revoking it first and then request a new access token.
+
 [[oidc-client-authentication]]
 === OidcClient Authentication
 

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClient.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/OidcClient.java
@@ -12,21 +12,35 @@ import io.smallrye.mutiny.Uni;
 public interface OidcClient extends Closeable {
 
     /**
-     * Returns the grant tokens
+     * Get the grant access and refresh tokens.
      */
     default Uni<Tokens> getTokens() {
         return getTokens(Collections.emptyMap());
     }
 
     /**
-     * Returns the grant tokens
+     * Get the grant access and refresh tokens with additional grant parameters.
      *
      * @param additionalGrantParameters additional grant parameters
+     * @return Uni<Tokens>
      */
     Uni<Tokens> getTokens(Map<String, String> additionalGrantParameters);
 
     /**
-     * Refreshes the grant tokens
+     * Refresh and return a new pair of access and refresh tokens.
+     * Note a refresh token grant will typically return not only a new access token but also a new refresh token.
+     *
+     * @param refreshToken refresh token
+     * @return Uni<Tokens>
      */
     Uni<Tokens> refreshTokens(String refreshToken);
+
+    /**
+     * Revoke the access token.
+     *
+     * @param refreshToken access token which needs to be revoked
+     * @return Uni<Boolean> true if the token has been revoked or found already being invalidated,
+     *         false if the token can not be currently revoked in which case a revocation request might be retried.
+     */
+    Uni<Boolean> revokeAccessToken(String accessToken);
 }

--- a/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
+++ b/extensions/oidc-client/runtime/src/main/java/io/quarkus/oidc/client/runtime/OidcClientImpl.java
@@ -20,6 +20,7 @@ import io.quarkus.oidc.client.Tokens;
 import io.quarkus.oidc.common.runtime.OidcCommonUtils;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.groups.UniOnItem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
@@ -37,6 +38,7 @@ public class OidcClientImpl implements OidcClient {
 
     private final WebClient client;
     private final String tokenRequestUri;
+    private final String tokenRevokeUri;
     private final MultiMap tokenGrantParams;
     private final MultiMap commonRefreshGrantParams;
     private final String grantType;
@@ -45,10 +47,11 @@ public class OidcClientImpl implements OidcClient {
     private final OidcClientConfig oidcConfig;
     private volatile boolean closed;
 
-    public OidcClientImpl(WebClient client, String tokenRequestUri, String grantType,
+    public OidcClientImpl(WebClient client, String tokenRequestUri, String tokenRevokeUri, String grantType,
             MultiMap tokenGrantParams, MultiMap commonRefreshGrantParams, OidcClientConfig oidcClientConfig) {
         this.client = client;
         this.tokenRequestUri = tokenRequestUri;
+        this.tokenRevokeUri = tokenRevokeUri;
         this.tokenGrantParams = tokenGrantParams;
         this.commonRefreshGrantParams = commonRefreshGrantParams;
         this.grantType = grantType;
@@ -78,6 +81,32 @@ public class OidcClientImpl implements OidcClient {
         return getJsonResponse(refreshGrantParams, Collections.emptyMap(), true);
     }
 
+    @Override
+    public Uni<Boolean> revokeAccessToken(String accessToken) {
+        checkClosed();
+        if (accessToken == null) {
+            throw new OidcClientException("Access token is null");
+        }
+        if (tokenRevokeUri != null) {
+            MultiMap tokenRevokeParams = new MultiMap(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+            tokenRevokeParams.set(OidcConstants.REVOCATION_TOKEN, accessToken);
+            return postRequest(client.postAbs(tokenRevokeUri), tokenRevokeParams, Map.of(), false)
+                    .transform(resp -> toRevokeResponse(resp));
+        } else {
+            LOG.debugf("%s OidcClient can not revoke the access token because the revocation endpoint URL is not set");
+            return Uni.createFrom().item(false);
+        }
+
+    }
+
+    private Boolean toRevokeResponse(HttpResponse<Buffer> resp) {
+        // Per RFC7009, 200 is returned if a token has been revoked successfully or if the client submitted an
+        // invalid token, https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.
+        // 503 is at least theoretically possible if the OIDC server declines and suggests to Retry-After some period of time.
+        // However this period of time can be set to unpredictable value.
+        return resp.statusCode() == 503 ? false : true;
+    }
+
     private Uni<Tokens> getJsonResponse(MultiMap formBody, Map<String, String> additionalGrantParameters, boolean refresh) {
         //Uni needs to be lazy by default, we don't send the request unless
         //something has subscribed to it. This is important for the CAS state
@@ -85,52 +114,62 @@ public class OidcClientImpl implements OidcClient {
         return Uni.createFrom().deferred(new Supplier<Uni<? extends Tokens>>() {
             @Override
             public Uni<Tokens> get() {
-                MultiMap body = formBody;
-                HttpRequest<Buffer> request = client.postAbs(tokenRequestUri);
-                request.putHeader(HttpHeaders.CONTENT_TYPE.toString(),
-                        HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
-                if (oidcConfig.headers != null) {
-                    for (Map.Entry<String, String> headerEntry : oidcConfig.headers.entrySet()) {
-                        request.putHeader(headerEntry.getKey(), headerEntry.getValue());
-                    }
-                }
-                if (clientSecretBasicAuthScheme != null) {
-                    request.putHeader(AUTHORIZATION_HEADER, clientSecretBasicAuthScheme);
-                } else if (clientJwtKey != null) {
-                    // if it is a refresh then a map has already been copied
-                    body = !refresh ? copyMultiMap(body) : body;
-                    String jwt = OidcCommonUtils.signJwtWithKey(oidcConfig, tokenRequestUri, clientJwtKey);
-
-                    if (OidcCommonUtils.isClientSecretPostJwtAuthRequired(oidcConfig.credentials)) {
-                        body.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
-                        body.add(OidcConstants.CLIENT_SECRET, jwt);
-                    } else {
-                        body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
-                        body.add(OidcConstants.CLIENT_ASSERTION, jwt);
-                    }
-                } else if (!OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
-                    body = copyMultiMap(body).set(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
-                }
-                if (!additionalGrantParameters.isEmpty()) {
-                    body = copyMultiMap(body);
-                    for (Map.Entry<String, String> entry : additionalGrantParameters.entrySet()) {
-                        body.add(entry.getKey(), entry.getValue());
-                    }
-                }
-                // Retry up to three times with a one-second delay between the retries if the connection is closed
-                Uni<HttpResponse<Buffer>> response = request.sendBuffer(OidcCommonUtils.encodeForm(body))
-                        .onFailure(ConnectException.class)
-                        .retry()
-                        .atMost(oidcConfig.connectionRetryCount)
-                        .onFailure().transform(t -> {
-                            LOG.warn("OIDC Server is not available:", t.getCause() != null ? t.getCause() : t);
-                            // don't wrap it to avoid information leak
-                            return new OidcClientException("OIDC Server is not available");
-                        });
-                return response.onItem()
+                return postRequest(client.postAbs(tokenRequestUri), formBody, additionalGrantParameters, refresh)
                         .transform(resp -> emitGrantTokens(resp, refresh));
             }
         });
+    }
+
+    private UniOnItem<HttpResponse<Buffer>> postRequest(HttpRequest<Buffer> request, MultiMap formBody,
+            Map<String, String> additionalGrantParameters,
+            boolean refresh) {
+        MultiMap body = formBody;
+        request.putHeader(HttpHeaders.CONTENT_TYPE.toString(),
+                HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED.toString());
+        if (oidcConfig.headers != null) {
+            for (Map.Entry<String, String> headerEntry : oidcConfig.headers.entrySet()) {
+                request.putHeader(headerEntry.getKey(), headerEntry.getValue());
+            }
+        }
+        if (clientSecretBasicAuthScheme != null) {
+            request.putHeader(AUTHORIZATION_HEADER, clientSecretBasicAuthScheme);
+        } else if (clientJwtKey != null) {
+            // if it is a refresh then a map has already been copied
+            body = !refresh ? copyMultiMap(body) : body;
+            String jwt = OidcCommonUtils.signJwtWithKey(oidcConfig, tokenRequestUri, clientJwtKey);
+
+            if (OidcCommonUtils.isClientSecretPostJwtAuthRequired(oidcConfig.credentials)) {
+                body.add(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
+                body.add(OidcConstants.CLIENT_SECRET, jwt);
+            } else {
+                body.add(OidcConstants.CLIENT_ASSERTION_TYPE, OidcConstants.JWT_BEARER_CLIENT_ASSERTION_TYPE);
+                body.add(OidcConstants.CLIENT_ASSERTION, jwt);
+            }
+        } else if (OidcCommonUtils.isClientSecretPostAuthRequired(oidcConfig.credentials)) {
+            body = !refresh ? copyMultiMap(body) : body;
+            body.set(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
+            body.set(OidcConstants.CLIENT_SECRET, OidcCommonUtils.clientSecret(oidcConfig.credentials));
+        } else {
+            body = !refresh ? copyMultiMap(body) : body;
+            body = copyMultiMap(body).set(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
+        }
+        if (!additionalGrantParameters.isEmpty()) {
+            body = copyMultiMap(body);
+            for (Map.Entry<String, String> entry : additionalGrantParameters.entrySet()) {
+                body.add(entry.getKey(), entry.getValue());
+            }
+        }
+        // Retry up to three times with a one-second delay between the retries if the connection is closed
+        Uni<HttpResponse<Buffer>> response = request.sendBuffer(OidcCommonUtils.encodeForm(body))
+                .onFailure(ConnectException.class)
+                .retry()
+                .atMost(oidcConfig.connectionRetryCount)
+                .onFailure().transform(t -> {
+                    LOG.warn("OIDC Server is not available:", t.getCause() != null ? t.getCause() : t);
+                    // don't wrap it to avoid information leak
+                    return new OidcClientException("OIDC Server is not available");
+                });
+        return response.onItem();
     }
 
     private Tokens emitGrantTokens(HttpResponse<Buffer> resp, boolean refresh) {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonConfig.java
@@ -33,6 +33,12 @@ public class OidcCommonConfig {
     public Optional<String> tokenPath = Optional.empty();
 
     /**
+     * Relative path or absolute URL of the OIDC token revocation endpoint.
+     */
+    @ConfigItem
+    public Optional<String> revokePath = Optional.empty();
+
+    /**
      * The client-id of the application. Each application has a client-id that is used to identify the application
      */
     @ConfigItem
@@ -603,6 +609,14 @@ public class OidcCommonConfig {
 
     public void setTokenPath(String tokenPath) {
         this.tokenPath = Optional.of(tokenPath);
+    }
+
+    public Optional<String> getRevokePath() {
+        return revokePath;
+    }
+
+    public void setRevokePath(String revokePath) {
+        this.revokePath = Optional.of(revokePath);
     }
 
     public Optional<String> getClientId() {

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcConstants.java
@@ -27,6 +27,8 @@ public final class OidcConstants {
     public static final String INTROSPECTION_TOKEN_USERNAME = "username";
     public static final String INTROSPECTION_TOKEN_SUB = "sub";
 
+    public static final String REVOCATION_TOKEN = "token";
+
     public static final String PASSWORD_GRANT_USERNAME = "username";
     public static final String PASSWORD_GRANT_PASSWORD = "password";
 

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt-build</artifactId>
         </dependency>
         <dependency>
@@ -92,6 +96,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-client-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -36,6 +36,7 @@ public class OidcResource {
     private volatile boolean rotate;
     private volatile int jwkEndpointCallCount;
     private volatile int introspectionEndpointCallCount;
+    private volatile int revokeEndpointCallCount;
     private volatile int userInfoEndpointCallCount;
     private volatile boolean enableDiscovery = true;
 
@@ -57,6 +58,7 @@ public class OidcResource {
                     "   \"token_endpoint\":" + "\"" + baseUri + "/token\"," +
                     "   \"introspection_endpoint\":" + "\"" + baseUri + "/introspect\"," +
                     "   \"userinfo_endpoint\":" + "\"" + baseUri + "/userinfo\"," +
+                    "   \"revocation_endpoint\":" + "\"" + baseUri + "/revoke\"," +
                     "   \"jwks_uri\":" + "\"" + baseUri + "/jwks\"" +
                     "  }";
         } else {
@@ -141,6 +143,27 @@ public class OidcResource {
                 "   \"introspection_client_secret\": \"" + introspectionClientSecret + "\"," +
                 "   \"client_id\": \"" + clientId + "\"" +
                 "  }";
+    }
+
+    @GET
+    @Path("revoke-endpoint-call-count")
+    public int revokeEndpointCallCount() {
+        return revokeEndpointCallCount;
+    }
+
+    @POST
+    @Path("revoke-endpoint-call-count")
+    public int resetRevokeEndpointCallCount() {
+        revokeEndpointCallCount = 0;
+        return revokeEndpointCallCount;
+    }
+
+    @POST
+    @Path("revoke")
+    public void revoke(@FormParam("token") String token) throws Exception {
+        if (token != null) {
+            revokeEndpointCallCount++;
+        }
     }
 
     @GET

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -8,6 +8,9 @@ quarkus.oidc.client-id=quarkus-app-a
 quarkus.oidc.credentials.secret=secret
 quarkus.oidc.application-type=service
 
+# Oidc Client
+quarkus.test.native-image-profile=test
+
 # Tenant B
 quarkus.oidc.tenant-b.auth-server-url=${keycloak.url}/realms/quarkus-b
 quarkus.oidc.tenant-b.client-id=quarkus-app-b

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -298,6 +298,7 @@ public class BearerTokenAuthorizationTest {
     public void testSimpleOidcJwtWithJwkRefresh() {
         RestAssured.when().post("/oidc/jwk-endpoint-call-count").then().body(equalTo("0"));
         RestAssured.when().post("/oidc/introspection-endpoint-call-count").then().body(equalTo("0"));
+        RestAssured.when().post("/oidc/revoke-endpoint-call-count").then().body(equalTo("0"));
         RestAssured.when().post("/oidc/disable-introspection").then().body(equalTo("false"));
         RestAssured.when().post("/oidc/disable-discovery").then().body(equalTo("false"));
         // Quarkus OIDC is initialized with JWK set with kid '1' as part of the discovery process
@@ -322,7 +323,7 @@ public class BearerTokenAuthorizationTest {
         RestAssured.when().post("/oidc/enable-introspection").then().body(equalTo("true"));
         // No timeout is required
         RestAssured.given().auth().oauth2(getAccessTokenFromSimpleOidc("3"))
-                .when().get("/tenant/tenant-oidc/api/user")
+                .when().get("/tenant/tenant-oidc/api/user?revoke=true")
                 .then()
                 .statusCode(200)
                 .body(equalTo("tenant-oidc:alice"));
@@ -340,6 +341,7 @@ public class BearerTokenAuthorizationTest {
         RestAssured.when().get("/oidc/jwk-endpoint-call-count").then().body(equalTo("2"));
         // both requests with kid `3` and with the opaque token required the remote introspection
         RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("3"));
+        RestAssured.when().get("/oidc/revoke-endpoint-call-count").then().body(equalTo("1"));
         RestAssured.when().post("/oidc/disable-introspection").then().body(equalTo("false"));
         RestAssured.when().post("/oidc/enable-discovery").then().body(equalTo("true"));
         RestAssured.when().post("/oidc/disable-rotate").then().body(equalTo("false"));


### PR DESCRIPTION
Fixes #26867 

Keeping this PR as a draft until I figure out how to test it.

I just had to refactor `OidcClientImpl` a little bit to reuse the code which is used to post a request.

`quarkus-oidc` may also support it in the next phase (ex, to revoke the failed bearer tokens, on local logouts, etc).

CC @FroMage, FYI, `OidcClient` can also be configured to talk to Apple OIDC 