### PR TITLE
Update docs website sync script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nb-configuration.xml
 .jbang
 .sdkmanrc
 .envrc
+.jekyll-cache


### PR DESCRIPTION
The script used to sync docs to the website is used in a few places. Would like to simplify that so it is easier to update files that should be ignored, etc.

Updates to this script ensure that it can be used for three use cases: (1) Release-time promotion of docs to latest; (2) nightly clone of docs from main into a snapshot version on the website; (3) local build for previewing.

The update to this file requires two changes: 

1. The build script to update docs at release time should add `QUARKUS_RELEASE=true`
2. https://github.com/quarkusio/quarkusio.github.io/blob/develop/.github/workflows/sync-main-doc.yml should be updated to use this script instead of defining its own rsync commands that have to be separately maintained.

For local use, this script is invoked with no arguments.