### PR TITLE
Replace InputStream bytes with InputStream.readAllBytes in RESTEasy Reactive

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/MessageReaderUtil.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/providers/serialisers/MessageReaderUtil.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.common.providers.serialisers;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -22,13 +21,7 @@ public class MessageReaderUtil {
     }
 
     public static byte[] readBytes(InputStream entityStream) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        byte[] buf = new byte[1024]; //TODO: fix, needs a pure vert.x async read model
-        int r;
-        while ((r = entityStream.read(buf)) > 0) {
-            out.write(buf, 0, r);
-        }
-        return out.toByteArray();
+        return entityStream.readAllBytes();
     }
 
     public static String readString(InputStream entityStream, MediaType mediaType) throws IOException {


### PR DESCRIPTION
This not only results is less code, but it's also more efficient as
it generally results in less array copying