### PR TITLE
Override target port used when creating openshift route

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyRouteTargetPortDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ApplyRouteTargetPortDecorator.java
@@ -1,0 +1,27 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.RoutePort;
+import io.fabric8.openshift.api.model.RouteSpecFluent;
+
+public class ApplyRouteTargetPortDecorator extends NamedResourceDecorator<RouteSpecFluent<?>> {
+
+    private IntOrString targetPort;
+
+    public ApplyRouteTargetPortDecorator(Integer port) {
+        super(ANY);
+        targetPort = new IntOrString(port);
+    }
+
+    public ApplyRouteTargetPortDecorator(String port) {
+        super(ANY);
+        targetPort = new IntOrString(port);
+    }
+
+    @Override
+    public void andThenVisit(RouteSpecFluent routeSpecFluent, ObjectMeta objectMeta) {
+        routeSpecFluent.withPort(new RoutePort(targetPort));
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -552,4 +552,8 @@ public class OpenshiftConfig implements PlatformConfiguration {
     public DeploymentResourceKind getDeploymentResourceKind() {
         return deploymentKind.orElse(DeploymentResourceKind.DeploymentConfig);
     }
+
+    public Optional<RouteConfig> getRoute() {
+        return Optional.ofNullable(route);
+    }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftProcessor.java
@@ -305,6 +305,12 @@ public class OpenshiftProcessor {
                 .findFirst().orElse(DEFAULT_HTTP_PORT);
         result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyHttpGetActionPortDecorator(name, name, port)));
 
+        // Route target port override
+        config.getRoute().ifPresentOrElse(
+                r -> result.add(new DecoratorBuildItem(OPENSHIFT,
+                        new ApplyRouteTargetPortDecorator(r.targetPort.orElse(HTTP_PORT)))),
+                () -> result.add(new DecoratorBuildItem(OPENSHIFT, new ApplyRouteTargetPortDecorator(HTTP_PORT))));
+
         // Handle non-openshift builds
         if (deploymentResourceKind == DeploymentResourceKind.DeploymentConfig
                 && !OpenshiftConfig.isOpenshiftBuildEnabled(containerImageConfig, capabilities)) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RouteConfig.java
@@ -27,4 +27,10 @@ public class RouteConfig {
     @ConfigItem
     Map<String, String> annotations;
 
+    /**
+     * Port of the Service to bind to
+     */
+    @ConfigItem
+    Optional<String> targetPort;
+
 }

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesCustomServicePortTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithRoutePropertiesCustomServicePortTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.kubernetes;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -16,14 +17,14 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class OpenshiftWithRoutePropertiesTest {
+public class OpenshiftWithRoutePropertiesCustomServicePortTest {
 
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
             .setApplicationName("openshift")
             .setApplicationVersion("0.1-SNAPSHOT")
-            .withConfigurationResource("openshift-with-route.properties");
+            .withConfigurationResource("openshift-with-route-custom-service-port.properties");
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
@@ -63,7 +64,7 @@ public class OpenshiftWithRoutePropertiesTest {
                     assertThat(m.getAnnotations()).contains(entry("kubernetes.io/tls-acme", "true"));
                     assertThat(m.getNamespace()).isEqualTo("applications");
                 });
-                assertThat(r.getSpec().getPort().getTargetPort().getStrVal()).isEqualTo("http");
+                assertThat(r.getSpec().getPort().getTargetPort().getStrVal()).isEqualTo("my-port");
                 assertThat(r.getSpec().getHost()).isEqualTo("foo.bar.io");
             });
         });

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-custom-service-port.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-route-custom-service-port.properties
@@ -1,0 +1,14 @@
+quarkus.http.port=9090
+quarkus.kubernetes.deployment-target=openshift
+quarkus.openshift.name=test-it
+quarkus.openshift.namespace=applications
+quarkus.openshift.labels.foo=bar
+quarkus.openshift.annotations.bar=baz
+quarkus.openshift.group=grp
+
+quarkus.openshift.route.expose=true
+quarkus.openshift.route.host=foo.bar.io
+quarkus.openshift.route.annotations."kubernetes.io/tls-acme"=true
+quarkus.openshift.route-target-port=my-port
+
+quarkus.s2i.registry=quay.io


### PR DESCRIPTION
Addressing issue https://github.com/quarkusio/quarkus/issues/26587

WIP, wanted to check with @geoand and/or @iocanel if you're happy with this approach? This change should have broken one of the ITs which I will update and extend if you think I'm heading in the right direction with this