### PR TITLE
Remove wrong LANG from dockerfile use parent default

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/tooling/dockerfiles/base/Dockerfile-layout.include.qute
@@ -77,7 +77,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/openjdk-{java.version}:1.11
 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
+ENV LANGUAGE='en_US:en'
 
 {#insert copy /}
 


### PR DESCRIPTION
Default in parent is `LANG="C.utf8"`:
- https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813?container-tabs=dockerfile
- https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?container-tabs=dockerfile

According to https://access.redhat.com/solutions/5211991 , the UBI image has glibc-minimal-langpack is installed by default for C, POSIX and C.UTF-8 locales. To use `en_US.utf8`, glibc-langpack-en would need to be installed but using `LANG="C.utf8"` should be ok.



 