### PR TITLE
Upgrade to SmallRye GraphQL 1.7.0 (graphql-java 19.0)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -44,7 +44,7 @@
         <smallrye-health.version>3.2.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.5</smallrye-metrics.version>
         <smallrye-open-api.version>2.1.23</smallrye-open-api.version>
-        <smallrye-graphql.version>1.6.2</smallrye-graphql.version>
+        <smallrye-graphql.version>1.7.0</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.5.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.5.3</smallrye-jwt.version>

--- a/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
+++ b/extensions/smallrye-graphql/deployment/src/main/java/io/quarkus/smallrye/graphql/deployment/SmallRyeGraphQLProcessor.java
@@ -46,6 +46,7 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.TransformedClassesBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBundleBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
@@ -192,6 +193,12 @@ public class SmallRyeGraphQLProcessor {
         // Config mapping between SmallRye / MP and Quarkus
         serviceProvider
                 .produce(ServiceProviderBuildItem.allProvidersFromClassPath(SmallRyeGraphQLConfigMapping.class.getName()));
+    }
+
+    @BuildStep
+    void registerNativeResourceBundle(BuildProducer<NativeImageResourceBundleBuildItem> nativeResourceBundleProvider)
+            throws IOException {
+        nativeResourceBundleProvider.produce(new NativeImageResourceBundleBuildItem("i18n.Validation"));
     }
 
     @BuildStep

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/HotReloadTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/HotReloadTest.java
@@ -52,7 +52,7 @@ public class HotReloadTest extends AbstractGraphQLTest {
                 .statusCode(200)
                 .and()
                 .body(CoreMatchers.containsString(
-                        "{\"errors\":[{\"message\":\"Validation error of type FieldUndefined: Field 'foo' in type 'TestPojo' is undefined @ 'foo/foo'\",\"locations\":[{\"line\":7,\"column\":5}],\"extensions\":{\"classification\":\"ValidationError\"}}],\"data\":null}"));
+                        "{\"errors\":[{\"message\":\"Validation error (FieldUndefined@[foo/foo]) : Field 'foo' in type 'TestPojo' is undefined\",\"locations\":[{\"line\":7,\"column\":5}],\"extensions\":{\"classification\":\"ValidationError\"}}],\"data\":null}"));
         LOG.info("Initial request done");
 
         // Make a code change (add a field)
