### PR TITLE
Support @BuildSteps on buildstep classes to apply conditions to all build steps of that class

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildSteps.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/BuildSteps.java
@@ -1,0 +1,37 @@
+package io.quarkus.deployment.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Applies configuration to all build steps defined in the same class.
+ * <p>
+ * This annotation is applied at the class level, and will result in conditions ({@link #onlyIf()}/{@link #onlyIfNot()})
+ * being prepended to all build steps defined in that class.
+ * <p>
+ * This is mainly useful for "enabled"-type conditions, where all steps in a class should be enabled/disabled
+ * based on a single condition, for example based on configuration properties.
+ *
+ * @see BuildStep
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface BuildSteps {
+
+    /**
+     * Only include build steps defined in this class if the given supplier class(es) return {@code true}.
+     *
+     * @return the supplier class array
+     */
+    Class<? extends BooleanSupplier>[] onlyIf() default {};
+
+    /**
+     * Only include build steps defined in this class if the given supplier class(es) return {@code false}.
+     *
+     * @return the supplier class array
+     */
+    Class<? extends BooleanSupplier>[] onlyIfNot() default {};
+}

--- a/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
+++ b/extensions/datasource/deployment/src/main/java/io/quarkus/datasource/deployment/devservices/DevServicesDatasourceProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -38,6 +39,7 @@ import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class DevServicesDatasourceProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesDatasourceProcessor.class);
@@ -48,7 +50,7 @@ public class DevServicesDatasourceProcessor {
 
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     DevServicesDatasourceResultBuildItem launchDatabases(CurateOutcomeBuildItem curateOutcomeBuildItem,
             DockerStatusBuildItem dockerStatusBuildItem,
             List<DefaultDataSourceDbKindBuildItem> installedDrivers,

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/DevServicesElasticsearchProcessor.java
@@ -18,6 +18,7 @@ import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
@@ -35,6 +36,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 /**
  * Starts an Elasticsearch server as dev service if needed.
  */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class DevServicesElasticsearchProcessor {
     private static final Logger log = Logger.getLogger(DevServicesElasticsearchProcessor.class);
 
@@ -52,7 +54,7 @@ public class DevServicesElasticsearchProcessor {
     static volatile ElasticsearchDevServicesBuildTimeConfig cfg;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public DevServicesResultBuildItem startElasticsearchDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -8,6 +8,7 @@ import org.hibernate.search.mapper.orm.coordination.outboxpolling.mapping.spi.Hi
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
@@ -21,11 +22,12 @@ import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchI
 import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationStaticConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit;
 
+@BuildSteps(onlyIf = HibernateSearchEnabled.class)
 class HibernateSearchOutboxPollingProcessor {
 
     private static final String HIBERNATE_SEARCH_ORM_COORDINATION_OUTBOX_POLLING = "Hibernate Search ORM - Coordination - Outbox polling";
 
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     void registerInternalModel(BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClasses,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
             BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel) {
@@ -38,7 +40,7 @@ class HibernateSearchOutboxPollingProcessor {
         }
     }
 
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void setStaticConfig(HibernateSearchOutboxPollingRecorder recorder,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
@@ -56,7 +58,7 @@ class HibernateSearchOutboxPollingProcessor {
         }
     }
 
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void setRuntimeConfig(HibernateSearchOutboxPollingRecorder recorder,
             HibernateSearchOutboxPollingRuntimeConfig runtimeConfig,

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
@@ -15,6 +15,7 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.hibernate.orm.PersistenceUnit;
@@ -22,10 +23,11 @@ import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 
+@BuildSteps(onlyIf = HibernateSearchEnabled.class)
 public class HibernateSearchElasticsearchCdiProcessor {
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     void generateSearchBeans(HibernateSearchElasticsearchRecorder recorder,
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
@@ -67,7 +69,7 @@ public class HibernateSearchElasticsearchCdiProcessor {
         return configurator.done();
     }
 
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     void registerAnnotations(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<BeanDefiningAnnotationBuildItem> beanDefiningAnnotations) {
         // add the @SearchExtension class

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
@@ -1,0 +1,47 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
+
+import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchProcessor.HIBERNATE_SEARCH_ELASTICSEARCH;
+
+import java.util.List;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.hibernate.orm.deployment.PersistenceUnitDescriptorBuildItem;
+import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
+import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationStaticConfiguredBuildItem;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRecorder;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+
+@BuildSteps(onlyIfNot = HibernateSearchEnabled.class)
+class HibernateSearchElasticsearchDisabledProcessor {
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    public void disableHibernateSearchStaticInit(HibernateSearchElasticsearchRecorder recorder,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
+            BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticIntegrations) {
+        for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
+            String puName = puDescriptor.getPersistenceUnitName();
+            staticIntegrations.produce(new HibernateOrmIntegrationStaticConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
+                    puName).setInitListener(recorder.createStaticInitInactiveListener()));
+        }
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void disableHibernateSearchRuntimeInit(HibernateSearchElasticsearchRecorder recorder,
+            HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
+            BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations) {
+        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
+            String puName = puDescriptor.getPersistenceUnitName();
+            runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,
+                    puName).setInitListener(recorder.createRuntimeInitInactiveListener()));
+        }
+    }
+
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchLoggingProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchLoggingProcessor.java
@@ -1,0 +1,26 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
+import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.graal.DisableLoggingFeature;
+
+// Note this is necessary even if Hibernate Search is disabled
+class HibernateSearchElasticsearchLoggingProcessor {
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    NativeImageFeatureBuildItem nativeImageFeature() {
+        return new NativeImageFeatureBuildItem(DisableLoggingFeature.class);
+    }
+
+    // Note this is necessary even if Hibernate Search is disabled
+    @BuildStep
+    void setupLogFilters(BuildProducer<LogCleanupFilterBuildItem> filters) {
+        // if the category changes, please also update DisableLoggingFeature in the runtime module
+        filters.produce(new LogCleanupFilterBuildItem(
+                "org.hibernate.search.mapper.orm.bootstrap.impl.HibernateSearchPreIntegrationService", "HSEARCH000034"));
+    }
+
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/devconsole/HibernateSearchElasticsearchDevConsoleProcessor.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
@@ -18,9 +19,10 @@ import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchE
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.devconsole.HibernateSearchDevConsoleRecorder;
 
+@BuildSteps(onlyIf = HibernateSearchEnabled.class)
 public class HibernateSearchElasticsearchDevConsoleProcessor {
 
-    @BuildStep(onlyIf = { HibernateSearchEnabled.class, IsDevelopment.class })
+    @BuildStep(onlyIf = IsDevelopment.class)
     @Record(RUNTIME_INIT)
     public DevConsoleRuntimeTemplateInfoBuildItem collectBeanInfo(HibernateSearchDevConsoleRecorder recorder,
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
@@ -33,7 +35,7 @@ public class HibernateSearchElasticsearchDevConsoleProcessor {
                 recorder.infoSupplier(runtimeConfig, persistenceUnitNames), this.getClass(), curateOutcomeBuildItem);
     }
 
-    @BuildStep(onlyIf = HibernateSearchEnabled.class)
+    @BuildStep
     @Record(value = STATIC_INIT, optional = true)
     DevConsoleRouteBuildItem invokeEndpoint(HibernateSearchDevConsoleRecorder recorder) {
         return new DevConsoleRouteBuildItem("entity-types", "POST", recorder.indexEntity());

--- a/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
+++ b/extensions/infinispan-client/deployment/src/main/java/io/quarkus/infinispan/client/deployment/devservices/InfinispanDevServiceProcessor.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -38,6 +39,7 @@ import io.quarkus.infinispan.client.deployment.InfinispanClientDevServiceBuildTi
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class InfinispanDevServiceProcessor {
     private static final Logger log = Logger.getLogger(InfinispanDevServiceProcessor.class);
 
@@ -57,7 +59,7 @@ public class InfinispanDevServiceProcessor {
     private static volatile InfinispanClientDevServiceBuildTimeConfig.DevServiceConfiguration capturedDevServicesConfiguration;
     private static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
+    @BuildStep
     public List<DevServicesResultBuildItem> startInfinispanContainers(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/ZipkinProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/ZipkinProcessor.java
@@ -5,10 +5,12 @@ import java.util.function.BooleanSupplier;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.jaeger.runtime.JaegerDeploymentRecorder;
 import io.quarkus.jaeger.runtime.ZipkinConfig;
 import io.quarkus.jaeger.runtime.ZipkinReporterProvider;
 
+@BuildSteps(onlyIf = ZipkinProcessor.ZipkinEnabled.class)
 public class ZipkinProcessor {
 
     static final String REGISTRY_CLASS_NAME = "zipkin2.reporter.urlconnection.URLConnectionSender";
@@ -22,7 +24,7 @@ public class ZipkinProcessor {
         }
     }
 
-    @BuildStep(onlyIf = ZipkinEnabled.class)
+    @BuildStep
     void addZipkinClasses(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 
         // Add Zipkin classes

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/DevServicesKafkaProcessor.java
@@ -27,6 +27,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -47,6 +48,7 @@ import io.strimzi.test.container.StrimziKafkaContainer;
 /**
  * Starts a Kafka broker as dev service if needed.
  */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class DevServicesKafkaProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesKafkaProcessor.class);
@@ -65,7 +67,7 @@ public class DevServicesKafkaProcessor {
     static volatile KafkaDevServiceCfg cfg;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public DevServicesResultBuildItem startKafkaDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerConfigUnremovableProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerConfigUnremovableProcessor.java
@@ -1,0 +1,17 @@
+package io.quarkus.micrometer.deployment;
+
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+
+public class MicrometerConfigUnremovableProcessor {
+
+    /**
+     * config objects are beans, but they are not unremovable by default
+     */
+    @BuildStep
+    UnremovableBeanBuildItem mpConfigAsBean() {
+        return UnremovableBeanBuildItem.beanTypes(MicrometerConfig.class);
+    }
+
+}

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/VertxBinderProcessor.java
@@ -6,6 +6,7 @@ import javax.interceptor.Interceptor;
 
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
@@ -20,6 +21,7 @@ import io.quarkus.vertx.core.deployment.VertxOptionsConsumerBuildItem;
  *
  * Avoid referencing classes that in turn import optional dependencies.
  */
+@BuildSteps(onlyIf = VertxBinderProcessor.VertxBinderEnabled.class)
 public class VertxBinderProcessor {
     static final String METRIC_OPTIONS_CLASS_NAME = "io.vertx.core.metrics.MetricsOptions";
     static final Class<?> METRIC_OPTIONS_CLASS = MicrometerRecorder.getClassForName(METRIC_OPTIONS_CLASS_NAME);
@@ -32,13 +34,13 @@ public class VertxBinderProcessor {
         }
     }
 
-    @BuildStep(onlyIf = VertxBinderEnabled.class)
+    @BuildStep
     @Record(value = ExecutionTime.STATIC_INIT)
     VertxOptionsConsumerBuildItem build(VertxMeterBinderRecorder recorder) {
         return new VertxOptionsConsumerBuildItem(recorder.setVertxMetricsOptions(), Interceptor.Priority.LIBRARY_AFTER);
     }
 
-    @BuildStep(onlyIf = VertxBinderEnabled.class)
+    @BuildStep
     @Record(value = ExecutionTime.RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     void setVertxConfig(VertxMeterBinderRecorder recorder) {

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/mpmetrics/MicroprofileMetricsProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/binder/mpmetrics/MicroprofileMetricsProcessor.java
@@ -28,6 +28,7 @@ import io.quarkus.micrometer.runtime.config.MicrometerConfig;
  *
  * Avoid importing classes that import MP Metrics API classes.
  */
+@BuildSteps(onlyIf = MicroprofileMetricsProcessor.MicroprofileMetricsEnabled.class)
 public class MicroprofileMetricsProcessor {
     private static final Logger log = Logger.getLogger(MicroprofileMetricsProcessor.class);
     static final Class<?> METRIC_ANNOTATION_CLASS = MicrometerRecorder
@@ -41,17 +42,17 @@ public class MicroprofileMetricsProcessor {
         }
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     IndexDependencyBuildItem addDependencies() {
         return new IndexDependencyBuildItem("org.eclipse.microprofile.metrics", "microprofile-metrics-api");
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     AutoInjectAnnotationBuildItem autoInjectMetric() {
         return new AutoInjectAnnotationBuildItem(MetricDotNames.METRIC);
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     AdditionalBeanBuildItem registerBeanClasses() {
         return AdditionalBeanBuildItem.builder()
                 .setUnremovable()
@@ -64,7 +65,7 @@ public class MicroprofileMetricsProcessor {
                 .build();
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     void logWarningForMpMetricsUsage(CombinedIndexBuildItem combinedIndexBuildItem,
             BeanRegistrationPhaseBuildItem beanRegistrationPhase,
             BuildProducer<BeanConfiguratorBuildItem> errors) {
@@ -105,7 +106,7 @@ public class MicroprofileMetricsProcessor {
     /**
      * Make sure all classes containing metrics annotations have a bean scope.
      */
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     AnnotationsTransformerBuildItem transformBeanScope(BeanArchiveIndexBuildItem index,
             CustomScopeAnnotationsBuildItem scopes) {
         return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
@@ -143,7 +144,7 @@ public class MicroprofileMetricsProcessor {
         });
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     UnremovableBeanBuildItem processAnnotatedMetrics(BuildProducer<GeneratedBeanBuildItem> generatedBeans,
             BuildProducer<AnnotationsTransformerBuildItem> annotationsTransformers,
             CombinedIndexBuildItem indexBuildItem) {
@@ -183,7 +184,7 @@ public class MicroprofileMetricsProcessor {
         });
     }
 
-    @BuildStep(onlyIf = MicroprofileMetricsEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     void configureRegistry(MpMetricsRecorder recorder,
             RootMeterRegistryBuildItem rootMeterRegistryBuildItem) {

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/JsonRegistryProcessor.java
@@ -7,6 +7,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
@@ -17,6 +18,7 @@ import io.quarkus.micrometer.runtime.registry.json.JsonMeterRegistry;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 
+@BuildSteps(onlyIf = JsonRegistryProcessor.JsonRegistryEnabled.class)
 public class JsonRegistryProcessor {
 
     private static final Logger log = Logger.getLogger(JsonRegistryProcessor.class);
@@ -29,7 +31,7 @@ public class JsonRegistryProcessor {
         }
     }
 
-    @BuildStep(onlyIf = JsonRegistryEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
     public void initializeJsonRegistry(MicrometerConfig config,
             BuildProducer<MicrometerRegistryProviderBuildItem> registryProviders,

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/export/PrometheusRegistryProcessor.java
@@ -7,6 +7,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
@@ -22,6 +23,7 @@ import io.quarkus.vertx.http.deployment.RouteBuildItem;
  * be available at deployment time for some projects: Avoid direct class
  * references.
  */
+@BuildSteps(onlyIf = PrometheusRegistryProcessor.PrometheusEnabled.class)
 public class PrometheusRegistryProcessor {
     private static final Logger log = Logger.getLogger(PrometheusRegistryProcessor.class);
 
@@ -36,7 +38,7 @@ public class PrometheusRegistryProcessor {
         }
     }
 
-    @BuildStep(onlyIf = PrometheusEnabled.class)
+    @BuildStep
     MicrometerRegistryProviderBuildItem createPrometheusRegistry(MicrometerConfig config,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 
@@ -53,7 +55,7 @@ public class PrometheusRegistryProcessor {
         return new MicrometerRegistryProviderBuildItem(REGISTRY_CLASS);
     }
 
-    @BuildStep(onlyIf = PrometheusEnabled.class)
+    @BuildStep
     @Record(value = ExecutionTime.STATIC_INIT)
     void createPrometheusRoute(BuildProducer<RouteBuildItem> routes,
             MicrometerConfig mConfig,

--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/DevServicesMongoProcessor.java
@@ -24,6 +24,7 @@ import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.net.URLEncodedUt
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -38,6 +39,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
 import io.quarkus.mongodb.runtime.MongodbConfig;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class DevServicesMongoProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesMongoProcessor.class);
@@ -46,7 +48,7 @@ public class DevServicesMongoProcessor {
     static volatile Map<String, CapturedProperties> capturedProperties;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public List<DevServicesResultBuildItem> startMongo(List<MongoConnectionNameBuildItem> mongoConnections,
             DockerStatusBuildItem dockerStatusBuildItem,
             MongoClientBuildTimeConfig mongoClientBuildTimeConfig,

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -6,6 +6,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.client.deployment.OidcClientBuildStep.IsEnabled;
@@ -15,18 +16,19 @@ import io.quarkus.oidc.client.filter.runtime.OidcClientFilterConfig;
 import io.quarkus.restclient.deployment.RestClientAnnotationProviderBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
+@BuildSteps(onlyIf = IsEnabled.class)
 public class OidcClientFilterBuildStep {
 
     private static final DotName OIDC_CLIENT_FILTER = DotName.createSimple(OidcClientFilter.class.getName());
 
     OidcClientFilterConfig config;
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC_CLIENT_FILTER);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ResteasyJaxrsProviderBuildItem> jaxrsProviders,

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -4,20 +4,22 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.client.deployment.OidcClientBuildStep.IsEnabled;
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
 
+@BuildSteps(onlyIf = IsEnabled.class)
 public class OidcClientReactiveFilterBuildStep {
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC_CLIENT_REACTIVE_FILTER);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -22,6 +22,7 @@ import io.quarkus.deployment.ApplicationArchive;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
@@ -46,29 +47,30 @@ import io.quarkus.oidc.client.runtime.TokensProducer;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 
+@BuildSteps(onlyIf = OidcClientBuildStep.IsEnabled.class)
 public class OidcClientBuildStep {
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC_CLIENT);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     ExtensionSslNativeSupportBuildItem enableSslInNative() {
         return new ExtensionSslNativeSupportBuildItem(Feature.OIDC_CLIENT);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(TokensProducer.class));
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void runtimeInitializeTokenHelper(BuildProducer<RuntimeInitializedClassBuildItem> runtime) {
         runtime.produce(new RuntimeInitializedClassBuildItem(TokensHelper.class.getName()));
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void extractInjectedOidcClientNames(
             ApplicationArchivesBuildItem beanArchiveIndex,
             BuildProducer<OidcClientNamesBuildItem> oidcClientNames) {
@@ -86,7 +88,7 @@ public class OidcClientBuildStep {
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void setup(
             OidcClientsConfig oidcConfig,
             TlsConfig tlsConfig,
@@ -136,7 +138,7 @@ public class OidcClientBuildStep {
                 .done();
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void createNonDefaultTokensProducers(
             BuildProducer<GeneratedBeanBuildItem> generatedBean,
             OidcClientNamesBuildItem oidcClientNames) {

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
@@ -6,18 +6,20 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
+@BuildSteps(onlyIf = OidcTokenPropagationReactiveBuildStep.IsEnabled.class)
 public class OidcTokenPropagationReactiveBuildStep {
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION_REACTIVE);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -8,6 +8,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.token.propagation.AccessToken;
@@ -19,6 +20,7 @@ import io.quarkus.oidc.token.propagation.runtime.OidcTokenPropagationConfig;
 import io.quarkus.restclient.deployment.RestClientAnnotationProviderBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 
+@BuildSteps(onlyIf = OidcTokenPropagationBuildStep.IsEnabled.class)
 public class OidcTokenPropagationBuildStep {
 
     private static final DotName ACCESS_TOKEN_CREDENTIAL = DotName.createSimple(AccessToken.class.getName());
@@ -26,12 +28,12 @@ public class OidcTokenPropagationBuildStep {
 
     OidcTokenPropagationConfig config;
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             BuildProducer<ResteasyJaxrsProviderBuildItem> jaxrsProviders,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -15,6 +15,7 @@ import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
@@ -46,15 +47,16 @@ import io.smallrye.jwt.auth.cdi.CommonJwtProducer;
 import io.smallrye.jwt.auth.cdi.JsonValueProducer;
 import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
 
+@BuildSteps(onlyIf = OidcBuildStep.IsEnabled.class)
 public class OidcBuildStep {
     public static final DotName DOTNAME_SECURITY_EVENT = DotName.createSimple(SecurityEvent.class.getName());
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     FeatureBuildItem featureBuildItem() {
         return new FeatureBuildItem(Feature.OIDC);
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {
         // TODO: By default quarkus.oidc.application-type = service
         // Also look at other options (web-app, hybrid)
@@ -62,7 +64,7 @@ public class OidcBuildStep {
                 .produce(SecurityInformationBuildItem.OPENIDCONNECT("quarkus.oidc.auth-server-url"));
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     AdditionalBeanBuildItem jwtClaimIntegration(Capabilities capabilities) {
         if (!capabilities.isPresent(Capability.JWT)) {
             AdditionalBeanBuildItem.Builder removable = AdditionalBeanBuildItem.builder();
@@ -76,7 +78,7 @@ public class OidcBuildStep {
         return null;
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void additionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();
@@ -106,13 +108,13 @@ public class OidcBuildStep {
                 .done();
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     ExtensionSslNativeSupportBuildItem enableSslInNative() {
         return new ExtensionSslNativeSupportBuildItem(Feature.OIDC);
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public SyntheticBeanBuildItem setup(
             OidcConfig config,
             OidcRecorder recorder,
@@ -128,7 +130,7 @@ public class OidcBuildStep {
 
     // Note that DefaultTenantConfigResolver injects quarkus.http.proxy.enable-forwarded-prefix
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     public void findSecurityEventObservers(
             OidcRecorder recorder,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -44,6 +44,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -70,6 +71,7 @@ import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { IsEnabled.class, GlobalDevServicesConfig.Enabled.class })
 public class KeycloakDevServicesProcessor {
     static volatile Vertx vertxInstance;
 
@@ -127,7 +129,7 @@ public class KeycloakDevServicesProcessor {
 
     OidcBuildTimeConfig oidcConfig;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { IsEnabled.class, GlobalDevServicesConfig.Enabled.class })
+    @BuildStep
     public DevServicesResultBuildItem startKeycloakContainer(
             DockerStatusBuildItem dockerStatusBuildItem,
             BuildProducer<KeycloakDevServicesConfigBuildItem> keycloakBuildItemBuildProducer,

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
@@ -5,6 +5,7 @@ import java.util.function.BooleanSupplier;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -13,6 +14,7 @@ import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterConfig;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterProvider;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerRecorder;
 
+@BuildSteps(onlyIf = JaegerExporterProcessor.JaegerExporterEnabled.class)
 public class JaegerExporterProcessor {
 
     static class JaegerExporterEnabled implements BooleanSupplier {
@@ -23,19 +25,19 @@ public class JaegerExporterProcessor {
         }
     }
 
-    @BuildStep(onlyIf = JaegerExporterEnabled.class)
+    @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.OPENTELEMETRY_JAEGER_EXPORTER);
     }
 
-    @BuildStep(onlyIf = JaegerExporterEnabled.class)
+    @BuildStep
     AdditionalBeanBuildItem createBatchSpanProcessor() {
         return AdditionalBeanBuildItem.builder()
                 .addBeanClass(JaegerExporterProvider.class)
                 .setUnremovable().build();
     }
 
-    @BuildStep(onlyIf = JaegerExporterEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void installBatchSpanProcessorForJaeger(JaegerRecorder recorder,
             LaunchModeBuildItem launchModeBuildItem,

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterProcessor.java
@@ -5,6 +5,7 @@ import java.util.function.BooleanSupplier;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -13,6 +14,7 @@ import io.quarkus.opentelemetry.exporter.otlp.runtime.OtlpExporterConfig;
 import io.quarkus.opentelemetry.exporter.otlp.runtime.OtlpExporterProvider;
 import io.quarkus.opentelemetry.exporter.otlp.runtime.OtlpRecorder;
 
+@BuildSteps(onlyIf = OtlpExporterProcessor.OtlpExporterEnabled.class)
 public class OtlpExporterProcessor {
 
     static class OtlpExporterEnabled implements BooleanSupplier {
@@ -23,19 +25,19 @@ public class OtlpExporterProcessor {
         }
     }
 
-    @BuildStep(onlyIf = OtlpExporterEnabled.class)
+    @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.OPENTELEMETRY_OTLP_EXPORTER);
     }
 
-    @BuildStep(onlyIf = OtlpExporterEnabled.class)
+    @BuildStep
     AdditionalBeanBuildItem createBatchSpanProcessor() {
         return AdditionalBeanBuildItem.builder()
                 .addBeanClass(OtlpExporterProvider.class)
                 .setUnremovable().build();
     }
 
-    @BuildStep(onlyIf = OtlpExporterEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void installBatchSpanProcessorForOtlp(OtlpRecorder recorder,
             LaunchModeBuildItem launchModeBuildItem,

--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/dev/DevServicesOpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/dev/DevServicesOpenTelemetryProcessor.java
@@ -11,13 +11,15 @@ import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.opentelemetry.deployment.OpenTelemetryEnabled;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { OpenTelemetryEnabled.class, GlobalDevServicesConfig.Enabled.class })
 public class DevServicesOpenTelemetryProcessor {
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { OpenTelemetryEnabled.class, GlobalDevServicesConfig.Enabled.class })
+    @BuildStep
     void devServicesDatasources(
             Optional<DevServicesDatasourceResultBuildItem> devServicesDatasources,
             BuildProducer<DevServicesAdditionalConfigBuildItem> devServicesAdditionalConfig) {

--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
@@ -21,6 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -38,6 +39,7 @@ import io.quarkus.redis.runtime.client.config.RedisConfig;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
 public class DevServicesRedisProcessor {
     private static final Logger log = Logger.getLogger(DevServicesRedisProcessor.class);
     private static final String REDIS_6_ALPINE = "docker.io/redis:6-alpine";
@@ -58,7 +60,7 @@ public class DevServicesRedisProcessor {
     private static volatile Map<String, DevServiceConfiguration> capturedDevServicesConfiguration;
     private static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
+    @BuildStep
     public List<DevServicesResultBuildItem> startRedisContainers(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/DevServicesApicurioRegistryProcessor.java
@@ -15,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -33,6 +34,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 /**
  * Starts Apicurio Registry as dev service if needed.
  */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class DevServicesApicurioRegistryProcessor {
 
     private static final Logger log = Logger.getLogger(DevServicesApicurioRegistryProcessor.class);
@@ -54,7 +56,7 @@ public class DevServicesApicurioRegistryProcessor {
     static volatile ApicurioRegistryDevServiceCfg cfg;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public DevServicesResultBuildItem startApicurioRegistryDevService(LaunchModeBuildItem launchMode,
             DockerStatusBuildItem dockerStatusBuildItem,
             ApicurioRegistryDevServicesBuildTimeConfig apicurioRegistryDevServices,

--- a/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
+++ b/extensions/smallrye-metrics/deployment/src/main/java/io/quarkus/smallrye/metrics/deployment/JaxRsMetricsProcessor.java
@@ -11,6 +11,7 @@ import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.ContainerRequestFilterBuildItem;
@@ -21,6 +22,7 @@ import io.quarkus.undertow.deployment.FilterBuildItem;
  * If resteasy metrics are enabled, register additional filters specific to smallrye metrics.
  *
  */
+@BuildSteps(onlyIf = JaxRsMetricsProcessor.RestMetricsEnabled.class)
 public class JaxRsMetricsProcessor {
     static final String SMALLRYE_JAXRS_FILTER_CLASS_NAME = "io.smallrye.metrics.jaxrs.JaxRsMetricsFilter";
     static final String SMALLRYE_JAXRS_SERVLET_FILTER_CLASS_NAME = "io.smallrye.metrics.jaxrs.JaxRsMetricsServletFilter";
@@ -39,7 +41,7 @@ public class JaxRsMetricsProcessor {
     }
 
     // Ensure class is present (smallrye metrics extension) and resteasy metrics are enabled
-    @BuildStep(onlyIf = RestMetricsEnabled.class)
+    @BuildStep
     void enableMetrics(Optional<MetricsCapabilityBuildItem> metricsCapabilityBuildItem,
             BuildProducer<ResteasyJaxrsProviderBuildItem> jaxRsProviders,
             BuildProducer<FilterBuildItem> servletFilters,

--- a/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-amqp/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/amqp/deployment/AmqpDevServicesProcessor.java
@@ -19,6 +19,7 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
@@ -37,6 +38,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
  * It uses https://quay.io/repository/artemiscloud/activemq-artemis-broker as image.
  * See https://artemiscloud.io/ for details.
  */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class AmqpDevServicesProcessor {
 
     private static final Logger log = Logger.getLogger(AmqpDevServicesProcessor.class);
@@ -62,7 +64,7 @@ public class AmqpDevServicesProcessor {
     static volatile AmqpDevServiceCfg cfg;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public DevServicesResultBuildItem startAmqpDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,

--- a/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
+++ b/extensions/smallrye-reactive-messaging-rabbitmq/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/rabbitmq/deployment/RabbitMQDevServicesProcessor.java
@@ -23,6 +23,7 @@ import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.DockerStatusBuildItem;
@@ -38,6 +39,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 /**
  * Starts a RabbitMQ broker as dev service if needed.
  */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
 public class RabbitMQDevServicesProcessor {
 
     private static final Logger log = Logger.getLogger(RabbitMQDevServicesProcessor.class);
@@ -62,7 +64,7 @@ public class RabbitMQDevServicesProcessor {
     static volatile RabbitMQDevServiceCfg cfg;
     static volatile boolean first = true;
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep
     public DevServicesResultBuildItem startRabbitMQDevService(
             DockerStatusBuildItem dockerStatusBuildItem,
             LaunchModeBuildItem launchMode,


### PR DESCRIPTION
Essentially the new annotation allows this kind of simplification, with the exact same behavior:

```diff
+@BuildSteps(onlyIf = MyExtensionEnabled.class)
 class MyExtensionProcessor {
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step1(...) {
         ...
     }
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step2...) {
         ...
     }
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step3(...) {
         ...
     }
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step4(...) {
         ...
     }
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step5(...) {
         ...
     }
 
-    @BuildStep(onlyIf = MyExtensionEnabled.class)
+    @BuildStep
     void step6(...) {
         ...
     }
 
 }
```

This is mostly syntactic sugar, but there's one obvious advantage: any newly added build step will also have the `@BuildSteps` conditions applied, so this makes "forgetting" about a global "enabled" switch much less likely.

It's particularly useful in large extensions. For example I intend to add a configuration property `quarkus.hibernate-orm.enabled`, which would disable most, if not all, of the build steps in the Hibernate ORM extension. But that extension is huge: `io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor` alone is 1600 lines long... The ability to just put a `@BuildSteps` annotation on the class simplifies things a lot.