### PR TITLE
Resteasy Reactive: Add JAXB API as runtime dependency

### DIFF
--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -353,7 +353,6 @@
                 <groupId>org.jboss.spec.javax.xml.bind</groupId>
                 <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
                 <version>${jboss-jaxb-api_2.3_spec.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
The Link java class from JAXRS API contains a JAXB Adapter that inherits of XmlAdapter (from JAXB API). 

The Mandrel native build detects the missing dependency and fails with:

```
Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing org.jboss.resteasy.reactive.common.headers.LinkDelegate$Parser.getLink() 
Parsing context:
   at org.jboss.resteasy.reactive.common.headers.LinkDelegate$Parser.getLink(LinkDelegate.java:29)
   at org.jboss.resteasy.reactive.common.headers.LinkDelegate.fromString(LinkDelegate.java:130)
   at org.jboss.resteasy.reactive.common.headers.LinkDelegate.fromString(LinkDelegate.java:15)
   at javax.ws.rs.core.MediaType.valueOf(MediaType.java:172)
   at org.jboss.resteasy.reactive.common.headers.HeaderUtil.getMediaType(HeaderUtil.java:117)
   at org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl.getMediaType(ResponseImpl.java:208)
```

Fix https://github.com/quarkusio/quarkus/issues/27211