### PR TITLE
Make it possible to inject Keycloak admin client

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -887,6 +887,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-flyway</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -1099,6 +1099,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1085,6 +1085,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-keycloak-admin-client-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -1,0 +1,136 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Using Keycloak Admin Client
+
+include::./attributes.adoc[]
+
+The Quarkus Keycloak Admin Client and its reactive twin facilitate running the Keycloak Admin Client in a native mode.
+This guide demonstrates how you can leverage the xref:cdi-reference.adoc[Quarkus ArC] and inject the admin client to your Quarkus application.
+To learn more about the Keycloak Admin Client, please refer to its https://www.keycloak.org/docs/latest/server_development/#example-using-java[reference guide].
+
+== Prerequisites
+
+:prerequisites-docker:
+include::{includes}/prerequisites.adoc[]
+* https://www.keycloak.org/docs/latest/server_installation/index.html[Keycloak]
+
+== Creating the Project
+
+First, we need a new project.
+Create a new project with the following command:
+
+:create-app-artifact-id: security-keycloak-admin-client
+:create-app-extensions: keycloak-admin-client-reactive,resteasy-reactive-jackson
+include::{includes}/devtools/create-app.adoc[]
+
+This command generates a project which imports the `keycloak-admin-client-reactive` and `resteasy-reactive-jackson` extensions.
+
+If you already have your Quarkus project configured, you can add the `keycloak-admin-client-reactive` and `resteasy-reactive-jackson` extensions
+to your project by running the following command in your project base directory:
+
+:add-extension-extensions: keycloak-admin-client-reactive,resteasy-reactive-jackson
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-keycloak-admin-client-reactive")
+implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
+----
+
+We also are going to need a simple resource with a `Keycloak` injected as request scoped CDI bean.
+
+[source,java]
+----
+package org.acme.keycloak.admin.client;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.List;
+
+@Path("/api/admin")
+public class RolesResource {
+
+        @Inject
+        Keycloak keycloak;
+
+        @GET
+        @Path("/roles")
+        public List<RoleRepresentation> getRoles() {
+            return keycloak.realm("quarkus").roles().list();
+        }
+
+}
+----
+
+Now, you can produce the `Keycloak` bean yourself, or you can instruct Quarkus to produce `Keycloak` bean.
+
+NOTE: If you produce the bean yourself, please remember that `org.keycloak.admin.client.Keycloak` implements `AutoCloseable` and it's important to avoid resource exhaustion and related exceptions. If you configure your beans as explained below, Quarkus will do it for you.
+
+The Keycloak admin client needs an access token as its Admin REST API requires authorization.
+If you exchange user's credentials for the access token, here is an example configuration for the `password` grant type:
+
+[source,properties]
+----
+quarkus.keycloak.admin-client=true
+quarkus.keycloak.admin-client.server-url=http://localhost:8081
+quarkus.keycloak.admin-client.realm=quarkus
+quarkus.keycloak.admin-client.client-id=quarkus-client
+quarkus.keycloak.admin-client.username=alice
+quarkus.keycloak.admin-client.password=alice
+quarkus.keycloak.admin-client.grant-type=PASSWORD <1>
+----
+<1> Use `password` grant type.
+
+An example using the `client-credentials` grant type needs only a minor adjustments:
+
+[source,properties]
+----
+quarkus.keycloak.admin-client=true
+quarkus.keycloak.admin-client.server-url=http://localhost:8081
+quarkus.keycloak.admin-client.realm=quarkus
+quarkus.keycloak.admin-client.client-id=quarkus-client
+quarkus.keycloak.admin-client.client-secret=secret
+quarkus.keycloak.admin-client.username= # remove default username
+quarkus.keycloak.admin-client.password= # remove default password
+quarkus.keycloak.admin-client.grant-type=CLIENT_CREDENTIALS <1>
+----
+<1> Use `client_credentials` grant type.
+
+NOTE: Note that the xref:security-openid-connect-client.adoc[OidcClient] can also be used to acquire tokens.
+
+[[arc-configuration-reference]]
+== Quarkus Keycloak Admin Client Configuration Reference
+
+include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+1, opts=optional]
+
+== References
+
+* https://www.keycloak.org/documentation.html[Keycloak Documentation]
+* xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
+* xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Application]
+* xref:security.adoc[Quarkus Security]
+* xref:security-openid-connect.adoc[Using OpenID Connect to Protect Service Applications]
+* xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]

