### PR TITLE
Enable SSL by default for SmallRye GraphQL Client

### DIFF
--- a/docs/src/main/asciidoc/native-and-ssl.adoc
+++ b/docs/src/main/asciidoc/native-and-ssl.adoc
@@ -106,6 +106,7 @@ As SSL is de facto the standard nowadays, we decided to enable its support autom
  * the Redis client extension (`quarkus-redis-client`),
  * the REST Client extension (`quarkus-rest-client`),
  * the REST Client Reactive extension (`quarkus-rest-client-reactive`),
+ * the SmallRye GraphQL Client extension (`quarkus-smallrye-graphql-client`),
  * the Spring Cloud Config client extension (`quarkus-spring-cloud-config-client`),
  * the Vault extension (`quarkus-vault`),
  * the Cassandra client extensions (`cassandra-quarkus-client`)

--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -26,6 +26,7 @@ import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageProxyDefinitionBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -47,6 +48,11 @@ public class SmallRyeGraphQLClientProcessor {
     @BuildStep
     void feature(BuildProducer<FeatureBuildItem> featureProducer) {
         featureProducer.produce(new FeatureBuildItem(Feature.SMALLRYE_GRAPHQL_CLIENT));
+    }
+
+    @BuildStep
+    ExtensionSslNativeSupportBuildItem activateSslNativeSupport() {
+        return new ExtensionSslNativeSupportBuildItem(Feature.SMALLRYE_GRAPHQL_CLIENT);
     }
 
     @BuildStep


### PR DESCRIPTION
Since
https://github.com/quarkusio/quarkus-quickstarts/commit/c8501a59d5af84b3e6ff3b0de9400830208bb24b,
the SmallRye GraphQL Client fails in native because no SSL is enabled.
I think similarly to all other clients, the SmallRye GraphQL one should
enable SSL in native by default.