### PR TITLE
Better scope and error messages for Hibernate Search beans

### DIFF
--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchCdiProcessor.java
@@ -3,8 +3,8 @@ package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 import java.util.List;
 import java.util.function.Supplier;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
-import javax.inject.Singleton;
 
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
@@ -54,7 +54,9 @@ public class HibernateSearchElasticsearchCdiProcessor {
             Class<T> type, Supplier<T> supplier) {
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
                 .configure(type)
-                .scope(Singleton.class)
+                // NOTE: this is using ApplicationScoped and not Singleton, by design, in order to be mockable
+                // See https://github.com/quarkusio/quarkus/issues/16437
+                .scope(ApplicationScoped.class)
                 .unremovable()
                 .supplier(supplier)
                 .setRuntimeInit();

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigActiveFalseAndIndexedEntityTest.java
@@ -33,8 +33,9 @@ public class ConfigActiveFalseAndIndexedEntityTest {
     public void test() {
         assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(
-                        "Cannot retrieve the SearchMapping: Hibernate Search was deactivated through configuration properties");
+                .hasMessageContainingAll(
+                        "Cannot retrieve the SearchMapping for persistence unit <default>",
+                        "Hibernate Search was deactivated through configuration properties");
 
         assertThatThrownBy(() -> Search.mapping(sessionFactory))
                 .isInstanceOf(SearchException.class)
@@ -42,8 +43,9 @@ public class ConfigActiveFalseAndIndexedEntityTest {
 
         assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(
-                        "Cannot retrieve the SearchSession: Hibernate Search was deactivated through configuration properties");
+                .hasMessageContainingAll(
+                        "Cannot retrieve the SearchSession for persistence unit <default>",
+                        "Hibernate Search was deactivated through configuration properties");
 
         try (Session session = sessionFactory.openSession()) {
             assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
@@ -1,22 +1,12 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import javax.inject.Inject;
-
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.mapping.SearchMapping;
-import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.common.SearchException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.arc.Arc;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -35,31 +25,8 @@ public class ConfigEnabledFalseAndActiveTrueTest {
                             "If you want Hibernate Search to be active at runtime, you must set 'quarkus.hibernate-search-orm.enabled' to 'true' at build time",
                             "If you don't want Hibernate Search to be active at runtime, you must leave 'quarkus.hibernate-search-orm.active' unset or set it to 'false'"));
 
-    @Inject
-    SessionFactory sessionFactory;
-
     @Test
     public void test() {
-        assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll(
-                        "Cannot retrieve the SearchMapping for persistence unit <default>",
-                        "Hibernate Search was disabled through configuration properties");
-
-        assertThatThrownBy(() -> Search.mapping(sessionFactory))
-                .isInstanceOf(SearchException.class)
-                .hasMessageContaining("Hibernate Search was not initialized.");
-
-        assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll(
-                        "Cannot retrieve the SearchSession for persistence unit <default>",
-                        "Hibernate Search was disabled through configuration properties");
-
-        try (Session session = sessionFactory.openSession()) {
-            assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))
-                    .isInstanceOf(SearchException.class)
-                    .hasMessageContaining("Hibernate Search was not initialized.");
-        }
+        // Startup should fail
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
@@ -42,8 +42,9 @@ public class ConfigEnabledFalseAndActiveTrueTest {
     public void test() {
         assertThatThrownBy(() -> Arc.container().instance(SearchMapping.class).get())
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(
-                        "Cannot retrieve the SearchMapping: Hibernate Search was disabled through configuration properties");
+                .hasMessageContainingAll(
+                        "Cannot retrieve the SearchMapping for persistence unit <default>",
+                        "Hibernate Search was disabled through configuration properties");
 
         assertThatThrownBy(() -> Search.mapping(sessionFactory))
                 .isInstanceOf(SearchException.class)
@@ -51,8 +52,9 @@ public class ConfigEnabledFalseAndActiveTrueTest {
 
         assertThatThrownBy(() -> Arc.container().instance(SearchSession.class).get())
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(
-                        "Cannot retrieve the SearchSession: Hibernate Search was disabled through configuration properties");
+                .hasMessageContainingAll(
+                        "Cannot retrieve the SearchSession for persistence unit <default>",
+                        "Hibernate Search was disabled through configuration properties");
 
         try (Session session = sessionFactory.openSession()) {
             assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndActiveTrueTest.java
@@ -20,7 +20,7 @@ public class ConfigEnabledFalseAndActiveTrueTest {
             .overrideConfigKey("quarkus.hibernate-search-orm.active", "true")
             .assertException(throwable -> assertThat(throwable)
                     .isInstanceOf(ConfigurationException.class)
-                    .hasMessageContaining(
+                    .hasMessageContainingAll(
                             "Hibernate Search activated explicitly, but Hibernate Search was disabled at build time",
                             "If you want Hibernate Search to be active at runtime, you must set 'quarkus.hibernate-search-orm.enabled' to 'true' at build time",
                             "If you don't want Hibernate Search to be active at runtime, you must leave 'quarkus.hibernate-search-orm.active' unset or set it to 'false'"));

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndIndexedEntityTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/ConfigEnabledFalseAndIndexedEntityTest.java
@@ -31,21 +31,30 @@ public class ConfigEnabledFalseAndIndexedEntityTest {
     SessionFactory sessionFactory;
 
     @Test
-    public void test() {
+    public void searchMapping() {
+        // The bean is not defined during static init, so it's null.
         assertThat(Arc.container().instance(SearchMapping.class).get())
                 .isNull();
 
+        // Hibernate Search APIs throw exceptions,
+        // even if the messages are not very explicit (we can't really do better).
         assertThatThrownBy(() -> Search.mapping(sessionFactory))
                 .isInstanceOf(SearchException.class)
-                .hasMessageContaining("Hibernate Search was not initialized.");
+                .hasMessageContaining("Hibernate Search was not initialized");
+    }
 
+    @Test
+    public void searchSession() {
+        // The bean is not defined during static init, so it's null.
         assertThat(Arc.container().instance(SearchSession.class).get())
                 .isNull();
 
+        // Hibernate Search APIs throw exceptions,
+        // even if the messages are not very explicit (we can't really do better).
         try (Session session = sessionFactory.openSession()) {
             assertThatThrownBy(() -> Search.session(session).search(IndexedEntity.class))
                     .isInstanceOf(SearchException.class)
-                    .hasMessageContaining("Hibernate Search was not initialized.");
+                    .hasMessageContaining("Hibernate Search was not initialized");
         }
     }
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRecorder.java
@@ -107,7 +107,8 @@ public class HibernateSearchElasticsearchRecorder {
                         .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
                 if (puRuntimeConfig != null && !puRuntimeConfig.active.orElse(true)) {
                     throw new IllegalStateException(
-                            "Cannot retrieve the SearchMapping: Hibernate Search was deactivated through configuration properties");
+                            "Cannot retrieve the SearchMapping for persistence unit " + persistenceUnitName
+                                    + ": Hibernate Search was deactivated through configuration properties");
                 }
                 SessionFactory sessionFactory;
                 if (isDefaultPersistenceUnit) {
@@ -130,7 +131,8 @@ public class HibernateSearchElasticsearchRecorder {
                         .getAllPersistenceUnitConfigsAsMap().get(persistenceUnitName);
                 if (puRuntimeConfig != null && !puRuntimeConfig.active.orElse(true)) {
                     throw new IllegalStateException(
-                            "Cannot retrieve the SearchSession: Hibernate Search was deactivated through configuration properties");
+                            "Cannot retrieve the SearchSession for persistence unit " + persistenceUnitName
+                                    + ": Hibernate Search was deactivated through configuration properties");
                 }
                 Session session;
                 if (isDefaultPersistenceUnit) {


### PR DESCRIPTION
This is mainly to be consistent with Hibernate ORM.

It also improves things slightly: beans involved in static init can now be injected with `SearchMapping`, as long as they don't use it until runtime init.