### PR TITLE
Make org.graalvm.regex:regex parent first

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -147,6 +147,7 @@
                         <parentFirstArtifact>org.wildfly.common:wildfly-common</parentFirstArtifact>
                         <parentFirstArtifact>org.graalvm.sdk:graal-sdk</parentFirstArtifact>
                         <parentFirstArtifact>org.graalvm.js:js</parentFirstArtifact>
+                        <parentFirstArtifact>org.graalvm.regex:regex</parentFirstArtifact>
                         <parentFirstArtifact>org.graalvm.truffle:truffle-api</parentFirstArtifact>
                         <parentFirstArtifact>org.graalvm.nativeimage:svm</parentFirstArtifact>
                         <parentFirstArtifact>io.quarkus:quarkus-bootstrap-core</parentFirstArtifact>


### PR DESCRIPTION
Fixes #27085

@rvansa can you try if this PR fixes your issue?
Also, if there are just a couple of artifacts that need syncing with the GraalVM version, maybe we could add them to the BOM if it makes things significantly easier. Let me know if you have a list. (I'm not really inclined to add 20 of them for such a use case but if it's 2 or 3, that could work)