### PR TITLE
Upgrade to Hibernate Search 6.1.6.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -92,7 +92,7 @@
         <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.7.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
-        <hibernate-search.version>6.1.5.Final</hibernate-search.version>
+        <hibernate-search.version>6.1.6.Final</hibernate-search.version>
         <narayana.version>5.12.7.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.16</agroal.version>


### PR DESCRIPTION
https://in.relation.to/2022/08/04/hibernate-search-6-1-6-Final

Highlights:

> This release mainly upgrades to Hibernate ORM 5.6.10.Final, upgrades to Hibernate ORM 6.0.2.Final and compatibility with Hibernate ORM 6.1.2.Final for -orm6 artifacts, upgrades to the latest version of Jakarta dependencies for -orm6/-jakarta artifacts, adds compatibility with CockroachDB, and fixes several bugs.
