### PR TITLE
Rest Client Reactive: Provide custom ObjectMapper in request scope

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/runtime/src/main/java/io/quarkus/resteasy/reactive/jackson/runtime/serialisers/ServerJacksonMessageBodyReader.java
@@ -18,6 +18,7 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 public class ServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReader implements ServerMessageBodyReader<Object> {
@@ -58,6 +59,7 @@ public class ServerJacksonMessageBodyReader extends JacksonBasicMessageBodyReade
             return null;
         }
         try {
+            ObjectReader reader = getEffectiveReader();
             return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
                     .readValue(entityStream);
         } catch (MismatchedInputException e) {

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/deployment/src/main/java/io/quarkus/rest/client/reactive/jackson/deployment/RestClientReactiveJacksonProcessor.java
@@ -9,12 +9,11 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
-
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.ClientJacksonMessageBodyReader;
 import io.quarkus.rest.client.reactive.jackson.runtime.serialisers.ClientJacksonMessageBodyWriter;
 import io.quarkus.resteasy.reactive.jackson.deployment.processor.ResteasyReactiveJacksonProviderDefinedBuildItem;
 import io.quarkus.resteasy.reactive.jackson.runtime.serialisers.vertx.VertxJsonArrayBasicMessageBodyReader;
@@ -48,13 +47,13 @@ public class RestClientReactiveJacksonProcessor {
         }
         // make these beans to they can get instantiated with the Quarkus CDI configured Jsonb object
         additionalBean.produce(AdditionalBeanBuildItem.builder()
-                .addBeanClass(JacksonBasicMessageBodyReader.class.getName())
+                .addBeanClass(ClientJacksonMessageBodyReader.class.getName())
                 .addBeanClass(ClientJacksonMessageBodyWriter.class.getName())
                 .setUnremovable().build());
 
         additionalReaders
                 .produce(
-                        new MessageBodyReaderBuildItem.Builder(JacksonBasicMessageBodyReader.class.getName(),
+                        new MessageBodyReaderBuildItem.Builder(ClientJacksonMessageBodyReader.class.getName(),
                                 Object.class.getName())
                                 .setMediaTypeStrings(HANDLED_READ_MEDIA_TYPES)
                                 .setBuiltin(true)

--- a/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
+++ b/extensions/resteasy-reactive/rest-client-reactive-jackson/runtime/src/main/java/io/quarkus/rest/client/reactive/jackson/runtime/serialisers/ClientJacksonMessageBodyReader.java
@@ -1,0 +1,50 @@
+package io.quarkus.rest.client.reactive.jackson.runtime.serialisers;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import org.jboss.resteasy.reactive.client.impl.RestClientRequestContext;
+import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
+import org.jboss.resteasy.reactive.server.jackson.JacksonBasicMessageBodyReader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+public class ClientJacksonMessageBodyReader extends JacksonBasicMessageBodyReader implements ClientRestHandler {
+
+    private final ConcurrentMap<ObjectMapper, ObjectReader> contextResolverMap = new ConcurrentHashMap<>();
+    private RestClientRequestContext context;
+
+    @Inject
+    public ClientJacksonMessageBodyReader(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public void handle(RestClientRequestContext requestContext) {
+        this.context = requestContext;
+    }
+
+    @Override
+    protected ObjectReader getEffectiveReader() {
+        if (context == null) {
+            // no context injected when reader is not running within a rest client context
+            return super.getEffectiveReader();
+        }
+
+        ObjectMapper objectMapper = context.getConfiguration().getFromContext(ObjectMapper.class);
+        if (objectMapper == null) {
+            return super.getEffectiveReader();
+        }
+
+        return contextResolverMap.computeIfAbsent(objectMapper, new Function<>() {
+            @Override
+            public ObjectReader apply(ObjectMapper objectMapper) {
+                return objectMapper.reader();
+            }
+        });
+    }
+}

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientResponseImpl.java
@@ -55,7 +55,7 @@ public class ClientResponseImpl extends ResponseImpl {
         MediaType mediaType = getMediaType();
         try {
             entity = ClientSerialisers.invokeClientReader(annotations, entityType, genericType, mediaType,
-                    restClientRequestContext.properties, getStringHeaders(),
+                    restClientRequestContext.properties, restClientRequestContext, getStringHeaders(),
                     restClientRequestContext.getRestClient().getClientContext().getSerialisers(),
                     entityStream, restClientRequestContext.getReaderInterceptors(), restClientRequestContext.configuration);
             consumed = true;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRestResponseImpl.java
@@ -55,7 +55,7 @@ public class ClientRestResponseImpl<T> extends RestResponseImpl<T> {
         MediaType mediaType = getMediaType();
         try {
             entity = (T) ClientSerialisers.invokeClientReader(annotations, entityType, genericType, mediaType,
-                    restClientRequestContext.properties, getStringHeaders(),
+                    restClientRequestContext.properties, restClientRequestContext, getStringHeaders(),
                     restClientRequestContext.getRestClient().getClientContext().getSerialisers(),
                     entityStream, restClientRequestContext.getReaderInterceptors(), restClientRequestContext.configuration);
             consumed = true;

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientSerialisers.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientSerialisers.java
@@ -25,6 +25,7 @@ import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.WriterInterceptor;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.client.providers.serialisers.ClientDefaultTextPlainBodyHandler;
+import org.jboss.resteasy.reactive.client.spi.ClientRestHandler;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.core.UnmanagedBeanFactory;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
@@ -104,19 +105,28 @@ public class ClientSerialisers extends Serialisers {
     // FIXME: pass InvocationState to wrap args?
     public static Buffer invokeClientWriter(Entity<?> entity, Object entityObject, Class<?> entityClass, Type entityType,
             MultivaluedMap<String, String> headerMap, MessageBodyWriter writer, WriterInterceptor[] writerInterceptors,
-            Map<String, Object> properties, Serialisers serialisers, ConfigurationImpl configuration)
+            Map<String, Object> properties, RestClientRequestContext clientRequestContext, Serialisers serialisers,
+            ConfigurationImpl configuration)
             throws IOException {
 
         if (writer.isWriteable(entityClass, entityType, entity.getAnnotations(), entity.getMediaType())) {
             if ((writerInterceptors == null) || writerInterceptors.length == 0) {
                 VertxBufferOutputStream out = new VertxBufferOutputStream();
+                if (writer instanceof ClientRestHandler) {
+                    try {
+                        ((ClientRestHandler) writer).handle(clientRequestContext);
+                    } catch (Exception e) {
+                        throw new WebApplicationException("Can't inject the client request context", e);
+                    }
+                }
+
                 writer.writeTo(entityObject, entityClass, entityType, entity.getAnnotations(),
                         entity.getMediaType(), headerMap, out);
                 return out.getBuffer();
             } else {
                 return runClientWriterInterceptors(entityObject, entityClass, entityType, entity.getAnnotations(),
-                        entity.getMediaType(), headerMap, writer, writerInterceptors, properties, serialisers,
-                        configuration);
+                        entity.getMediaType(), headerMap, writer, writerInterceptors, properties, clientRequestContext,
+                        serialisers, configuration);
             }
         }
 
@@ -124,25 +134,26 @@ public class ClientSerialisers extends Serialisers {
     }
 
     public static Buffer runClientWriterInterceptors(Object entity, Class<?> entityClass, Type entityType,
-            Annotation[] annotations, MediaType mediaType,
-            MultivaluedMap<String, String> headers, MessageBodyWriter writer,
-            WriterInterceptor[] writerInterceptors, Map<String, Object> properties, Serialisers serialisers,
+            Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> headers, MessageBodyWriter writer,
+            WriterInterceptor[] writerInterceptors, Map<String, Object> properties,
+            RestClientRequestContext clientRequestContext, Serialisers serialisers,
             ConfigurationImpl configuration) throws IOException {
         ClientWriterInterceptorContextImpl wc = new ClientWriterInterceptorContextImpl(writerInterceptors, writer,
-                annotations, entityClass, entityType, entity, mediaType, headers, properties, serialisers, configuration);
+                annotations, entityClass, entityType, entity, mediaType, headers, properties, clientRequestContext, serialisers,
+                configuration);
         wc.proceed();
         return wc.getResult();
     }
 
     public static Object invokeClientReader(Annotation[] annotations, Class<?> entityClass, Type entityType,
-            MediaType mediaType, Map<String, Object> properties,
+            MediaType mediaType, Map<String, Object> properties, RestClientRequestContext clientRequestContext,
             MultivaluedMap metadata, Serialisers serialisers, InputStream in, ReaderInterceptor[] interceptors,
             ConfigurationImpl configuration)
             throws WebApplicationException, IOException {
         // FIXME: perhaps optimise for when we have no interceptor?
         ClientReaderInterceptorContextImpl context = new ClientReaderInterceptorContextImpl(annotations,
-                entityClass, entityType, mediaType,
-                properties, metadata, configuration, serialisers, in, interceptors);
+                entityClass, entityType, mediaType, properties, clientRequestContext,
+                metadata, configuration, serialisers, in, interceptors);
         return context.proceed();
     }
 

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InboundSseEventImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/InboundSseEventImpl.java
@@ -118,7 +118,7 @@ public class InboundSseEventImpl implements InboundSseEvent {
         InputStream in = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         try {
             return (T) ClientSerialisers.invokeClientReader(null, type.getRawType(), type.getType(),
-                    mediaType, null, Serialisers.EMPTY_MULTI_MAP,
+                    mediaType, null, null, Serialisers.EMPTY_MULTI_MAP,
                     serialisers, in, Serialisers.NO_READER_INTERCEPTOR, configuration);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -180,8 +180,8 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         if (in == null)
             return null;
         return (T) ClientSerialisers.invokeClientReader(null, responseType.getRawType(), responseType.getType(),
-                mediaType, properties, metadata, restClient.getClientContext().getSerialisers(), in, getReaderInterceptors(),
-                configuration);
+                mediaType, properties, this, metadata, restClient.getClientContext().getSerialisers(), in,
+                getReaderInterceptors(), configuration);
     }
 
     public ReaderInterceptor[] getReaderInterceptors() {
@@ -244,7 +244,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
                 RuntimeType.CLIENT);
         for (MessageBodyWriter<?> w : writers) {
             Buffer ret = ClientSerialisers.invokeClientWriter(entity, entityObject, entityClass, entityType, headerMap, w,
-                    interceptors, properties, restClient.getClientContext().getSerialisers(), configuration);
+                    interceptors, properties, this, restClient.getClientContext().getSerialisers(), configuration);
             if (ret != null) {
                 return ret;
             }

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/multipart/QuarkusMultipartForm.java
@@ -118,8 +118,7 @@ public class QuarkusMultipartForm implements Iterable<QuarkusMultipartFormDataPa
             for (MessageBodyWriter<?> w : writers) {
                 Buffer ret = ClientSerialisers.invokeClientWriter(entity, entityObject, entityClass, entityType, headers, w,
                         context.getConfiguration().getWriterInterceptors().toArray(Serialisers.NO_WRITER_INTERCEPTOR),
-                        context.getProperties(),
-                        serialisers, context.getConfiguration());
+                        context.getProperties(), context, serialisers, context.getConfiguration());
                 if (ret != null) {
                     value = ret;
                     break;

--- a/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonBasicMessageBodyReader.java
+++ b/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonBasicMessageBodyReader.java
@@ -17,11 +17,11 @@ import org.jboss.resteasy.reactive.common.util.EmptyInputStream;
 
 public class JacksonBasicMessageBodyReader extends AbstractJsonMessageBodyReader {
 
-    protected final ObjectReader reader;
+    protected final ObjectReader defaultReader;
 
     @Inject
     public JacksonBasicMessageBodyReader(ObjectMapper mapper) {
-        this.reader = mapper.reader();
+        this.defaultReader = mapper.reader();
     }
 
     @Override
@@ -34,10 +34,15 @@ public class JacksonBasicMessageBodyReader extends AbstractJsonMessageBodyReader
         }
     }
 
+    protected ObjectReader getEffectiveReader() {
+        return defaultReader;
+    }
+
     private Object doReadFrom(Class<Object> type, Type genericType, InputStream entityStream) throws IOException {
         if (entityStream instanceof EmptyInputStream) {
             return null;
         }
+        ObjectReader reader = getEffectiveReader();
         return reader.forType(reader.getTypeFactory().constructType(genericType != null ? genericType : type))
                 .readValue(entityStream);
     }

--- a/integration-tests/rest-client-reactive/pom.xml
+++ b/integration-tests/rest-client-reactive/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/ClientWithCustomObjectMapperTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/ClientWithCustomObjectMapperTest.java
@@ -1,0 +1,138 @@
+package io.quarkus.it.rest.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+
+@QuarkusTest
+public class ClientWithCustomObjectMapperTest {
+
+    MyClient clientAllowsUnknown;
+    MyClient clientDisallowsUnknown;
+    WireMockServer wireMockServer;
+
+    @BeforeEach
+    public void setUp() throws MalformedURLException {
+        wireMockServer = new WireMockServer(options().port(20001));
+        wireMockServer.start();
+
+        clientAllowsUnknown = RestClientBuilder.newBuilder()
+                .baseUrl(new URL(wireMockServer.baseUrl()))
+                .register(ClientObjectMapperUnknown.class)
+                .build(MyClient.class);
+
+        clientDisallowsUnknown = RestClientBuilder.newBuilder()
+                .baseUrl(new URL(wireMockServer.baseUrl()))
+                .register(ClientObjectMapperNoUnknown.class)
+                .build(MyClient.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void testCustomObjectMappersShouldBeUsed() {
+        var json = "{ \"value\": \"someValue\", \"secondValue\": \"toBeIgnored\" }";
+        wireMockServer.stubFor(
+                WireMock.get(WireMock.urlMatching("/get"))
+                        .willReturn(okJson(json)));
+
+        // FAIL_ON_UNKNOWN_PROPERTIES disabled
+        assertThat(clientAllowsUnknown.get().await().indefinitely())
+                .isEqualTo(new Request("someValue"));
+
+        // FAIL_ON_UNKNOWN_PROPERTIES enabled
+        assertThatThrownBy(() -> clientDisallowsUnknown.get().await().indefinitely())
+                .isInstanceOf(ClientWebApplicationException.class);
+    }
+
+    @Path("/get")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public interface MyClient {
+        @GET
+        Uni<Request> get();
+    }
+
+    public static class Request {
+        private String value;
+
+        public Request() {
+
+        }
+
+        public Request(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Request request = (Request) o;
+            return Objects.equals(value, request.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static class ClientObjectMapperUnknown implements ContextResolver<ObjectMapper> {
+        @Override
+        public ObjectMapper getContext(Class<?> type) {
+            return new ObjectMapper()
+                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        }
+    }
+
+    public static class ClientObjectMapperNoUnknown implements ContextResolver<ObjectMapper> {
+        @Override
+        public ObjectMapper getContext(Class<?> type) {
+            return new ObjectMapper()
+                    .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        }
+    }
+}


### PR DESCRIPTION
With these changes, we can now register custom object mappers when creating a client programmatically:

```
clientAllowsUnknown = RestClientBuilder.newBuilder()
                .baseUrl(new URL(wireMockServer.baseUrl()))
                .register(ClientObjectMapperUnknown.class)
                .build(MyClient.class);
```

where ClientObjectMapperUnknown is:

```
public static class ClientObjectMapperUnknown implements ContextResolver<ObjectMapper> {
        @Override
        public ObjectMapper getContext(Class<?> type) {
            return new ObjectMapper()
                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
        }
    }
```

I implemented this feature by injecting the rest client context via the interface ClientRestHandler. Then, the rest client context has registered all the context resolvers, so the jackson message reader/writer can get the custom object mappers. 

Fix https://github.com/quarkusio/quarkus/issues/26152
Relates https://github.com/quarkusio/quarkus/pull/26988