### PR TITLE
Fix detection of active persistence units in Hibernate Search dev UI

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole;
 
 import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,6 +14,7 @@ import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.devconsole.runtime.spi.FlashScopeUtil;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfigPersistenceUnit;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -23,7 +25,12 @@ public class HibernateSearchDevConsoleRecorder {
 
     public Supplier<HibernateSearchSupplier.IndexedPersistenceUnits> infoSupplier(
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
-        return new HibernateSearchSupplier(runtimeConfig, persistenceUnitNames);
+        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> puConfigs = runtimeConfig
+                .getAllPersistenceUnitConfigsAsMap();
+        Set<String> activePersistenceUnitNames = persistenceUnitNames.stream()
+                .filter(name -> puConfigs.get(name).active.orElse(true))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return new HibernateSearchSupplier(activePersistenceUnitNames);
     }
 
     public Handler<RoutingContext> indexEntity() {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchSupplier.java
@@ -20,24 +20,18 @@ import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.PersistenceUnit;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 
 public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier.IndexedPersistenceUnits> {
 
-    private final HibernateSearchElasticsearchRuntimeConfig runtimeConfig;
-    private final Set<String> persistenceUnitNames;
+    private final Set<String> activePersistenceUnitNames;
 
-    HibernateSearchSupplier(HibernateSearchElasticsearchRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
-        this.runtimeConfig = runtimeConfig;
-        this.persistenceUnitNames = persistenceUnitNames;
+    HibernateSearchSupplier(Set<String> activePersistenceUnitNames) {
+        this.activePersistenceUnitNames = activePersistenceUnitNames;
     }
 
     @Override
     public IndexedPersistenceUnits get() {
-        if (!isActive()) {
-            return new IndexedPersistenceUnits();
-        }
-        Map<String, SearchMapping> mappings = searchMapping(persistenceUnitNames);
+        Map<String, SearchMapping> mappings = searchMapping(activePersistenceUnitNames);
         if (mappings.isEmpty()) {
             return new IndexedPersistenceUnits();
         }
@@ -50,10 +44,6 @@ public class HibernateSearchSupplier implements Supplier<HibernateSearchSupplier
                             left.addAll(right);
                             return left;
                         }));
-    }
-
-    private boolean isActive() {
-        return runtimeConfig.defaultPersistenceUnit.active.orElse(true);
     }
 
     public static Map<String, SearchMapping> searchMapping(Set<String> persistenceUnitNames) {

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleHibernateSearchActiveFalseAndNamedPuActiveTrueTest.java
@@ -1,0 +1,51 @@
+package io.quarkus.test.devconsole;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.quarkus.test.devconsole.namedpu.MyNamedPuIndexedEntity;
+import io.restassured.RestAssured;
+
+/**
+ * Note that this test cannot be placed under the relevant {@code -deployment} module because then the DEV UI processor would
+ * not be able to locate the template resources correctly.
+ */
+public class DevConsoleHibernateSearchActiveFalseAndNamedPuActiveTrueTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar.addAsResource(
+                    new StringAsset("quarkus.datasource.db-kind=h2\n"
+                            + "quarkus.datasource.jdbc.url=jdbc:h2:mem:test\n"
+                            + "quarkus.datasource.\"nameddatasource\".db-kind=h2\n"
+                            + "quarkus.datasource.\"nameddatasource\".jdbc.url=jdbc:h2:mem:test2\n"
+                            // Hibernate Search is inactive for the default PU
+                            + "quarkus.hibernate-orm.datasource=<default>\n"
+                            + "quarkus.hibernate-orm.packages=io.quarkus.test.devconsole\n"
+                            + "quarkus.hibernate-search-orm.active=false\n"
+                            + "quarkus.hibernate-search-orm.elasticsearch.version=7.10\n"
+                            // ... but it's (implicitly) active for a named PU
+                            + "quarkus.hibernate-orm.\"namedpu\".datasource=nameddatasource\n"
+                            + "quarkus.hibernate-orm.\"namedpu\".packages=io.quarkus.test.devconsole.namedpu\n"
+                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version=7.10\n"
+                            // Start Hibernate Search offline for the named PU,
+                            // because we don't have dev services except for the default PU
+                            + "quarkus.hibernate-search-orm.\"namedpu\".schema-management.strategy=none\n"
+                            + "quarkus.hibernate-search-orm.\"namedpu\".elasticsearch.version-check.enabled=false\n"),
+                    "application.properties")
+                    .addClasses(MyIndexedEntity.class)
+                    .addClasses(MyNamedPuIndexedEntity.class));
+
+    @Test
+    public void testPages() {
+        RestAssured.get("q/dev/io.quarkus.quarkus-hibernate-search-orm-elasticsearch/entity-types")
+                .then()
+                .statusCode(200)
+                .body(Matchers.containsString(MyNamedPuIndexedEntity.class.getName()))
+                .body(Matchers.not(Matchers.containsString(MyIndexedEntity.class.getName())));
+    }
+
+}

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/namedpu/MyNamedPuIndexedEntity.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/namedpu/MyNamedPuIndexedEntity.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.devconsole.namedpu;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class MyNamedPuIndexedEntity {
+
+    @Id
+    Long id;
+
+    @FullTextField
+    String field;
+
+}


### PR DESCRIPTION
We used to consider the `.active` property of the default persistence unit only, which is wrong.

~~Creating this PR as draft, because it is based on #26960 , which must be merged first.~~ => Done