### PR TITLE
Deprecate HibernateValidatorFactoryCustomizer in favor of ValidatorFactoryCustomizer

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -309,6 +309,33 @@ However, in the case of ``ConstraintValidator``s that are dependent of attribute
 use the `@Dependent` scope to make sure each annotation context has a separate instance of the `ConstraintValidator` bean.
 ====
 
+If customizing the `ValidatorFactory` through the available configuration properties and the CDI beans above doesn't cover your requirements,
+you can customize it further by registering `ValidatorFactoryCustomizer` beans.
+
+For instance, you could override the built-in validator enforcing the `@Email` constraint and use `MyEmailValidator` instead with the following class:
+
+[source,java]
+----
+@ApplicationScoped
+public class MyEmailValidatorFactoryCustomizer implements ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+
+        constraintMapping
+                .constraintDefinition(Email.class)
+                .includeExistingValidators(false)
+                .validatedBy(MyEmailValidator.class);
+
+        configuration.addMapping(constraintMapping);
+    }
+}
+----
+
+All beans implementing `ValidatorFactoryCustomizer` are applied, meaning you can have several of them.
+If you need to enforce some ordering, you can use the usual `@javax.annotation.Priority` annotation - beans with higher priority are applied first.
+
 ==== Constraint validators as beans
 
 You can declare your constraint validators as CDI beans:

--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -333,13 +333,16 @@ public class MyConstraintValidator implements ConstraintValidator<MyConstraint, 
 ----
 
 When initializing a constraint validator of a given type,
-Quarkus will check if a bean of this type is available and, if so, it will use it instead of instantiating one.
+Quarkus will check if a bean of this type is available and, if so, it will use it instead of instantiating a `ConstraintValidator`.
 
 Thus, as demonstrated in our example, you can fully use injection in your constraint validator beans.
 
-[NOTE]
+[WARNING]
 ====
-Except in very specific situations, it is recommended to make the said beans `@ApplicationScoped`.
+The scope you choose for your `ConstraintValidator` bean is important:
+
+- If the same instance of the `ConstraintValidator` bean can be used across the whole application, use the `@ApplicationScoped` scope.
+- If the `ConstraintValidator` bean implements the `initialize(A constraintAnnotation)` method and depends on the state of the constraint annotation, use the `@Dependent` scope to make sure each annotation context has a separate and properly configured instance of the `ConstraintValidator` bean.
 ====
 
 === Validation and localization

--- a/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
+++ b/extensions/hibernate-validator/deployment/src/main/java/io/quarkus/hibernate/validator/deployment/HibernateValidatorProcessor.java
@@ -75,7 +75,7 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.logging.LogCleanupFilterBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.hibernate.validator.HibernateValidatorFactoryCustomizer;
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
 import io.quarkus.hibernate.validator.runtime.DisableLoggingFeature;
 import io.quarkus.hibernate.validator.runtime.HibernateValidatorBuildTimeConfig;
 import io.quarkus.hibernate.validator.runtime.HibernateValidatorRecorder;