@@ -94,7 +94,7 @@ public class HotReloadTest extends AbstractGraphQLTest {
                 .statusCode(200)
                 .and()
                 .body(CoreMatchers.containsString(
-                        "{\"errors\":[{\"message\":\"Validation error of type FieldUndefined: Field 'foo' in type 'TestPojo' is undefined @ 'foo/foo'\",\"locations\":[{\"line\":7,\"column\":5}],\"extensions\":{\"classification\":\"ValidationError\"}}],\"data\":null}"));
+                        "{\"errors\":[{\"message\":\"Validation error (FieldUndefined@[foo/foo]) : Field 'foo' in type 'TestPojo' is undefined\",\"locations\":[{\"line\":7,\"column\":5}],\"extensions\":{\"classification\":\"ValidationError\"}}],\"data\":null}"));
 
         LOG.info("Code change done - field removed");
 

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/InstrumentationTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/InstrumentationTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static io.quarkus.smallrye.graphql.deployment.AbstractGraphQLTest.getPropertyAsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.smallrye.common.annotation.NonBlocking;
+
+public class InstrumentationTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(FooApi.class, Foo.class)
+                    .addAsResource(new StringAsset(getPropertyAsString(configuration())), "application.properties")
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Test
+    public void testQueryDepth() {
+        String query = getPayload("{ foo { nestedFoo { nestedFoo { message}}}}");
+        RestAssured.given()
+                .body(query)
+                .contentType(MEDIATYPE_JSON)
+                .post("/graphql/")
+                .then()
+                .log().all()
+                .assertThat()
+                .body("errors[0].message", equalTo("maximum query depth exceeded 4 > 1"))
+                .body("data", nullValue());
+    }
+
+    private static Map<String, String> configuration() {
+        Map<String, String> m = new HashMap<>();
+        m.put("quarkus.smallrye-graphql.events.enabled", "true");
+        m.put("quarkus.smallrye-graphql.instrumentation-query-depth", "1");
+        return m;
+    }
+
+    public static class Foo {
+
+        private String message;
+
+        public Foo(String foo) {
+            this.message = foo;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+    }
+
+    @GraphQLApi
+    public static class FooApi {
+
+        @Query
+        @NonBlocking
+        public Foo foo() {
+            return new Foo("foo");
+        }
+
+        public Foo nestedFoo(@Source Foo foo) {
+            return new Foo("foo");
+        }
+    }
+
+}

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfig.java
@@ -152,17 +152,59 @@ public class SmallRyeGraphQLConfig {
     public Optional<List<String>> unwrapExceptions;
 
     /**
-     * SmallRye GraphQL UI configuration
-     */
-    @ConfigItem
-    @ConfigDocSection
-    public SmallRyeGraphQLUIConfig ui;
-
-    /**
      * Subprotocols that should be supported by the server for graphql-over-websocket use cases.
      * Allowed subprotocols are "graphql-ws" and "graphql-transport-ws". By default, both are enabled.
      */
     @ConfigItem
     public Optional<List<String>> websocketSubprotocols;
 
+    /**
+     * Set to true if ignored chars should be captured as AST nodes. Default to false
+     */
+    @ConfigItem
+    public Optional<Boolean> parserCaptureIgnoredChars;
+
+    /**
+     * Set to true if `graphql.language.Comment`s should be captured as AST nodes
+     */
+    @ConfigItem
+    public Optional<Boolean> parserCaptureLineComments;
+
+    /**
+     * Set to true true if `graphql.language.SourceLocation`s should be captured as AST nodes. Default to true
+     */
+    @ConfigItem
+    public Optional<Boolean> parserCaptureSourceLocation;
+
+    /**
+     * The maximum number of raw tokens the parser will accept, after which an exception will be thrown. Default to 15000
+     */
+    @ConfigItem
+    public Optional<Integer> parserMaxTokens;
+
+    /**
+     * The maximum number of raw whitespace tokens the parser will accept, after which an exception will be thrown. Default to
+     * 200000
+     */
+    @ConfigItem
+    public Optional<Integer> parserMaxWhitespaceTokens;
+
+    /**
+     * Abort a query if the total number of data fields queried exceeds the defined limit. Default to no limit
+     */
+    @ConfigItem
+    public Optional<Integer> instrumentationQueryComplexity;
+
+    /**
+     * Abort a query if the total depth of the query exceeds the defined limit. Default to no limit
+     */
+    @ConfigItem
+    public Optional<Integer> instrumentationQueryDepth;
+
+    /**
+     * SmallRye GraphQL UI configuration
+     */
+    @ConfigItem
+    @ConfigDocSection
+    public SmallRyeGraphQLUIConfig ui;
 }

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfigMapping.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLConfigMapping.java
@@ -49,6 +49,13 @@ public class SmallRyeGraphQLConfigMapping extends RelocateConfigSourceIntercepto
         mapKey(relocations, ConfigKey.LOG_PAYLOAD, QUARKUS_LOG_PAYLOAD);
         mapKey(relocations, ConfigKey.FIELD_VISIBILITY, QUARKUS_FIELD_VISIBILITY);
         mapKey(relocations, ConfigKey.UNWRAP_EXCEPTIONS, QUARKUS_UNWRAP_EXCEPTIONS);
