### PR TITLE
Skip tests for snapshots deployment

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -44,7 +44,7 @@ jobs:
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
         run: |
           ./mvnw -e -B --settings .github/mvn-settings.xml \
-            -DskipITs -Dno-format -Dinvoker.skip=true \
+            -DskipTests -DskipITs -Dno-format -Dinvoker.skip=true \
             -DretryFailedDeploymentCount=10 \
             -pl !integration-tests/gradle \
             clean deploy


### PR DESCRIPTION
I am the one who asked for tests but in the end it's counter productive
as, as soon as we have a flaky test failing, we don't have our
snapshots published.
Let's be lighter on the testing.