### PR TITLE
Small typo in Kafka guide

### DIFF
--- a/docs/src/main/asciidoc/smallrye-kafka-incoming.adoc
+++ b/docs/src/main/asciidoc/smallrye-kafka-incoming.adoc
@@ -69,7 +69,7 @@ Type: _string_ | true |
 
 Type: _int_ | false | `1`
 
-| [.no-hyphens]#*group.id* | A unique string that identifies the consumer group the application belongs to.
+| [.no-hyphens]#*group.id*# | A unique string that identifies the consumer group the application belongs to.
 
 If not set, defaults to the application name as set by the `quarkus.application.name` configuration property.
 


### PR DESCRIPTION
Avoid a strange rendering 
![image](https://user-images.githubusercontent.com/1819009/183928775-a9f89b4d-6070-4327-8943-9931edb4a766.png)