+        mapKey(relocations, ConfigKey.PARSER_CAPTURE_IGNORED_CHARS, QUARKUS_PARSER_CAPTURE_IGNORED_CHARS);
+        mapKey(relocations, ConfigKey.PARSER_CAPTURE_LINE_COMMENTS, QUARKUS_PARSER_CAPTURE_LINE_COMMENTS);
+        mapKey(relocations, ConfigKey.PARSER_CAPTURE_SOURCE_LOCATION, QUARKUS_PARSER_CAPTURE_SOURCE_LOCATION);
+        mapKey(relocations, ConfigKey.PARSER_MAX_TOKENS, QUARKUS_PARSER_MAX_TOKENS);
+        mapKey(relocations, ConfigKey.PARSER_MAX_WHITESPACE_TOKENS, QUARKUS_PARSER_MAX_WHITESPACE_TOKENS);
+        mapKey(relocations, ConfigKey.INSTRUMENTATION_QUERY_COMPLEXITY, QUARKUS_INSTRUMENTATION_QUERY_COMPLEXITY);
+        mapKey(relocations, ConfigKey.INSTRUMENTATION_QUERY_DEPTH, QUARKUS_INSTRUMENTATION_QUERY_DEPTH);
         mapKey(relocations, SHOW_ERROR_MESSAGE, QUARKUS_SHOW_ERROR_MESSAGE);
         mapKey(relocations, HIDE_ERROR_MESSAGE, QUARKUS_HIDE_ERROR_MESSAGE);
         return Collections.unmodifiableMap(relocations);
@@ -75,5 +82,12 @@ public class SmallRyeGraphQLConfigMapping extends RelocateConfigSourceIntercepto
     private static final String QUARKUS_LOG_PAYLOAD = "quarkus.smallrye-graphql.log-payload";
     private static final String QUARKUS_FIELD_VISIBILITY = "quarkus.smallrye-graphql.field-visibility";
     private static final String QUARKUS_UNWRAP_EXCEPTIONS = "quarkus.smallrye-graphql.unwrap-exceptions";
+    private static final String QUARKUS_PARSER_CAPTURE_IGNORED_CHARS = "quarkus.smallrye-graphql.parser-capture-ignored-chars";
+    private static final String QUARKUS_PARSER_CAPTURE_LINE_COMMENTS = "quarkus.smallrye-graphql.parser-capture-line-comments";
+    private static final String QUARKUS_PARSER_CAPTURE_SOURCE_LOCATION = "quarkus.smallrye-graphql.parser-capture-source-location";
+    private static final String QUARKUS_PARSER_MAX_TOKENS = "quarkus.smallrye-graphql.parser-max-tokens";
+    private static final String QUARKUS_PARSER_MAX_WHITESPACE_TOKENS = "quarkus.smallrye-graphql.parser-max-whitespace-tokens";
+    private static final String QUARKUS_INSTRUMENTATION_QUERY_COMPLEXITY = "quarkus.smallrye-graphql.instrumentation-query-complexity";
+    private static final String QUARKUS_INSTRUMENTATION_QUERY_DEPTH = "quarkus.smallrye-graphql.instrumentation-query-depth";
 
 }

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -451,7 +451,7 @@ recipeList:
       newValue: 6.0.0-RC4
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-graphql.version
-      newValue: 2.0.0.RC6
+      newValue: 2.0.0.RC7
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-health.version
       newValue: 4.0.0-RC2