--- a/docs/src/main/asciidoc/security-keycloak-authorization.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-authorization.adoc
@@ -472,3 +472,4 @@ include::{generated-dir}/config/quarkus-keycloak-keycloak-policy-enforcer-config
 * https://openid.net/connect/[OpenID Connect]
 * https://tools.ietf.org/html/rfc7519[JSON Web Token]
 * xref:security.adoc[Quarkus Security]
+* xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -198,6 +198,7 @@ Import the {quickstarts-tree-url}/security-openid-connect-quickstart/config/quar
 
 NOTE: If you want to use the Keycloak Admin Client to configure your server from your application you need to include the
 either `quarkus-keycloak-admin-client` or the `quarkus-keycloak-admin-client-reactive` (if the application uses `quarkus-rest-client-reactive`) extension.
+See the xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client] guide for more information.
 
 [[keycloak-dev-mode]]
 === Running the Application in Dev mode
@@ -1151,3 +1152,4 @@ Note Quarkus `web-app` applications always require `quarkus.oidc.client-id` prop
 * xref:security-jwt-build.adoc[Sign and encrypt JWT tokens with SmallRye JWT Build]
 * xref:security.adoc#oidc-jwt-oauth2-comparison[Summary of Quarkus OIDC, JWT and OAuth2 features]
 * xref:security.adoc[Quarkus Security]
+* xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client]

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -83,7 +83,7 @@ If you use Keycloak and Bearer tokens then also see the xref:security-keycloak-a
 
 [NOTE]
 ====
-If you need to configure Keycloak programmatically then consider using https://www.keycloak.org/docs/latest/server_development/#admin-rest-api[Keycloak Admin REST API] with the help of the `quarkus-keycloak-admin-client` or `quarkus-keycloak-admin-client-reactive` (if the application uses `quarkus-rest-client-reactive`) extension.
+If you need to configure Keycloak programmatically then consider using https://www.keycloak.org/docs/latest/server_development/#admin-rest-api[Keycloak Admin REST API] with the help of the `quarkus-keycloak-admin-client` or `quarkus-keycloak-admin-client-reactive` (if the application uses `quarkus-rest-client-reactive`) extension. See the xref:security-keycloak-admin-client.adoc[Quarkus Keycloak Admin Client] guide for more information.
 ====
 
 === OpenID Connect Client and Filters

--- a/extensions/keycloak-admin-client-common/deployment/pom.xml
+++ b/extensions/keycloak-admin-client-common/deployment/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-keycloak-admin-client-common-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
+    <name>Quarkus - Keycloak Admin Client - Common - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientBuildTimeConfig.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientBuildTimeConfig.java
@@ -1,0 +1,19 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Keycloak Admin Client
+ */
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME, name = "keycloak.admin-client")
+public class KeycloakAdminClientBuildTimeConfig {
+
+    /**
+     * Set to true if you want Quarkus to create the client bean for you.
+     */
+    @ConfigItem(name = ConfigItem.PARENT, defaultValue = "false")
+    public boolean enabled = false;
+
+}

--- a/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientInjectionEnabled.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientInjectionEnabled.java
@@ -1,0 +1,13 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import java.util.function.BooleanSupplier;
+
+public class KeycloakAdminClientInjectionEnabled implements BooleanSupplier {
+
+    KeycloakAdminClientBuildTimeConfig config;
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled;
+    }
+}

