### PR TITLE
Favor HTTPS over HTTP in documentations and comments

### DIFF
--- a/docs/src/main/asciidoc/amqp-reference.adoc
+++ b/docs/src/main/asciidoc/amqp-reference.adoc
@@ -14,7 +14,7 @@ TIP: This documentation does not cover all the details of the connector.
 Refer to the https://smallrye.io/smallrye-reactive-messaging[SmallRye Reactive Messaging website] for further details.
 
 The AMQP connector allows Quarkus applications to send and receive messages using the AMQP 1.0 protocol.
-More details about the protocol can be found in http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html[the AMQP 1.0 specification].
+More details about the protocol can be found in https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html[the AMQP 1.0 specification].
 It's important to note that AMQP 1.0 and AMQP 0.9.1 (implemented by RabbitMQ) are incompatible.
 Check <<using-rabbitmq,Using RabbitMQ>> to get more details.
 
@@ -163,12 +163,12 @@ metadata.ifPresent(meta -> {
 The connector converts incoming AMQP Messages into Reactive Messaging `Message<T>` instances.
 `T` depends on the _body_ of the received AMQP Message.
 
-The http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html[AMQP Type System] defines the supported types.
+The https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html[AMQP Type System] defines the supported types.
 
 [options="header"]
 |===
 | AMQP Body Type | `<T>`
-| AMQP Value containing a http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-primitive-type-definitions[AMQP Primitive Type] | the corresponding Java type
+| AMQP Value containing a https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-primitive-type-definitions[AMQP Primitive Type] | the corresponding Java type
 | AMQP Value using the `Binary` type | `byte[]`
 | AMQP Sequence | `List`
 | AMQP Data (with binary content) and the `content-type` is set to `application/json` | https://vertx.io/docs/apidocs/io/vertx/core/json/JsonObject.html[`JsonObject`]
@@ -207,7 +207,7 @@ NOTE: The `mapTo` method uses the Quarkus Jackson mapper. Check xref:rest-json.a
 
 === Acknowledgement
 
-When a Reactive Messaging Message associated with an AMQP Message is acknowledged, it informs the broker that the message has been http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted].
+When a Reactive Messaging Message associated with an AMQP Message is acknowledged, it informs the broker that the message has been https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted].
 
 === Failure Management
 
@@ -217,16 +217,16 @@ The AMQP connector supports six strategies:
 * `fail` - fail the application; no more AMQP messages will be processed (default).
 The AMQP message is marked as rejected.
 * `accept` - this strategy marks the AMQP message as _accepted_. The processing continues ignoring the failure.
-Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted delivery state documentation].
+Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-accepted[accepted delivery state documentation].
 * `release` - this strategy marks the AMQP message as _released_. The processing continues with the next message. The broker can redeliver the message.
-Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-released[released delivery state documentation].
+Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-released[released delivery state documentation].
 * `reject` - this strategy marks the AMQP message as rejected. The processing continues with the next message.
-Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-rejected[rejected delivery state documentation].
+Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-rejected[rejected delivery state documentation].
 * `modified-failed` - this strategy marks the AMQP
 message as _modified_ and indicates that it failed (with the `delivery-failed` attribute). The processing continues with the next message, but the broker may attempt to redeliver the message.
-Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
+Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
 * `modified-failed-undeliverable-here` - this strategy marks the AMQP message as _modified_ and indicates that it failed (with the `delivery-failed` attribute). It also indicates that the application cannot process the message, meaning that the broker will not attempt to redeliver the message to this node. The processing continues with the next message.
-Refer to the http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
+Refer to the https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified[modified delivery state documentation]
 
 == Sending AMQP messages
 

--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -496,7 +496,7 @@ To do so, our extension will deploy, in the user application, a Servlet exposing
 
 The `runtime` module is where you develop the feature you want to propose to your users, so it's time to create our Web Servlet.
 
-To use Servlets in your applications you need to have a Servlet Container such as http://undertow.io[Undertow].
+To use Servlets in your applications you need to have a Servlet Container such as https://undertow.io[Undertow].
 Luckily, `quarkus-bom` imported by our parent `pom.xml` already includes the Undertow Quarkus extension.
 
 All we need to do is add `quarkus-undertow` as dependency to our `./greeting-extension/runtime/pom.xml`:
@@ -663,7 +663,7 @@ That's why the tests will be hosted in the `deployment` module.
 
 Quarkus proposes facilities to test extensions via the `quarkus-junit5-internal` artifact (which should already be in the deployment pom.xml), in particular the `io.quarkus.test.QuarkusUnitTest` runner which starts an application with your extension.
 
-We will use http://rest-assured.io[RestAssured] (massively used in Quarkus) to test our HTTP endpoint.
+We will use https://rest-assured.io[RestAssured] (massively used in Quarkus) to test our HTTP endpoint.
 Let's add the `rest-assured` dependency into the  `./greeting-extension/deployment/pom.xml`.
 
 [source, xml]

--- a/docs/src/main/asciidoc/camel.adoc
+++ b/docs/src/main/asciidoc/camel.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-http://camel.apache.org/[Apache Camel] is the Swiss knife of integrating heterogeneous systems with more than a decade
+https://camel.apache.org/[Apache Camel] is the Swiss knife of integrating heterogeneous systems with more than a decade
 of history and a lively community of users and developers.
 
 The support for Apache Camel on top of Quarkus is provided by the

