### PR TITLE
Add support for ignoreMigrationPatterns config in Flyway

### DIFF
--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayCreator.java
@@ -60,16 +60,23 @@ class FlywayCreator {
         configure.baselineOnMigrate(flywayRuntimeConfig.baselineOnMigrate);
         configure.validateOnMigrate(flywayRuntimeConfig.validateOnMigrate);
         configure.validateMigrationNaming(flywayRuntimeConfig.validateMigrationNaming);
-        List<String> patterns = new ArrayList<>(2);
-        //https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns
-        if (flywayRuntimeConfig.ignoreMissingMigrations) {
-            patterns.add("*:Missing");
+
+        final String[] ignoreMigrationPatterns;
+        if (flywayRuntimeConfig.ignoreMigrationPatterns.isPresent()) {
+            ignoreMigrationPatterns = flywayRuntimeConfig.ignoreMigrationPatterns.get();
+        } else {
+            List<String> patterns = new ArrayList<>(2);
+            if (flywayRuntimeConfig.ignoreMissingMigrations) {
+                patterns.add("*:Missing");
+            }
+            if (flywayRuntimeConfig.ignoreFutureMigrations) {
+                patterns.add("*:Future");
+            }
+            // Default is *:Future
+            ignoreMigrationPatterns = patterns.toArray(new String[0]);
         }
-        if (flywayRuntimeConfig.ignoreFutureMigrations) {
-            patterns.add("*:Future");
-        }
-        // Default is *:Future
-        configure.ignoreMigrationPatterns(patterns.toArray(new String[0]));
+
+        configure.ignoreMigrationPatterns(ignoreMigrationPatterns);
         configure.cleanOnValidationError(flywayRuntimeConfig.cleanOnValidationError);
         configure.outOfOrder(flywayRuntimeConfig.outOfOrder);
         if (flywayRuntimeConfig.baselineVersion.isPresent()) {

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -187,4 +187,13 @@ public final class FlywayDataSourceRuntimeConfig {
      */
     @ConfigItem
     public boolean validateMigrationNaming;
+
+    /**
+     * Ignore migrations during validate and repair according to a given list of patterns (see
+     * https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns for more information).
+     * When this configuration is set, the ignoreFutureMigrations and ignoreMissingMigrations settings are ignored. Patterns are
+     * comma separated.
+     */
+    @ConfigItem
+    public Optional<String[]> ignoreMigrationPatterns = Optional.empty();
 }

--- a/extensions/flyway/runtime/src/test/java/io/quarkus/flyway/runtime/FlywayCreatorTest.java
+++ b/extensions/flyway/runtime/src/test/java/io/quarkus/flyway/runtime/FlywayCreatorTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.flyway.runtime;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.Location;
 import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.flywaydb.core.internal.util.ValidatePatternUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -256,6 +258,23 @@ class FlywayCreatorTest {
         runtimeConfig.validateMigrationNaming = true;
         creator = new FlywayCreator(runtimeConfig, buildConfig);
         assertTrue(createdFlywayConfig().isValidateMigrationNaming());
+    }
+
+    @Test
+    @DisplayName("validateIgnoreMigrationPatterns defaults to false and it is correctly set")
+    void testIgnoreMigrationPatterns() {
+        creator = new FlywayCreator(runtimeConfig, buildConfig);
+        assertEquals(0, createdFlywayConfig().getIgnoreMigrationPatterns().length);
+        assertFalse(runtimeConfig.ignoreMigrationPatterns.isPresent());
+
+        runtimeConfig.ignoreMigrationPatterns = Optional.of(new String[] { "*:missing" });
+        creator = new FlywayCreator(runtimeConfig, buildConfig);
+        final ValidatePattern[] existingIgnoreMigrationPatterns = createdFlywayConfig().getIgnoreMigrationPatterns();
+        assertEquals(1, existingIgnoreMigrationPatterns.length);
+        final String[] ignoreMigrationPatterns = runtimeConfig.ignoreMigrationPatterns.get();
+        final ValidatePattern[] validatePatterns = Arrays.stream(ignoreMigrationPatterns)
+                .map(ValidatePattern::fromPattern).toArray(ValidatePattern[]::new);
+        assertArrayEquals(validatePatterns, existingIgnoreMigrationPatterns);
     }
 
     private static List<String> pathList(Location[] locations) {


### PR DESCRIPTION
Added `quarkus.flyway.ignore-migration-patterns` parameter to quarkus config.

Resolves https://github.com/quarkusio/quarkus/issues/27099