### PR TITLE
Context propagation - cleared Arc snapshot should destroy its state once the invocation ends

### DIFF
--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/RequestBean.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/RequestBean.java
@@ -1,11 +1,19 @@
 package io.quarkus.context.test;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.RequestScoped;
 
 @RequestScoped
 public class RequestBean {
 
+    public static volatile int DESTROY_INVOKED = 0;
+
     public String callMe() {
         return "Hello " + System.identityHashCode(this);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        DESTROY_INVOKED++;
     }
 }

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -75,14 +76,20 @@ public class SimpleContextPropagationTest {
 
     @Test()
     public void testArcMEContextPropagationDisabled() {
+        // reset state
+        RequestBean.DESTROY_INVOKED = 0;
         RestAssured.when().get("/context/noarc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
+        Assertions.assertEquals(2, RequestBean.DESTROY_INVOKED);
     }
 
     @Test()
     public void testArcTCContextPropagationDisabled() {
+        // reset state
+        RequestBean.DESTROY_INVOKED = 0;
         RestAssured.when().get("/context/noarc-tc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
+        Assertions.assertEquals(2, RequestBean.DESTROY_INVOKED);
     }
 
     @Test()


### PR DESCRIPTION
Related to a Zulip thread discussion.
A quick sum up is that this focuses on a scenario where used specifically wants to execute action(s) that will *not* propagate Arc context and wants a new context instead. This is supported by MP CP. However, in our code, we never destroy any instances created in this new context before we restore previous state which I think is incorrect. However I might be missing some other case where destroying them might be a bad move?

The PR has the needed code adjustment plus a test hopefully showing exactly what I mean with the description above^

Ccing @mkouba and @Ladicek whom I discussed this with. Thoughts, ideas, counterexamples? :)