--- a/docs/src/main/asciidoc/context-propagation.adoc
+++ b/docs/src/main/asciidoc/context-propagation.adoc
@@ -34,7 +34,7 @@ The solution is located in the `context-propagation-quickstart` {quickstarts-tre
 
 == Setting it up
 
-If you are using link:http://smallrye.io/smallrye-mutiny[Mutiny] (the `quarkus-mutiny` extension), you just need to add
+If you are using link:https://smallrye.io/smallrye-mutiny[Mutiny] (the `quarkus-mutiny` extension), you just need to add
 the `quarkus-smallrye-context-propagation` extension to enable context propagation.
 
 In other words, add the following dependencies to your build file:
@@ -186,7 +186,7 @@ The following configuration properties allow you to specify the default sets of 
 |`mp.context.ThreadContext.unchanged`
 |The comma-separated set of unchanged contexts
 |`None` (no context)
-|=== 
+|===
 
 The following contexts are available in Quarkus either out of the box, or depending on whether you include
 their extensions:
@@ -222,7 +222,7 @@ their extensions:
 |`Application`
 |https://javadoc.io/static/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api/1.2/org/eclipse/microprofile/context/ThreadContext.html#APPLICATION[`ThreadContext.APPLICATION`]
 |The current `ThreadContextClassLoader`
-|=== 
+|===
 
 === Overriding the propagated contexts using annotations
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -1076,7 +1076,7 @@ remove duplicates. If you want to only enable a test resource on a single test c
 Quarkus provides a few implementations of `QuarkusTestResourceLifecycleManager` out of the box (see `io.quarkus.test.h2.H2DatabaseTestResource` which starts an H2 database, or `io.quarkus.test.kubernetes.client.KubernetesServerTestResource` which starts a mock Kubernetes API server),
 but it is common to create custom implementations to address specific application needs.
 Common cases include starting docker containers using https://www.testcontainers.org/[Testcontainers] (an example of which can be found https://github.com/quarkusio/quarkus/blob/main/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/server/KeycloakTestResourceLifecycleManager.java[here]),
-or starting a mock HTTP server using http://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/main/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).
+or starting a mock HTTP server using https://wiremock.org/[Wiremock] (an example of which can be found https://github.com/geoand/quarkus-test-demo/blob/main/src/test/java/org/acme/getting/started/country/WiremockCountries.java[here]).
 
 
 === Altering the test class

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -37,7 +37,7 @@ include::{includes}/prerequisites.adoc[]
 ====
 If you have multiple JDK's installed, it is not certain Maven will pick up the expected java
 and you could end up with unexpected results.
-You can verify which JDK Maven uses by running `mvn --version`. 
+You can verify which JDK Maven uses by running `mvn --version`.
 ====
 
 
@@ -407,7 +407,7 @@ public class GreetingResourceTest {
 <1> By using the `QuarkusTest` runner, you instruct JUnit to start the application before the tests.
 <2> Check the HTTP response status code and content
 
-These tests use http://rest-assured.io/[RestAssured], but feel free to use your favorite library.
+These tests use https://rest-assured.io/[RestAssured], but feel free to use your favorite library.
 
 You can run these using Maven:
 

--- a/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-reactive-panache.adoc
@@ -8,7 +8,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 include::./attributes.adoc[]
 :config-file: application.properties
 
-link:http://hibernate.org/reactive/[Hibernate Reactive] is the only reactive JPA implementation and offers you the full 
+link:https://hibernate.org/reactive/[Hibernate Reactive] is the only reactive JPA implementation and offers you the full
 breadth of an Object Relational Mapper allowing you to access your database over reactive drivers.
 It makes complex mappings possible, but it does not make simple and common mappings trivial.
 Hibernate Reactive with Panache focuses on making your entities trivial and fun to write in Quarkus.

--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -95,7 +95,7 @@ If REST Assured is used for testing and `quarkus.http.root-path` is set then Qua
 base URL for use in Quarkus tests, so test URL's should not include the root path.
 
 
-In general, path configurations for web content are interpreted relative to `quarkus.http.root-path` (which is / by default). 
+In general, path configurations for web content are interpreted relative to `quarkus.http.root-path` (which is / by default).
 
 - To specify paths within this context root, use a relative path that does not begin with a forward slash.
 
@@ -442,7 +442,7 @@ implementation("io.quarkus:quarkus-undertow")
 
 You can make use of the Undertow predicate language using an `undertow-handlers.conf` file. This file should be placed
 in the `META-INF` directory of your application jar. This file contains handlers defined using the
-link:http://undertow.io/undertow-docs/undertow-docs-2.0.0/index.html#predicates-attributes-and-handlers[Undertow predicate language].
+link:https://undertow.io/undertow-docs/undertow-docs-2.0.0/index.html#predicates-attributes-and-handlers[Undertow predicate language].
 
 === web.xml
 

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -7,7 +7,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-This guide shows how your Quarkus application can use Apache Kafka, http://avro.apache.org/docs/current/[Avro] serialized
+This guide shows how your Quarkus application can use Apache Kafka, https://avro.apache.org/docs/current/[Avro] serialized
 records, and connect to a schema registry (such as the https://docs.confluent.io/platform/current/schema-registry/index.html[Confluent Schema Registry] or https://www.apicur.io/registry/[Apicurio Registry]).
 
 If you are not familiar with Kafka and Kafka in Quarkus in particular, consider
@@ -557,7 +557,7 @@ If we couldn't use Dev Services and wanted to start a Kafka broker and Apicurio 
 .build.gradle
 ----
 testImplementation("io.strimzi:strimzi-test-container:0.22.1") {
-    exclude group: "org.apache.logging.log4j", module: "log4j-core" 
+    exclude group: "org.apache.logging.log4j", module: "log4j-core"
 }
 ----
 

--- a/docs/src/main/asciidoc/kogito-pmml.adoc
+++ b/docs/src/main/asciidoc/kogito-pmml.adoc
@@ -86,7 +86,7 @@ implementation("org.kie.kogito:kogito-quarkus")
 
 == Writing the application
 
-Predictions are evaluated based on a PMML model, whose standard and specifications may be read http://dmg.org/pmml/v4-4-1/GeneralStructure.html[here]. 
+Predictions are evaluated based on a PMML model, whose standard and specifications may be read https://dmg.org/pmml/v4-4-1/GeneralStructure.html[here].
 Let's start by adding a simple PMML file: `LogisticRegressionIrisData.pmml`. It contains a _Regression_ model named `LogisticRegressionIrisData`, and it uses a regression function to predict plant species from sepal and petal dimensions:
 
 [source,xml]

--- a/docs/src/main/asciidoc/mongodb.adoc
+++ b/docs/src/main/asciidoc/mongodb.adoc
@@ -577,7 +577,7 @@ public class CodecFruitService {
 
 == The POJO Codec
 
-The link:http://mongodb.github.io/mongo-java-driver/3.12/bson/pojos[POJO Codec] provides a set of annotations that enable the customization of
+The link:https://mongodb.github.io/mongo-java-driver/3.12/bson/pojos/[POJO Codec] provides a set of annotations that enable the customization of
 the way a POJO is mapped to a MongoDB collection and this codec is initialized automatically by Quarkus
 
 One of these annotations is the `@BsonDiscriminator` annotation that allows to storage multiple Java types in a single MongoDB collection by adding

--- a/docs/src/main/asciidoc/platform.adoc
+++ b/docs/src/main/asciidoc/platform.adoc
@@ -33,7 +33,7 @@ Quarkus applications that want to include extensions from a Quarkus platform wil
 [[platform-descriptor]]
 === Quarkus Platform Descriptor
 
-Quarkus platform descriptor is a JSON artifact that provides information about the platform and its extensions to the Quarkus tools. E.g. http://code.quarkus.io and the Quarkus command line tools consult this descriptor to list, add and remove extensions to/from the project on user's request.
+Quarkus platform descriptor is a JSON artifact that provides information about the platform and its extensions to the Quarkus tools. E.g. https://code.quarkus.io/ and the Quarkus command line tools consult this descriptor to list, add and remove extensions to/from the project on user's request.
 This artifact is also used as a Quarkus platform identifier. When Quarkus tools need to identify the Quarkus platform(s) used in the project, they will analyze the dependency version constraints of the project (the effective list of the managed dependencies from the `dependencyManagement` section in Maven terms) looking for the platform descriptor artifact(s) among them. Given that the platform descriptors are included into the Quarkus platform BOMs, every Quarkus application will inherit the platform descriptor artifact from the imported platform BOM(s) as a dependency version constraint (managed dependency in Maven terms).
 
 To be able to easily identify Quarkus platform descriptors among the project's dependency constraints, the platform descriptor Maven artifact coordinates should follow the following naming convention:

--- a/docs/src/main/asciidoc/rest-client-multipart.adoc
+++ b/docs/src/main/asciidoc/rest-client-multipart.adoc
@@ -39,7 +39,7 @@ The solution is located in the `rest-client-multipart-quickstart` {quickstarts-t
 
 First, we need a new project. Create a new project with the following command:
 
- 
+
 
 :create-app-artifact-id: rest-client-multipart-quickstart
 :create-app-extensions: rest-client,resteasy,resteasy-multipart
@@ -260,7 +260,7 @@ public class MultipartClientResourceTest {
 }
 ----
 
-The code above uses link:http://rest-assured.io/[REST Assured] to assert that the returned content from the echo service contains multipart elements
+The code above uses link:https://rest-assured.io/[REST Assured] to assert that the returned content from the echo service contains multipart elements
 
 Because the test runs in a different port, we also need to include an `application.properties` in our `src/test/resources` with the following content:
 

--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -368,7 +368,7 @@ public class ExtensionsResourceTest {
 }
 ----
 
-The code above uses link:http://rest-assured.io/[REST Assured]'s link:https://github.com/rest-assured/rest-assured/wiki/GettingStarted#jsonpath[json-path] capabilities.
+The code above uses link:https://rest-assured.io/[REST Assured]'s link:https://github.com/rest-assured/rest-assured/wiki/GettingStarted#jsonpath[json-path] capabilities.
 
 
 [#async-support]

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -320,7 +320,7 @@ public class ExtensionsResourceTest {
 }
 ----
 
-The code above uses link:http://rest-assured.io/[REST Assured]'s link:https://github.com/rest-assured/rest-assured/wiki/GettingStarted#jsonpath[json-path] capabilities.
+The code above uses link:https://rest-assured.io/[REST Assured]'s link:https://github.com/rest-assured/rest-assured/wiki/GettingStarted#jsonpath[json-path] capabilities.
 
 
 == Async Support
@@ -630,7 +630,7 @@ However, you can change this default behavior and constrain a provider to:
 == Using a Mock HTTP Server for tests
 
 Setting up a mock HTTP server, against which tests are run, is a common testing pattern.
-Examples of such servers are link:http://wiremock.org/[Wiremock] and link:https://docs.hoverfly.io/projects/hoverfly-java/en/latest/index.html[Hoverfly].
+Examples of such servers are link:https://wiremock.org/[Wiremock] and link:https://docs.hoverfly.io/projects/hoverfly-java/en/latest/index.html[Hoverfly].
 In this section we'll demonstrate how Wiremock can be leveraged for testing the `ExtensionsService` which was developed above.
 
 First, Wiremock needs to be added as a test dependency. For a Maven project that would happen like so:

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -144,7 +144,7 @@ method will be mapped to the method:
 
 .Table HTTP method annotations
 |===
-|Annotation|Usage 
+|Annotation|Usage
 
 |link:{jaxrsapi}/javax/ws/rs/GET.html[`@GET`]
 |Obtain a resource representation, should not modify state, link:{httpspec}#section-4.2.2[idempotent] (link:{httpspec}#section-4.3.1[HTTP docs])
@@ -200,7 +200,7 @@ public class Endpoint {
 === Declaring endpoints: representation / content types
 
 Each endpoint method may consume or produce specific resource representations, which are indicated by
-the HTTP link:{httpspec}#section-3.1.1.5[`Content-Type`] header, which in turn contains 
+the HTTP link:{httpspec}#section-3.1.1.5[`Content-Type`] header, which in turn contains
 link:{httpspec}#section-3.1.1.1[MIME (Media Type)] values, such as the following:
 
 - `text/plain` which is the default for any endpoint returning a `String`.
@@ -209,12 +209,12 @@ link:{httpspec}#section-3.1.1.1[MIME (Media Type)] values, such as the following
 - `text/*` which is a sub-type wildcard for any text media type
 - `\*/*` which is a wildcard for any media type
 
-You may annotate your endpoint class with the link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces`] 
+You may annotate your endpoint class with the link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces`]
 or link:{jaxrsapi}/javax/ws/rs/Consumes.html[`@Consumes`] annotations, which
 allow you to specify one or more media types that your endpoint may accept as HTTP request body
 or produce as HTTP response body. Those class annotations apply to each method.
 
-Any method may also be annotated with the link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces`] 
+Any method may also be annotated with the link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces`]
 or link:{jaxrsapi}/javax/ws/rs/Consumes.html[`@Consumes`] annotations, in which
 case they override any eventual class annotation.
 
@@ -234,11 +234,11 @@ The following HTTP request elements may be obtained by your endpoint method:
 
 .Table HTTP request parameter annotations
 |===
-|HTTP element|Annotation|Usage 
+|HTTP element|Annotation|Usage
 
 |[[path-parameter]]Path parameter
 |link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestPath.html[`@RestPath`] (or nothing)
-|URI template parameter (simplified version of the https://tools.ietf.org/html/rfc6570[URI Template specification]), 
+|URI template parameter (simplified version of the https://tools.ietf.org/html/rfc6570[URI Template specification]),
 see <<uri-parameters,URI parameters>> for more information.
 
 |Query parameter
@@ -396,10 +396,10 @@ The following parameter types will be supported out of the box:
 
 |link:{jsonpapi}/javax/json/JsonArray.html[`JsonArray`], link:{jsonpapi}/javax/json/JsonObject.html[`JsonObject`],
 link:{jsonpapi}/javax/json/JsonStructure.html[`JsonStructure`], link:{jsonpapi}/javax/json/JsonValue.html[`JsonValue`]
-|JSON value types  
+|JSON value types
 
 |link:{vertxapi}io/vertx/core/buffer/Buffer.html[`Buffer`]
-|Vert.x Buffer 
+|Vert.x Buffer
 
 |any other type
 |Will be <<json,mapped from JSON to that type>>
@@ -411,7 +411,7 @@ NOTE: You can add support for more <<readers-writers,body parameter types>>.
 [[multipart]]
 === Handling Multipart Form data
 
-To handle HTTP requests that have `multipart/form-data` as their content type, RESTEasy Reactive introduces the 
+To handle HTTP requests that have `multipart/form-data` as their content type, RESTEasy Reactive introduces the
 link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/MultipartForm.html[`@MultipartForm`] annotation.
 Let us look at an example of its use.
 
@@ -437,7 +437,7 @@ public class FormData {
 }
 ----
 
-The `name` field will contain the data contained in the part of HTTP request called `description` (because 
+The `name` field will contain the data contained in the part of HTTP request called `description` (because
 link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestForm.html[`@RestForm`] does not define a value, the field name is used),
 while the `file` field will contain data about the uploaded file in the `image` part of HTTP request.
 
@@ -568,8 +568,8 @@ In addition, the following return types are also supported:
 
 |===
 
-Alternately, you can also return a <<reactive,reactive type>> such as link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`], 
-link:{mutinyapi}/io/smallrye/mutiny/Multi.html[`Multi`] or 
+Alternately, you can also return a <<reactive,reactive type>> such as link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`],
+link:{mutinyapi}/io/smallrye/mutiny/Multi.html[`Multi`] or
 link:{jdkapi}/java/util/concurrent/CompletionStage.html[`CompletionStage`]
 that resolve to one of the mentioned return types.
 
@@ -652,7 +652,7 @@ public class Endpoint {
 [[reactive]]
 
 If your endpoint method needs to accomplish an asynchronous or reactive task before
-being able to answer, you can declare your method to return the 
+being able to answer, you can declare your method to return the
 link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`] type (from https://smallrye.io/smallrye-mutiny/[Mutiny]), in which
 case the current HTTP request will be automatically suspended after your method, until
 the returned link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni`] instance resolves to a value,
@@ -679,7 +679,7 @@ public class Endpoint {
 
 This allows you to not block the event-loop thread while the book is being fetched from the
 database, and allows Quarkus to serve more requests until your book is ready to
-be sent to the client and terminate this request. Check out our 
+be sent to the client and terminate this request. Check out our
 <<execution-model,Execution Model documentation>> for more information.
 
 The link:{jdkapi}/java/util/concurrent/CompletionStage.html[`CompletionStage`] return
@@ -687,7 +687,7 @@ type is also supported.
 
 === Streaming support
 
-If you want to stream your response element by element, you can make your endpoint method return a 
+If you want to stream your response element by element, you can make your endpoint method return a
 link:{mutinyapi}/io/smallrye/mutiny/Multi.html[`Multi`] type (from https://smallrye.io/smallrye-mutiny/[Mutiny]).
 This is especially useful for streaming text or binary data.
 
@@ -726,11 +726,11 @@ response. Exception mappers are also not invoked because part of the response ma
 
 === Server-Sent Event (SSE) support
 
-If you want to stream JSON objects in your response, you can use 
+If you want to stream JSON objects in your response, you can use
 https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Events]
-by just annotating your endpoint method with 
+by just annotating your endpoint method with
 link:{jaxrsapi}/javax/ws/rs/Produces.html[`@Produces(MediaType.SERVER_SENT_EVENTS)`]
-and specifying that each element should be <<json,serialised to JSON>> with 
+and specifying that each element should be <<json,serialised to JSON>> with
 `@RestStreamElementType(MediaType.APPLICATION_JSON)`.
 
 [source,java]
@@ -862,7 +862,7 @@ public class Endpoint {
 }
 ----
 
-You can also inject those context objects using 
+You can also inject those context objects using
 https://javadoc.io/static/javax.inject/javax.inject/1/javax/inject/Inject.html[`@Inject`] on fields of the same
 type:
 
@@ -1231,7 +1231,7 @@ public class CustomJaxbContext {
 
 [IMPORTANT]
 ====
-Note that if you provide your custom JAXB context instance, you will need to register the classes you want to use for the XML serialization. This means that Quarkus will not update your custom JAXB context instance with the auto-discovered classes. 
+Note that if you provide your custom JAXB context instance, you will need to register the classes you want to use for the XML serialization. This means that Quarkus will not update your custom JAXB context instance with the auto-discovered classes.
 ====
 
 === Web Links support
@@ -1329,7 +1329,7 @@ Using this injected bean of type `RestLinksProvider`, you can get the links by t
 
 ==== JSON Hypertext Application Language (HAL) support
 
-The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links. 
+The https://tools.ietf.org/id/draft-kelly-json-hal-01.html[HAL] standard is a simple format to represent web links.
 
 To enable the HAL support, add the `quarkus-hal` extension to your project. Also, as HAL needs JSON support, you need to add either the `quarkus-resteasy-reactive-jsonb` or the `quarkus-resteasy-reactive-jackson` extension.
 
@@ -1368,7 +1368,7 @@ public class RecordsResource {
 }
 ----
 
-Now, the endpoints `/records` and `/records/{id}` will accept the media type both `json` and `hal+json` to print the records in Hal format. 
+Now, the endpoints `/records` and `/records/{id}` will accept the media type both `json` and `hal+json` to print the records in Hal format.
 
 For example, if we invoke the `/records` endpoint using curl to return a list of records, the HAL format will look like as follows:
 
@@ -1460,7 +1460,7 @@ public class RecordsResource {
     @RestLink(rel = "self")
     @InjectRestLinks(RestLinkType.INSTANCE)
     public HalEntityWrapper get(@PathParam("id") int id) {
-        Record entity = // ... 
+        Record entity = // ...
         HalEntityWrapper halEntity = new HalEntityWrapper(entity, linksProvider.getInstanceLinks(entity));
         halEntity.addLinks(Link.fromPath("/records/1/parent").rel("parent-record").build());
         return halEntity;
@@ -1543,7 +1543,7 @@ public class Endpoint {
 ----
 
 Most of the time, there are ways to achieve the same blocking operations in an asynchronous/reactive
-way, using https://smallrye.io/smallrye-mutiny/[Mutiny], http://hibernate.org/reactive/[Hibernate Reactive] 
+way, using https://smallrye.io/smallrye-mutiny/[Mutiny], https://hibernate.org/reactive/[Hibernate Reactive]
 or any of the xref:quarkus-reactive-architecture.adoc#quarkus-extensions-enabling-reactive[Quarkus Reactive extensions] for example:
 
 [source,java]
@@ -1615,10 +1615,10 @@ public class Endpoint {
 
 If your endpoint method is delegating calls to another service layer which
 does not know of JAX-RS, you need a way to turn service exceptions to an
-HTTP response, and you can do that using the 
+HTTP response, and you can do that using the
 link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerExceptionMapper.html[`@ServerExceptionMapper`]
 annotation on a method, with one parameter of the exception type you want to handle, and turning
-that exception into a link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`] (or a 
+that exception into a link:{resteasy-reactive-common-api}/org/jboss/resteasy/reactive/RestResponse.html[`RestResponse`] (or a
 link:{mutinyapi}/io/smallrye/mutiny/Uni.html[`Uni<RestResponse<?>>`]):
 
 [source,java]
@@ -1639,7 +1639,7 @@ import org.jboss.resteasy.reactive.RestResponse;
 
 class UnknownCheeseException extends RuntimeException {
     public final String name;
-    
+
     public UnknownCheeseException(String name) {
         this.name = name;
     }
@@ -1647,7 +1647,7 @@ class UnknownCheeseException extends RuntimeException {
 
 @ApplicationScoped
 class CheeseService {
-    private static final Map<String, String> cheeses = 
+    private static final Map<String, String> cheeses =
             Map.of("camembert", "Camembert is a very nice cheese",
                    "gouda", "Gouda is acceptable too, especially with cumin");
 
@@ -1664,12 +1664,12 @@ public class Endpoint {
 
     @Inject
     CheeseService cheeses;
-    
+
     @ServerExceptionMapper
     public RestResponse<String> mapException(UnknownCheeseException x) {
         return RestResponse.status(Response.Status.NOT_FOUND, "Unknown cheese: " + x.name);
     }
-    
+
     @GET
     public String findCheese(String cheese) {
         if(cheese == null)
@@ -1677,7 +1677,7 @@ public class Endpoint {
             throw new BadRequestException();
         return cheeses.findCheese(cheese);
     }
-} 
+}
 ----
 
 NOTE: exception mappers defined in REST endpoint classes will only be called if the
@@ -1746,7 +1746,7 @@ These filters allow you to do various things such as examine the request URI,
 HTTP method, influence routing, look or change request headers, abort the request,
 or modify the response.
 
-Request filters can be declared with the 
+Request filters can be declared with the
 link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerRequestFilter.html[`@ServerRequestFilter`]
 annotation:
 
@@ -1755,7 +1755,7 @@ annotation:
 import java.util.Optional;
 
 class Filters {
-    
+
     @ServerRequestFilter(preMatching = true)
     public void preMatchingFilter(ContainerRequestContext requestContext) {
         // make sure we don't lose cheese lovers
@@ -1763,7 +1763,7 @@ class Filters {
             requestContext.setRequestUri(URI.create("/cheese"));
         }
     }
-    
+
     @ServerRequestFilter
     public Optional<RestResponse<Void>> getFilter(ContainerRequestContext ctx) {
         // only allow GET methods for now
@@ -1788,7 +1788,7 @@ run on a worker thread, then `@ServerRequestFilter(nonBlocking=true)` can be use
 Note however, that these filters need to be run before **any** filter that does not use that setting and would run on a worker thread.
 ====
 
-Similarly, response filters can be declared with the 
+Similarly, response filters can be declared with the
 link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/ServerResponseFilter.html[`@ServerResponseFilter`]
 annotation:
 
@@ -1932,7 +1932,7 @@ import javax.ws.rs.Path;
 
 class Cheese {
     public String name;
-    
+
     public Cheese(String name) {
         this.name = name;
     }
@@ -1975,19 +1975,19 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class CheeseBodyHandler implements MessageBodyReader<Cheese>, 
+public class CheeseBodyHandler implements MessageBodyReader<Cheese>,
                                            MessageBodyWriter<Cheese> {
 
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, 
+    public boolean isWriteable(Class<?> type, Type genericType,
                                Annotation[] annotations, MediaType mediaType) {
         return type == Cheese.class;
     }
 
     @Override
-    public void writeTo(Cheese t, Class<?> type, Type genericType, 
+    public void writeTo(Cheese t, Class<?> type, Type genericType,
                         Annotation[] annotations, MediaType mediaType,
-                        MultivaluedMap<String, Object> httpHeaders, 
+                        MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream)
             throws IOException, WebApplicationException {
         entityStream.write(("[CheeseV1]" + t.name)
@@ -1995,13 +1995,13 @@ public class CheeseBodyHandler implements MessageBodyReader<Cheese>,
     }
 
     @Override
-    public boolean isReadable(Class<?> type, Type genericType, 
+    public boolean isReadable(Class<?> type, Type genericType,
                               Annotation[] annotations, MediaType mediaType) {
         return type == Cheese.class;
     }
 
     @Override
-    public Cheese readFrom(Class<Cheese> type, Type genericType, 
+    public Cheese readFrom(Class<Cheese> type, Type genericType,
                             Annotation[] annotations, MediaType mediaType,
                             MultivaluedMap<String, String> httpHeaders,
                             InputStream entityStream)
@@ -2015,7 +2015,7 @@ public class CheeseBodyHandler implements MessageBodyReader<Cheese>,
 }
 ----
 
-If you want to get the most performance our of your writer, you can extend the 
+If you want to get the most performance our of your writer, you can extend the
 link:{resteasy-reactive-api}/org/jboss/resteasy/reactive/server/spi/ServerMessageBodyWriter.html[`ServerMessageBodyWriter`]
 instead of link:{jaxrsapi}/javax/ws/rs/ext/MessageBodyWriter.html[`MessageBodyWriter`]
 where you will be able to use less reflection and bypass the blocking IO layer:
@@ -2042,34 +2042,34 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
 @Provider
-public class CheeseBodyHandler implements MessageBodyReader<Cheese>, 
+public class CheeseBodyHandler implements MessageBodyReader<Cheese>,
                                            ServerMessageBodyWriter<Cheese> {
 
     // …
 
     @Override
-    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target, 
+    public boolean isWriteable(Class<?> type, ResteasyReactiveResourceInfo target,
                                MediaType mediaType) {
         return type == Cheese.class;
     }
 
     @Override
-    public void writeResponse(Cheese t, ServerRequestContext context) 
+    public void writeResponse(Cheese t, ServerRequestContext context)
       throws WebApplicationException, IOException {
         context.serverResponse().end("[CheeseV1]" + t.name);
     }
 }
 ----
 
-NOTE: You can restrict which content-types your reader/writer apply to by adding 
+NOTE: You can restrict which content-types your reader/writer apply to by adding
 link:{jaxrsapi}/javax/ws/rs/Consumes.html[`Consumes`]/link:{jaxrsapi}/javax/ws/rs/Produces.html[`Produces`] annotations
 on your provider class.
 
 === Reader and Writer interceptors
 
 Just as you can intercept requests and responses, you can also intercept readers and writers, by
-extending the link:{jaxrsapi}/javax/ws/rs/ext/ReaderInterceptor.html[`ReaderInterceptor`] or 
-link:{jaxrsapi}/javax/ws/rs/ext/WriterInterceptor.html[`WriterInterceptor`] on a class annotated with 
+extending the link:{jaxrsapi}/javax/ws/rs/ext/ReaderInterceptor.html[`ReaderInterceptor`] or
+link:{jaxrsapi}/javax/ws/rs/ext/WriterInterceptor.html[`WriterInterceptor`] on a class annotated with
 link:{jaxrsapi}/javax/ws/rs/ext/Provider.html[`@Provider`].
 
 If we look at this endpoint:
@@ -2152,14 +2152,14 @@ However, you can change this default behavior and constrain a provider to:
 All <<request-parameters,Request Parameters>> can be declared as link:{jdkapi}/java/lang/String.html[`String`], but also
 any of the following types:
 
-- Types for which a link:{jaxrsapi}/javax/ws/rs/ext/ParamConverter.html[`ParamConverter`] is available via a registered 
+- Types for which a link:{jaxrsapi}/javax/ws/rs/ext/ParamConverter.html[`ParamConverter`] is available via a registered
 link:{jaxrsapi}/javax/ws/rs/ext/ParamConverterProvider.html[`ParamConverterProvider`].
 - Primitive types.
 - Types that have a constructor that accepts a single link:{jdkapi}/java/lang/String.html[`String`] argument.
 - Types that have a static method named `valueOf` or `fromString` with a single link:{jdkapi}/java/lang/String.html[`String`] argument
 that return an instance of the type. If both methods are present then `valueOf` will be used unless
 the type is an `enum` in which case `fromString` will be used.
-- link:{jdkapi}/java/util/List.html[`List<T>`], link:{jdkapi}/java/util/Set.html[`Set<T>`], or 
+- link:{jdkapi}/java/util/List.html[`List<T>`], link:{jdkapi}/java/util/Set.html[`Set<T>`], or
 link:{jdkapi}/java/util/SortedSet.html[`SortedSet<T>`], where `T` satisfies any above criterion.
 
 The following example illustrates all those possibilities:
@@ -2192,7 +2192,7 @@ class MyConverterProvider implements ParamConverterProvider {
         }
         return null;
     }
-    
+
 }
 
 // this is my custom converter
@@ -2207,7 +2207,7 @@ class MyConverter implements ParamConverter<Converter> {
     public String toString(Converter value) {
         return value.value;
     }
-    
+
 }
 
 // this uses a converter
@@ -2243,9 +2243,9 @@ public class Endpoint {
     @Path("{converter}/{constructor}/{primitive}/{valueOf}")
     @GET
     public String conversions(Converter converter, Constructor constructor,
-                              int primitive, ValueOf valueOf, 
+                              int primitive, ValueOf valueOf,
                               @RestQuery List<Constructor> list) {
-        return converter + "/" + constructor + "/" + primitive 
+        return converter + "/" + constructor + "/" + primitive
                + "/" + valueOf + "/" + list;
     }
 }
@@ -2293,7 +2293,7 @@ public class Endpoint {
     private int version = 1;
     private EntityTag tag = new EntityTag("v1");
     private String resource = "Some resource";
-    
+
     @GET
     public Response get(Request request) {
         // first evaluate preconditions
@@ -2440,7 +2440,7 @@ public class Endpoint {
 }
 ----
 
-The user will be able to select which representation it gets with the 
+The user will be able to select which representation it gets with the
 link:{httpspec}#section-5.3.2[`Accept`] header, in the case of JSON:
 
 [source,sh]
@@ -2452,8 +2452,8 @@ link:{httpspec}#section-5.3.2[`Accept`] header, in the case of JSON:
 < HTTP/1.1 200 OK
 < Content-Type: application/json
 < Content-Length: 18
-< 
-< {"name":"Morbier"} 
+<
+< {"name":"Morbier"}
 ----
 
 And for text:
@@ -2463,12 +2463,12 @@ And for text:
 > GET /negotiated HTTP/1.1
 > Host: localhost:8080
 > Accept: text/plain
-> 
+>
 < HTTP/1.1 200 OK
 < Content-Type: text/plain
 < Content-Length: 15
-< 
-< Cheese: Morbier 
+<
+< Cheese: Morbier
 ----
 
 Similarly, you can `PUT` two different representations. JSON:
@@ -2479,14 +2479,14 @@ Similarly, you can `PUT` two different representations. JSON:
 > Host: localhost:8080
 > Content-Type: application/json
 > Content-Length: 16
-> 
+>
 > {"name": "brie"}
 
 < HTTP/1.1 200 OK
 < Content-Type: application/json;charset=UTF-8
 < Content-Length: 15
-< 
-< {"name":"brie"} 
+<
+< {"name":"brie"}
 ----
 
 Or plain text:
@@ -2499,12 +2499,12 @@ Or plain text:
 > Content-Length: 9
 >
 > roquefort
- 
+
 < HTTP/1.1 200 OK
 < Content-Type: application/json;charset=UTF-8
 < Content-Length: 20
-< 
-< {"name":"roquefort"} 
+<
+< {"name":"roquefort"}
 ----
 
 === HTTP Compression

--- a/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-http/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -208,7 +208,7 @@ public class LambdaHttpHandler implements RequestHandler<APIGatewayV2HTTPEvent, 
 
         HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
         if (request.getBody() != null) {
-            // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+            // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
             nettyRequest.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
             if (request.getIsBase64Encoded()) {
                 ByteBuf body = Unpooled.wrappedBuffer(Base64.getDecoder().decode(request.getBody()));

--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpHandler.java
@@ -195,7 +195,7 @@ public class LambdaHttpHandler implements RequestHandler<AwsProxyRequest, AwsPro
 
         HttpContent requestContent = LastHttpContent.EMPTY_LAST_CONTENT;
         if (request.getBody() != null) {
-            // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+            // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
             nettyRequest.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
             if (request.isBase64Encoded()) {
                 ByteBuf body = Unpooled.wrappedBuffer(Base64.getDecoder().decode(request.getBody()));

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanDefiningAnnotationBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/BeanDefiningAnnotationBuildItem.java
@@ -6,7 +6,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * This build item is used to specify additional bean defining annotations. See also
- * <a href="http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#bean_defining_annotations">2.5.1. Bean defining annotations</a>.
+ * <a href="https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#bean_defining_annotations">2.5.1. Bean defining annotations</a>.
  * <p>
  * By default, the resulting beans must not be removed even if they are considered unused and
  * {@link ArcConfig#removeUnusedBeans} is enabled.

--- a/extensions/oidc-client/deployment/pom.xml
+++ b/extensions/oidc-client/deployment/pom.xml
@@ -176,7 +176,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/extensions/reactive-mysql-client/deployment/pom.xml
+++ b/extensions/reactive-mysql-client/deployment/pom.xml
@@ -193,7 +193,7 @@
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
-                                            <!--   good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <!--   good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <!-- the sqladmin check seems more reliable than a tcp check, especially with
                                            diverse container runtimes -->
                                             <healthy>true</healthy>

--- a/extensions/reactive-oracle-client/deployment/pom.xml
+++ b/extensions/reactive-oracle-client/deployment/pom.xml
@@ -155,7 +155,7 @@
                                             <color>red</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
                                             <!-- leverage the healthcheck in the image we use -->
@@ -207,7 +207,7 @@
         </profile>
 
         <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
-         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1 -->
         <profile>
             <id>mac-m1</id>
             <activation>

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/HeaderUtilsReplacement.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/graal/HeaderUtilsReplacement.java
@@ -7,7 +7,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 /**
- * @author <a href="http://kenfinnigan.me">Ken Finnigan</a>
+ * @author <a href="https://kenfinnigan.me/">Ken Finnigan</a>
  */
 @TargetClass(className = "org.jboss.resteasy.microprofile.client.header.HeaderUtils")
 final class HeaderUtilsReplacement {

--- a/integration-tests/hibernate-reactive-db2/pom.xml
+++ b/integration-tests/hibernate-reactive-db2/pom.xml
@@ -194,7 +194,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <log>.*INSTANCE.*</log>
                                             <!-- Unfortunately booting DB2 is slow, needs to set a generous (15m) timeout;
                                              it generally starts in 2-3 minutes, but it's been occasionally slightly above 10m -->

--- a/integration-tests/hibernate-reactive-mysql/pom.xml
+++ b/integration-tests/hibernate-reactive-mysql/pom.xml
@@ -208,7 +208,7 @@
                                         <!--                                         Speed things up a bit by not actually flushing writes to disk -->
                                         <!--                                         <tmpfs>/var/lib/mysql</tmpfs> -->
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>

--- a/integration-tests/jpa-db2/pom.xml
+++ b/integration-tests/jpa-db2/pom.xml
@@ -12,11 +12,11 @@
     <artifactId>quarkus-integration-test-jpa-db2</artifactId>
     <name>Quarkus - Integration Tests - JPA - DB2</name>
     <description>Module that contains JPA related tests running with the DB2 database</description>
-    
+
     <properties>
         <jdbc-db2.url>jdbc:db2://localhost:50000/hreact</jdbc-db2.url>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -188,7 +188,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <log>.*INSTANCE.*</log>
                                             <!-- Unfortunately booting DB2 is slow, needs to set a generous (15m) timeout;
                                              it generally starts in 2-3 minutes, but it's been occasionally slightly above 10m -->

--- a/integration-tests/jpa-mysql/pom.xml
+++ b/integration-tests/jpa-mysql/pom.xml
@@ -198,7 +198,7 @@
                                         </log>
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
-                                        <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                        <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                         <wait>
                                             <time>20000</time>
                                             <healthy>true</healthy>

--- a/integration-tests/jpa-oracle/pom.xml
+++ b/integration-tests/jpa-oracle/pom.xml
@@ -206,7 +206,7 @@
                                             <color>red</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
                                             <log>DATABASE IS READY TO USE!</log>
@@ -256,7 +256,7 @@
             </build>
         </profile>
         <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
-         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+         db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1 -->
         <profile>
             <id>mac-m1</id>
             <activation>

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/pojo/OptionalPropertyCodecProvider.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/pojo/OptionalPropertyCodecProvider.java
@@ -15,7 +15,7 @@ import org.bson.codecs.pojo.TypeWithTypeParameters;
  * This class is an example of a PropertyCodecProvider, it handle the Optional type for the POJO Codec.
  * It is used to test that the mongodb-client extension correctly register all PropertyCodecProvider within the POJO Codec.
  *
- * See: http://mongodb.github.io/mongo-java-driver/3.12/bson/pojos/#generics-support
+ * See: https://mongodb.github.io/mongo-java-driver/3.12/bson/pojos/#generics-support
  */
 public class OptionalPropertyCodecProvider implements PropertyCodecProvider {
     @Override

--- a/integration-tests/oidc-client-reactive/pom.xml
+++ b/integration-tests/oidc-client-reactive/pom.xml
@@ -241,7 +241,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/oidc-client/pom.xml
+++ b/integration-tests/oidc-client/pom.xml
@@ -211,7 +211,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/oidc-code-flow/pom.xml
+++ b/integration-tests/oidc-code-flow/pom.xml
@@ -254,7 +254,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/oidc-tenancy/pom.xml
+++ b/integration-tests/oidc-tenancy/pom.xml
@@ -218,7 +218,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/reactive-db2-client/pom.xml
+++ b/integration-tests/reactive-db2-client/pom.xml
@@ -189,7 +189,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <log>.*INSTANCE.*</log>
                                             <!-- Unfortunately booting DB2 is slow, needs to set a generous (15m) timeout;
                                              it generally starts in 2-3 minutes, but it's been occasionally slightly above 10m -->

--- a/integration-tests/reactive-mysql-client/pom.xml
+++ b/integration-tests/reactive-mysql-client/pom.xml
@@ -218,7 +218,7 @@
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <tmpfs>/var/lib/mysql</tmpfs>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>20000</time>
                                             <healthy>true</healthy>
                                         </wait>

--- a/integration-tests/reactive-oracle-client/pom.xml
+++ b/integration-tests/reactive-oracle-client/pom.xml
@@ -176,7 +176,7 @@
                                             <color>red</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <!-- Unfortunately booting this is slow, needs to set a generous timeout: -->
                                             <time>60000</time>
                                             <log>DATABASE IS READY TO USE!</log>
@@ -226,7 +226,7 @@
             </build>
         </profile>
         <!-- In general, we want to avoid os- or arch-based guards on tests, but the Oracle
-   db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1-->
+   db would not start on M1 - see https://stackoverflow.com/questions/68605011/oracle-12c-docker-setup-on-apple-m1 -->
         <profile>
             <id>mac-m1</id>
             <activation>

--- a/integration-tests/redis-client/pom.xml
+++ b/integration-tests/redis-client/pom.xml
@@ -173,7 +173,7 @@
                                         </log>
                                         <!-- Speed things up a bit by not actually flushing writes to disk -->
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#start-wait -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#start-wait -->
                                             <time>5000</time>
                                             <!-- wait until Redis is actually up by checking if we can ping the server-->
                                             <exec>

--- a/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
+++ b/integration-tests/smallrye-jwt-oidc-webapp/pom.xml
@@ -208,7 +208,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/smallrye-jwt-token-propagation/pom.xml
+++ b/integration-tests/smallrye-jwt-token-propagation/pom.xml
@@ -94,7 +94,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>
@@ -225,7 +225,7 @@
                                             <color>cyan</color>
                                         </log>
                                         <wait>
-                                            <!-- good docs found at: http://dmp.fabric8.io/#build-healthcheck -->
+                                            <!-- good docs found at: https://dmp.fabric8.io/#build-healthcheck -->
                                             <http>
                                                 <url>http://localhost:8180</url>
                                             </http>

--- a/integration-tests/virtual-http/src/test/java/io/quarkus/it/virtual/HttpRequestMessageMock.java
+++ b/integration-tests/virtual-http/src/test/java/io/quarkus/it/virtual/HttpRequestMessageMock.java
@@ -72,7 +72,7 @@ public class HttpRequestMessageMock implements HttpRequestMessage<Optional<Strin
     public void setBody(String body) {
         this.body = body;
         if (body != null) {
-            // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+            // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
             getHeaders().put("Content-Length", Integer.toString(body.length()));
         }
     }


### PR DESCRIPTION
Use when possible HTTPS instead of HTTP for links in documentations and comments.

A lot of trailing whitespaces has been removed in the process. This should not be a problem so I kept those modifications. 