### PR TITLE
Restore the original sync-web-site.sh

### DIFF
--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ $BRANCH == "main" ]]; then
-  TARGET_GUIDES=target/web-site/_versions/main/guides
+  TARGET_GUIDES=target/web-site/_guides
   TARGET_CONFIG=target/web-site/_generated-config/latest
 else
   TARGET_GUIDES=target/web-site/_versions/${BRANCH}/guides
@@ -59,7 +59,7 @@ Run one of the following command to check the web site (if not done already):
   - you may need to add an environment variable if you are running rootless: -e JEKYLL_ROOTLESS=1
   - More: https://github.com/envygeeks/jekyll-docker/blob/master/README.md
 
-- For either docker/podman, you may want to add a volume to store built bundles:
+- For either Docker/Podman, you may want to add a volume to store built bundles:
       docker volume create quarkus-jekyll-bundles
   - Add the volume to the command: --volume quarkus-jekyll-bundles:/usr/local/bundle
 "


### PR DESCRIPTION
Nobody should run this script except me for the releases.

Related to https://github.com/quarkusio/quarkus/pull/27076 . The publication of the documentation when releasing was broken.

/cc @ebullient please make sure you haven't documented that people should use this script: they shouldn't by any means. And make sure that the documentation team is aware of this.

- The main doc is published every night by a separate process
- This script is used to sync the doc for releases