### PR TITLE
Fix condition for enabling longpaths in Windows native tests

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -684,7 +684,7 @@ jobs:
       matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.native_matrix) }}
     steps:
       - name: Support longpaths on Windows
-        if: "startsWith(matrix.os-name, 'windows')"
+        if: startsWith(matrix.os-name, 'windows')
         run: git config --global core.longpaths true
       - uses: actions/checkout@v2
       - name: Reclaim Disk Space


### PR DESCRIPTION
The condition is a string, so I think it doesn't get properly evaluated, and thus longpaths don't get enabled in windows native tests (see an example failure: https://github.com/quarkusio/quarkus/runs/7519620552?check_suite_focus=true); I think this will fix it