### PR TITLE
Add configuration to make the bot push items to projects automatically

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -4,6 +4,20 @@
 features: [ALL]
 workflowRunAnalysis:
   workflows: ["Quarkus CI"]
+projectsClassic:
+  rules:
+    - labels: [area/documentation]
+      project: 21
+      issues: true
+      pullRequests: true
+      status: To do
+projects:
+  rules:
+    - labels: [area/jakarta]
+      project: 13
+      issues: true
+      pullRequests: false
+      status: Todo
 triage:
   discussions:
     monitoredCategories: [33575230]


### PR DESCRIPTION
This for:
- area/jakarta
- area/documentation

Let's experiment with this for a little while and, now that we have the basics, we can fine tune things if needed.