### PR TITLE
Ensure that dev services properties are cleared in QuarkusIntegrationTestExtension

### DIFF
--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/BookResourceTest.java
@@ -10,18 +10,12 @@ import javax.json.bind.Jsonb;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.mongodb.health.MongoHealthCheck;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoTestResource;
 import io.restassured.RestAssured;
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource.class)
-@DisabledOnOs(OS.WINDOWS)
 public class BookResourceTest {
     private static Jsonb jsonb;
 

--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/BookResourceWithParameterInjectionTest.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/BookResourceWithParameterInjectionTest.java
@@ -8,12 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.mongodb.MongoTestResource;
 
 @QuarkusTest
-@QuarkusTestResource(MongoTestResource.class)
 @DisabledOnOs(OS.WINDOWS)
 public class BookResourceWithParameterInjectionTest {
 

--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/DummyTestProfile.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/DummyTestProfile.java
@@ -1,0 +1,6 @@
+package io.quarkus.it.mongodb;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DummyTestProfile implements QuarkusTestProfile {
+}

--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/OtherProfileBookResourceIT.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/OtherProfileBookResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.mongodb;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class OtherProfileBookResourceIT extends OtherProfileBookResourceTest {
+}

--- a/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/OtherProfileBookResourceTest.java
+++ b/integration-tests/mongodb-devservices/src/test/java/io/quarkus/it/mongodb/OtherProfileBookResourceTest.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.mongodb;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DummyTestProfile.class)
+public class OtherProfileBookResourceTest {
+
+    @Test
+    public void testBlockingClient() {
+        Utils.callTheEndpoint("/books");
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -120,6 +120,9 @@ public class NativeTestExtension
             Class<?> requiredTestClass = context.getRequiredTestClass();
 
             Map<String, String> sysPropRestore = getSysPropsToRestore();
+            for (String devServicesProp : devServicesProps.keySet()) {
+                sysPropRestore.put(devServicesProp, null); // used to signal that the property needs to be cleared
+            }
             TestProfileAndProperties testProfileAndProperties = determineTestProfileAndProperties(profile, sysPropRestore);
 
             testResourceManager = new TestResourceManager(requiredTestClass, quarkusTestProfile,

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -175,7 +175,7 @@ public class QuarkusIntegrationTestExtension
                     System.setProperty(i.getKey(), i.getValue());
                 }
             }
-            context.getStore(ExtensionContext.Namespace.GLOBAL).put(NativeTestExtension.class.getName() + ".systemProps",
+            context.getStore(ExtensionContext.Namespace.GLOBAL).put(QuarkusIntegrationTestExtension.class.getName() + ".systemProps",
                     new ExtensionContext.Store.CloseableResource() {
                         @Override
                         public void close() throws Throwable {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -149,6 +149,9 @@ public class QuarkusIntegrationTestExtension
             Class<?> requiredTestClass = context.getRequiredTestClass();
 
             Map<String, String> sysPropRestore = getSysPropsToRestore();
+            for (String devServicesProp : devServicesProps.keySet()) {
+                sysPropRestore.put(devServicesProp, null); // used to signal that the property needs to be cleared
+            }
             TestProfileAndProperties testProfileAndProperties = determineTestProfileAndProperties(profile, sysPropRestore);
 
             testResourceManager = new TestResourceManager(requiredTestClass, quarkusTestProfile,
@@ -175,7 +178,8 @@ public class QuarkusIntegrationTestExtension
                     System.setProperty(i.getKey(), i.getValue());
                 }
             }
-            context.getStore(ExtensionContext.Namespace.GLOBAL).put(QuarkusIntegrationTestExtension.class.getName() + ".systemProps",
+            context.getStore(ExtensionContext.Namespace.GLOBAL).put(
+                    QuarkusIntegrationTestExtension.class.getName() + ".systemProps",
                     new ExtensionContext.Store.CloseableResource() {
                         @Override
                         public void close() throws Throwable {


### PR DESCRIPTION
This is needed to ensure the subsequent tests that need to relaunch dev-services
because of the use a different test profile

Fixes: #27075