### PR TITLE
Workaround a GraalVM + Jakarta Yasson limitation by adding setters

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/ClientResource.java
@@ -204,9 +204,9 @@ public class ClientResource {
         return Multi.createFrom().emitter(emitter -> {
             try {
                 communes.forEach((commune) -> {
-                    commune.codesPostaux.forEach((postalCode) -> {
+                    commune.getCodesPostaux().forEach((postalCode) -> {
                         int level = org.jboss.resteasy.core.ResteasyContext.getContextDataLevelCount();
-                        api.getCommunes(postalCode).forEach(c -> emitter.emit(c.code + "-" + level));
+                        api.getCommunes(postalCode).forEach(c -> emitter.emit(c.getCode() + "-" + level));
                     });
                 });
             } catch (Exception e) {

--- a/integration-tests/main/src/main/java/io/quarkus/it/rest/Commune.java
+++ b/integration-tests/main/src/main/java/io/quarkus/it/rest/Commune.java
@@ -3,15 +3,15 @@ package io.quarkus.it.rest;
 import java.util.Set;
 
 public class Commune {
-    public String code;
-    public String nom;
-    public Set<String> codesPostaux;
-    public String codeDepartement;
-    public String codeRegion;
+    private String code;
+    private String nom;
+    private Set<String> codesPostaux;
+    private String codeDepartement;
+    private String codeRegion;
     // departement
     // region
-    public Integer population;
-    public Float surface;
+    private Integer population;
+    private Float surface;
 
     public Commune() {
     }
@@ -24,5 +24,61 @@ public class Commune {
         this.codeRegion = codeRegion;
         this.codesPostaux = codePostaux;
         this.population = population;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public Set<String> getCodesPostaux() {
+        return codesPostaux;
+    }
+
+    public void setCodesPostaux(Set<String> codesPostaux) {
+        this.codesPostaux = codesPostaux;
+    }
+
+    public String getCodeDepartement() {
+        return codeDepartement;
+    }
+
+    public void setCodeDepartement(String codeDepartement) {
+        this.codeDepartement = codeDepartement;
+    }
+
+    public String getCodeRegion() {
+        return codeRegion;
+    }
+
+    public void setCodeRegion(String codeRegion) {
+        this.codeRegion = codeRegion;
+    }
+
+    public Integer getPopulation() {
+        return population;
+    }
+
+    public void setPopulation(Integer population) {
+        this.population = population;
+    }
+
+    public Float getSurface() {
+        return surface;
+    }
+
+    public void setSurface(Float surface) {
+        this.surface = surface;
     }
 }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Car.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Car.java
@@ -4,5 +4,22 @@ import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 
 @BsonDiscriminator(key = "type", value = "CAR")
 public class Car extends Vehicle {
-    public int seatNumber;
+
+    private int seatNumber;
+
+    public Car() {
+    }
+
+    public Car(String type, String name, int seatNumber) {
+        super(type, name);
+        this.seatNumber = seatNumber;
+    }
+
+    public int getSeatNumber() {
+        return seatNumber;
+    }
+
+    public void setSeatNumber(int seatNumber) {
+        this.seatNumber = seatNumber;
+    }
 }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Moto.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Moto.java
@@ -4,5 +4,22 @@ import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 
 @BsonDiscriminator(key = "type", value = "MOTO")
 public class Moto extends Vehicle {
-    public boolean sideCar;
+
+    private boolean sideCar;
+
+    public Moto() {
+    }
+
+    public Moto(String type, String name, boolean sideCar) {
+        super(type, name);
+        this.sideCar = sideCar;
+    }
+
+    public boolean isSideCar() {
+        return sideCar;
+    }
+
+    public void setSideCar(boolean sideCar) {
+        this.sideCar = sideCar;
+    }
 }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Vehicle.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/Vehicle.java
@@ -4,6 +4,32 @@ import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 
 @BsonDiscriminator(key = "type")
 public abstract class Vehicle {
-    public String type;
-    public String name;
+
+    private String type;
+    private String name;
+
+    public Vehicle() {
+    }
+
+    public Vehicle(String type, String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
 }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/VehicleResource.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/VehicleResource.java
@@ -52,7 +52,8 @@ public class VehicleResource {
     @POST
     public Response addVehicle(Vehicle vehicle) throws UnsupportedEncodingException {
         getCollection().insertOne(vehicle);
-        return Response.created(URI.create("/vehicle/" + URLEncoder.encode(vehicle.name, StandardCharsets.UTF_8.toString())))
+        return Response
+                .created(URI.create("/vehicle/" + URLEncoder.encode(vehicle.getName(), StandardCharsets.UTF_8.toString())))
                 .build();
     }
 }

--- a/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/jsonb/VehicleDeserializer.java
+++ b/integration-tests/mongodb-client/src/main/java/io/quarkus/it/mongodb/discriminator/jsonb/VehicleDeserializer.java
@@ -18,19 +18,11 @@ public class VehicleDeserializer implements JsonbDeserializer<Vehicle> {
         String type = json.getString("type");
         switch (type) {
             case "CAR":
-                Car car = new Car();
-                car.type = type;
-                car.seatNumber = json.getInt("seatNumber");
-                car.name = json.getString("name");
-                return car;
+                return new Car(type, json.getString("name"), json.getInt("seatNumber"));
             case "MOTO":
-                Moto moto = new Moto();
-                moto.type = type;
-                moto.name = json.getString("name");
-                moto.sideCar = json.getBoolean("sideCar");
-                return moto;
+                return new Moto(type, json.getString("name"), json.getBoolean("sideCar"));
             default:
-                throw new RuntimeException("Type " + type + "not managed");
+                throw new RuntimeException("Type " + type + " not managed");
         }
     }
 }

--- a/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/VehicleResourceTest.java
+++ b/integration-tests/mongodb-client/src/test/java/io/quarkus/it/mongodb/VehicleResourceTest.java
@@ -32,17 +32,12 @@ public class VehicleResourceTest {
 
     @Test
     public void testVehicleEndpoint() {
-        Car car = new Car();
-        car.name = "Renault Clio";
-        car.type = "CAR";
-        car.seatNumber = 5;
+        Car car = new Car("CAR", "Renault Clio", 5);
         given().header("Content-Type", "application/json").body(car)
                 .when().post("/vehicles")
                 .then().statusCode(201);
 
-        Moto moto = new Moto();
-        moto.name = "Harley Davidson Sportster";
-        moto.type = "MOTO";
+        Moto moto = new Moto("MOTO", "Harley Davidson Sportster", false);
         given().header("Content-Type", "application/json").body(moto)
                 .when().post("/vehicles")
                 .then().statusCode(201);


### PR DESCRIPTION
This is related to a bug in GraalVM. It just switches things to use getters/setters instead of accessing public fields as it's causing issues with the MethodHandles code in GraalVM.
See https://github.com/quarkusio/quarkus/issues/27064 for all the gory details.

Fixes #27064