@@ -109,8 +109,8 @@ class HibernateValidatorProcessor {
     private static final DotName PROPERTY_NODE_NAME_PROVIDER = DotName
             .createSimple(PropertyNodeNameProvider.class.getName());
 
-    private static final DotName CONSTRAINT_MAPPING_PROVIDER = DotName
-            .createSimple(HibernateValidatorFactoryCustomizer.class.getName());
+    private static final DotName VALIDATOR_FACTORY_CUSTOMIZER = DotName
+            .createSimple(ValidatorFactoryCustomizer.class.getName());
 
     private static final DotName CONSTRAINT_VALIDATOR = DotName.createSimple(ConstraintValidator.class.getName());
     private static final DotName VALUE_EXTRACTOR = DotName.createSimple(ValueExtractor.class.getName());
@@ -192,7 +192,7 @@ class HibernateValidatorProcessor {
                         || beanInfo.hasType(GETTER_PROPERTY_SELECTION_STRATEGY)
                         || beanInfo.hasType(LOCALE_RESOLVER)
                         || beanInfo.hasType(PROPERTY_NODE_NAME_PROVIDER)
-                        || beanInfo.hasType(CONSTRAINT_MAPPING_PROVIDER);
+                        || beanInfo.hasType(VALIDATOR_FACTORY_CUSTOMIZER);
             }
         }));
     }

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MultipleHibernateValidatorFactoryCustomizersTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MultipleHibernateValidatorFactoryCustomizersTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class MultipleHibernateFactoryCustomizersTest {
+public class MultipleHibernateValidatorFactoryCustomizersTest {
 
     @Inject
     ValidatorFactory validatorFactory;

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MultipleValidatorFactoryCustomizersTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MultipleValidatorFactoryCustomizersTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Min;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MultipleValidatorFactoryCustomizersTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(MyEmailValidatorFactoryCustomizer.class, MyNumberValidatorFactoryCustomizer.class,
+                    MyEmailValidator.class,
+                    MyNumValidator.class));
+
+    @Test
+    public void testOverrideConstraintValidatorConstraint() {
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(2);
+    }
+
+    static class TestBean {
+        @Email
+        public String email;
+
+        @Min(-1)
+        public int num;
+
+        public TestBean() {
+            this.email = "test@acme.com";
+            this.num = -1;
+        }
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyEmailValidatorFactoryCustomizer.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyEmailValidatorFactoryCustomizer.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.Email;
+
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+
+@ApplicationScoped
+public class MyEmailValidatorFactoryCustomizer implements ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+
+        constraintMapping
+                .constraintDefinition(Email.class)
+                .includeExistingValidators(false)
+                .validatedBy(MyEmailValidator.class);
+
+        configuration.addMapping(constraintMapping);
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyMultipleValidatorFactoryCustomizer.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyMultipleValidatorFactoryCustomizer.java
@@ -1,0 +1,35 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Min;
+
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+
+@ApplicationScoped
+public class MyMultipleValidatorFactoryCustomizer implements ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+
+        constraintMapping
+                .constraintDefinition(Email.class)
+                .includeExistingValidators(false)
+                .validatedBy(MyEmailValidator.class);
+
+        configuration.addMapping(constraintMapping);
+
+        constraintMapping = configuration.createConstraintMapping();
+
+        constraintMapping
+                .constraintDefinition(Min.class)
+                .includeExistingValidators(false)
+                .validatedBy(MyNumValidator.class);
+
+        configuration.addMapping(constraintMapping);
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyNumberValidatorFactoryCustomizer.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/MyNumberValidatorFactoryCustomizer.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.constraints.Min;
+
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+
+@ApplicationScoped
+public class MyNumberValidatorFactoryCustomizer implements ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+
+        constraintMapping
+                .constraintDefinition(Min.class)
+                .includeExistingValidators(false)
+                .validatedBy(MyNumValidator.class);
+
+        configuration.addMapping(constraintMapping);
+    }
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryCustomizerTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryCustomizerTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Min;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ValidatorFactoryCustomizerTest {
+
+    @Inject
+    ValidatorFactory validatorFactory;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(MyMultipleValidatorFactoryCustomizer.class, MyEmailValidator.class,
+                    MyNumValidator.class));
+
+    @Test
+    public void testOverrideConstraintValidatorConstraint() {
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(2);
+    }
+
+    static class TestBean {
+        @Email
+        public String email;
+
+        @Min(-1)
+        public int num;
+
+        public TestBean() {
+            this.email = "test@acme.com";
+            this.num = -1;
+        }
+    }
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/ValidatorFactoryCustomizer.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/ValidatorFactoryCustomizer.java
@@ -10,11 +10,8 @@ import org.hibernate.validator.BaseHibernateValidatorConfiguration;
  * {@link javax.validation.ValidatorFactory}.
  * <p>
  * Customizers are applied in the order of {@link javax.annotation.Priority}.
- *
- * @deprecated Implement {@link ValidatorFactoryCustomizer} instead.
  */
-@Deprecated(forRemoval = true)
-public interface HibernateValidatorFactoryCustomizer extends ValidatorFactoryCustomizer {
+public interface ValidatorFactoryCustomizer {
 
     void customize(BaseHibernateValidatorConfiguration<?> configuration);
 }

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/HibernateValidatorRecorder.java
@@ -26,7 +26,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.BeanContainerListener;
-import io.quarkus.hibernate.validator.HibernateValidatorFactoryCustomizer;
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyConfigSupport;
 import io.quarkus.runtime.LocalesBuildTimeConfig;
 import io.quarkus.runtime.ShutdownContext;
@@ -150,12 +150,12 @@ public class HibernateValidatorRecorder {
                     configuration.addValueExtractor(valueExtractor);
                 }
 
-                List<InstanceHandle<HibernateValidatorFactoryCustomizer>> constraintMappingProviderList = Arc.container()
-                        .listAll(HibernateValidatorFactoryCustomizer.class);
-                for (InstanceHandle<HibernateValidatorFactoryCustomizer> cmpInstanceHandle : constraintMappingProviderList) {
-                    if (cmpInstanceHandle.isAvailable()) {
-                        final HibernateValidatorFactoryCustomizer hibernateValidatorFactoryCustomizer = cmpInstanceHandle.get();
-                        hibernateValidatorFactoryCustomizer.customize(configuration);
+                List<InstanceHandle<ValidatorFactoryCustomizer>> validatorFactoryCustomizers = Arc.container()
+                        .listAll(ValidatorFactoryCustomizer.class);
+                for (InstanceHandle<ValidatorFactoryCustomizer> validatorFactoryInstanceHandle : validatorFactoryCustomizers) {
+                    if (validatorFactoryInstanceHandle.isAvailable()) {
+                        final ValidatorFactoryCustomizer validatorFactoryCustomizer = validatorFactoryInstanceHandle.get();
+                        validatorFactoryCustomizer.customize(configuration);
                     }
                 }
 


### PR DESCRIPTION
And document it.
While working on the documentation, I realized that we are referencing
ValidatorFactory everywhere so it makes no sense to call the customizer
with the Hibernate prefix.

For now, I deprecated the interface, it will be dropped in the next minor version
as it was only in one micro and the usage is relatively narrow.