### PR TITLE
Bump kubernetes-client-bom from 5.12.2 to 5.12.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -151,7 +151,7 @@
         <kotlin.version>1.6.21</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.3.3</kotlin-serialization.version>
-        <kubernetes-client.version>5.12.2</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>5.12.3</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <dekorate.version>2.11.0</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
Kubernetes Client 5.12.3 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v5.12.3

Just speeding up the dependabot process to see if CI reports any issue.

Note that https://github.com/quarkusio/quarkus/pull/26107 is already open but requires a Dekorate compatible version.

/cc @metacosm
