### PR TITLE
Replace InputStream bytes with InputStream.readAllBytes in Vert.x

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -3,7 +3,6 @@ package io.quarkus.vertx.http.runtime;
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setCurrentContextSafe;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -998,13 +997,7 @@ public class VertxHttpRecorder {
     }
 
     private static byte[] doRead(InputStream is) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024];
-        int r;
-        while ((r = is.read(buf)) > 0) {
-            out.write(buf, 0, r);
-        }
-        return out.toByteArray();
+        return is.readAllBytes();
     }
 
     private static HttpServerOptions createHttpServerOptions(


### PR DESCRIPTION
This not only results is less code, but it's also more efficient as
it generally results in less array copying