### PR TITLE
Provide the ability to log MDC data in access_log

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -359,6 +359,7 @@ include::{generated-dir}/config/quarkus-vertx-http-config-group-access-log-confi
 |Request header                                                               |          | `%{i,request_header_name}`
 |Response header                                                              |          | `%{o,response_header_name}`
 |Vert.x Routing Context Internal Data                                         |          | `%{d,map_key}`
+|Vert.x MDC data (e.g. 'traceId' for OpenTelemetry)                           |          | `%{X,mdc-key}`
 |===
 
 

--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -109,6 +109,9 @@ quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317 // <3>
 quarkus.opentelemetry.tracer.exporter.otlp.headers=Authorization=Bearer my_secret // <4>
 
 quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n  // <5>
+
+# Alternative to the console log
+quarkus.http.access-log.pattern="...traceId=%{X,traceId} spanId=%{X,spanId}" // <6>
 ----
 
 <1> All spans created from the application will include an OpenTelemetry `Resource` indicating the span was created by the `myservice` application. If not set, it will default to the artifact id.
@@ -116,6 +119,8 @@ quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{pa
 <3> gRPC endpoint for sending spans
 <4> Optional gRPC headers commonly used for authentication
 <5> Add tracing information into log message.
+<6> You can also only put the trace info into the access log. In this case you must omit the info in the console log format.
+
 == Run the application
 
 The first step is to configure and start the https://opentelemetry.io/docs/collector/[OpenTelemetry Collector] to receive, process and export telemetry data to https://www.jaegertracing.io/[Jaeger] that will display the captured traces.

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttribute.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttribute.java
@@ -1,0 +1,52 @@
+package io.quarkus.vertx.http.runtime.attribute;
+
+import io.quarkus.vertx.core.runtime.VertxMDC;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Provide entries from the MDC section of the RoutingContext.
+ * This is especially helpful to put OTel data 'traceId' and 'spanId'
+ * into the access log.
+ */
+public class VertxMDCDataAttribute implements ExchangeAttribute {
+
+    private final String dataKey;
+
+    public VertxMDCDataAttribute(String dataKey) {
+        this.dataKey = dataKey;
+    }
+
+    @Override
+    public String readAttribute(RoutingContext exchange) {
+        VertxMDC mdc = VertxMDC.INSTANCE;
+        return mdc.get(dataKey);
+    }
+
+    @Override
+    public void writeAttribute(RoutingContext exchange, String newValue) throws ReadOnlyAttributeException {
+        throw new ReadOnlyAttributeException();
+    }
+
+    public static final class Builder implements ExchangeAttributeBuilder {
+
+        @Override
+        public String name() {
+            return "OTel data";
+        }
+
+        @Override
+        public ExchangeAttribute build(final String token) {
+            if (token.startsWith("%{X,") && token.endsWith("}")) {
+                final String dataItemName = token.substring(4, token.length() - 1);
+                return new VertxMDCDataAttribute(dataItemName);
+            }
+            return null;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/accesslog/AccessLogHandler.java
@@ -85,6 +85,7 @@ import io.vertx.ext.web.RoutingContext;
  * <li><code>%{r,xxx}</code> xxx is an attribute in the ServletRequest
  * <li><code>%{s,xxx}</code> xxx is an attribute in the HttpSession
  * <li><code>%{d,xxx}</code> xxx is a data item in the exchange</li>
+ * <li><code>%{X,xxx}</code> xxx is a key in the Vert.X MDC</li>
  * </ul>
  *
  * @author Stuart Douglas

--- a/extensions/vertx-http/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
+++ b/extensions/vertx-http/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
@@ -29,3 +29,5 @@ io.quarkus.vertx.http.runtime.attribute.RequestPathAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.NullAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.AllRequestHeadersAttribute$Builder
 io.quarkus.vertx.http.runtime.attribute.ExchangeDataAttribute$Builder
+io.quarkus.vertx.http.runtime.attribute.VertxMDCDataAttribute$Builder
+

--- a/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttributeTest.java
+++ b/extensions/vertx-http/runtime/src/test/java/io/quarkus/vertx/http/runtime/attribute/VertxMDCDataAttributeTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.vertx.http.runtime.attribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.vertx.core.runtime.VertxMDC;
+
+class VertxMDCDataAttributeTest {
+
+    @Test
+    void returnsCorrectValue() {
+        VertxMDC mdc = VertxMDC.INSTANCE;
+        mdc.put("traceId", "123");
+
+        VertxMDCDataAttribute mdcDataAttribute = new VertxMDCDataAttribute("traceId");
+        assertThat(mdcDataAttribute.readAttribute(null)).isEqualTo("123");
+    }
+
+    @Test
+    void returnsNullOnKeyNotInMDC() {
+        VertxMDC mdc = VertxMDC.INSTANCE;
+        mdc.put("traceId", "123");
+
+        VertxMDCDataAttribute mdcDataAttribute = new VertxMDCDataAttribute("spanId");
+        assertNull(mdcDataAttribute.readAttribute(null));
+    }
+}


### PR DESCRIPTION
A config entry in application.properties like:

`quarkus.http.access-log.pattern="%h %l %u %t \"%r\" %s %b traceId=%{X,traceId}"`

would end up in

`2022-07-28 17:46:56,512 INFO  [access_log] (executor-thread-2) "127.0.0.1 - hrupp 28/Jul/2022:17:46:56 +0200 "GET /api/policies/v1.0/policies HTTP/1.1" 404 -  traceId=797e67544634cff6b25a7d6ab429e67e"`

This is similar to #26339 

Unfortunately the `%{X,..}` syntax in access log patterns is different from the `%X{..}` syntax for console logs.

cc @brunobat 
