### PR TITLE
Fix regression with locationPackages paths on Windows

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsoleProcessor.java
@@ -940,7 +940,7 @@ public class DevConsoleProcessor {
                 for (Path sourcePaths : sourcesDir) {
                     List<String> packages = sourcePackagesForRoot(sourcePaths);
                     if (!packages.isEmpty()) {
-                        sourcePackagesByDir.put(sourcePaths.toAbsolutePath().toString(), packages);
+                        sourcePackagesByDir.put(sourcePaths.toAbsolutePath().toString().replace("\\", "/"), packages);
                     }
                 }
                 return sourcePackagesByDir;


### PR DESCRIPTION
Fixes a regression that was introduced through [commit f7b28fa0](https://github.com/quarkusio/quarkus/commit/f7b28fa018886921ab1f2229ea73732a4cdd79df#diff-5d886c297bbf81799a7e65ae5aec5de0966e6a5dbe06641a569a7c5afa0cf5b1L893) where the replacement of backslashes for to forward slashes in Windows paths.

fixes #26831