### PR TITLE
Upgrade mongo client to 4.7.1 and mongo-crypt to 1.5.2

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -161,8 +161,8 @@
         <liquibase.version>4.15.0</liquibase.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <mongo-client.version>4.6.1</mongo-client.version>
-        <mongo-crypt.version>1.4.1</mongo-crypt.version>
+        <mongo-client.version>4.7.1</mongo-client.version>
+        <mongo-crypt.version>1.5.2</mongo-crypt.version>
         <proton-j.version>0.33.10</proton-j.version>
         <javaparser.version>3.24.2</javaparser.version>
         <okhttp.version>3.14.9</okhttp.version><!-- keep in sync with okio -->


### PR DESCRIPTION
Both upgrade must be done together or the native build will fail