### PR TITLE
Keycloak Authz - make request for party token work in native mode

### DIFF
--- a/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
+++ b/extensions/keycloak-authorization/deployment/src/main/java/io/quarkus/keycloak/pep/deployment/KeycloakReflectionBuildStep.java
@@ -8,6 +8,7 @@ import org.keycloak.adapters.authorization.ClaimInformationPointProviderFactory;
 import org.keycloak.adapters.authorization.cip.ClaimsInformationPointProviderFactory;
 import org.keycloak.adapters.authorization.cip.HttpClaimInformationPointProviderFactory;
 import org.keycloak.authorization.client.representation.ServerConfiguration;
+import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSHeader;
@@ -42,6 +43,7 @@ public class KeycloakReflectionBuildStep {
     public void registerReflectionItems(BuildProducer<ReflectiveClassBuildItem> reflectiveItems) {
         reflectiveItems.produce(new ReflectiveClassBuildItem(true, true,
                 JsonWebToken.class.getName(),
+                TokenIntrospectionResponse.class.getName(),
                 JWSHeader.class.getName(),
                 AccessToken.class.getName(),
                 IDToken.class.getName(),

--- a/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/keycloak-authorization/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 
@@ -89,5 +90,13 @@ public class ProtectedResource {
     @GET
     public String getEntitlements() {
         return authzClient.authorization().authorize().getToken();
+    }
+
+    @Produces("application/json")
+    @Path("/party-token-permissions-size")
+    @GET
+    public int getPartyTokenPermissionsSize() {
+        return authzClient.protection().introspectRequestingPartyToken(authzClient.authorization().authorize().getToken())
+                .getPermissions().size();
     }
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerInGraalITCase.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerInGraalITCase.java
@@ -1,10 +1,24 @@
 package io.quarkus.it.keycloak;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 @QuarkusIntegrationTest
 public class PolicyEnforcerInGraalITCase extends PolicyEnforcerTest {
+
+    @Test
+    public void testPartyTokenRequest() {
+        // the point is to check TokenIntrospectionToken can be deserialized
+        final var response = RestAssured.given().auth().oauth2(getAccessToken("alice"))
+                .when().get("/api/permission/party-token-permissions-size");
+        Assertions.assertEquals(200, response.statusCode());
+        Assertions.assertTrue(response.body().as(int.class) > 0);
+    }
+
 }

--- a/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
+++ b/integration-tests/keycloak-authorization/src/test/java/io/quarkus/it/keycloak/PolicyEnforcerTest.java
@@ -221,7 +221,7 @@ public class PolicyEnforcerTest {
                 .statusCode(404);
     }
 
-    private String getAccessToken(String userName) {
+    protected String getAccessToken(String userName) {
         return RestAssured
                 .given()
                 .param("grant_type", "password")


### PR DESCRIPTION
Register `TokenIntrospectionResponse` for the reflection as in native mode token introspection fails. The issue can be clear from the test I've added (`testPartyTokenRequest`).

We have experienced this issue in our daily CI builds https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/2743129511 where in native mode this issue prevents application from start.