### PR TITLE
Docs - fix 404 Smallrye Config URL by replacing `latest` with variable

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,6 +23,8 @@
         <quarkus-home-url>https://quarkus.io</quarkus-home-url>
         <quarkus-base-url>https://github.com/quarkusio/quarkus</quarkus-base-url>
         <quickstarts-base-url>https://github.com/quarkusio/quarkus-quickstarts</quickstarts-base-url>
+        <!-- DO NOT MODIFY MANUALLY: smallrye-config.version is managed by the Dependabot -->
+        <smallrye-config.version>2.11.1</smallrye-config.version>
     </properties>
 
     <name>Quarkus - Documentation</name>
@@ -2840,6 +2842,7 @@
                         <!-- avoid content security policy violations -->
                         <skip-front-matter>true</skip-front-matter>
 
+                        <smallrye-config-version>${smallrye-config.version}</smallrye-config-version>
                         <quarkus-version>${project.version}</quarkus-version>
                         <surefire-version>${version.surefire.plugin}</surefire-version>
                         <graalvm-version>${graal-sdk.version-for-documentation}</graalvm-version>
@@ -2952,6 +2955,13 @@
                         <groupId>${project.groupId}</groupId>
                         <artifactId>${project.artifactId}</artifactId>
                         <version>${project.version}</version>
+                    </dependency>
+                    <!-- Dependabot will only update config property 'smallrye-config.version' if some of our dependencies is using it -->
+                    <!-- 'smallrye-config.version' is used as a documentation attribute and need to stay up to date -->
+                    <dependency>
+                        <groupId>io.smallrye.config</groupId>
+                        <artifactId>smallrye-config-common</artifactId>
+                        <version>${smallrye-config.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/docs/src/main/asciidoc/config-reference.adoc
+++ b/docs/src/main/asciidoc/config-reference.adoc
@@ -62,7 +62,7 @@ the value `youshallnotpass` to the attribute `quarkus.datasource.password`.
 NOTE: Environment variables names follow the conversion rules specified by
 link:https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#default-configsources[MicroProfile Config].
 
-NOTE: SmallRye Config specifies link:https://smallrye.io/smallrye-config/latest/config/environment-variables/[additional conversion rules].
+NOTE: SmallRye Config specifies link:https://smallrye.io/smallrye-config/{smallrye-config-version}/config/environment-variables/[additional conversion rules].
 
 [[env-file]]
 === `.env` file in the current working directory
@@ -561,7 +561,7 @@ Quarkus relies on link:https://github.com/smallrye/smallrye-config/[SmallRye Con
 * Hide secrets
 
 For more information, please check the
-link:https://smallrye.io/smallrye-config/latest[SmallRye Config documentation].
+link:https://smallrye.io/smallrye-config/{smallrye-config-version}[SmallRye Config documentation].
 
 == Configuration Reference
 

--- a/docs/src/main/asciidoc/config.adoc
+++ b/docs/src/main/asciidoc/config.adoc
@@ -128,7 +128,7 @@ public String hello() {
 ----
 
 TIP: Use `@io.smallrye.config.ConfigMapping` annotation to group multiple configurations in a single interface. Please,
-check the https://smallrye.io/smallrye-config/latest/config/mappings/[Config Mappings] documentation.
+check the https://smallrye.io/smallrye-config/{smallrye-config-version}/config/mappings/[Config Mappings] documentation.
 
 == Update the test
 
@@ -240,4 +240,4 @@ Quarkus relies on link:https://github.com/smallrye/smallrye-config/[SmallRye Con
 * Hide secrets
 
 For more information, please check the
-link:https://smallrye.io/smallrye-config/latest/[SmallRye Config documentation].
+link:https://smallrye.io/smallrye-config/{smallrye-config-version}[SmallRye Config documentation].

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -193,4 +193,6 @@ complete list of externalized variables for use is given in the following table:
 
 |\{graalvm-version}|{graalvm-version}| Recommended GraalVM version to use.
 |\{graalvm-flavor}|{graalvm-flavor}| The full flavor of GraalVM to use e.g. `19.3.1-java11`. Make sure to use a `java11` version.
+
+|\{smallrye-config-version}|{smallrye-config-version}| The current version of the Smallrye Config used by the Quarkus.
 |===


### PR DESCRIPTION
URL `https://smallrye.io/smallrye-config/latest` leads to `NOT FOUND`, this PR replaces hard coded `latest` with variable - the version of the Smallrye Config used by the Quarkus. The way I read the Dependabot reference guide, it requires some dependency (won't update just property without dependency). I have limited experience with the Dependabot though.

I added tiny dep `smallrye-config-common` to the plugin dependencies. I also checked and `docs/pom.xml` is among files monitored by the Dependabot, so whenever `smallrye-config.version` in BOM is updated, newly added version should also be updated.