--- a/extensions/keycloak-admin-client-common/deployment/src/test/java/io/quarkus/keycloak/admin/client/common/ConfigValidationTest.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/test/java/io/quarkus/keycloak/admin/client/common/ConfigValidationTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfigUtil.validate;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConfigValidationTest {
+
+    @Test
+    public void serverUrlIsRequiredTest() {
+        final KeycloakAdminClientConfig config = createConfig();
+        config.serverUrl = Optional.empty();
+        Assertions.assertThrows(KeycloakAdminClientConfigUtil.KeycloakAdminClientException.class, () -> validate(config));
+    }
+
+    @Test
+    public void passwordGrantTypeTest() {
+        // negative test
+        Assertions.assertDoesNotThrow(() -> validate(createConfig()));
+
+        // username is required
+        Assertions.assertThrows(KeycloakAdminClientConfigUtil.KeycloakAdminClientException.class, () -> {
+            KeycloakAdminClientConfig config = createConfig();
+            config.username = Optional.empty();
+            validate(config);
+        });
+
+        // password is required
+        Assertions.assertThrows(KeycloakAdminClientConfigUtil.KeycloakAdminClientException.class, () -> {
+            KeycloakAdminClientConfig config = createConfig();
+            config.password = Optional.empty();
+            validate(config);
+        });
+    }
+
+    @Test
+    public void clientCredentialsGrantTypeTest() {
+        // negative test
+        Assertions.assertDoesNotThrow(() -> validate(createClientCredentialsConfig()));
+
+        // client secret is required
+        Assertions.assertThrows(KeycloakAdminClientConfigUtil.KeycloakAdminClientException.class, () -> {
+            KeycloakAdminClientConfig config = createClientCredentialsConfig();
+            config.clientSecret = Optional.empty();
+            validate(config);
+        });
+    }
+
+    private KeycloakAdminClientConfig createConfig() {
+        final KeycloakAdminClientConfig config = new KeycloakAdminClientConfig();
+        config.serverUrl = Optional.of("https://localhost:8081");
+        config.grantType = KeycloakAdminClientConfig.GrantType.PASSWORD;
+        config.clientId = "client id";
+        config.clientSecret = Optional.empty();
+        config.username = Optional.of("john");
+        config.password = Optional.of("pwd");
+        config.realm = "master";
+        config.scope = Optional.empty();
+        return config;
+    }
+
+    private KeycloakAdminClientConfig createClientCredentialsConfig() {
+        final KeycloakAdminClientConfig config = createConfig();
+        config.grantType = KeycloakAdminClientConfig.GrantType.CLIENT_CREDENTIALS;
+        config.password = Optional.empty();
+        config.username = Optional.empty();
+        config.clientSecret = Optional.of("client secret");
+        return config;
+    }
+
+}

--- a/extensions/keycloak-admin-client-common/pom.xml
+++ b/extensions/keycloak-admin-client-common/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-keycloak-admin-client-common-parent</artifactId>
+    <name>Quarkus - Keycloak Admin Client - Common - Parent</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+</project>

