### PR TITLE
Fix native build parameter for maven

### DIFF
--- a/docs/src/main/asciidoc/includes/devtools/build-native-container-parameters.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native-container-parameters.adoc
@@ -8,7 +8,7 @@ ifdef::devtools-wrapped[+]
 [source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
-./mvnw package -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
+./mvnw package -Pnative -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 endif::[]
 ifndef::devtools-no-gradle[]

--- a/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
@@ -15,10 +15,10 @@ ifdef::devtools-wrapped[+]
 .Maven
 ----
 ifdef::build-additional-parameters[]
-./mvnw package -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
+./mvnw package -Pnative -Dquarkus.native.container-build=true {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-./mvnw package -Dnative -Dquarkus.native.container-build=true
+./mvnw package -Pnative -Dquarkus.native.container-build=true
 endif::[]
 ----
 endif::[]

--- a/docs/src/main/asciidoc/includes/devtools/build-native.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native.adoc
@@ -14,10 +14,10 @@ ifdef::devtools-wrapped[+]
 .Maven
 ----
 ifdef::build-additional-parameters[]
-./mvnw package -Dnative {build-additional-parameters}
+./mvnw package -Pnative {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-./mvnw package -Dnative
+./mvnw package -Pnative
 endif::[]
 ----
 endif::[]


### PR DESCRIPTION
https://quarkus.io/guides/building-native-image#producing-a-native-executable references the profile native from a previous tutorial. Profiles should be activated by using -P whereas -D would set a system profile.