### PR TITLE
Bump kafka3.version to 3.2.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <mutiny.version>1.7.0</mutiny.version>
-        <kafka3.version>3.1.0</kafka3.version>
+        <kafka3.version>3.2.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.8.4</snappy.version>
         <strimzi-test-container.version>0.100.0</strimzi-test-container.version>

--- a/docs/src/main/asciidoc/kafka-dev-services.adoc
+++ b/docs/src/main/asciidoc/kafka-dev-services.adoc
@@ -84,15 +84,15 @@ without trying to re-partition the existing topic to a different number of parti
 
 You can configure timeout for Kafka admin client calls used in topic creation using `quarkus.kafka.devservices.topic-partitions-timeout`, it defaults to 2 seconds.
 
-[[redpanda-enabling-transactions]]
-== Enabling transactions
+[[redpanda-transactions]]
+== Transactional and Idempotent producers support
 
-By default, the Red Panda broker does not act as a transaction coordinator.
-To enable transactions, set:
+By default, the Red Panda broker is configured to enable transactions and idempotence features.
+You can disable those using:
 
 [source, properties]
 ----
-quarkus.kafka.devservices.redpanda.transaction-enabled=true
+quarkus.kafka.devservices.redpanda.transaction-enabled=false
 ----
 
-NOTE: It also enables producer idempotence support.
+NOTE: Redpanda transactions does not support exactly-once processing.

--- a/docs/src/main/asciidoc/kafka.adoc
+++ b/docs/src/main/asciidoc/kafka.adoc
@@ -61,7 +61,7 @@ implementation("io.quarkus:quarkus-smallrye-reactive-messaging-kafka")
 
 [NOTE]
 ====
-The extension includes `kafka-clients` version 3.1.0 as a transitive dependency and is compatible with Kafka brokers version 2.x.
+The extension includes `kafka-clients` version 3.2.1 as a transitive dependency and is compatible with Kafka brokers version 2.x.
 ====
 
 == Configuring Smallrye Kafka Connector
@@ -1120,11 +1120,6 @@ If you'd like to consume records only written and committed inside a Kafka trans
 ----
 mp.messaging.incoming.prices-in.isolation.level=read_committed
 ----
-
-[NOTE]
-====
-If you are using Dev Services for Kafka using Redpanda, you need to <<kafka-dev-services.adoc#redpanda-enabling-transactions, enable transactions>>.
-====
 
 == Processing Messages
 

--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedPandaBuildTimeConfig.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/RedPandaBuildTimeConfig.java
@@ -26,6 +26,6 @@ public class RedPandaBuildTimeConfig {
      * <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=89068820">KIP-360 (Improve reliability of
      * idempotent/transactional producer)</a> are <em>not</em> supported.
      */
-    @ConfigItem(defaultValue = "false")
+    @ConfigItem(defaultValue = "true")
     public boolean transactionEnabled;
 }

--- a/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsPropertiesTest.java
+++ b/integration-tests/kafka-streams/src/test/java/io/quarkus/it/kafka/streams/KafkaStreamsPropertiesTest.java
@@ -24,7 +24,7 @@ public class KafkaStreamsPropertiesTest {
     @Test
     public void testProperties() throws Exception {
         // reflection hack ... no other way to get raw props ...
-        Field configField = KafkaStreams.class.getDeclaredField("config");
+        Field configField = KafkaStreams.class.getDeclaredField("applicationConfigs");
         configField.setAccessible(true);
         StreamsConfig config = (StreamsConfig) configField.get(streams);
 


### PR DESCRIPTION
- Configure redpanda dev service to enable idempotence and transactions by default: Since 3.2.1 Kafka producers are idempotent by default.
- Fix kafka streams test