--- a/tcks/microprofile-graphql/src/main/resources/overrides/createNewNullNamedHero/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/createNewNullNamedHero/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (WrongType@[createNewHero]) : argument 'hero.name' with value 'NullValue{}' must not be null",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 19
+                }
+            ]
+        }
+    ],
+    "data": null
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/createNewUnnamedHero/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/createNewUnnamedHero/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (WrongType@[createNewHero]) : argument 'hero' with value 'ObjectValue{objectFields=[ObjectField{name='realName', value=StringValue{value='John Smith'}}]}' is missing required fields '[name]'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 19
+                }
+            ]
+        }
+    ],
+    "data": null
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidDataTypeValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidDataTypeValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'powerLevel' with value 'StringValue{value='Unlimited'}' is not a valid 'Int'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 37
+                }
+            ]
+        }
+    ],
+    "data": {
+        "updateItemPowerLevel": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidEnumValue/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidEnumValue/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (WrongType@[createNewHero]) : argument 'hero.tshirtSize' with value 'EnumValue{name='XLTall'}' is not a valid 'ShirtSize' - Expected enum literal value not in allowable values -  'EnumValue{name='XLTall'}'.",
+            "locations": [
+                {
+                    "line": 3,
+                    "column": 19
+                }
+            ]
+        }
+    ],
+    "data": null
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateFormattedValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateFormattedValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'date' with value 'StringValue{value='Today'}' is not a valid 'Date'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 49
+                }
+            ]
+        }
+    ],
+    "data": {
+        "checkInWithCorrectDateFormat": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateTimeFormattedValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateTimeFormattedValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'dateTime' with value 'StringValue{value='Today'}' is not a valid 'DateTime'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 48
+                }
+            ]
+        }
+    ],
+    "data": {
+        "battleWithCorrectDateFormat": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateTimeValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateTimeValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'dateTime' with value 'StringValue{value='Today'}' is not a valid 'DateTime'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 27
+                }
+            ]
+        }
+    ],
+    "data": {
+        "battle": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalDateValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'date' with value 'StringValue{value='Today'}' is not a valid 'Date'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 28
+                }
+            ]
+        }
+    ],
+    "data": {
+        "checkIn": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalTimeFormattedValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalTimeFormattedValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'time' with value 'StringValue{value='Today'}' is not a valid 'Time'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 57
+                }
+            ]
+        }
+    ],
+    "data": {
+        "startPatrollingWithCorrectDateFormat": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalTimeValue/output3.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/invalidLocalTimeValue/output3.json
@@ -1,0 +1,16 @@
+{
+    "errors": [
+        {
+            "message": "argument 'time' with value 'StringValue{value='Today'}' is not a valid 'Time'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 36
+                }
+            ]
+        }
+    ],
+    "data": {
+        "startPatrolling": null
+    }
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/unknownField/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/unknownField/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (FieldUndefined@[allHeroes/weaknesses]) : Field 'weaknesses' in type 'SuperHero' is undefined",
+            "locations": [
+                {
+                    "line": 4,
+                    "column": 5
+                }
+            ]
+        }
+    ],
+    "data": null
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/unknownMutation/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/unknownMutation/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (FieldUndefined@[createNewHeroCat]) : Field 'createNewHeroCat' in type 'Mutation' is undefined",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ]
+        }
+    ],
+    "data": null
+}

--- a/tcks/microprofile-graphql/src/main/resources/overrides/unknownQuery/output2.json
+++ b/tcks/microprofile-graphql/src/main/resources/overrides/unknownQuery/output2.json
@@ -1,0 +1,14 @@
+{
+    "errors": [
+        {
+            "message": "Validation error (FieldUndefined@[allHeroesWhoLikeIceCream]) : Field 'allHeroesWhoLikeIceCream' in type 'Query' is undefined",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        }
+    ],
+    "data": null
+}


### PR DESCRIPTION
This PR upgrades to [SmallRye GraphQL 1.7.0](https://github.com/smallrye/smallrye-graphql/releases/tag/1.7.0) that contains a new version of [graphql-java (v19.0)](https://github.com/graphql-java/graphql-java/releases/tag/v19.0). The validation messages now supports i18n and the default message changed slightly (hence the overrides in the MicroProfile GraphQL TCK)

This PR also adds some new configuration options:

- quarkus.smallrye-graphql.instrumentation-query-complexity
- quarkus.smallrye-graphql.instrumentation-query-depth
- quarkus.smallrye-graphql.parser-capture-ignored-chars
- quarkus.smallrye-graphql.parser-capture-line-comments
- quarkus.smallrye-graphql.parser-capture-source-location
- quarkus.smallrye-graphql.parser-max-tokens
- quarkus.smallrye-graphql.parser-max-whitespace-tokens

Signed-off-by: Phillip Kruger <phillip.kruger@gmail.com>