--- a/extensions/keycloak-admin-client-common/runtime/pom.xml
+++ b/extensions/keycloak-admin-client-common/runtime/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-keycloak-admin-client-common-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+    <name>Quarkus - Keycloak Admin Client - Common - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/AutoCloseableDestroyer.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/AutoCloseableDestroyer.java
@@ -1,0 +1,21 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import java.util.Map;
+
+import javax.enterprise.context.spi.CreationalContext;
+
+import io.quarkus.arc.BeanDestroyer;
+
+public final class AutoCloseableDestroyer implements BeanDestroyer<AutoCloseable> {
+
+    @Override
+    public void destroy(AutoCloseable instance, CreationalContext<AutoCloseable> creationalContext,
+            Map<String, Object> params) {
+        try {
+            instance.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
@@ -1,0 +1,72 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Keycloak Admin Client
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "keycloak.admin-client")
+public class KeycloakAdminClientConfig {
+
+    /**
+     * Realm.
+     */
+    @ConfigItem(defaultValue = "master")
+    public String realm;
+
+    /**
+     * Keycloak server URL, for example, `https://host:port`.
+     */
+    @ConfigItem
+    public Optional<String> serverUrl;
+
+    /**
+     * Client id.
+     */
+    @ConfigItem(defaultValue = "admin-cli")
+    public String clientId;
+
+    /**
+     * Client secret. Required with a `client_credentials` grant type.
+     */
+    @ConfigItem
+    public Optional<String> clientSecret;
+
+    /**
+     * Username. Required with a `password` grant type.
+     */
+    @ConfigItem(defaultValue = "admin")
+    public Optional<String> username;
+
+    /**
+     * Password. Required with a `password` grant type.
+     */
+    @ConfigItem(defaultValue = "admin")
+    public Optional<String> password;
+
+    /**
+     * OAuth 2.0 <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">Access Token Scope</a>.
+     */
+    @ConfigItem
+    public Optional<String> scope;
+
+    /**
+     * OAuth Grant Type.
+     */
+    @ConfigItem(defaultValue = "PASSWORD")
+    public GrantType grantType;
+
+    public enum GrantType {
+        PASSWORD,
+        CLIENT_CREDENTIALS;
+
+        public String asString() {
+            return this.toString().toLowerCase();
+        }
+    }
+
+}

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfigUtil.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfigUtil.java
@@ -1,0 +1,36 @@
+package io.quarkus.keycloak.admin.client.common;
+
+import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig.GrantType.PASSWORD;
+
+public class KeycloakAdminClientConfigUtil {
+
+    /**
+     * Validates configuration properties. KeycloakBuilder also validates inputs (our config properties) when build()
+     * is called but that validation is done when the request scoped bean is created and sooner the validation is done, better.
+     */
+    public static void validate(KeycloakAdminClientConfig config) {
+
+        if (config.serverUrl.isEmpty()) {
+            throw new KeycloakAdminClientException("configuration property 'server-url' is required");
+        }
+
+        // client id is also required in both cases, but since it's not nullable, we can skip its validation
+        if (config.grantType == PASSWORD) {
+            if (config.password.isEmpty() || config.username.isEmpty()) {
+                throw new KeycloakAdminClientException("grant type 'password' requires username and password");
+            }
+        } else {
+            if (config.clientSecret.isEmpty()) {
+                throw new KeycloakAdminClientException("grant type 'client_credentials' requires client secret");
+            }
+        }
+    }
+
+    static final class KeycloakAdminClientException extends RuntimeException {
+
+        private KeycloakAdminClientException(String message) {
+            super(String.format("Failed to create Keycloak admin client: %s.", message));
+        }
+
+    }
+}

--- a/extensions/keycloak-admin-client-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,5 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Keycloak Admin Client Common"
+metadata:
+  unlisted: true # should be only used as a part of the Keycloak Admin Client (Reactive)

--- a/extensions/keycloak-admin-client-reactive/deployment/pom.xml
+++ b/extensions/keycloak-admin-client-reactive/deployment/pom.xml
@@ -21,6 +21,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -32,9 +36,25 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -48,7 +68,40 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*DevServicesTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>test-devservices</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/keycloak-admin-client-reactive/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
+++ b/extensions/keycloak-admin-client-reactive/deployment/src/main/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientReactiveProcessor.java
@@ -1,12 +1,16 @@
 package io.quarkus.keycloak.admin.client.reactive;
 
+import javax.enterprise.context.RequestScoped;
+
 import org.jboss.jandex.DotName;
+import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.spi.ResteasyClientProvider;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.json.StringListMapDeserializer;
 import org.keycloak.json.StringOrArrayDeserializer;
 import org.keycloak.json.StringOrArraySerializer;
 
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -17,6 +21,8 @@ import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+import io.quarkus.keycloak.admin.client.common.AutoCloseableDestroyer;
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientInjectionEnabled;
 import io.quarkus.keycloak.admin.client.reactive.runtime.ResteasyReactiveClientProvider;
 import io.quarkus.keycloak.admin.client.reactive.runtime.ResteasyReactiveKeycloakAdminClientRecorder;
 
@@ -53,4 +59,19 @@ public class KeycloakAdminClientReactiveProcessor {
         recorder.setClientProvider();
     }
 
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep(onlyIf = KeycloakAdminClientInjectionEnabled.class)
+    public void registerKeycloakAdminClientBeans(ResteasyReactiveKeycloakAdminClientRecorder recorder,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
+        syntheticBeanBuildItemBuildProducer.produce(SyntheticBeanBuildItem
+                .configure(Keycloak.class)
+                // use @RequestScoped as we don't want to keep client connection open too long
+                .scope(RequestScoped.class)
+                .setRuntimeInit()
+                .defaultBean()
+                .unremovable()
+                .supplier(recorder.createAdminClient())
+                .destroyer(AutoCloseableDestroyer.class)
+                .done());
+    }
 }

--- a/extensions/keycloak-admin-client-reactive/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientInjectionDevServicesTest.java
+++ b/extensions/keycloak-admin-client-reactive/deployment/src/test/java/io/quarkus/keycloak/admin/client/reactive/KeycloakAdminClientInjectionDevServicesTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.keycloak.admin.client.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+public class KeycloakAdminClientInjectionDevServicesTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(AdminResource.class)
+                    .addAsResource("app-dev-mode-config.properties", "application.properties"));
+
+    @Test
+    public void testGetRoles() {
+        // use 'password' grant type
+        final Response getRolesReq = RestAssured.given().get("/api/admin/roles");
+        assertEquals(200, getRolesReq.statusCode());
+        final List<RoleRepresentation> roles = getRolesReq.jsonPath().getList(".", RoleRepresentation.class);
+        assertNotNull(roles);
+        // assert there are roles admin and user (among others)
+        assertTrue(roles.stream().anyMatch(rr -> "user".equals(rr.getName())));
+        assertTrue(roles.stream().anyMatch(rr -> "admin".equals(rr.getName())));
+    }
+
+    @Path("/api/admin")
+    public static class AdminResource {
+
+        @Inject
+        Keycloak keycloak;
+
+        @GET
+        @Path("/roles")
+        public List<RoleRepresentation> getRoles() {
+            return keycloak.realm("quarkus").roles().list();
+        }
+
+    }
+}

