### PR TITLE
Add MacOS M1 runs to incremental builds

### DIFF
--- a/.github/filter-jvm-tests-json.sh
+++ b/.github/filter-jvm-tests-json.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")
+
+# Filter out mac os from a matrix of build configurations.
+# The reason we do this is that running mac on a fork won't work; the fork won't have a self-hosted runner
+
+# See https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
+
+repoName=${GITHUB_REPOSITORY}
+
+if [[ $repoName == "quarkusio/quarkus" ]]
+then
+    matrix=$(cat $BASEDIR/matrix-jvm-tests.json)
+else
+  # Use jq to read in a json file that represents the matrix configuration.
+  matrix=$(jq 'map(. | select(.["os-name"]!="macos-arm64-latest"))' $BASEDIR/matrix-jvm-tests.json)
+fi
+
+echo \{java: ${matrix}\}

--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -1,0 +1,36 @@
+[ {
+  "name": "11",
+  "java-version": 11,
+  "maven_args": "$JVM_TEST_MAVEN_ARGS",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
+  "os-name": "ubuntu-latest"
+}
+, {
+  "name": "17",
+  "java-version": 17,
+  "maven_args": "$JVM_TEST_MAVEN_ARGS",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
+  "os-name": "ubuntu-latest"
+}
+, {
+  "name": "18",
+  "java-version": 18,
+  "maven_args": "$JVM_TEST_MAVEN_ARGS",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
+  "os-name": "ubuntu-latest"
+}
+, {
+  "name": "11 Windows",
+  "java-version": 11,
+  "maven_args": "-DskipDocs -Dformat.skip",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g -Xlog:gc*=debug:file=windows-java-11.txt",
+ "os-name": "windows-latest"
+}
+, {
+  "name": "17 MacOS M1",
+  "java-version": 17,
+  "maven_args": "-DskipDocs -Dformat.skip",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
+  "architecture": "aarch64",
+  "os-name": "macos-arm64-latest"
+}]

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -222,6 +222,7 @@ jobs:
       GIB_IMPACTED_MODULES: ${{ needs.build-jdk11.outputs.gib_impacted }}
     outputs:
       native_matrix: ${{ steps.calc-native-matrix.outputs.matrix }}
+      jvm_matrix: ${{ steps.calc-jvm-matrix.outputs.matrix }}
       run_jvm: ${{ steps.calc-run-flags.outputs.run_jvm }}
       run_devtools: ${{ steps.calc-run-flags.outputs.run_devtools }}
       run_gradle: ${{ steps.calc-run-flags.outputs.run_gradle }}
@@ -234,6 +235,12 @@ jobs:
         run: |
           echo "GIB_IMPACTED_MODULES: ${GIB_IMPACTED_MODULES}"
           json=$(.github/filter-native-tests-json.sh "${GIB_IMPACTED_MODULES}" | tr -d '\n')
+          echo "${json}"
+          echo "::set-output name=matrix::${json}"
+      - name: Calculate matrix from matrix-jvm-tests.json
+        id: calc-jvm-matrix
+        run: |
+          json=$(.github/filter-jvm-tests-json.sh)
           echo "${json}"
           echo "::set-output name=matrix::${json}"
       - name: Calculate run flags
@@ -267,40 +274,12 @@ jobs:
       MAVEN_OPTS: ${{ matrix.java.maven_opts }}
     strategy:
       fail-fast: false
-      matrix:
-        java:
-          - {
-            name: "11",
-            java-version: 11,
-            maven_args: "$JVM_TEST_MAVEN_ARGS",
-            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
-            os-name: "ubuntu-latest"
-          }
-          - {
-            name: "17",
-            java-version: 17,
-            maven_args: "$JVM_TEST_MAVEN_ARGS",
-            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
-            os-name: "ubuntu-latest"
-          }
-          - {
-            name: "18",
-            java-version: 18,
-            maven_args: "$JVM_TEST_MAVEN_ARGS",
-            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g",
-            os-name: "ubuntu-latest"
-          }
-          - {
-            name: "11 Windows",
-            java-version: 11,
-            maven_args: "-DskipDocs -Dformat.skip",
-            maven_opts: "-Xmx2g -XX:MaxMetaspaceSize=1g -Xlog:gc*=debug:file=windows-java-11.txt",
-            os-name: "windows-latest"
-          }
+      matrix: ${{ fromJson(needs.calculate-test-jobs.outputs.jvm_matrix) }}
+
 
     steps:
       - name: Stop mysql
