### PR TITLE
Fix links in javadoc and documentations

### DIFF
--- a/.github/docker-prune.sh
+++ b/.github/docker-prune.sh
@@ -4,7 +4,7 @@ set -e
 
 # pruning is only run when inside CI to avoid accidentally removing stuff
 # GITHUB_ACTIONS is always set to true inside Github Actions
-# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables
 if [ "${GITHUB_ACTIONS}" == true ] ; then
   docker container prune -f
   docker image prune -f

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ fixes, documentation, examples... But first, read this page (including the small
 * [The small print](#the-small-print)
 * [Frequently Asked Questions](#frequently-asked-questions)
 
-<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with
+<small><i><a href='https://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with
 markdown-toc</a></i></small>
 
 ## Legal

--- a/core/builder/src/main/java/io/quarkus/builder/Json.java
+++ b/core/builder/src/main/java/io/quarkus/builder/Json.java
@@ -345,7 +345,7 @@ final class Json {
      *
      * @param value
      * @return escaped value
-     * @see <a href="http://www.ietf.org/rfc/rfc4627.txt">http://www.ietf.org/rfc/rfc4627.txt</a>
+     * @see <a href="https://www.ietf.org/rfc/rfc4627.txt">https://www.ietf.org/rfc/rfc4627.txt</a>
      */
     static String escape(String value) {
         StringBuilder builder = new StringBuilder();

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -8,8 +8,8 @@ This guide describes the asciidoc format and conventions that Quarkus has adopte
 The following links provide background on the general conventions and Asciidoc syntax.
 
 * https://redhat-documentation.github.io/asciidoc-markup-conventions/[AsciiDoc Mark-up Quick Reference for Documentation]
-* http://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual]
-* http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc Syntax Quick Reference]
+* https://docs.asciidoctor.org/[Asciidoctor Documentation Site]
+* https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/[AsciiDoc Syntax Quick Reference]
 
 == Variables for Use in Documents
 

--- a/docs/src/main/asciidoc/camel.adoc
+++ b/docs/src/main/asciidoc/camel.adoc
@@ -12,4 +12,4 @@ of history and a lively community of users and developers.
 
 The support for Apache Camel on top of Quarkus is provided by the
 https://github.com/apache/camel-quarkus[Apache Camel Quarkus project]. Please refer to
-https://camel.apache.org/camel-quarkus/latest/[their documentation] for more information.
+https://camel.apache.org/camel-quarkus/[their documentation] for more information.

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -15,7 +15,7 @@ Quarkus DI solution (also called ArC) is based on the https://jakarta.ee/specifi
 However, it is not a full CDI implementation verified by the TCK.
 Only a subset of the CDI features is implemented - see also <<supported_features,the list of supported features>> and <<limitations,the list of limitations>>.
 
-TIP: If you're new to CDI then we recommend you to read the xref:cdi.adoc[Introduction to CDI] first. 
+TIP: If you're new to CDI then we recommend you to read the xref:cdi.adoc[Introduction to CDI] first.
 
 NOTE: Most of the existing CDI code should work just fine but there are some small differences which follow from the Quarkus architecture and goals.
 
@@ -37,7 +37,7 @@ The bean archive is synthesized from:
 Bean classes that don't have a https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#bean_defining_annotations[bean defining annotation, window="_blank"] are not discovered.
 This behavior is defined by CDI.
 But producer methods and fields and observer methods are discovered even if the declaring class is not annotated with a bean defining annotation (this behavior is different to what is defined in CDI).
-In fact, the declaring bean classes are considered annotated with `@Dependent`. 
+In fact, the declaring bean classes are considered annotated with `@Dependent`.
 
 NOTE: Quarkus extensions may declare additional discovery rules. For example, `@Scheduled` business methods are registered even if the declaring class is not annotated with a bean defining annotation.
 
@@ -108,7 +108,7 @@ The `quarkus.arc.exclude-types` property accepts a list of string values that ar
 |Value|Description
 |`org.acme.Foo`| Match the fully qualified name of the class
 |`org.acme.*`| Match classes with package `org.acme`
-|`org.acme.**`| Match classes where the package starts with `org.acme` 
+|`org.acme.**`| Match classes where the package starts with `org.acme`
 |`Bar`| Match the simple name of the class
 |===
 
@@ -122,7 +122,7 @@ quarkus.arc.exclude-types=org.acme.Foo,org.acme.*,Bar <1><2><3>
 <3> Exclude all types whose simple name is `Bar`
 
 It is also possible to exclude a dependency artifact that would be otherwise scanned for beans.
-For example, because it contains a `beans.xml` descriptor.  
+For example, because it contains a `beans.xml` descriptor.
 
 .Example application.properties
 [source,properties]
@@ -136,7 +136,7 @@ quarkus.arc.exclude-dependency.acme.artifact-id=acme-services <2>
 == Native Executables and Private Members
 
 Quarkus is using GraalVM to build a native executable.
-One of the limitations of GraalVM is the usage of https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Limitations.md#reflection[Reflection, window="_blank"].
+One of the limitations of GraalVM is the usage of https://www.graalvm.org/22.2/reference-manual/native-image/Reflection/[Reflection, window="_blank"].
 Reflective operations are supported but all relevant members must be registered for reflection explicitly.
 Those registrations result in a bigger native executable.
 
@@ -154,7 +154,7 @@ public class CounterBean {
 
     @Inject
     CounterService counterService; <1>
-    
+
     void onMessage(@Observes Event msg) { <2>
     }
 }
@@ -190,7 +190,7 @@ public class CounterBean {
 ** Stereotypes
 * Dependency injection and lookup
 ** Field, constructor and initializer/setter injection
-** Type-safe resolution 
+** Type-safe resolution
 ** Programmatic lookup via `javax.enterprise.inject.Instance`
 ** Client proxies
 ** Injection point metadata
@@ -227,7 +227,7 @@ public class CounterBean {
 By default, CDI beans are created lazily, when needed.
 What exactly "needed" means depends on the scope of a bean.
 
-* A *normal scoped bean* (`@ApplicationScoped`, `@RequestScoped`, etc.) is needed when a method is invoked upon an injected instance (contextual reference per the specification). 
+* A *normal scoped bean* (`@ApplicationScoped`, `@RequestScoped`, etc.) is needed when a method is invoked upon an injected instance (contextual reference per the specification).
 +
 In other words, injecting a normal scoped bean will not suffice because a _client proxy_ is injected instead of a contextual instance of the bean.
 
@@ -255,10 +255,10 @@ public class PingResource {
 
   @Inject
   AmazingService s1; <1>
-  
+
   @Inject
   CoolService s2; <2>
-  
+
   @GET
   public String ping() {
     return s1.ping() + s2.ping(); <3>
@@ -266,7 +266,7 @@ public class PingResource {
 }
 ----
 <1> Injection triggers the instantiation of `AmazingService`.
-<2> Injection itself does not result in the instantiation of `CoolService`. A client proxy is injected. 
+<2> Injection itself does not result in the instantiation of `CoolService`. A client proxy is injected.
 <3> The first invocation upon the injected proxy triggers the instantiation of `CoolService`.
 
 [[startup_event]]
@@ -286,7 +286,7 @@ class CoolService {
 ----
 <1> A `CoolService` is created during startup to service the observer method invocation.
 
-* Use the bean in an observer of the `StartupEvent` - normal scoped beans must be used as described in <<lazy_by_default>>:    
+* Use the bean in an observer of the `StartupEvent` - normal scoped beans must be used as described in <<lazy_by_default>>:
 +
 [source,java]
 ----
@@ -405,7 +405,7 @@ In such cases, you'll notice a big warning in the log.
 Users and extension authors have several options <<eliminate_false_positives,how to eliminate false positives>>.
 
 The optimization can be disabled by setting `quarkus.arc.remove-unused-beans` to `none` or `false`.
-Quarkus also provides a middle ground where application beans are never removed whether or not they are unused, while the optimization proceeds normally for non application classes. 
+Quarkus also provides a middle ground where application beans are never removed whether or not they are unused, while the optimization proceeds normally for non application classes.
 To use this mode, set `quarkus.arc.remove-unused-beans` to `fwk` or `framework`.
 
 ==== What's Removed?
@@ -638,7 +638,7 @@ The priority declared via `@Priority` or `@AlternativePriority` is overridden.
 |Value|Description
 |`org.acme.Foo`| Match the fully qualified name of the bean class or the bean class of the bean that declares the producer
 |`org.acme.*`| Match beans where the package of the bean class is `org.acme`
-|`org.acme.**`| Match beans where the package of the bean class starts with `org.acme` 
+|`org.acme.**`| Match beans where the package of the bean class starts with `org.acme`
 |`Bar`| Match the simple name of the bean class or the bean class of the bean that declares the producer
 |===
 
@@ -651,7 +651,7 @@ quarkus.arc.selected-alternatives=org.acme.Foo,org.acme.*,Bar
 === Simplified Producer Method Declaration
 
 In CDI, a producer method must be always annotated with `@Produces`.
- 
+
 [source,java]
 ----
 class Producers {
@@ -684,11 +684,11 @@ class Producers {
 }
 ----
 
-=== Interception of Static Methods 
+=== Interception of Static Methods
 
 The Interceptors specification is clear that _around-invoke_ methods must not be declared static.
 However, this restriction was driven mostly by technical limitations.
-And since Quarkus is a build-time oriented stack that allows for additional class transformations, those limitations don't apply anymore. 
+And since Quarkus is a build-time oriented stack that allows for additional class transformations, those limitations don't apply anymore.
 It's possible to annotate a non-private static method with an interceptor binding:
 
 [source,java]
@@ -704,7 +704,7 @@ class Services {
 }
 ----
 <1> `Logged` is an interceptor binding.
-<2> Each method invocation is intercepted if there is an interceptor associated with `Logged`. 
+<2> Each method invocation is intercepted if there is an interceptor associated with `Logged`.
 
 ==== Limitations
 
@@ -727,7 +727,7 @@ Quarkus however, can overcome these limitations when `quarkus.arc.transform-unpr
 There is no standard concurrency control mechanism for CDI beans.
 Nevertheless, a bean instance can be shared and accessed concurrently from multiple threads.
 In that case it should be thread-safe.
-You can use standard Java constructs (`volatile`, `synchronized`, `ReadWriteLock`, etc.) or let the container control the concurrent access. 
+You can use standard Java constructs (`volatile`, `synchronized`, `ReadWriteLock`, etc.) or let the container control the concurrent access.
 Quarkus provides `@io.quarkus.arc.Lock` and a built-in interceptor for this interceptor binding.
 Each interceptor instance associated with a contextual instance of an intercepted bean holds a separate `ReadWriteLock` with non-fair ordering policy.
 
@@ -745,7 +745,7 @@ class SharedService {
   void addAmount(BigDecimal amount) {
     // ...changes some internal state of the bean
   }
-  
+
   @Lock(value = Lock.Type.READ, time = 1, unit = TimeUnit.SECONDS) <2> <3>
   BigDecimal getAmount() {
     // ...it is safe to read the value concurrently
@@ -753,7 +753,7 @@ class SharedService {
 }
 ----
 <1> `@Lock` (which maps to `@Lock(Lock.Type.WRITE)`) declared on the class instructs the container to lock the bean instance for any invocation of any business method, i.e. the client has "exclusive access" and no concurrent invocations will be allowed.
-<2> `@Lock(Lock.Type.READ)` overrides the value specified at class level. It means that any number of clients can invoke the method concurrently, unless the bean instance is locked by `@Lock(Lock.Type.WRITE)`. 
+<2> `@Lock(Lock.Type.READ)` overrides the value specified at class level. It means that any number of clients can invoke the method concurrently, unless the bean instance is locked by `@Lock(Lock.Type.WRITE)`.
 <3> You can also specify the "wait time". If it's not possible to acquire the lock in the given time a `LockException` is thrown.
 
 === Repeatable interceptor bindings
@@ -819,32 +819,32 @@ The result is computed on the first call and the same value is returned for all 
 [source,java]
 ----
 class Producer {
-     
+
   AtomicLong nextLong = new AtomicLong();
   AtomicInteger nextInt = new AtomicInteger();
- 
+
    @Dependent
-   @Produces 
+   @Produces
    Integer produceInt() {
      return nextInt.incrementAndGet();
    }
-     
+
    @Dependent
-   @Produces 
+   @Produces
    Long produceLong() {
      return nextLong.incrementAndGet();
    }
 }
 
 class Consumer {
-  
+
   @Inject
   Instance<Long> longInstance;
 
   @Inject
   @WithCaching
   Instance<Integer> intInstance;
-     
+
   // this method should always return true
   // Producer#produceInt() is only called once
   boolean pingInt() {
@@ -879,30 +879,30 @@ Alternatively, you can use the `@LookupIfProperty` and `@LookupUnlessProperty` a
  interface Service {
     String name();
  }
- 
+
  @LookupIfProperty(name = "service.foo.enabled", stringValue = "true")
  @ApplicationScoped
  class ServiceFoo implements Service {
- 
+
     public String name() {
        return "foo";
     }
  }
- 
+
  @ApplicationScoped
  class ServiceBar implements Service {
- 
+
     public String name() {
        return "bar";
     }
  }
- 
+
  @ApplicationScoped
  class Client {
- 
+
     @Inject
     Instance<Service> service;
-    
+
     void printServiceName() {
        // This will print "bar" if the property "service.foo.enabled" is NOT set to "true"
        // If "service.foo.enabled" is set to "true" then service.get() would result in an AmbiguousResolutionException
@@ -946,7 +946,7 @@ public class Processor {
      @Inject
      @All
      List<InstanceHandle<Service>> services;
-     
+
      public void doSomething() {
        for (InstanceHandle<Service> handle : services) {
          if (handle.getBean().getScope().equals(Dependent.class)) {

--- a/docs/src/main/asciidoc/elasticsearch.adoc
+++ b/docs/src/main/asciidoc/elasticsearch.adoc
@@ -319,7 +319,7 @@ public class SSLContextConfigurator implements RestClientBuilder.HttpClientConfi
     }
 }
 ----
-See https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_encrypted_communication.html[Elasticsearch documentation] for more details on this particular example.
+See https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_encrypted_communication.html[Elasticsearch documentation] for more details on this particular example.
 
 [NOTE]
 ====

--- a/docs/src/main/asciidoc/ide-tooling.adoc
+++ b/docs/src/main/asciidoc/ide-tooling.adoc
@@ -12,7 +12,7 @@ The following IDEs have support for the community developed Quarkus Tools:
 * https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus[Quarkus Tools for Visual Studio Code]
 * https://marketplace.eclipse.org/content/quarkus-tools[Quarkus Tools for Eclipse]
 * https://plugins.jetbrains.com/plugin/13234-quarkus/versions[Quarkus Tools for IntelliJ IDEA]
-* https://github.com/eclipse/che-devfile-registry/blob/main/devfiles/quarkus/devfile.yaml[Quarkus Tools for Eclipse Che]
+* https://github.com/eclipse-che/che-devfile-registry/tree/main/devfiles/quarkus[Quarkus Tools for Eclipse Che]
 
 In addition, IntelliJ IDEA has additional support for Quarkus in their Ultimate non-open source version.
 
@@ -20,7 +20,7 @@ In addition, IntelliJ IDEA has additional support for Quarkus in their Ultimate 
 
 The table below gives an overview of the current IDEs with links and a high-level overview of their features.
 
-:vscode-logo: https://simpleicons.org/icons/visualstudiocode.svg 
+:vscode-logo: https://simpleicons.org/icons/visualstudiocode.svg
 :eclipse-logo: https://simpleicons.org/icons/eclipseide.svg
 :intellij-logo: https://simpleicons.org/icons/intellijidea.svg
 :che-logo: https://simpleicons.org/icons/eclipseche.svg
@@ -44,7 +44,7 @@ IntelliJ IDEA Ultimate
 Eclipse Che
 
 |Description
-|Visual Studio Code extension to install using the marketplace  
+|Visual Studio Code extension to install using the marketplace
 |Eclipse plugin to install into Eclipse using an update-site
 |IntelliJ IDEA plugin that works in IntelliJ IDEA Community and Ultimate. Available from Marketplace.
 |Built-in Quarkus features available only in IntelliJ IDEA Ultimate
@@ -131,7 +131,7 @@ https://download.jboss.org/jbosstools/intellij/snapshots/intellij-quarkus/[Devel
 |icon:check[]
 |icon:check[]
 
-|Config outline 
+|Config outline
 |icon:check[]
 |icon:check[]
 |icon:check[]

--- a/docs/src/main/asciidoc/infinispan-client.adoc
+++ b/docs/src/main/asciidoc/infinispan-client.adoc
@@ -437,7 +437,7 @@ production, so you can disable this from occurring by configuring the
 `quarkus.infinispan-client.use-schema-registration` to `false`.
 
 To configure the schema manually
-please use https://infinispan.org/docs/infinispan-operator/master/operator.html[Infinispan Operator]
+please use https://infinispan.org/docs/infinispan-operator/main/operator.html[Infinispan Operator]
 for Kubernetes deployments, Infinispan Console,
 https://infinispan.org/docs/stable/titles/rest/rest.html#rest_v2_protobuf_schemas[REST API] or the
 https://infinispan.org/docs/stable/titles/encoding/encoding.html#registering-sci-remote-caches_marshalling[Hot Rod Java Client].

--- a/docs/src/main/asciidoc/javascript/asciidoc-tabs.js
+++ b/docs/src/main/asciidoc/javascript/asciidoc-tabs.js
@@ -1,5 +1,5 @@
 // code originally coming from:
-// https://github.com/bmuschko/asciidocj-tabbed-code-extension
+// https://github.com/bmuschko/asciidoctorj-tabbed-code-extension
 // adapted to work with jQuery
 
 $(document).ready(function() {

--- a/docs/src/main/asciidoc/jreleaser.adoc
+++ b/docs/src/main/asciidoc/jreleaser.adoc
@@ -537,7 +537,7 @@ JReleaser will perform the following tasks for us:
 * Upload assets to JFrog Artifactory or AWS S3. We also skip this step as it's not configured.
 * Create a Git release at the chosen repository, tagging it.
 * Upload all assets, including checksums.
-* Create a Homebrew formula, publishing to pass:[https://gitcom.com/aamiray/homebrew-tap].
+* Create a Homebrew formula, publishing to pass:[https://github.com/aalmiray/homebrew-tap].
 
 Of course no remote repository was affected as we can appreciate the `-Djreleaser.dryrun` property was in effect. If you're
 so inclined inspect the contents of `target/jreleaser/package/app/brew/Formula/app.rb` which defines the Homebrew formula

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -718,6 +718,6 @@ regular getter will be generated. Defaults to `false`
 
 == Further reading
 
-* link:https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2.9/kafka/kafka.html[SmallRye Reactive Messaging Kafka] documentation
+* link:https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/3.4/kafka/kafka.html[SmallRye Reactive Messaging Kafka] documentation
 * link:https://quarkus.io/blog/kafka-avro/[How to Use Kafka, Schema Registry and Avro with Quarkus] - a blog post on which
 the guide is based. It gives a good introduction to Avro and the concept of schema registry

--- a/docs/src/main/asciidoc/kotlin.adoc
+++ b/docs/src/main/asciidoc/kotlin.adoc
@@ -196,7 +196,7 @@ Similar to the Maven configuration, when using Gradle, the following modificatio
 ----
 plugins {
     id 'java'
-    id 'io.quarkus' 
+    id 'io.quarkus'
 
     id "org.jetbrains.kotlin.jvm" version "{kotlin-version}" // <1>
     id "org.jetbrains.kotlin.plugin.allopen" version "{kotlin-version}" // <1>
@@ -207,11 +207,11 @@ repositories {
     mavenCentral()
 }
 
-dependencies { 
+dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:{kotlin-version}'
 
    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
- 
+
     implementation 'io.quarkus:quarkus-resteasy-reactive'
     implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
     implementation 'io.quarkus:quarkus-kotlin'
@@ -507,14 +507,14 @@ The following extensions provide support for Kotlin Coroutines by allowing the u
 === Kotlin coroutines and Mutiny
 
 Kotlin coroutines provide an imperative programming model that actually gets executed in an asynchronous, reactive manner.
-To simplify the interoperability between Mutiny and Kotlin there is the module `io.smallrye.reactive:mutiny-kotlin`, described link:https://smallrye.io/smallrye-mutiny/guides/kotlin[here].
+To simplify the interoperability between Mutiny and Kotlin there is the module `io.smallrye.reactive:mutiny-kotlin`, described link:https://smallrye.io/smallrye-mutiny/latest/guides/kotlin/[here].
 
 == CDI @Inject with Kotlin
 
 Kotlin reflection annotation processing differs from Java.  You may experience an error when using CDI @Inject such as:
 "kotlin.UninitializedPropertyAccessException: lateinit property xxx has not been initialized"
 
-In the example below, this can be easily solved by adapting the annotation, adding @field: Default, to handle the lack of a @Target on the Kotlin reflection annotation definition. 
+In the example below, this can be easily solved by adapting the annotation, adding @field: Default, to handle the lack of a @Target on the Kotlin reflection annotation definition.
 
 [source,kotlin]
 ----
@@ -542,7 +542,7 @@ class GreetingService {
 class ReactiveGreetingResource {
 
     @Inject
-    @field: Default // <1> 
+    @field: Default // <1>
     lateinit var service: GreetingService
 
     @GET

--- a/docs/src/main/asciidoc/lra.adoc
+++ b/docs/src/main/asciidoc/lra.adoc
@@ -17,7 +17,7 @@ retaining the option to compensate for any actions performed during the computat
 This kind of loose coupling of services bridges the gap between strong consistency models
 such as JTA/XA and "home-grown" ad hoc consistency solutions.
 
-The model is based on the https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc#eclipse-microprofile-lra[Eclipse MicroProfile LRA specification].
+The model is based on the https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.asciidoc[Eclipse MicroProfile LRA specification].
 The approach is for the developer to annotate a business method with a Java annotation
 (https://download.eclipse.org/microprofile/microprofile-lra-1.0/apidocs/[`@LRA`]).
 When such a method is called, an LRA context is created (if one is not already present) which is passed
@@ -215,4 +215,4 @@ the method finishes and the `end = true` element on the confirmTrip method force
 (started by the bookTrip method) to be closed when the method finishes. Note that this
 end element can be placed on any JAX-RS resource (ie one service can start the LRA whilst
 a different service ends it). There are many more examples in the
-https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.adoc#java-annotations[Microprofile LRA specification document] and in the https://github.com/eclipse/microprofile-lra/tree/master/tck/src/main/java/org/eclipse/microprofile/lra/tck[Microprofile LRA TCK].
+https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.asciidoc#java-annotations-for-lras[Microprofile LRA specification document] and in the https://github.com/eclipse/microprofile-lra/tree/master/tck/src/main/java/org/eclipse/microprofile/lra/tck[Microprofile LRA TCK].

--- a/docs/src/main/asciidoc/mutiny-primer.adoc
+++ b/docs/src/main/asciidoc/mutiny-primer.adoc
@@ -32,7 +32,7 @@ You observe them (_subscription_) and you get notified when they emit an item, a
 When you (the subscriber) receive the event, you can process it (e.g., transform it, filter it).
 With Mutiny, you are going to write code like _onX().action()_, which reads as “on item X do action”.
 
-If you want to know more about Mutiny, and the concepts behind it, check https://smallrye.io/smallrye-mutiny/pages/philosophy[the Mutiny Philosophy].
+If you want to know more about Mutiny, and the concepts behind it, check https://smallrye.io/smallrye-mutiny/latest/reference/why-is-asynchronous-important[the Mutiny Reference documentation].
 
 == Mutiny in Quarkus
 
@@ -198,7 +198,7 @@ As we have seen in the previous section, it could indicate the successful insert
 
 Transforming an item is done using: `onItem().transform(item -> ....)`.
 
-More details about transformation can be found in the https://smallrye.io/smallrye-mutiny/getting-started/transforming-items[Mutiny documentation].
+More details about transformation can be found in the https://smallrye.io/smallrye-mutiny/latest/tutorials/transforming-items/[Mutiny documentation].
 
 === Sequential composition
 
@@ -212,7 +212,7 @@ uni1
 .onItem().transformtoUni(item -> anotherAsynchronousAction(item));
 ----
 
-More details about asynchronous transformation can be found in the https://smallrye.io/smallrye-mutiny/getting-started/transforming-items-async[Mutiny documentation].
+More details about asynchronous transformation can be found in the https://smallrye.io/smallrye-mutiny/latest/tutorials/transforming-items-asynchronously/[Mutiny documentation].
 
 === Failure handling
 
@@ -236,7 +236,7 @@ uni1
 .onFailure().retry().atMost(5);
 ----
 
-More info about failure recovery can be found on https://smallrye.io/smallrye-mutiny/getting-started/handling-failures[the handling failure documentation] and https://smallrye.io/smallrye-mutiny/getting-started/retry[the retry documentation].
+More info about failure recovery can be found on https://smallrye.io/smallrye-mutiny/latest/tutorials/handling-failures/[the handling failure documentation] and https://smallrye.io/smallrye-mutiny/latest/tutorials/retrying/[the retrying on failures documentation].
 
 == Events and Actions
 
@@ -256,7 +256,7 @@ The following tables list the events that you can receive for Uni and Multi. Eac
 |Cancellation, Request
 |===
 
-Check the full list of events on https://smallrye.io/smallrye-mutiny/getting-started/observing-events[the event documentation].
+Check the full list of events on https://smallrye.io/smallrye-mutiny/latest/tutorials/observing-events/[the event documentation].
 
 |===
 | Action |API |Comment
@@ -277,9 +277,9 @@ Head over to the https://smallrye.io/smallrye-mutiny[Mutiny documentation] to se
 
 Some frequently asked guides are the following:
 
-1. merge vs. concatenation - https://smallrye.io/smallrye-mutiny/guides/merge-concat
-2. controlling the emission thread - https://smallrye.io/smallrye-mutiny/guides/emit-subscription
-3. explicit blocking  - https://smallrye.io/smallrye-mutiny/guides/imperative-to-reactive
+1. merge vs. concatenation - https://smallrye.io/smallrye-mutiny/latest/guides/merging-and-concatenating-streams/
+2. controlling the emission thread - https://smallrye.io/smallrye-mutiny/latest/guides/emit-on-vs-run-subscription-on/
+3. explicit blocking  - https://smallrye.io/smallrye-mutiny/latest/guides/imperative-to-reactive/
 
 == Shortcuts
 
@@ -357,7 +357,7 @@ Mutiny exposes hooks that allow Quarkus and Mutiny to be closely integrated:
 * The default Mutiny thread pool is the Quarkus worker thread pool;
 * Context Propagation is enabled by default when using Mutiny Uni and Multi
 
-More details about the infrastructure integration can be found on https://smallrye.io/smallrye-mutiny/guides/infrastructure.
+More details about the infrastructure integration can be found on https://smallrye.io/smallrye-mutiny/latest/guides/framework-integration/.
 
 
 

--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -251,7 +251,7 @@ The file containing the custom TrustStore does *not* (and probably should not) h
 
 === Run time configuration
 
-Using the runtime certificate configuration, supported by GraalVM since 21.3 does not require any special or additional configuration compared to regular java programs or Quarkus in jvm mode. See the https://www.graalvm.org/reference-manual/native-image/CertificateManagement/#run-time-options[GraalVM documentation] for more information.
+Using the runtime certificate configuration, supported by GraalVM since 21.3 does not require any special or additional configuration compared to regular java programs or Quarkus in jvm mode. See the https://www.graalvm.org/22.2/reference-manual/native-image/CertificateManagement/#run-time-options[GraalVM documentation] for more information.
 
 [#working-with-containers]
 === Working with containers

--- a/docs/src/main/asciidoc/native-reference.adoc
+++ b/docs/src/main/asciidoc/native-reference.adoc
@@ -1205,7 +1205,7 @@ Similarly, we can get a backtrace of the call graph of other threads.
 [source]
 ----
 (gdb) info threads
-  Id   Target Id                                             Frame 
+  Id   Target Id                                             Frame
   1    Thread 0x7fcc62a07d00 (LWP 322) "debugging-nativ" 0x00007fcc62b8b77a in __futex_abstimed_wait_common () from /lib64/libc.so.6
   2    Thread 0x7fcc60eff640 (LWP 326) "gnal Dispatcher" 0x00007fcc62b8b77a in __futex_abstimed_wait_common () from /lib64/libc.so.6
 * 4    Thread 0x7fcc5b7fe640 (LWP 328) "ecutor-thread-0" com.oracle.svm.core.UnmanagedMemoryUtil::copyLongsBackward(org.graalvm.word.Pointer *, org.graalvm.word.Pointer *, org.graalvm.word.UnsignedWord *) () at com/oracle/svm/core/UnmanagedMemoryUtil.java:169
@@ -1230,9 +1230,9 @@ Similarly, we can get a backtrace of the call graph of other threads.
 ----
 (gdb) bt
 #0  __futex_abstimed_wait_common64 (private=0, cancel=true, abstime=0x0, op=393, expected=0, futex_word=0x2cd7adc) at futex-internal.c:57
-#1  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x2cd7adc, expected=expected@entry=0, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=0, 
+#1  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x2cd7adc, expected=expected@entry=0, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=0,
     cancel=cancel@entry=true) at futex-internal.c:87
-#2  0x00007ffff7bdd79f in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x2cd7adc, expected=expected@entry=0, clockid=clockid@entry=0, abstime=abstime@entry=0x0, 
+#2  0x00007ffff7bdd79f in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x2cd7adc, expected=expected@entry=0, clockid=clockid@entry=0, abstime=abstime@entry=0x0,
     private=private@entry=0) at futex-internal.c:139
 #3  0x00007ffff7bdfeb0 in __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x2ca07b0, cond=0x2cd7ab0) at pthread_cond_wait.c:504
 #4  ___pthread_cond_wait (cond=0x2cd7ab0, mutex=0x2ca07b0) at pthread_cond_wait.c:619
@@ -1616,7 +1616,7 @@ Once the image is compiled, enable and start JFR via runtime flags: `-XX:+Flight
     -XX:StartFlightRecording="filename=recording.jfr"
 ----
 
-For more details on using JFR, see https://www.graalvm.org/reference-manual/native-image/JFR[here].
+For more details on using JFR, see https://www.graalvm.org/22.2/reference-manual/native-image/debugging-and-diagnostics/JFR/[here].
 
 === How can we troubleshoot performance problems only reproducible in production?
 

--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -9,7 +9,7 @@ include::./attributes.adoc[]
 :jaxrsapi: https://javadoc.io/doc/javax.ws.rs/javax.ws.rs-api/2.1.1
 :jaxrsspec: /specs/jaxrs/2.1/index.html
 :jdkapi: https://docs.oracle.com/en/java/javase/11/docs/api/java.base
-:mutinyapi: https://smallrye.io/smallrye-mutiny/apidocs
+:mutinyapi: https://javadoc.io/doc/io.smallrye.reactive/mutiny/1.6.0
 :httpspec: https://tools.ietf.org/html/rfc7231
 :jsonpapi: https://javadoc.io/doc/javax.json/javax.json-api/1.1.4
 :vertxapi: https://javadoc.io/doc/io.vertx/vertx-core/latest/index.html

--- a/docs/src/main/asciidoc/scheduler.adoc
+++ b/docs/src/main/asciidoc/scheduler.adoc
@@ -126,7 +126,7 @@ it should be invoked as soon as possible. The invocation of the scheduled method
 Edit the `application.properties` file and add the `cron.expr` configuration:
 [source,properties]
 ----
-# By default, the syntax used for cron expressions is based on Quartz - http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
+# By default, the syntax used for cron expressions is based on Quartz - https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
 # You can change the syntax using the following property:
 # quarkus.scheduler.cron-type=unix
 cron.expr=*/5 * * * * ?

--- a/docs/src/main/asciidoc/vertx-reference.adoc
+++ b/docs/src/main/asciidoc/vertx-reference.adoc
@@ -105,7 +105,7 @@ Refer to the associated documentation to learn how to use them.
 
 |MQTT Client
 |`io.quarkus:quarkus-smallrye-reactive-messaging-mqtt` (extension)
-|https://quarkus.io/guides/mqtt
+|No guide yet
 
 |MS SQL Client
 |`io.quarkus:quarkus-reactive-mssql-client` (extension)

--- a/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/ElasticsearchConfig.java
+++ b/extensions/elasticsearch-rest-client/runtime/src/main/java/io/quarkus/elasticsearch/restclient/lowlevel/runtime/ElasticsearchConfig.java
@@ -69,8 +69,8 @@ public class ElasticsearchConfig {
      * Thread counts higher than the number of processors should not be necessary because the I/O threads rely on non-blocking
      * operations, but you may want to use a thread count lower than the number of processors.
      *
-     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_number_of_threads.html">number of
-     *      threads</a>
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_number_of_threads.html">
+     *      number of threads</a>
      */
     @ConfigItem
     public Optional<Integer> ioThreadCounts;

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2BuildTimeConfig.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2BuildTimeConfig.java
@@ -5,7 +5,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
- * See http://docs.wildfly.org/14/WildFly_Elytron_Security.html#validating-oauth2-bearer-tokens
+ * See https://docs.wildfly.org/14/WildFly_Elytron_Security.html#validating-oauth2-bearer-tokens
  */
 @ConfigRoot(name = "oauth2", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class OAuth2BuildTimeConfig {

--- a/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
+++ b/extensions/elytron-security-oauth2/runtime/src/main/java/io/quarkus/elytron/security/oauth2/runtime/OAuth2RuntimeConfig.java
@@ -7,7 +7,7 @@ import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
 /**
- * See http://docs.wildfly.org/14/WildFly_Elytron_Security.html#validating-oauth2-bearer-tokens
+ * See https://docs.wildfly.org/14/WildFly_Elytron_Security.html#validating-oauth2-bearer-tokens
  */
 @ConfigRoot(name = "oauth2", phase = ConfigPhase.RUN_TIME)
 public class OAuth2RuntimeConfig {

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmConfigPersistenceUnit.java
@@ -210,7 +210,8 @@ public class HibernateOrmConfigPersistenceUnit {
 
     /**
      * Defines the method for multi-tenancy (DATABASE, NONE, SCHEMA). The complete list of allowed values is available in the
-     * https://docs.jboss.org/hibernate/stable/orm/javadocs/org/hibernate/MultiTenancyStrategy.html[Hibernate ORM JavaDoc].
+     * https://javadoc.io/doc/org.hibernate/hibernate-core/5.6.10.Final/org/hibernate/MultiTenancyStrategy.html[Hibernate ORM
+     * JavaDoc].
      * The type DISCRIMINATOR is currently not supported. The default value is NONE (no multi-tenancy).
      *
      * @asciidoclet

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dialect/QuarkusH2Dialect.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/dialect/QuarkusH2Dialect.java
@@ -21,9 +21,9 @@ public class QuarkusH2Dialect extends H2Dialect {
             throws SQLException {
         // H2 by default consider identifiers as upper case
         // unless DATABASE_TO_UPPER=false but that's not the default
-        // and Thomas Mueller says it's normal ANSI-SQL SQL-92 behavior
-        // http://h2-database.66688.n3.nabble.com/Case-of-column-name-td3485519.html
-        // http://www.h2database.com/html/grammar.html#name
+        // and it's normal ANSI-SQL SQL-92 behavior
+        // https://groups.google.com/g/h2-database/c/0gHNCR0yo_s/m/g9nkLh2uvS8J
+        // https://www.h2database.com/html/grammar.html#name
         // DATABASE_TO_LOWER=TRUE will come with H2's next version as of Feb 2019 but only for PostgreSQL compat
         builder.setUnquotedCaseStrategy(IdentifierCaseStrategy.UPPER);
         // then delegate to the database metadata driver identifier casing selection

--- a/extensions/infinispan-client/README.MD
+++ b/extensions/infinispan-client/README.MD
@@ -16,7 +16,7 @@ hotrod.client-properties file to be `infinispan.client.hotrod.marshaller=org.inf
 which allows support for protobuf marshalling. You can also provide `org.infinispan.protostream.MessageMarshaller` via @Produces
 and we will automatically register those marshallers with the global ProtoStreamMarshaller.
 
-### Protobuf Marshalling 
+### Protobuf Marshalling
 
 A user can define Injected protobuf Marshaller and FileDescriptorSource to configure the
 ProtoStreamMarshaller if it is in use.
@@ -90,7 +90,7 @@ DIGEST_MD5, PLAIN, EXTERNAL were all tested to work.
 
 Querying is also supported. To be able to do DSL based queries you need to add the infinispan-query-dsl artifact to your
 list of dependencies and then you can use it as normal. A simple example can be seen at
-http://infinispan.org/docs/dev/user_guide/user_guide.html#a_remote_query_example
+https://infinispan.org/docs/stable/titles/query/query.html#ickle-query-language
 
 ### Counters
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ExpireArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ExpireArgs.java
@@ -7,7 +7,7 @@ import io.quarkus.redis.datasource.RedisCommandExtraArguments;
 
 /**
  * Argument for the Redis <a href="https://redis.io/commands/expire">EXPIRE</a> and
- * <a href="https://redis.io/commands/expireeat">EXPIREAT</a> commands.
+ * <a href="https://redis.io/commands/expireat">EXPIREAT</a> commands.
  */
 public class ExpireArgs implements RedisCommandExtraArguments {
     private boolean xx;

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
@@ -332,7 +332,7 @@ public final class Json {
      *
      * @param value
      * @return escaped value
-     * @see <a href="http://www.ietf.org/rfc/rfc4627.txt">http://www.ietf.org/rfc/rfc4627.txt</a>
+     * @see <a href="https://www.ietf.org/rfc/rfc4627.txt">https://www.ietf.org/rfc/rfc4627.txt</a>
      */
     static String escape(String value) {
         StringBuilder builder = new StringBuilder();

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/ErasedGenericTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/ErasedGenericTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Test for https://github.com/quarkus-project/quarkus/issues/120
+ * Test for https://github.com/quarkusio/quarkus/issues/120
  */
 public class ErasedGenericTest {
     @RegisterExtension

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>${maven-invoker-plugin.version}</version>
-                <!-- http://maven.apache.org/plugins/maven-invoker-plugin/usage.html -->
+                <!-- https://maven.apache.org/plugins/maven-invoker-plugin/usage.html -->
                 <configuration>
                     <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                     <settingsFile>src/it/settings.xml</settingsFile>

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/Encode.java
@@ -30,7 +30,7 @@ public class Encode {
 
     static {
         /*
-         * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
+         * Encode via <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
          *
          * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
          * sub-delims = "!" / "$" / "&" / "'" / "(" / ")"
@@ -76,7 +76,7 @@ public class Encode {
         System.arraycopy(pathEncoding, 0, pathSegmentEncoding, 0, pathEncoding.length);
         pathSegmentEncoding['/'] = "%2F";
         /*
-         * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>.
+         * Encode via <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>.
          *
          * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
          * space encoded as '+'
@@ -301,7 +301,7 @@ public class Encode {
     }
 
     /**
-     * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
+     * Encode via <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
      * <p>
      * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
      * sub-delims = "!" / "$" / "&#x26;" / "'" / "(" / ")"
@@ -328,7 +328,7 @@ public class Encode {
     }
 
     /**
-     * Encode via <a href="http://ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
+     * Encode via <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>. PCHAR is allowed allong with '/'
      * <p>
      * unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
      * sub-delims = "!" / "$" / "&#x26;" / "'" / "(" / ")"

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ExtendedCacheControl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/ExtendedCacheControl.java
@@ -7,7 +7,7 @@ import javax.ws.rs.core.CacheControl;
  *
  * @author <a href="http://community.jboss.org/people/jharting">Jozef Hartinger</a>
  *
- * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">RFC-2616 Section 14</a>
+ * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">RFC-2616 Section 14</a>
  */
 public class ExtendedCacheControl extends CacheControl {
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/code/quarkiverse/java/README.tpl.qute.md
@@ -12,13 +12,13 @@ You can find the basic info, Quarkiverse policies and conventions in [the Quarki
 
 In case you are creating a Quarkus extension project for the first time, please follow [Building My First Extension](https://quarkus.io/guides/building-my-first-extension) guide.
 
-Other useful articles related to Quarkus extension development can be found under the [Writing Extensions](https://quarkus.io/guides/#writing-extensions) guide category on the [Quarkus.io](http://quarkus.io) website.
+Other useful articles related to Quarkus extension development can be found under the [Writing Extensions](https://quarkus.io/guides/#writing-extensions) guide category on the [Quarkus.io](https://quarkus.io) website.
 
 Thanks again, good luck and have fun!
 
 ## Documentation
 
-The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory. 
+The documentation for this extension should be maintained as part of this repository and it is stored in the `docs/` directory.
 
 The layout should follow the [Antora's Standard File and Directory Set](https://docs.antora.org/antora/2.3/standard-directories/).
 

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/tooling/git/base/..gitignore
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus-extension/tooling/git/base/..gitignore
@@ -19,7 +19,7 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 # Eclipse

--- a/integration-tests/awt/doc/README.md
+++ b/integration-tests/awt/doc/README.md
@@ -1,6 +1,6 @@
 # Test application
 
-The test application broadens the coverage for a basic watermarking endpoint: [awt-graphics-rest-quickstart](https://github.com/quarkus/quarkus-quickstarts/tree/main/awt-graphics-rest-quickstart).
+The test application broadens the coverage for a basic watermarking endpoint: [awt-graphics-rest-quickstart](https://github.com/quarkusio/quarkus-quickstarts/tree/main/awt-graphics-rest-quickstart).
 
 ## [Image decoders](../src/test/java/io/quarkus/awt/it/ImageDecodersTest.java)
 ![Decoders](./decoders.png)
@@ -8,7 +8,7 @@ The test application broadens the coverage for a basic watermarking endpoint: [a
 The test suite iterates over two sets of images, [ordinary](../src/test/resources/ordinary)
 and [complex](../src/test/resources/complex).
 
-**Ordinary** images are all valid, either 
+**Ordinary** images are all valid, either
 converted with ImageMagic or manually edited with GIMP or Fiji. They cover all JDK's built-in decoders.
 The decoder test reads not only the image data, but also metadata, exercising metadata related code paths.
 The test is not exhaustive, e.g. embedded thumbnails for containers that support those are not covered.
@@ -18,7 +18,7 @@ The template for many image data was [Commodore Grace M. Hopper, USN](https://en
 **Complex** images set contains some outright incorrect images created with Radamsa fuzzing ImageMagic output.
 They test e.g. error messages i18n properties, throwing ImageIO exceptions in native-image etc.
 
-## [Image encoders](../src/test/java/io/quarkus/awt/it/ImageEncodersTest.java) 
+## [Image encoders](../src/test/java/io/quarkus/awt/it/ImageEncodersTest.java)
 ![Decoders](./encoders.png)
 
 A simple, easily testable image is generated and encoded into a wide variety of valid image type,

--- a/integration-tests/elasticsearch-rest-client/README.md
+++ b/integration-tests/elasticsearch-rest-client/README.md
@@ -27,4 +27,4 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 
 You can then execute your native executable with: `./target/quarkus-integration-test-elasticsearch-rest-client-1.0-SNAPSHOT-runner`
 
-If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image-guide.
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.

--- a/integration-tests/elasticsearch-rest-high-level-client/README.md
+++ b/integration-tests/elasticsearch-rest-high-level-client/README.md
@@ -27,4 +27,4 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 
 You can then execute your native executable with: `./target/quarkus-integration-test-elasticsearch-rest-high-level-client-1.0-SNAPSHOT-runner`
 
-If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image-guide.
+If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.

--- a/integration-tests/hibernate-search-orm-opensearch/pom.xml
+++ b/integration-tests/hibernate-search-orm-opensearch/pom.xml
@@ -186,7 +186,7 @@
                                             <discovery.type>single-node</discovery.type>
                                             <plugins.security.disabled>true</plugins.security.disabled>
                                             <!-- ISM floods the logs with errors, and we don't need it.
-                                                 See https://docs-beta.opensearch.org/im-plugin/ism/settings/
+                                                 See https://opensearch.org/docs/latest/im-plugin/ism/settings/
                                              -->
                                             <plugins.index_state_management.enabled>false</plugins.index_state_management.enabled>
                                         </env>


### PR DESCRIPTION
- fix broken links (using their new URL or an alternative URL),
- remove the link to https://quarkus.io/guides/mqtt for now (this guide does not exist),
- use direct links instead of redirects for some links.

A lot of trailing whitespaces has been removed in the process. This should not be a problem so I kept those modifications.