### PR TITLE
Add debug information to OTel flaky test

### DIFF
--- a/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/HelloRouterTest.java
+++ b/integration-tests/opentelemetry-vertx/src/test/java/io/quarkus/it/opentelemetry/vertx/HelloRouterTest.java
@@ -19,6 +19,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -30,7 +31,10 @@ import org.junit.jupiter.api.Test;
 
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.vertx.core.http.HttpMethod;
 
@@ -119,7 +123,9 @@ class HelloRouterTest {
         assertEquals("hello to bus", messages.get(0));
 
         await().atMost(5, TimeUnit.SECONDS).until(() -> getSpans().size() == 3);
+        RestAssured.filters(new RequestLoggingFilter(), new ResponseLoggingFilter());
         List<Map<String, Object>> spans = getSpans();
+        RestAssured.replaceFiltersWith(Collections.emptyList());
         assertEquals(3, spans.size());
 
         assertEquals(spans.get(0).get("traceId"), spans.get(1).get("traceId"));


### PR DESCRIPTION
Not sure why io.quarkus.it.opentelemetry.vertx.HelloRouterTest#bus fails some times:
https://github.com/quarkusio/quarkus/pulls?q=is%3Apr+io.quarkus.it.opentelemetry.vertx.HelloRouterTest%23bus+

I suspect it may be related to the span start time since we cannot rely on their order because we cannot control when they are pushed to the exporter, so we sort by start time. Still, I was not able to replicate it. I've added some log to help figure out the issue when it happens again.