### PR TITLE
JAXB: Not bound classes annotated with XmlSchema to the JaxbContext

### DIFF
--- a/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
+++ b/extensions/jaxb/deployment/src/main/java/io/quarkus/jaxb/deployment/JaxbProcessor.java
@@ -211,8 +211,6 @@ class JaxbProcessor {
                 String className = xmlSchemaInstance.target().asClass().name().toString();
 
                 reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, className));
-
-                classesToBeBound.add(className);
             }
         }
 

--- a/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/info/package-info.java
+++ b/extensions/jaxb/deployment/src/test/java/io/quarkus/jaxb/deployment/info/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * The inclusion of this file is to verify that the produced JAXBContext works fine with it, otherwise the build fails.
+ */
+@XmlSchema(namespace = "http://abc.com", xmlns = {
+        @XmlNs(prefix = "abc", namespaceURI = "http://abc.com")
+})
+package io.quarkus.jaxb.deployment.info;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlSchema;


### PR DESCRIPTION
The classes annotated with @XmlSchema within package-info results into errors because the package-info is not a class. 

These changes fix this issue by adding a package-info.java class and not bounding this class to the JAXBContext.

Fix https://github.com/quarkusio/quarkus/issues/27003