### PR TITLE
Support authenticating to OpenID Introspection endpoint

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -1101,6 +1101,18 @@ quarkus.oidc.tls.trust-store-password=${trust-store-password}
 #quarkus.oidc.tls.trust-store-alias=certAlias
 ----
 
+=== Introspection Endpoint Authentication
+
+Some OpenID Connect Providers may require authenticating to its introspection endpoint using Basic Authentication with the credentials different to `client_id` and `client_secret` which may have already been configured to support `client_secret_basic` or `client_secret_post` client authentication methods described in the <<oidc-provider-client-authentication, Oidc Provider Client Authentication>> section.
+
+If the tokens have to be introspected and the introspection endpoint specific authentication mechanism is required then you can configure `quarkus-oidc` like this:
+
+[source,properties]
+----
+quarkus.oidc.introspection-credentials.name=introspection-user-name
+quarkus.oidc.introspection-credentials.secret=introspection-user-secret
+----
+
 [[integration-testing]]
 === Testing
 

--- a/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
+++ b/extensions/oidc-common/runtime/src/main/java/io/quarkus/oidc/common/runtime/OidcCommonUtils.java
@@ -373,12 +373,15 @@ public class OidcCommonUtils {
 
     public static String initClientSecretBasicAuth(OidcCommonConfig oidcConfig) {
         if (isClientSecretBasicAuthRequired(oidcConfig.credentials)) {
-            return OidcConstants.BASIC_SCHEME + " "
-                    + Base64.getEncoder().encodeToString(
-                            (oidcConfig.getClientId().get() + ":"
-                                    + clientSecret(oidcConfig.credentials)).getBytes(StandardCharsets.UTF_8));
+            return basicSchemeValue(oidcConfig.getClientId().get(), clientSecret(oidcConfig.credentials));
         }
         return null;
+    }
+
+    public static String basicSchemeValue(String name, String secret) {
+        return OidcConstants.BASIC_SCHEME + " "
+                + Base64.getEncoder().encodeToString((name + ":" + secret).getBytes(StandardCharsets.UTF_8));
+
     }
 
     public static Key initClientJwtKey(OidcCommonConfig oidcConfig) {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -86,6 +86,49 @@ public class OidcTenantConfig extends OidcCommonConfig {
     public Optional<String> publicKey = Optional.empty();
 
     /**
+     * Introspection Basic Authentication which must be configured only if the introspection is required
+     * and OpenId Connect Provider does not support the OIDC client authentication configured with
+     * {@link OidcCommonConfig#credentials} for its introspection endpoint.
+     */
+    @ConfigItem
+    public IntrospectionCredentials introspectionCredentials = new IntrospectionCredentials();
+
+    /**
+     * Introspection Basic Authentication configuration
+     */
+    @ConfigGroup
+    public static class IntrospectionCredentials {
+        /**
+         * Name
+         */
+        @ConfigItem
+        public Optional<String> name = Optional.empty();
+
+        /**
+         * Secret
+         */
+        @ConfigItem
+        public Optional<String> secret = Optional.empty();
+
+        public Optional<String> getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = Optional.of(name);
+        }
+
+        public Optional<String> getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = Optional.of(secret);
+        }
+
+    }
+
+    /**
      * Configuration to find and parse a custom claim containing the roles information.
      */
     @ConfigItem
@@ -1202,5 +1245,13 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
     public void setCacheUserInfoInIdtoken(boolean cacheUserInfoInIdtoken) {
         this.cacheUserInfoInIdtoken = cacheUserInfoInIdtoken;
+    }
+
+    public IntrospectionCredentials getIntrospectionCredentials() {
+        return introspectionCredentials;
+    }
+
+    public void setIntrospectionCredentials(IntrospectionCredentials introspectionCredentials) {
+        this.introspectionCredentials = introspectionCredentials;
     }
 }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -87,17 +87,21 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.setAuthServerUrl(authServerUri);
                     config.setDiscoveryEnabled(false);
                     config.authentication.setUserInfoRequired(true);
