### PR TITLE
Fix Opentelemetry docs

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -129,15 +129,12 @@ receivers:
     protocols:
       grpc:
         endpoint: otel-collector:4317
-  otlp/2:
-    protocols:
-      grpc:
-        endpoint: otel-collector:55680
 
 exporters:
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:
@@ -167,8 +164,8 @@ services:
     image: jaegertracing/all-in-one:latest
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+      - "14268:14268"
+      - "14250:14250"
   # Collector
   otel-collector:
     image: otel/opentelemetry-collector:latest
@@ -178,7 +175,6 @@ services:
     ports:
       - "13133:13133" # Health_check extension
       - "4317:4317"   # OTLP gRPC receiver
-      - "55680:55680" # OTLP gRPC receiver alternative port
     depends_on:
       - jaeger-all-in-one
 ----
@@ -189,7 +185,7 @@ include::{includes}/devtools/dev.adoc[]
 
 or if configuring the OTLP gRPC endpoint via JVM arguments:
 
-:dev-additional-parameters: -Djvm.args="-Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:55680"
+:dev-additional-parameters: -Djvm.args="-Dquarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317"
 include::{includes}/devtools/dev.adoc[]
 :!dev-additional-parameters:
 


### PR DESCRIPTION
Removed port 55680 as the default one is 4317 (based on https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md + https://github.com/open-telemetry/opentelemetry-python/issues/1515).

Fixed insecure flag (explained in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5377).

Use fixed ports for jaegertracing container (easier to refer to those numbers).