### PR TITLE
Remove Oracle's BlockReleaser from runtime initialization

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleNativeImage.java
@@ -32,9 +32,6 @@ public final class OracleNativeImage {
     void runtimeInitialization(BuildProducer<RuntimeInitializedClassBuildItem> runtimeInitializedClass) {
         runtimeInitializedClass
                 .produce(new RuntimeInitializedClassBuildItem("oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource"));
-        runtimeInitializedClass
-                .produce(new RuntimeInitializedClassBuildItem(
-                        "oracle.jdbc.driver.BlockSource$ThreadedCachingBlockSource$BlockReleaser"));
     }
 
 }


### PR DESCRIPTION
Closes: https://github.com/quarkusio/quarkus/issues/27246

I have tested against this quarkus test suite branch: https://github.com/pjgg/quarkus-test-suite/pull/new/revert_native_patch
by running the following statements:

*  ubi-quarkus-mandrel:22.1-java11

`mvn clean verify -Dnative -Dall-modules -pl sql-db/vertx-sql -Dit.test=OracleHandlerIT -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.1-java11`

* ubi-quarkus-native-image:22.1-java11

` mvn clean verify -Dnative -Dall-modules -pl sql-db/vertx-sql -Dit.test=OracleHandlerIT -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.1-java11`

Is very important to verify these scenarios against Java Temurin-11.0.16+8

```
openjdk 11.0.16 2022-07-19
OpenJDK Runtime Environment Temurin-11.0.16+8 (build 11.0.16+8)
OpenJDK 64-Bit Server VM Temurin-11.0.16+8 (build 11.0.16+8, mixed mode)
```

@gsmet FYI