### PR TITLE
Ensure that HTTP OPTIONS handling involves the proper handler chain

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/OptionsRequestTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/OptionsRequestTest.java
@@ -1,0 +1,64 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerResponseContext;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class OptionsRequestTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(Resource.class, Filters.class);
+                }
+            });
+
+    @Test
+    public void testJsonHeaderAdded() {
+        String allowValue = when()
+                .options("/test")
+                .then()
+                .statusCode(200)
+                .header("Foo", equalTo("Bar"))
+                .body(is(emptyOrNullString()))
+                .extract().header("Allow");
+
+        Assertions.assertThat(allowValue).contains("GET", "HEAD", "OPTIONS");
+    }
+
+    @Path("test")
+    public static class Resource {
+
+        @GET
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    public static class Filters {
+        @ServerResponseFilter
+        public void preMatchingFilter(ContainerResponseContext context) {
+            context.getHeaders().putSingle("Foo", "Bar");
+        }
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ClassRoutingHandler.java
@@ -44,7 +44,7 @@ public class ClassRoutingHandler implements ServerRestHandler {
             if (requestMethod.equals(HttpMethod.HEAD)) {
                 mapper = mappers.get(HttpMethod.GET);
             } else if (requestMethod.equals(HttpMethod.OPTIONS)) {
-                Set<CharSequence> allowedMethods = new HashSet<>();
+                Set<String> allowedMethods = new HashSet<>();
                 for (String method : mappers.keySet()) {
                     if (method == null) {
                         continue;
@@ -53,7 +53,7 @@ public class ClassRoutingHandler implements ServerRestHandler {
                 }
                 allowedMethods.add(HttpMethod.OPTIONS);
                 allowedMethods.add(HttpMethod.HEAD);
-                requestContext.serverResponse().setResponseHeader(HttpHeaders.ALLOW, allowedMethods).end();
+                requestContext.abortWith(Response.ok().allow(allowedMethods).build());
                 return;
             }
             if (mapper == null) {


### PR DESCRIPTION
This is done in order to be more consistent with how
other cases are handled and how RESTEasy Classic handles things as well

Fixes: #26828