### PR TITLE
Improve error message when multiple container image extensions are present

### DIFF
--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBuild.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftBuild.java
@@ -6,7 +6,7 @@ import io.quarkus.container.image.deployment.ContainerImageConfig;
 
 public class OpenshiftBuild implements BooleanSupplier {
 
-    private ContainerImageConfig containerImageConfig;
+    private final ContainerImageConfig containerImageConfig;
 
     OpenshiftBuild(ContainerImageConfig containerImageConfig) {
         this.containerImageConfig = containerImageConfig;

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBuild.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iBuild.java
@@ -6,7 +6,7 @@ import io.quarkus.container.image.deployment.ContainerImageConfig;
 
 public class S2iBuild implements BooleanSupplier {
 
-    private ContainerImageConfig containerImageConfig;
+    private final ContainerImageConfig containerImageConfig;
 
     S2iBuild(ContainerImageConfig containerImageConfig) {
         this.containerImageConfig = containerImageConfig;

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
@@ -1,6 +1,5 @@
 package io.quarkus.container.image.deployment;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -11,14 +10,12 @@ import io.quarkus.deployment.Capability;
 
 public final class ContainerImageCapabilitiesUtil {
 
-    public final static Map<String, String> CAPABILITY_TO_EXTENSION_NAME = new HashMap<>();
-    static {
-        CAPABILITY_TO_EXTENSION_NAME.put(Capability.CONTAINER_IMAGE_JIB, "quarkus-container-image-jib");
-        CAPABILITY_TO_EXTENSION_NAME.put(Capability.CONTAINER_IMAGE_DOCKER, "quarkus-container-image-docker");
-        CAPABILITY_TO_EXTENSION_NAME.put(Capability.CONTAINER_IMAGE_S2I, "quarkus-container-image-s2i");
-        CAPABILITY_TO_EXTENSION_NAME.put(Capability.CONTAINER_IMAGE_OPENSHIFT, "quarkus-container-image-openshift");
-        CAPABILITY_TO_EXTENSION_NAME.put(Capability.CONTAINER_IMAGE_BUILDPACK, "quarkus-container-image-buildpack");
-    }
+    public final static Map<String, String> CAPABILITY_TO_EXTENSION_NAME = Map.of(
+            Capability.CONTAINER_IMAGE_JIB, "quarkus-container-image-jib",
+            Capability.CONTAINER_IMAGE_DOCKER, "quarkus-container-image-docker",
+            Capability.CONTAINER_IMAGE_S2I, "quarkus-container-image-s2i",
+            Capability.CONTAINER_IMAGE_OPENSHIFT, "quarkus-container-image-openshift",
+            Capability.CONTAINER_IMAGE_BUILDPACK, "quarkus-container-image-buildpack");
 
     private ContainerImageCapabilitiesUtil() {
     }

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/ContainerImageCapabilitiesUtil.java
@@ -17,6 +17,13 @@ public final class ContainerImageCapabilitiesUtil {
             Capability.CONTAINER_IMAGE_OPENSHIFT, "quarkus-container-image-openshift",
             Capability.CONTAINER_IMAGE_BUILDPACK, "quarkus-container-image-buildpack");
 
+    private final static Map<String, String> CAPABILITY_TO_BUILDER_NAME = Map.of(
+            Capability.CONTAINER_IMAGE_JIB, "jib",
+            Capability.CONTAINER_IMAGE_DOCKER, "docker",
+            Capability.CONTAINER_IMAGE_S2I, "s2i",
+            Capability.CONTAINER_IMAGE_OPENSHIFT, "openshift",
+            Capability.CONTAINER_IMAGE_BUILDPACK, "buildpack");
+
     private ContainerImageCapabilitiesUtil() {
     }
 
@@ -29,16 +36,34 @@ public final class ContainerImageCapabilitiesUtil {
         if (activeContainerImageCapabilities.size() > 1) {
             throw new IllegalStateException(String.join(" and ", activeContainerImageCapabilities)
                     + " were detected, at most one container-image extension can be present.\n"
-                    + "Either remove the unneeded ones, or select one by adding the property 'quarkus.container-image.builder=<extension name (without the `container-image-` prefix)>' in application.properties or as a system property.");
+                    + "Either remove the unneeded ones, or select one by setting any of the following configuration properties: "
+                    + createBuilderSelectionPropertySuggestion(capabilities));
         }
         return activeContainerImageCapabilities.isEmpty() ? Optional.empty()
                 : Optional.of(activeContainerImageCapabilities.iterator().next());
     }
 
+    private static StringBuilder createBuilderSelectionPropertySuggestion(Capabilities capabilities) {
+        StringBuilder suggestion = new StringBuilder();
+        boolean isFirst = true;
+        for (String capability : capabilities.getCapabilities()) {
+            if (!isContainerImageCapability(capability)) {
+                continue;
+            }
+            if (!isFirst) {
+                suggestion.append(", ");
+            }
+            isFirst = false;
+            suggestion.append('\'').append("quarkus.container-image.builder=")
+                    .append(CAPABILITY_TO_BUILDER_NAME.get(capability)).append('\'');
+        }
+        return suggestion;
+    }
+
     private static Set<String> getContainerImageCapabilities(Capabilities capabilities) {
         Set<String> activeContainerImageCapabilities = new HashSet<>();
         for (String capability : capabilities.getCapabilities()) {
-            if (capability.toLowerCase().contains("container.image")) {
+            if (isContainerImageCapability(capability)) {
                 if (!CAPABILITY_TO_EXTENSION_NAME.containsKey(capability)) {
                     throw new IllegalArgumentException("Unknown container image capability: " + capability);
                 }
@@ -46,5 +71,9 @@ public final class ContainerImageCapabilitiesUtil {
             }
         }
         return activeContainerImageCapabilities;
+    }
+
+    private static boolean isContainerImageCapability(String capability) {
+        return capability.toLowerCase().contains("container.image");
     }
 }


### PR DESCRIPTION
The error message now looks something like:

> [ERROR]         [error]: Build step io.quarkus.container.image.deployment.ContainerImageProcessor#publishImageInfo threw an exception: java.lang.IllegalStateException: quarkus-container-image-jib and quarkus-container-image-docker were detected, at most one container-image extension can be present.
> [ERROR] Either remove the unneeded ones, or select one by setting any of the following configuration properties: 'quarkus.container-image.builder=docker','quarkus.container-image.builder=jib'

where it used to be:

> [ERROR]         [error]: Build step io.quarkus.container.image.deployment.ContainerImageProcessor#publishImageInfo threw an exception: java.lang.IllegalStateException: quarkus-container-image-jib and quarkus-container-image-docker were detected, at most one container-image extension can be present.
> [ERROR] Either remove the unneeded ones, or select one by adding the property 'quarkus.container-image.builder=<extension name (without the `container-image-` prefix)>' in application.properties or as a system property.

Closes: #26589