### PR TITLE
Add `@InjectSpy.delegate` to evade errors with `default` methods in intermediate spring-data repo interfaces

### DIFF
--- a/integration-tests/spring-data-jpa/pom.xml
+++ b/integration-tests/spring-data-jpa/pom.xml
@@ -42,6 +42,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PostRepositorySpyTest.java
+++ b/integration-tests/spring-data-jpa/src/test/java/io/quarkus/it/spring/data/jpa/PostRepositorySpyTest.java
@@ -1,0 +1,26 @@
+package io.quarkus.it.spring.data.jpa;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+
+@QuarkusTest
+public class PostRepositorySpyTest {
+
+    // Without delegate = true, the call to the spy will fail with:
+    // "Cannot call abstract real method on java object!"
+    @InjectSpy(delegate = true)
+    PostRepository repo;
+
+    @Test
+    void testDefaultMethodOfIntermediateRepositoryInSpy() {
+        doReturn(new Post()).when(repo).findMandatoryById(1111L);
+        assertNotNull(repo.findMandatoryById(1111L));
+        verify(repo).findMandatoryById(1111L);
+    }
+}

--- a/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
+++ b/test-framework/junit5-mockito/src/main/java/io/quarkus/test/junit/mockito/InjectSpy.java
@@ -12,4 +12,15 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InjectSpy {
+
+    /**
+     * {@code true} will create a mock that <em>delegates</em> all calls to the real bean, instead of creating a regular Mockito
+     * spy.
+     * <p/>
+     * You should try this mode when you get errors like "Cannot call abstract real method on java object!" when calling a
+     * {@code default} interface method of a spied bean.
+     *
+     * @see org.mockito.AdditionalAnswers#delegatesTo(Object)
+     */
+    boolean delegate() default false;
 }


### PR DESCRIPTION
Evades:
```
org.mockito.exceptions.base.MockitoException: 
Cannot call abstract real method on java object!
Calling real methods is only possible when mocking non abstract method.
  //correct example:
  when(mockOfConcreteClass.nonAbstractMethod()).thenCallRealMethod();
	at io.quarkus.it.spring.data.jpa.IntermediateRepository.findMandatoryById(IntermediateRepository.java:15)
```

It can also help with other cases, see https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#delegating_call_to_real_instance

For this specific case of spring repos, I can't help but think that there might be another solution on class generation level, but I'm lacking the time to dig deeper.
If I create a dummy impl of a repo class, trying to mimic what's happening in ArC, then mockito has no issue with calling a `default` method in an intermediate interface of that repo. So something might be incompatible here (between mockito/bytebuddy and quarkus/arc)...
I can provide that small playground project if required.

I hope the test class I added is sufficient to play around with. The crucial thing is that `PostRepository` implements https://github.com/quarkusio/quarkus/blob/main/integration-tests/spring-data-jpa/src/main/java/io/quarkus/it/spring/data/jpa/IntermediateRepository.java

I can't prove it, but I guess that issue could surface for other, non-spring-repo beans as well.