--- a/extensions/keycloak-admin-client-reactive/deployment/src/test/resources/app-dev-mode-config.properties
+++ b/extensions/keycloak-admin-client-reactive/deployment/src/test/resources/app-dev-mode-config.properties
@@ -1,0 +1,6 @@
+# Configure Dev Services for Keycloak
+quarkus.keycloak.devservices.port=8082
+
+# Configure Keycloak Admin Client
+quarkus.keycloak.admin-client=true
+quarkus.keycloak.admin-client.server-url=http://localhost:${quarkus.keycloak.devservices.port}

--- a/extensions/keycloak-admin-client-reactive/runtime/pom.xml
+++ b/extensions/keycloak-admin-client-reactive/runtime/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
@@ -1,13 +1,49 @@
 package io.quarkus.keycloak.admin.client.reactive.runtime;
 
-import org.keycloak.admin.client.Keycloak;
+import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfigUtil.validate;
 
+import java.util.function.Supplier;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class ResteasyReactiveKeycloakAdminClientRecorder {
 
+    private final RuntimeValue<KeycloakAdminClientConfig> keycloakAdminClientConfigRuntimeValue;
+
+    public ResteasyReactiveKeycloakAdminClientRecorder(
+            RuntimeValue<KeycloakAdminClientConfig> keycloakAdminClientConfigRuntimeValue) {
+        this.keycloakAdminClientConfigRuntimeValue = keycloakAdminClientConfigRuntimeValue;
+    }
+
     public void setClientProvider() {
         Keycloak.setClientProvider(new ResteasyReactiveClientProvider());
+    }
+
+    public Supplier<Keycloak> createAdminClient() {
+
+        final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
+        validate(config);
+        final KeycloakBuilder keycloakBuilder = KeycloakBuilder
+                .builder()
+                .clientId(config.clientId)
+                .clientSecret(config.clientSecret.orElse(null))
+                .grantType(config.grantType.asString())
+                .username(config.username.orElse(null))
+                .password(config.password.orElse(null))
+                .realm(config.realm)
+                .serverUrl(config.serverUrl.orElse(null))
+                .scope(config.scope.orElse(null));
+        return new Supplier<Keycloak>() {
+            @Override
+            public Keycloak get() {
+                return keycloakBuilder.build();
+            }
+        };
     }
 }

