### PR TITLE
Remove support for field-based and constructor-based BuildProducers and forbid build steps that produce nothing

### DIFF
--- a/core/builder/pom.xml
+++ b/core/builder/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
+++ b/core/builder/src/main/java/io/quarkus/builder/BuildStepBuilder.java
@@ -194,6 +194,15 @@ public final class BuildStepBuilder {
      */
     public BuildChainBuilder build() {
         final BuildChainBuilder chainBuilder = this.buildChainBuilder;
+        if (produces.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Build step '" + buildStep.getId()
+                            + "' does not produce any build item and thus will never get executed."
+                            + " Either change the return type of the method to a build item type,"
+                            + " add a parameter of type BuildProducer<[some build item type]>/Consumer<[some build item type]>,"
+                            + " or annotate the method with @Produces."
+                            + " Use @Produce(EmptyBuildItem.class) if you want to always execute this step.");
+        }
         if (BuildChainBuilder.LOG_CONFLICT_CAUSING) {
             chainBuilder.addStep(this, new Exception().getStackTrace());
         } else {

--- a/core/builder/src/test/java/io/quarkus/builder/BasicTests.java
+++ b/core/builder/src/test/java/io/quarkus/builder/BasicTests.java
@@ -1,5 +1,6 @@
 package io.quarkus.builder;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -174,6 +175,32 @@ public class BasicTests {
         final BuildResult result = chain.createExecutionBuilder("my-app.jar").execute();
         assertNotNull(result.consume(DummyItem.class));
         assertFalse(ran.get());
+    }
+
+    @Test
+    public void testMissingProduces() {
+        final BuildChainBuilder builder = BuildChain.builder();
+        BuildStepBuilder stepBuilder = builder.addBuildStep(new BuildStep() {
+            @Override
+            public void execute(final BuildContext context) {
+                context.produce(new DummyItem());
+            }
+
+            @Override
+            public String getId() {
+                return "myBuildStepId";
+            }
+        });
+        stepBuilder.consumes(DummyItem.class);
+        assertThatThrownBy(stepBuilder::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContainingAll(
+                        "Build step 'myBuildStepId'",
+                        "does not produce any build item and thus will never get executed",
+                        "change the return type of the method to a build item type",
+                        "add a parameter of type BuildProducer<[some build item type]>/Consumer<[some build item type]>",
+                        "annotate the method with @Produces",
+                        "Use @Produce(EmptyBuildItem.class) if you want to always execute this step");
     }
 
     @Test

--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/Overridable.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/Overridable.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
  * Indicate that the given produced item is produced only if no other steps produce that item.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Target({ ElementType.METHOD, ElementType.PARAMETER })
 public @interface Overridable {
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/annotations/Weak.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/annotations/Weak.java
@@ -10,6 +10,6 @@ import java.lang.annotation.Target;
  * by a step, the step is not included. If applied to a method, the return value of the method is considered "weak".
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Target({ ElementType.METHOD, ElementType.PARAMETER })
 public @interface Weak {
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -77,6 +77,7 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanTypeExclusion;
 import io.quarkus.arc.deployment.staticmethods.InterceptedStaticMethodsTransformersRegisteredBuildItem;
 import io.quarkus.arc.processor.DotNames;
+import io.quarkus.builder.item.EmptyBuildItem;
 import io.quarkus.datasource.common.runtime.DataSourceUtil;
 import io.quarkus.datasource.common.runtime.DatabaseKind;
 import io.quarkus.deployment.Capabilities;
@@ -87,6 +88,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
 import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
@@ -197,6 +199,7 @@ public final class HibernateOrmProcessor {
     }
 
     @BuildStep
+    @Produce(EmptyBuildItem.class)
     void checkTransactionsSupport(Capabilities capabilities) {
         // JTA is necessary for blocking Hibernate ORM but not necessarily for Hibernate Reactive
         if (capabilities.isMissing(Capability.TRANSACTIONS)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
@@ -17,12 +17,14 @@ import org.jboss.jandex.IndexView;
 import org.jboss.resteasy.reactive.common.util.RestMediaType;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.builder.item.EmptyBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.GeneratedClassGizmoAdaptor;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -83,6 +85,7 @@ final class LinksProcessor {
     }
 
     @BuildStep
+    @Produce(EmptyBuildItem.class)
     void validateJsonNeededForHal(Capabilities capabilities,
             ResteasyReactiveResourceMethodEntriesBuildItem resourceMethodEntriesBuildItem) {
         boolean isHalSupported = capabilities.isPresent(Capability.HAL);


### PR DESCRIPTION
The main goal was to forbid build steps that produce nothing, because those are never going to be executed: they are basically either a bug or dead code in an extension. It turns out we had several such build steps in Quarkus Core, which were never going to be executed.

But it was unclear to me what would happen when a build step produces build items through build producers injected into the constructors and/or fields. Since that injection is a legacy, deprecated feature (nowadays we expect build producers to be passed to the build step method directly, or the build step method to return a build item directly), I proposed that we remove that feature (see https://groups.google.com/g/quarkus-dev/c/JUwVPsAYVP0/m/SMcjGzu6CwAJ), which was agreed upon. Hence the first two commits.