### PR TITLE
Make sure referenced upstream platform is also pulled in when resolving extension catalog directly

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -37,9 +37,9 @@ import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.QuarkusBuildCloseablesBuildItem;
 import io.quarkus.deployment.configuration.ClassLoadingConfig;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACT;
-import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.DirectoryPathTree;
 import io.quarkus.paths.MultiRootPathTree;
@@ -176,10 +176,10 @@ public class ApplicationArchiveBuildStep {
         }
         try {
             for (IndexDependencyBuildItem indexDependencyBuildItem : indexDependencyBuildItems) {
-                final ArtifactKey key = new GACT(indexDependencyBuildItem.getGroupId(),
+                final ArtifactKey key = ArtifactKey.of(indexDependencyBuildItem.getGroupId(),
                         indexDependencyBuildItem.getArtifactId(),
                         indexDependencyBuildItem.getClassifier(),
-                        GACTV.TYPE_JAR);
+                        ArtifactCoords.TYPE_JAR);
                 final ResolvedDependency artifact = userMap.get(key);
                 if (artifact == null) {
                     throw new RuntimeException(

--- a/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectCreateForPlatformTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/MavenProjectCreateForPlatformTest.java
@@ -1,0 +1,137 @@
+package io.quarkus.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.bootstrap.resolver.maven.workspace.ModelUtils;
+import io.quarkus.devtools.testing.registry.client.TestRegistryClientBuilder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import picocli.CommandLine;
+
+public class MavenProjectCreateForPlatformTest extends RegistryClientBuilderTestBase {
+
+    @BeforeAll
+    static void configureRegistryAndMavenRepo() {
+        TestRegistryClientBuilder.newInstance()
+                .baseDir(registryConfigDir())
+                .persistPlatformDescriptorsAsMavenArtifacts()
+                .newRegistry("registry.acme.com")
+                .newPlatform("com.acme.quarkus.platform")
+                .newStream("9.0")
+                .newRelease("9.0.0")
+                .quarkusVersion("9.0.0.acme-1")
+                .upstreamQuarkusVersion("9.0.0")
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .release()
+                .newMember("acme-bom")
+                .addExtension("io.quarkus.platform", "acme-quarkus-supersonic", "9.0.0.acme-1")
+                .addExtension("io.quarkus.platform", "acme-quarkus-subatomic", "9.0.0.acme-1")
+                .release().stream().platform()
+                .newStream("8.0")
+                .newRelease("8.0.0")
+                .quarkusVersion("8.0.0.acme-1")
+                .upstreamQuarkusVersion("8.0.0")
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .release()
+                .newMember("acme-supersonic-bom")
+                .addExtension("io.quarkus.platform", "acme-quarkus-supersonic", "8.0.0.acme-1")
+                .registry()
+                .clientBuilder()
+                .newRegistry("registry.acme.org")
+                .newPlatform("io.quarkus.platform")
+                .newStream("9.0")
+                .newRelease("9.0.0")
+                .quarkusVersion("9.0.0")
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .release()
+                .newMember("acme-bom").addExtension("acme-quarkus-supersonic").addExtension("acme-quarkus-subatomic")
+                .release().stream().platform()
+                .newStream("8.0")
+                .newRelease("8.0.0")
+                .quarkusVersion("8.0.0")
+                .addCoreMember()
+                .alignPluginsOnQuarkusVersion()
+                .release()
+                .newMember("acme-supersonic-bom").addExtension("acme-quarkus-supersonic").release()
+                .newMember("acme-subatomic-bom").addExtension("acme-quarkus-subatomic")
+                .registry()
+                .newNonPlatformCatalog(getCurrentQuarkusVersion())
+                .addExtension("org.acme", "acme-quarkiverse-extension", "1.0")
+                .registry()
+                .clientBuilder()
+                .build();
+    }
+
+    @Test
+    void testCreateForPlatformWithUpstream() throws Exception {
+
+        final CliDriver.Result createResult = run(workDir(), "create", "create-for-platform",
+                "-P com.acme.quarkus.platform:acme-supersonic-bom:8.0.0", "-x supersonic,subatomic");
+        createResult.echoSystemOut();
+        createResult.echoSystemErr();
+        assertThat(createResult.exitCode).isEqualTo(CommandLine.ExitCode.OK)
+                .as(() -> "Expected OK return code." + createResult);
+        assertThat(createResult.stdout).contains("SUCCESS")
+                .as(() -> "Expected confirmation that the project has been created." + createResult);
+
+        final Path projectDir = workDir().resolve("create-for-platform");
+        assertThat(projectDir).exists();
+        final Path pomXml = projectDir.resolve("pom.xml");
+        assertThat(pomXml).exists();
+
+        final Model model = ModelUtils.readModel(pomXml);
+        final Properties pomProps = model.getProperties();
+        assertThat(pomProps).containsEntry("quarkus-plugin.version", "8.0.0.acme-1");
+        assertThat(pomProps).containsEntry("quarkus.platform.artifact-id", "quarkus-bom");
+        assertThat(pomProps).containsEntry("quarkus.platform.group-id", "com.acme.quarkus.platform");
+        assertThat(pomProps).containsEntry("quarkus.platform.version", "8.0.0");
+
+        final DependencyManagement dm = model.getDependencyManagement();
+        assertThat(dm).isNotNull();
+        final List<Dependency> managed = dm.getDependencies();
+        assertThat(managed).hasSize(3);
+
+        Dependency bomImport = managed.get(0);
+        assertThat(bomImport.getGroupId()).isEqualTo("${quarkus.platform.group-id}");
+        assertThat(bomImport.getArtifactId()).isEqualTo("${quarkus.platform.artifact-id}");
+        assertThat(bomImport.getVersion()).isEqualTo("${quarkus.platform.version}");
+        assertThat(bomImport.getType()).isEqualTo("pom");
+        assertThat(bomImport.getScope()).isEqualTo("import");
+
+        bomImport = managed.get(1);
+        assertThat(bomImport.getGroupId()).isEqualTo("${quarkus.platform.group-id}");
+        assertThat(bomImport.getArtifactId()).isEqualTo("acme-supersonic-bom");
+        assertThat(bomImport.getVersion()).isEqualTo("${quarkus.platform.version}");
+        assertThat(bomImport.getType()).isEqualTo("pom");
+        assertThat(bomImport.getScope()).isEqualTo("import");
+
+        bomImport = managed.get(2);
+        assertThat(bomImport.getGroupId()).isEqualTo("io.quarkus.platform");
+        assertThat(bomImport.getArtifactId()).isEqualTo("acme-subatomic-bom");
+        assertThat(bomImport.getVersion()).isEqualTo("8.0.0");
+        assertThat(bomImport.getType()).isEqualTo("pom");
+        assertThat(bomImport.getScope()).isEqualTo("import");
+
+        final Set<ArtifactCoords> pomDeps = model.getDependencies().stream()
+                .map(d -> ArtifactCoords.of(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()))
+                .collect(Collectors.toSet());
+        assertThat(pomDeps).contains(ArtifactCoords.of("io.quarkus.platform", "acme-quarkus-subatomic",
+                ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR, null));
+        assertThat(pomDeps).contains(ArtifactCoords.of("io.quarkus.platform", "acme-quarkus-supersonic",
+                ArtifactCoords.DEFAULT_CLASSIFIER, ArtifactCoords.TYPE_JAR, null));
+    }
+}

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -739,7 +739,7 @@ public class DevMojo extends AbstractMojo {
 
     private void addProject(MavenDevModeLauncher.Builder builder, ResolvedDependency module, boolean root) throws Exception {
 
-        if (!ArtifactCoords.TYPE_JAR.equals(module.getType())) {
+        if (!module.isJar()) {
             return;
         }
 

--- a/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -327,7 +327,7 @@ public class QuarkusBootstrapProvider implements Closeable {
             if (coordsArr.length == 3) {
                 version = coordsArr[2];
             } else if (coordsArr.length > 3) {
-                classifier = coordsArr[2] == null ? "" : coordsArr[2];
+                classifier = coordsArr[2] == null ? ArtifactCoords.DEFAULT_CLASSIFIER : coordsArr[2];
                 type = coordsArr[3] == null ? ArtifactCoords.TYPE_JAR : coordsArr[3];
                 if (coordsArr.length > 4) {
                     version = coordsArr[4];

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
@@ -5,7 +5,7 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
     String groupId;
     String artifactId;
     String classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
-    String type = GACTV.TYPE_JAR;
+    String type = ArtifactCoords.TYPE_JAR;
     String version;
     String scope = "compile";
     int flags;

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -480,11 +480,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
         }
         if (artifactNode == null || groupId == null || artifactId == null || version == null) {
-            final ArtifactCoords coords = new GACTV(
+            final ArtifactCoords coords = ArtifactCoords.jar(
                     groupId == null ? project.getGroupId() : groupId,
                     artifactId == null ? project.getArtifactId() : artifactId,
-                    null,
-                    ArtifactCoords.TYPE_JAR,
                     version == null ? project.getVersion() : version);
             extObject.put("artifact", coords.toString());
         }

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -494,11 +494,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
             }
         }
         if (artifactNode == null || groupId == null || artifactId == null || version == null) {
-            final ArtifactCoords coords = new GACTV(
+            final ArtifactCoords coords = ArtifactCoords.jar(
                     groupId == null ? project.getGroupId() : groupId,
                     artifactId == null ? project.getArtifactId() : artifactId,
-                    null,
-                    ArtifactCoords.TYPE_JAR,
                     version == null ? project.getVersion() : version);
             extObject.put("artifact", coords.toString());
         }

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/tools/ToolsUtils.java
@@ -86,7 +86,12 @@ public class ToolsUtils {
 
     public static ExtensionCatalog resolvePlatformDescriptorDirectly(String bomGroupId, String bomArtifactId, String bomVersion,
             MavenArtifactResolver artifactResolver, MessageWriter log) {
-        // TODO remove this method once we have the registry service available
+        return resolvePlatformDescriptorDirectly(bomGroupId, bomArtifactId, bomVersion, artifactResolver, log, 1);
+    }
+
+    private static ExtensionCatalog resolvePlatformDescriptorDirectly(String bomGroupId, String bomArtifactId,
+            String bomVersion,
+            MavenArtifactResolver artifactResolver, MessageWriter log, int registryPreference) {
         if (bomVersion == null) {
             throw new IllegalArgumentException("BOM version was not provided");
         }
@@ -95,6 +100,7 @@ public class ToolsUtils {
                 (bomArtifactId == null ? ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID : bomArtifactId)
                         + BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX,
                 bomVersion, "json", bomVersion);
+
         Path platformJson = null;
         try {
             log.debug("Resolving platform descriptor %s", catalogCoords);
@@ -159,7 +165,8 @@ public class ToolsUtils {
                             }
                         }
 
-                        final OriginPreference originPreference = new OriginPreference(1, 1, 1, ++memberIndex, 1);
+                        final OriginPreference originPreference = new OriginPreference(registryPreference, 1, 1, ++memberIndex,
+                                1);
                         Map<String, Object> metadata = new HashMap<>(memberCatalog.getMetadata());
                         metadata.put("origin-preference", originPreference);
                         ExtensionCatalog.Mutable mutableMemberCatalog = memberCatalog.mutable();
@@ -168,6 +175,20 @@ public class ToolsUtils {
                     }
                     catalog = CatalogMergeUtility.merge(catalogs);
                 }
+            }
+        }
+        if (catalog.getUpstreamQuarkusCoreVersion() != null
+                && !catalog.getUpstreamQuarkusCoreVersion().isBlank()
+                && !(bomVersion.equals(catalog.getUpstreamQuarkusCoreVersion())
+                        && catalogCoords.getGroupId().equals(ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID)
+                        && catalogCoords.getArtifactId().equals(ToolsConstants.DEFAULT_PLATFORM_BOM_ARTIFACT_ID
+                                + BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX))) {
+            try {
+                final ExtensionCatalog upstreamCatalog = resolvePlatformDescriptorDirectly(null, null,
+                        catalog.getUpstreamQuarkusCoreVersion(), artifactResolver, log, registryPreference + 1);
+                catalog = CatalogMergeUtility.merge(List.of(catalog, upstreamCatalog));
+            } catch (Exception e) {
+                log.warn(e.getLocalizedMessage());
             }
         }
         return catalog;

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/registry/client/TestRegistryClientBuilder.java
@@ -56,6 +56,7 @@ public class TestRegistryClientBuilder {
     private List<Extension> externalExtensions = List.of();
     private List<TestCodestartBuilder> externalCodestartBuilders = List.of();
     private MavenArtifactResolver resolver;
+    private boolean persistPlatformDescriptorsAsMavenArtifacts;
 
     public static TestRegistryClientBuilder newInstance() {
         return new TestRegistryClientBuilder();
@@ -71,6 +72,11 @@ public class TestRegistryClientBuilder {
 
     public TestRegistryClientBuilder debug() {
         this.config.setDebug(true);
+        return this;
+    }
+
+    public TestRegistryClientBuilder persistPlatformDescriptorsAsMavenArtifacts() {
+        this.persistPlatformDescriptorsAsMavenArtifacts = true;
         return this;
     }
 
@@ -766,7 +772,7 @@ public class TestRegistryClientBuilder {
                 registry().clientBuilder().getResolver().install(new DefaultArtifact(
                         coords.getGroupId(), coords.getArtifactId(), coords.getClassifier(), coords.getType(),
                         coords.getVersion(),
-                        Collections.emptyMap(), path.toFile()));
+                        Map.of(), path.toFile()));
             } catch (BootstrapMavenException e) {
                 throw new IllegalStateException("Failed to install " + path + " as " + coords, e);
             }
@@ -780,6 +786,10 @@ public class TestRegistryClientBuilder {
                 extensions.persist(json);
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to persist extension catalog " + json, e);
+            }
+
+            if (registry().clientBuilder().persistPlatformDescriptorsAsMavenArtifacts) {
+                install(PlatformArtifacts.ensureCatalogArtifact(bom), json);
             }
 
             Path artifactPath = registry().clientBuilder().getTmpPath(bom);


### PR DESCRIPTION
This change will allow `quarkus create -P com.redhat.quarkus.platform:quarkus-bom:xxx -x kogito-decisions` pulling the kogito-decisions extension from the corresponding upstream platform if it's not present in the com.redhat.quarkus.platform.