--- a/extensions/keycloak-admin-client/deployment/pom.xml
+++ b/extensions/keycloak-admin-client/deployment/pom.xml
@@ -29,6 +29,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -40,9 +44,25 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -56,7 +76,40 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*DevServicesTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>test-devservices</id>
+            <activation>
+                <property>
+                    <name>test-containers</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!-- force the default, overriding the DevServices exclude -->
+                                <exclude>**/*$*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/keycloak-admin-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientInjectionDevServicesTest.java
+++ b/extensions/keycloak-admin-client/deployment/src/test/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientInjectionDevServicesTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.keycloak.adminclient.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+public class KeycloakAdminClientInjectionDevServicesTest {
+
+    @RegisterExtension
+    final static QuarkusDevModeTest app = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> jar
+                    .addClasses(AdminResource.class)
+                    .addAsResource("app-dev-mode-config.properties", "application.properties"));
+
+    @Test
+    public void testGetRoles() {
+        // use 'password' grant type
+        final Response getRolesReq = RestAssured.given().get("/api/admin/roles");
+        assertEquals(200, getRolesReq.statusCode());
+        final List<RoleRepresentation> roles = getRolesReq.jsonPath().getList(".", RoleRepresentation.class);
+        assertNotNull(roles);
+        // assert there are roles admin and user (among others)
+        assertTrue(roles.stream().anyMatch(rr -> "user".equals(rr.getName())));
+        assertTrue(roles.stream().anyMatch(rr -> "admin".equals(rr.getName())));
+    }
+
+    @Path("/api/admin")
+    public static class AdminResource {
+
+        @Inject
+        Keycloak keycloak;
+
+        @GET
+        @Path("/roles")
+        public List<RoleRepresentation> getRoles() {
+            return keycloak.realm("quarkus").roles().list();
+        }
+
+    }
+}

--- a/extensions/keycloak-admin-client/deployment/src/test/resources/app-dev-mode-config.properties
+++ b/extensions/keycloak-admin-client/deployment/src/test/resources/app-dev-mode-config.properties
@@ -1,0 +1,6 @@
+# Configure Dev Services for Keycloak
+quarkus.keycloak.devservices.port=8082
+
+# Configure Keycloak Admin Client
+quarkus.keycloak.admin-client=true
+quarkus.keycloak.admin-client.server-url=http://localhost:${quarkus.keycloak.devservices.port}

--- a/extensions/keycloak-admin-client/runtime/pom.xml
+++ b/extensions/keycloak-admin-client/runtime/pom.xml
@@ -94,6 +94,10 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
@@ -1,0 +1,45 @@
+package io.quarkus.keycloak.adminclient;
+
+import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfigUtil.validate;
+
+import java.util.function.Supplier;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+
+import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class ResteasyKeycloakAdminClientRecorder {
+
+    private final RuntimeValue<KeycloakAdminClientConfig> keycloakAdminClientConfigRuntimeValue;
+
+    public ResteasyKeycloakAdminClientRecorder(
+            RuntimeValue<KeycloakAdminClientConfig> keycloakAdminClientConfigRuntimeValue) {
+        this.keycloakAdminClientConfigRuntimeValue = keycloakAdminClientConfigRuntimeValue;
+    }
+
+    public Supplier<Keycloak> createAdminClient() {
+
+        final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
+        validate(config);
+        final KeycloakBuilder keycloakBuilder = KeycloakBuilder
+                .builder()
+                .clientId(config.clientId)
+                .clientSecret(config.clientSecret.orElse(null))
+                .grantType(config.grantType.asString())
+                .username(config.username.orElse(null))
+                .password(config.password.orElse(null))
+                .realm(config.realm)
+                .serverUrl(config.serverUrl.orElse(null))
+                .scope(config.scope.orElse(null));
+        return new Supplier<Keycloak>() {
+            @Override
+            public Keycloak get() {
+                return keycloakBuilder.build();
+            }
+        };
+    }
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -136,6 +136,7 @@
         <module>oidc-token-propagation</module>
         <module>oidc-token-propagation-reactive</module>
         <module>keycloak-authorization</module>
+        <module>keycloak-admin-client-common</module>
         <module>keycloak-admin-client</module>
         <module>keycloak-admin-client-reactive</module>
         <module>credentials</module>

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -80,3 +80,7 @@ quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.path=/api-permission-weba
 quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.claim-information-point.claims.static-claim=static-claim
 
 admin-url=${keycloak.url}
+
+# Configure Keycloak Admin Client
+quarkus.keycloak.admin-client=true
+quarkus.keycloak.admin-client.server-url=${admin-url}


### PR DESCRIPTION
closes: #26837

Keycloak admin client can be configured in `application.properties` and injected as a CDI bean.