### PR TITLE
Update jandex gradle plugin version in docs

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,6 +35,7 @@
 
         <!-- jandex maven plugin version -->
         <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
+        <jandex-gradle-plugin.version>0.13.0</jandex-gradle-plugin.version>
 
         <!-- These properties are needed in order for them to be resolvable by the documentation -->
         <!-- The Graal version we suggest using in documentation - as that's

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2855,6 +2855,7 @@
                         <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
 
                         <jandex-maven-plugin-version>${jandex-maven-plugin.version}</jandex-maven-plugin-version>
+                        <jandex-gradle-plugin-version>${jandex-gradle-plugin.version}</jandex-gradle-plugin-version>
                         <kotlin-version>${kotlin.version}</kotlin-version>
 
                         <grpc-version>${grpc.version}</grpc-version>

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -44,8 +44,11 @@ NOTE: Quarkus extensions may declare additional discovery rules. For example, `@
 === How to Generate a Jandex Index
 
 A dependency with a Jandex index is automatically scanned for beans.
-To generate the index just add the following to your `pom.xml`:
+To generate the index just add the following plugin to your build file :
 
+[role="primary asciidoc-tabs-sync-maven"]
+.Maven
+****
 [source,xml,subs="attributes+"]
 ----
 <build>
@@ -66,15 +69,33 @@ To generate the index just add the following to your `pom.xml`:
   </plugins>
 </build>
 ----
+****
 
-If you are using gradle, you can apply the following plugin to your `build.gradle`:
+[role="secondary asciidoc-tabs-sync-gradle-groovy"]
+.Gradle (Groovy DSL)
+****
 
-[source,groovy]
+[source,groovy,subs=attributes+]
 ----
 plugins {
-    id 'org.kordamp.gradle.jandex' version '0.11.0'
+    id 'org.kordamp.gradle.jandex' version '{jandex-gradle-plugin-version}'
 }
 ----
+
+****
+
+[role="secondary asciidoc-tabs-sync-gradle-kotlin"]
+.Gradle (Kotlin DSL)
+****
+
+[source,kotlin,subs=attributes+]
+----
+plugins {
+    id("org.kordamp.gradle.jandex") version '{jandex-gradle-plugin-version}'
+}
+----
+****
+
 
 If you can't modify the dependency, you can still index it by adding `quarkus.index-dependency` entries to your `application.properties`:
 


### PR DESCRIPTION
This update the version of jandex in documentation following the update. 