### PR TITLE
Introduce a new set of test callbacks used right before and after test execution

### DIFF
--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -427,6 +427,8 @@ Alternatively or additionally to an interceptor, you can enrich *all* your `@Qua
 * `io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback`
 * `io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback`
 * `io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback`
+* `io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback`
+* `io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback`
 * `io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback`
 
 Such a callback implementation has to be registered as a "service provider" as defined by `java.util.ServiceLoader`.

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusBeforeAndAfterTestCallbacksTest.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusBeforeAndAfterTestCallbacksTest.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class QuarkusBeforeAndAfterTestCallbacksTest {
+
+    @BeforeEach
+    @AfterEach
+    public void ensureMissingSystemProperty() {
+        assertNull(System.getProperty("quarkus.test.method"));
+    }
+
+    @Test
+    public void actualTest() {
+        assertEquals("actualTest", System.getProperty("quarkus.test.method"));
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SystemPropertySetterAfterTestExecutionCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SystemPropertySetterAfterTestExecutionCallback.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.main;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+public class SystemPropertySetterAfterTestExecutionCallback implements QuarkusTestAfterTestExecutionCallback {
+
+    @Override
+    public void afterTestExecution(QuarkusTestMethodContext context) {
+        System.clearProperty("quarkus.test.method");
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SystemPropertySetterBeforeTestExecutionCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SystemPropertySetterBeforeTestExecutionCallback.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.main;
+
+import io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+public class SystemPropertySetterBeforeTestExecutionCallback implements QuarkusTestBeforeTestExecutionCallback {
+
+    @Override
+    public void beforeTestExecution(QuarkusTestMethodContext context) {
+        System.setProperty("quarkus.test.method", context.getTestMethod().getName());
+    }
+}

--- a/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback
+++ b/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback
@@ -1,0 +1,1 @@
+io.quarkus.it.main.SystemPropertySetterAfterTestExecutionCallback

--- a/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback
+++ b/integration-tests/main/src/test/resources/META-INF/services/io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback
@@ -1,0 +1,1 @@
+io.quarkus.it.main.SystemPropertySetterBeforeTestExecutionCallback

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestAfterTestExecutionCallback.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestAfterTestExecutionCallback.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.junit.callback;
+
+/**
+ * Can be implemented by classes that shall be called immediately after a test method in a {@code @QuarkusTest}.
+ * These callbacks run before {@link QuarkusTestAfterEachCallback} callbacks and are usually accompanied by
+ * {@link QuarkusTestBeforeTestExecutionCallback}.
+ * <p>
+ * The implementing class has to be {@linkplain java.util.ServiceLoader deployed as service provider on the class path}.
+ */
+public interface QuarkusTestAfterTestExecutionCallback {
+
+    void afterTestExecution(QuarkusTestMethodContext context);
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeTestExecutionCallback.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/callback/QuarkusTestBeforeTestExecutionCallback.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.junit.callback;
+
+/**
+ * Can be implemented by classes that shall be called right before a test method in a {@code @QuarkusTest}.
+ * These callbacks run after {@link QuarkusTestBeforeEachCallback} callbacks and are usually accompanied by
+ * {@link QuarkusTestAfterTestExecutionCallback}.
+ * <p>
+ * The implementing class has to be {@linkplain java.util.ServiceLoader deployed as service provider on the class path}.
+ */
+public interface QuarkusTestBeforeTestExecutionCallback {
+
+    void beforeTestExecution(QuarkusTestMethodContext context);
+}


### PR DESCRIPTION
These callbacks essentially offer similar functionality to JUnit's
`org.junit.jupiter.api.extension.BeforeTestExecutionCallback` and
`org.junit.jupiter.api.extension.AfterTestExecutionCallback`

Closes: #26999