### PR TITLE
Allow second pass on dependencies-only PRs for finer triage

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -363,6 +363,7 @@ triage:
         - .github/dependabot.yml
         - bom/
         - build-parent/
+      allowSecondPass: true
     - labels: [area/devtools]
       directories:
         - devtools/


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus-github-bot#triage-pull-requests

Essentially this allows the Quarkus GitHub bot to apply triage rules
again if the first pass based on changed files only detects that the
PR is about dependencies.

The second pass, however, is based on the PR title and body, so that
it can detect what the PR is about from keywords appearing there.

This is useful because PRs about dependencies generally only modify a
pom.xml, and there's little information we can get from that.

~~@gsmet Marking as draft because I don't know if you deployed https://github.com/quarkusio/quarkus-github-bot/pull/243#event-7041871505 already? We need to deploy before this can be merged, I think.~~ => Deployed by @gsmet 