### PR TITLE
Smallrye GraphQL - refactor context termination handler

### DIFF
--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java
@@ -30,7 +30,8 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
     private final CurrentIdentityAssociation currentIdentityAssociation;
     private final CurrentVertxRequest currentVertxRequest;
     private final ManagedContext currentManagedContext;
-    private final Handler currentManagedContextTerminationHandler;
+    private final Handler<Void> currentManagedContextTerminationHandler;
+    private final Handler<Throwable> currentManagedContextExceptionHandler;
     private final boolean runBlocking;
 
     private volatile ExecutionService executionService;
@@ -46,12 +47,16 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
         this.currentVertxRequest = currentVertxRequest;
         this.currentManagedContext = Arc.container().requestContext();
         this.runBlocking = runBlocking;
-        this.currentManagedContextTerminationHandler = new Handler() {
+        this.currentManagedContextTerminationHandler = createCurrentManagedContextTerminationHandler();
+        this.currentManagedContextExceptionHandler = createCurrentManagedContextTerminationHandler();
+    }
+
+    private <T> Handler<T> createCurrentManagedContextTerminationHandler() {
+        return new Handler<>() {
             @Override
             public void handle(Object e) {
                 currentManagedContext.terminate();
             }
-
         };
     }
 
@@ -60,7 +65,7 @@ public abstract class SmallRyeGraphQLAbstractHandler implements Handler<RoutingC
 
         ctx.response()
                 .endHandler(currentManagedContextTerminationHandler)
-                .exceptionHandler(currentManagedContextTerminationHandler)
+                .exceptionHandler(currentManagedContextExceptionHandler)
                 .closeHandler(currentManagedContextTerminationHandler);
         if (!currentManagedContext.isActive()) {
             currentManagedContext.activate();


### PR DESCRIPTION
When using `smallrye-graphql` extension `unchecked conversion/method invocation` is logged. I mentioned when running `mvn clean verify -Dtest=GraphQLTerminateContextTest -Dsurefire.failIfNoSpecifiedTests=false`. This was brought in intentionally by #26777 as it's a trade off - using checked handler means storing 2 handlers per instance instead of one. I realize it's opinionated subject and I might be a minority here, but following is logged and it looks bad in my eyes:

```
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ quarkus-smallrye-graphql ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 18 source files to /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/target/classes
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[62,28] unchecked method invocation: method endHandler in interface io.vertx.core.http.HttpServerResponse is applied to given types
  required: io.vertx.core.Handler<java.lang.Void>
  found:    <anonymous io.vertx.core.Handler>
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[62,29] unchecked conversion
  required: io.vertx.core.Handler<java.lang.Void>
  found:    <anonymous io.vertx.core.Handler>
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[69,34] unchecked method invocation: method exceptionHandler in interface io.vertx.core.http.HttpServerResponse is applied to given types
  required: io.vertx.core.Handler<java.lang.Throwable>
  found:    <anonymous io.vertx.core.Handler>
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[69,35] unchecked conversion
  required: io.vertx.core.Handler<java.lang.Throwable>
  found:    <anonymous io.vertx.core.Handler>
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[76,30] unchecked method invocation: method closeHandler in interface io.vertx.core.http.HttpServerResponse is applied to given types
  required: io.vertx.core.Handler<java.lang.Void>
  found:    <anonymous io.vertx.core.Handler>
[WARNING] /home/mvavrik/sources/quarkus/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLAbstractHandler.java:[76,31] unchecked conversion
  required: io.vertx.core.Handler<java.lang.Void>
  found:    <anonymous io.vertx.core.Handler>
```