### PR TITLE
Change HV validator interceptor to dynamically resolve Validator bean instance

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ValidatorForEarlyInitializedBeanTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ValidatorForEarlyInitializedBeanTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.validator.test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolationException;
+import javax.validation.constraints.NotNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that validation can be used for early initialized beans that observe {@code @Initialized(ApplicationScoped.class)}
+ */
+public class ValidatorForEarlyInitializedBeanTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(EagerInitBean.class, ValidatorForEarlyInitializedBeanTest.class));
+    @Inject
+    EagerInitBean someBean;
+
+    @Test
+    void test() {
+        Assertions.assertTrue(EagerInitBean.initInvoked);
+        try {
+            someBean.call(null);
+            Assertions.fail();
+        } catch (ConstraintViolationException e) {
+            // OK, expected
+        }
+
+    }
+
+    @ApplicationScoped
+    static final class EagerInitBean {
+
+        static boolean initInvoked = false;
+
+        // App scoped is activated very early (compared to observing Startup event)
+        void startUp(@Observes @Initialized(ApplicationScoped.class) final Object event) {
+            initInvoked = true;
+        }
+
+        void call(@NotNull final Object o) {
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #26931 

This is what I had in mind - it will delay resolution to always happen in runtime where the `Validator` bean is present and ready.
The `@WithCaching` annotation caches results of dependent beans and avoid trying to re-resolve them every time so it perhaps can save a few method invocations but it would work without it as well.

The attached test is just a twist on the reproducer in mentioned issue.