### PR TITLE
Completely disable all relevant build steps of extensions (except FeatureBuildItem production) when their "enabled" configuration switch is set to false

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchAlwaysEnabledProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+class HibernateSearchElasticsearchAlwaysEnabledProcessor {
+
+    @BuildStep
+    public FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.HIBERNATE_SEARCH_ELASTICSEARCH);
+    }
+
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -31,7 +31,6 @@ import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -41,7 +40,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.DevServicesAdditionalConfigBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -81,11 +79,8 @@ class HibernateSearchElasticsearchProcessor {
             BuildProducer<HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem> configuredPersistenceUnits,
             BuildProducer<HibernateOrmIntegrationStaticConfiguredBuildItem> staticIntegrations,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations,
-            BuildProducer<FeatureBuildItem> feature,
             BuildProducer<NativeImageResourceBuildItem> nativeImageResources,
             BuildProducer<HotDeploymentWatchedFileBuildItem> hotDeploymentWatchedFiles) {
-        feature.produce(new FeatureBuildItem(Feature.HIBERNATE_SEARCH_ELASTICSEARCH));
-
         IndexView index = combinedIndexBuildItem.getIndex();
         Collection<AnnotationInstance> indexedAnnotations = index.getAnnotations(INDEXED);
 

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerAlwaysEnabledProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.jaeger.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class JaegerAlwaysEnabledProcessor {
+
+    @BuildStep
+    public FeatureBuildItem build() {
+        return new FeatureBuildItem(Feature.JAEGER);
+    }
+
+}

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.jaegertracing.internal.JaegerTracer;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
@@ -18,6 +19,7 @@ import io.quarkus.jaeger.runtime.ZipkinConfig;
 import io.quarkus.runtime.ApplicationConfig;
 import io.quarkus.runtime.metrics.MetricsFactory;
 
+@BuildSteps(onlyIf = JaegerEnabled.class)
 public class JaegerProcessor {
 
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
@@ -32,16 +34,14 @@ public class JaegerProcessor {
             JaegerConfig jaeger, ApplicationConfig appConfig, Optional<MetricsCapabilityBuildItem> metricsCapability,
             ZipkinConfig zipkinConfig) {
 
-        if (buildTimeConfig.enabled) {
-            if (buildTimeConfig.metricsEnabled && metricsCapability.isPresent()) {
-                if (metricsCapability.get().metricsSupported(MetricsFactory.MICROMETER)) {
-                    jdr.registerTracerWithMicrometerMetrics(jaeger, appConfig, zipkinConfig);
-                } else {
-                    jdr.registerTracerWithMpMetrics(jaeger, appConfig, zipkinConfig);
-                }
+        if (buildTimeConfig.metricsEnabled && metricsCapability.isPresent()) {
+            if (metricsCapability.get().metricsSupported(MetricsFactory.MICROMETER)) {
+                jdr.registerTracerWithMicrometerMetrics(jaeger, appConfig, zipkinConfig);
             } else {
-                jdr.registerTracerWithoutMetrics(jaeger, appConfig, zipkinConfig);
+                jdr.registerTracerWithMpMetrics(jaeger, appConfig, zipkinConfig);
             }
+        } else {
+            jdr.registerTracerWithoutMetrics(jaeger, appConfig, zipkinConfig);
         }
 
         // Indicates that this extension would like the SSL support to be enabled

--- a/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
+++ b/extensions/jaeger/deployment/src/main/java/io/quarkus/jaeger/deployment/JaegerProcessor.java
@@ -8,7 +8,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -47,11 +46,6 @@ public class JaegerProcessor {
 
         // Indicates that this extension would like the SSL support to be enabled
         return new ExtensionSslNativeSupportBuildItem(Feature.JAEGER.getName());
-    }
-
-    @BuildStep
-    public FeatureBuildItem build() {
-        return new FeatureBuildItem(Feature.JAEGER);
     }
 
     @BuildStep

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -9,6 +9,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
@@ -24,9 +25,10 @@ import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 
+@BuildSteps(onlyIf = KeycloakPolicyEnforcerBuildStep.IsEnabled.class)
 public class KeycloakPolicyEnforcerBuildStep {
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     RequireBodyHandlerBuildItem requireBody(OidcBuildTimeConfig oidcBuildTimeConfig, KeycloakPolicyEnforcerConfig config) {
         if (oidcBuildTimeConfig.enabled) {
             if (isBodyHandlerRequired(config.defaultTenant)) {
@@ -67,7 +69,7 @@ public class KeycloakPolicyEnforcerBuildStep {
         return false;
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public AdditionalBeanBuildItem beans(OidcBuildTimeConfig oidcBuildTimeConfig, KeycloakPolicyEnforcerConfig config) {
         if (oidcBuildTimeConfig.enabled) {
             return AdditionalBeanBuildItem.builder().setUnremovable()
@@ -82,7 +84,7 @@ public class KeycloakPolicyEnforcerBuildStep {
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public SyntheticBeanBuildItem setup(OidcBuildTimeConfig oidcBuildTimeConfig, OidcConfig oidcRunTimeConfig,
             TlsConfig tlsConfig,
             KeycloakPolicyEnforcerConfig keycloakConfig, KeycloakPolicyEnforcerRecorder recorder) {

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerBuildStep.java
@@ -12,7 +12,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerAuthorizer;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerBuildTimeConfig;
 import io.quarkus.keycloak.pep.runtime.KeycloakPolicyEnforcerConfig;
@@ -26,11 +25,6 @@ import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vertx.http.deployment.RequireBodyHandlerBuildItem;
 
 public class KeycloakPolicyEnforcerBuildStep {
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.KEYCLOAK_AUTHORIZATION);
-    }
 
     @BuildStep(onlyIf = IsEnabled.class)
     RequireBodyHandlerBuildItem requireBody(OidcBuildTimeConfig oidcBuildTimeConfig, KeycloakPolicyEnforcerConfig config) {

--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerFeatureAlwaysEnabledProcessor.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakPolicyEnforcerFeatureAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.keycloak.pep.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class KeycloakPolicyEnforcerFeatureAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.KEYCLOAK_AUTHORIZATION);
+    }
+
+}

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerConfigAlwaysEnabledProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerConfigAlwaysEnabledProcessor.java
@@ -1,10 +1,18 @@
 package io.quarkus.micrometer.deployment;
 
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
 
-public class MicrometerConfigUnremovableProcessor {
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class MicrometerConfigAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.MICROMETER);
+    }
 
     /**
      * config objects are beans, but they are not unremovable by default

--- a/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
+++ b/extensions/micrometer/deployment/src/main/java/io/quarkus/micrometer/deployment/MicrometerProcessor.java
@@ -28,14 +28,12 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.Annotations;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.InterceptorBindingRegistrar;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
@@ -76,11 +74,6 @@ public class MicrometerProcessor {
     }
 
     MicrometerConfig mConfig;
-
-    @BuildStep
-    FeatureBuildItem feature() {
-        return new FeatureBuildItem(Feature.MICROMETER);
-    }
 
     @BuildStep(onlyIfNot = PrometheusRegistryProcessor.PrometheusEnabled.class)
     MetricsCapabilityBuildItem metricsCapabilityBuildItem() {

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterAlwaysEnabledProcessor.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.client.filter.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcClientFilterAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC_CLIENT_FILTER);
+    }
+
+}

--- a/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
+++ b/extensions/oidc-client-filter/deployment/src/main/java/io/quarkus/oidc/client/filter/deployment/OidcClientFilterBuildStep.java
@@ -3,11 +3,9 @@ package io.quarkus.oidc.client.filter.deployment;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.client.deployment.OidcClientBuildStep.IsEnabled;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
@@ -22,11 +20,6 @@ public class OidcClientFilterBuildStep {
     private static final DotName OIDC_CLIENT_FILTER = DotName.createSimple(OidcClientFilter.class.getName());
 
     OidcClientFilterConfig config;
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC_CLIENT_FILTER);
-    }
 
     @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterAlwaysEnabledProcessor.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.client.reactive.filter.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcClientReactiveFilterAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC_CLIENT_REACTIVE_FILTER);
+    }
+
+}

--- a/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
+++ b/extensions/oidc-client-reactive-filter/deployment/src/main/java/io/quarkus/oidc/client/reactive/filter/deployment/OidcClientReactiveFilterBuildStep.java
@@ -1,23 +1,16 @@
 package io.quarkus.oidc.client.reactive.filter.deployment;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.client.deployment.OidcClientBuildStep.IsEnabled;
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter;
 
 @BuildSteps(onlyIf = IsEnabled.class)
 public class OidcClientReactiveFilterBuildStep {
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC_CLIENT_REACTIVE_FILTER);
-    }
 
     @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientAlwaysEnabledProcessor.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.client.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcClientAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC_CLIENT);
+    }
+
+}

--- a/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
+++ b/extensions/oidc-client/deployment/src/main/java/io/quarkus/oidc/client/deployment/OidcClientBuildStep.java
@@ -27,7 +27,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.ClassOutput;
@@ -49,11 +48,6 @@ import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 
 @BuildSteps(onlyIf = OidcClientBuildStep.IsEnabled.class)
 public class OidcClientBuildStep {
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC_CLIENT);
-    }
 
     @BuildStep
     ExtensionSslNativeSupportBuildItem enableSslInNative() {

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveAlwaysEnabledProcessor.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.token.propagation.reactive;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcTokenPropagationReactiveAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION_REACTIVE);
+    }
+
+}

--- a/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
+++ b/extensions/oidc-token-propagation-reactive/deployment/src/main/java/io/quarkus/oidc/token/propagation/reactive/OidcTokenPropagationReactiveBuildStep.java
@@ -3,21 +3,14 @@ package io.quarkus.oidc.token.propagation.reactive;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 @BuildSteps(onlyIf = OidcTokenPropagationReactiveBuildStep.IsEnabled.class)
 public class OidcTokenPropagationReactiveBuildStep {
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION_REACTIVE);
-    }
 
     @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationAlwaysEnabledProcessor.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.token.propagation.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcTokenPropagationAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION);
+    }
+
+}

--- a/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
+++ b/extensions/oidc-token-propagation/deployment/src/main/java/io/quarkus/oidc/token/propagation/deployment/OidcTokenPropagationBuildStep.java
@@ -5,11 +5,9 @@ import java.util.function.BooleanSupplier;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.token.propagation.AccessToken;
 import io.quarkus.oidc.token.propagation.AccessTokenRequestFilter;
@@ -27,11 +25,6 @@ public class OidcTokenPropagationBuildStep {
     private static final DotName JWT_ACCESS_TOKEN_CREDENTIAL = DotName.createSimple(JsonWebToken.class.getName());
 
     OidcTokenPropagationConfig config;
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC_TOKEN_PROPAGATION);
-    }
 
     @BuildStep
     void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcAlwaysEnabledProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OidcAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem(Feature.OIDC);
+    }
+
+}

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildStep.java
@@ -20,7 +20,6 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.oidc.SecurityEvent;
@@ -50,11 +49,6 @@ import io.smallrye.jwt.auth.cdi.RawClaimTypeProducer;
 @BuildSteps(onlyIf = OidcBuildStep.IsEnabled.class)
 public class OidcBuildStep {
     public static final DotName DOTNAME_SECURITY_EVENT = DotName.createSimple(SecurityEvent.class.getName());
-
-    @BuildStep
-    FeatureBuildItem featureBuildItem() {
-        return new FeatureBuildItem(Feature.OIDC);
-    }
 
     @BuildStep
     public void provideSecurityInformation(BuildProducer<SecurityInformationBuildItem> securityInformationProducer) {

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterAlwaysEnabledProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.opentelemetry.exporter.jaeger.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class JaegerExporterAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.OPENTELEMETRY_JAEGER_EXPORTER);
+    }
+
+}

--- a/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-jaeger/deployment/src/main/java/io/quarkus/opentelemetry/exporter/jaeger/deployment/JaegerExporterProcessor.java
@@ -3,12 +3,10 @@ package io.quarkus.opentelemetry.exporter.jaeger.deployment;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterConfig;
 import io.quarkus.opentelemetry.exporter.jaeger.runtime.JaegerExporterProvider;
@@ -23,11 +21,6 @@ public class JaegerExporterProcessor {
         public boolean getAsBoolean() {
             return jaegerExporterConfig.enabled;
         }
-    }
-
-    @BuildStep
-    FeatureBuildItem feature() {
-        return new FeatureBuildItem(Feature.OPENTELEMETRY_JAEGER_EXPORTER);
     }
 
     @BuildStep

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterAlwaysEnabledProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.opentelemetry.exporter.otlp.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OtlpExporterAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.OPENTELEMETRY_OTLP_EXPORTER);
+    }
+
+}

--- a/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterProcessor.java
+++ b/extensions/opentelemetry/opentelemetry-exporter-otlp/deployment/src/main/java/io/quarkus/opentelemetry/exporter/otlp/deployment/OtlpExporterProcessor.java
@@ -3,12 +3,10 @@ package io.quarkus.opentelemetry.exporter.otlp.deployment;
 import java.util.function.BooleanSupplier;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.opentelemetry.exporter.otlp.runtime.OtlpExporterConfig;
 import io.quarkus.opentelemetry.exporter.otlp.runtime.OtlpExporterProvider;
@@ -23,11 +21,6 @@ public class OtlpExporterProcessor {
         public boolean getAsBoolean() {
             return otlpExporterConfig.enabled;
         }
-    }
-
-    @BuildStep
-    FeatureBuildItem feature() {
-        return new FeatureBuildItem(Feature.OPENTELEMETRY_OTLP_EXPORTER);
     }
 
     @BuildStep

--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryAlwaysEnabledProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.opentelemetry.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class OpenTelemetryAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.OPENTELEMETRY);
+    }
+
+}

--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/OpenTelemetryProcessor.java
@@ -15,14 +15,12 @@ import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.deployment.InterceptorBindingRegistrarBuildItem;
 import io.quarkus.arc.processor.InterceptorBindingRegistrar;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -46,11 +44,6 @@ public class OpenTelemetryProcessor {
         public boolean getAsBoolean() {
             return IS_REST_CLIENT_AVAILABLE;
         }
-    }
-
-    @BuildStep
-    FeatureBuildItem feature() {
-        return new FeatureBuildItem(Feature.OPENTELEMETRY);
     }
 
     @BuildStep

--- a/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnFeatureAlwaysEnabledProcessor.java
+++ b/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnFeatureAlwaysEnabledProcessor.java
@@ -1,0 +1,15 @@
+package io.quarkus.security.webauthn.deployment;
+
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+class QuarkusSecurityWebAuthnFeatureAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(Feature.SECURITY_WEBAUTHN);
+    }
+
+}

--- a/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
+++ b/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
@@ -7,12 +7,10 @@ import javax.inject.Singleton;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
-import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.security.webauthn.WebAuthnAuthenticationMechanism;
 import io.quarkus.security.webauthn.WebAuthnAuthenticatorStorage;
@@ -27,11 +25,6 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.vertx.ext.auth.webauthn.impl.attestation.Attestation;
 
 class QuarkusSecurityWebAuthnProcessor {
-
-    @BuildStep
-    FeatureBuildItem feature() {
-        return new FeatureBuildItem(Feature.SECURITY_WEBAUTHN);
-    }
 
     @BuildStep(onlyIf = IsEnabled.class)
     public void myBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {

--- a/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
+++ b/extensions/security-webauthn/deployment/src/main/java/io/quarkus/security/webauthn/deployment/QuarkusSecurityWebAuthnProcessor.java
@@ -9,6 +9,7 @@ import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -24,9 +25,10 @@ import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
 import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.vertx.ext.auth.webauthn.impl.attestation.Attestation;
 
+@BuildSteps(onlyIf = QuarkusSecurityWebAuthnProcessor.IsEnabled.class)
 class QuarkusSecurityWebAuthnProcessor {
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void myBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder().setUnremovable();
 
@@ -38,7 +40,7 @@ class QuarkusSecurityWebAuthnProcessor {
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public void setup(
             WebAuthnRecorder recorder,
             VertxWebRouterBuildItem vertxWebRouterBuildItem,
@@ -48,12 +50,12 @@ class QuarkusSecurityWebAuthnProcessor {
                 nonApplicationRootPathBuildItem.getNonApplicationRootPath());
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     public ServiceProviderBuildItem serviceLoader() {
         return ServiceProviderBuildItem.allProvidersFromClassPath(Attestation.class.getName());
     }
 
-    @BuildStep(onlyIf = IsEnabled.class)
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem initWebAuthnAuth(
             WebAuthnRecorder recorder) {


### PR DESCRIPTION
In particular, when such an extension is disabled:

* ~~Don't display the feature in logs on startup~~ => changed following comments, see conversation below.
* Don't enable SSL
* Don't add reflective classes in native mode

EDIT: Also, regardless of whether the extension is enabled or not, always display the feature in logs on startup.

~~Creating this PR as draft, because it's based on #26965 , which must be merged first.~~ => Done

I separated this PR from #26965 because #26965 doesn't alter the behavior of any extension, while this PR does (but for the better, IMO).