### PR TITLE
Reduce the number of vert.x eventloops started by default

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -274,8 +274,7 @@ public class VertxHttpRecorder {
             doServerStart(vertx, buildConfig, config, LaunchMode.DEVELOPMENT, new Supplier<Integer>() {
                 @Override
                 public Integer get() {
-                    return ProcessorInfo.availableProcessors()
-                            * 2; //this is dev mode, so the number of IO threads not always being 100% correct does not really matter in this case
+                    return ProcessorInfo.availableProcessors(); //this is dev mode, so the number of IO threads not always being 100% correct does not really matter in this case
                 }
             }, null, false);
         } catch (Exception e) {

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerContextTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/MessageConsumerContextTest.java
@@ -84,11 +84,7 @@ public class MessageConsumerContextTest {
                 })
                 .await().atMost(Duration.ofSeconds(3));
 
-        if (Runtime.getRuntime().availableProcessors() > 1) {
-            assertEquals(3, MessageConsumers.MESSAGES.size());
-        } else {
-            assertTrue(MessageConsumers.MESSAGES.size() >= 2);
-        }
+        assertTrue(MessageConsumers.MESSAGES.size() >= 2);
     }
 
     @ApplicationScoped

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/VertxCoreRecorder.java
@@ -381,7 +381,10 @@ public class VertxCoreRecorder {
         //it's hard to say what this number should be, but it is also obvious
         //that for constrained environments we don't want a lot of event loops
         //lets start with 10mb and adjust as needed
-        int recommended = ProcessorInfo.availableProcessors() * 2;
+        //We used to recommend a default of twice the number of cores,
+        //but more recent developments seem to suggest matching the number of cores 1:1
+        //being a more reasonable default. It also saves memory.
+        int recommended = ProcessorInfo.availableProcessors();
         long mem = Runtime.getRuntime().maxMemory();
         long memInMb = mem / (1024 * 1024);
         long maxAllowed = memInMb / 10;

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/core/runtime/config/VertxConfiguration.java
@@ -23,7 +23,7 @@ public class VertxConfiguration {
     public boolean classpathResolving;
 
     /**
-     * The number of event loops. 2 x the number of core by default.
+     * The number of event loops. By default, it matches the number of CPUs detected on the system.
      */
     @ConfigItem
     public OptionalInt eventLoopsPoolSize;


### PR DESCRIPTION
As discussed at JNation, we have some experiments showing that:
 - there's no compelling reason to start more eventloops than available cores
 - it's actually harmful for performance in some cases

And obviously it saves a little chunk of memory as well. We briefly discussed the possibility to create "named profiles" so that people could experiment with different scaling formulas, but we decided to keep it simple: this is just the default meant to provide a reasonable OOB experience, while people wanting to tune things further can set the appropriate configuration property.

cc/ @franz1981 