### PR TITLE
Remove spaces between key and value for DevServices properties in DevUI

### DIFF
--- a/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/dev-services.html
+++ b/extensions/vertx-http/deployment/src/main/resources/dev-templates/io.quarkus.quarkus-vertx-http/dev-services.html
@@ -31,7 +31,7 @@
                 <h5 class="card-title">Config</h5>
                 <code class="h-100">
                 {#for config in service.configs}
-                    {config.key} = {config.value}
+                    {config.key}={config.value}
                     <br/>
                 {/for}
                 </code>


### PR DESCRIPTION
This makes it easier to copy and paste these as system properties