### PR TITLE
Move quarkus.smallrye-openapi.servers to a runtime config

### DIFF
--- a/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
+++ b/extensions/smallrye-openapi-common/deployment/src/main/java/io/quarkus/smallrye/openapi/common/deployment/SmallRyeOpenApiConfig.java
@@ -3,7 +3,6 @@ package io.quarkus.smallrye.openapi.common.deployment;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -143,12 +142,6 @@ public final class SmallRyeOpenApiConfig {
      */
     @ConfigItem
     public Optional<String> openApiVersion;
-
-    /**
-     * Specify the list of global servers that provide connectivity information
-     */
-    @ConfigItem
-    public Optional<Set<String>> servers;
 
     /**
      * Set the title in Info tag in the Schema document

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/jaxrs/OpenApiWithConfigTestCase.java
@@ -17,7 +17,7 @@ public class OpenApiWithConfigTestCase {
                     .addClasses(OpenApiResource.class, ResourceBean.class)
                     .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
                     .addAsResource(new StringAsset("mp.openapi.scan.disable=true"
-                            + "\nmp.openapi.servers=https://api.acme.org/"
+                            + "\nquarkus.smallrye-openapi.servers=https://api.acme.org/"
                             + "\nquarkus.smallrye-openapi.info-title=Bla"),
                             "application.properties"));
 

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiWithConfigTestCase.java
@@ -16,7 +16,9 @@ public class OpenApiWithConfigTestCase {
             .withApplicationRoot((jar) -> jar
                     .addClasses(OpenApiRoute.class)
                     .addAsManifestResource("test-openapi.yaml", "openapi.yaml")
-                    .addAsResource(new StringAsset("mp.openapi.scan.disable=true\nmp.openapi.servers=https://api.acme.org/"),
+                    .addAsResource(
+                            new StringAsset(
+                                    "mp.openapi.scan.disable=true\nquarkus.smallrye-openapi.servers=https://api.acme.org/"),
                             "application.properties"));
 
     @Test

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiDocumentService.java
@@ -27,6 +27,12 @@ public class OpenApiDocumentService implements OpenApiDocumentHolder {
     private final OpenApiDocumentHolder documentHolder;
 
     public OpenApiDocumentService(OASFilter autoSecurityFilter, Config config) {
+
+        String servers = config.getOptionalValue("quarkus.smallrye-openapi.servers", String.class).orElse(null);
+        if (servers != null && !servers.isEmpty()) {
+            System.setProperty("mp.openapi.servers", servers);
+        }
+
         if (config.getOptionalValue("quarkus.smallrye-openapi.always-run-filter", Boolean.class).orElse(Boolean.FALSE)) {
             this.documentHolder = new DynamicDocument(config, autoSecurityFilter);
         } else {

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRuntimeConfig.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRuntimeConfig.java
@@ -1,5 +1,8 @@
 package io.quarkus.smallrye.openapi.runtime;
 
+import java.util.Optional;
+import java.util.Set;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -13,4 +16,9 @@ public class OpenApiRuntimeConfig {
     @ConfigItem(defaultValue = "true")
     public boolean enable;
 
+    /**
+     * Specify the list of global servers that provide connectivity information
+     */
+    @ConfigItem
+    public Optional<Set<String>> servers;
 }


### PR DESCRIPTION
Fix #26136

This PR move the `quarkus.smallrye-openapi.servers` to a runtime config so that users can set the servers with a `java -Dquarkus.smallrye-openapi.servers`. As discussed here #26124

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>