-                    if ("tenant-oidc-introspection-only".equals(tenantId)) {
-                        config.setAllowTokenIntrospectionCache(false);
-                        config.setAllowUserInfoCache(false);
-                    }
                     config.setIntrospectionPath("introspect");
                     config.setUserInfoPath("userinfo");
-                    config.setClientId("client-introspection-only");
-                    Credentials creds = config.getCredentials();
-                    creds.clientSecret.setMethod(Credentials.Secret.Method.POST_JWT);
-                    creds.getJwt().setKeyFile("ecPrivateKey.pem");
-                    creds.getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
+                    if ("tenant-oidc-introspection-only".equals(tenantId)) {
+                        config.setClientId("client-introspection-only");
+                        config.setAllowTokenIntrospectionCache(false);
+                        config.setAllowUserInfoCache(false);
+                        Credentials creds = config.getCredentials();
+                        creds.clientSecret.setMethod(Credentials.Secret.Method.POST_JWT);
+                        creds.getJwt().setKeyFile("ecPrivateKey.pem");
+                        creds.getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
+                    } else {
+                        config.setClientId("client-introspection-only-cache");
+                        config.getIntrospectionCredentials().setName("bob");
+                        config.getIntrospectionCredentials().setSecret("bob_secret");
+                    }
                     return config;
                 } else if ("tenant-oidc-no-opaque-token".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantResource.java
@@ -66,6 +66,8 @@ public class TenantResource {
         if (tenant.startsWith("tenant-oidc-introspection-only")) {
             TokenIntrospection introspection = securityIdentity.getAttribute("introspection");
             response += (",client_id:" + introspection.getString("client_id"));
+            response += (",introspection_client_id:" + introspection.getString("introspection_client_id"));
+            response += (",introspection_client_secret:" + introspection.getString("introspection_client_secret"));
             response += (",active:" + introspection.getBoolean("active"));
             response += (",cache-size:" + tokenCache.getCacheSize());
         }

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -396,7 +396,8 @@ public class BearerTokenAuthorizationTest {
                     .then()
                     .statusCode(200)
                     .body(equalTo(
-                            "tenant-oidc-introspection-only:alice,client_id:client-introspection-only,active:true,cache-size:0"));
+                            "tenant-oidc-introspection-only:alice,client_id:client-introspection-only,"
+                                    + "introspection_client_id:none,introspection_client_secret:none,active:true,cache-size:0"));
         }
 
         RestAssured.when().get("/oidc/jwk-endpoint-call-count").then().body(equalTo("0"));
@@ -441,7 +442,8 @@ public class BearerTokenAuthorizationTest {
                     .then()
                     .statusCode(200)
                     .body(equalTo(
-                            "tenant-oidc-introspection-only-cache:alice,client_id:client-introspection-only,active:true,cache-size:"
+                            "tenant-oidc-introspection-only-cache:alice,client_id:client-introspection-only-cache,"
+                                    + "introspection_client_id:bob,introspection_client_secret:bob_secret,active:true,cache-size:"
                                     + expectedCacheSize));
         }
         RestAssured.when().get("/oidc/introspection-endpoint-call-count").then().body(equalTo("1"));


### PR DESCRIPTION
Fixes #26796.

This PR supports a case where, according to #29796, `introspection endpoint is protected by basic auth and a different client-id/client-secret combination than the usual combination used for authorization code flow` and I believe it is not the first time I'm hearing about such a requirement.

PR itself is simple, it adds an option to configure `quarkus.oidc.introspection-credentials.name` and `quarkus.oidc.introspection-credentials.secret` (I just called the last one `secret` instead of `password` because we already have `quarkus.oidc.credentials.secret` for the usual client authentication). If the introspection credentials are configured and it is introspection then they will be sent as a basic auth scheme value. And finally the tests are modified to check that in one of the tests involving the introspection the the introspection credentials are indeed used to form a Basic Authentication scheme value.

@gastaldi Have a look please as Pedro may not be available right now. It is really only about adding one more (basic auth) way for Quarkus to authenticate to OpenId Connect provider, does not change anything with respect to the way OIDC flows are handled.