-        if: "!startsWith(matrix.java.os-name, 'windows')"
+        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
         shell: bash
         run: |
           ss -ln
@@ -316,12 +295,12 @@ jobs:
         run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
 
       - name: apt clean
-        if: "!startsWith(matrix.java.os-name, 'windows')"
+        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
         shell: bash
         run: sudo apt-get clean
 
       - name: Reclaim Disk Space
-        if: "!startsWith(matrix.java.os-name, 'windows')"
+        if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
         run: .github/ci-prerequisites.sh
 
       - name: Set up JDK ${{ matrix.java.java-version }}
@@ -329,6 +308,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java.java-version }}
+          architecture: ${{ matrix.java.architecture || 'x64' }}
 
       - name: Download Maven Repo
         uses: actions/download-artifact@v3

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -122,4 +122,31 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Disabled pending fix of #28033 -->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/integration-tests/hibernate-orm-graphql-panache/pom.xml
+++ b/integration-tests/hibernate-orm-graphql-panache/pom.xml
@@ -119,4 +119,31 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Disabled pending fix of #28035 -->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -139,4 +139,30 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Disabled pending fix of #28035 -->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/jackson/pom.xml
+++ b/integration-tests/jackson/pom.xml
@@ -85,4 +85,30 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Disabled pending fix of #28035 -->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/smallrye-config/pom.xml
+++ b/integration-tests/smallrye-config/pom.xml
@@ -190,4 +190,31 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Disabled pending fix of #28057 -->
+    <profile>
+      <id>mac-m1</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -139,4 +139,30 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Disabled pending fix of #28035 -->
+        <profile>
+            <id>mac-m1</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
I have set up a self-hosted runner on a Mac Mini which can now start running builds. Before this PR is merged, we will need to adjust the quarkus repository settings to wire in the runner.

As a first pass, I've added the runner to the JVM matrix in the incremental build. 
- We may also want to add it to the native matrix since that could be a place where we see lots of errors 
- We only have a single machine, so if the load is too high, we may want to move M1 to a less widely used workflow, or a lighter set of tests within the incremental CI workflow, or put a condition on its execution. However, I saw that the ubuntu builds Java 17 took 3 hours and the M1 build took 1 hour (and got further), so we may find that having the fast M1 machine serving build requests is a good way for contributors to get fast feedback.

I disabled some linux-specific steps which are not currently run on windows, so skipping them on mac should also be safe. (Although I wonder about the mongodb one, and whether we should find a platform-agnostic way to stop it if it leaks).

https://github.com/holly-cummins/quarkus/actions/runs/2798189377 has build output for my PR, on a runner I attached to my fork. The [M1 build](https://pipelines.actions.githubusercontent.com/serviceHosts/6988dfa3-64ca-4ca9-84b2-9ac77fd4da30/_apis/pipelines/1/runs/15/signedlogcontent/24?urlExpires=2022-08-05T11%3A32%3A10.4616635Z&urlSigningMethod=HMACV1&urlSignature=kUeih8ySs9hWNniEF7zmf8xPZ%2FaDdn7t0Rq%2BfZttmE8%3D) did not succeed, which isn't totally surprising because we know we have a range of issues on that platform (which is why we want an M1 build!). However, it got about as far as the ubuntu [Java 17 build](https://pipelines.actions.githubusercontent.com/serviceHosts/6988dfa3-64ca-4ca9-84b2-9ac77fd4da30/_apis/pipelines/1/runs/15/signedlogcontent/22?urlExpires=2022-08-05T11%3A36%3A46.3751116Z&urlSigningMethod=HMACV1&urlSignature=xdSBzOvJiud4j0rZzQx9jxH5YGx51enNr0bu058ulZA%3D). Both seemed to fail in the first `extensions` test suite they ran. 

The M1 failure was in mongodb, which makes me a bit nervous that stopping mongo will be needed in some way, especially since self-hosted-runners don't run on a fresh machine each time. I think it might be helpful to iterate on that while the M1 facility is available, to start building up some coverage of how often we see failures and where else they are. For example, I'm surprised I didn't see #25230 in the Actions build. 