### PR TITLE
Fix `Category#mutable` default method to return copy

### DIFF
--- a/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/Category.java
+++ b/independent-projects/tools/registry-client/src/main/java/io/quarkus/registry/catalog/Category.java
@@ -16,7 +16,7 @@ public interface Category {
     Map<String, Object> getMetadata();
 
     default Mutable mutable() {
-        return Category.builder();
+        return new CategoryImpl.Builder(this);
     }
 
     interface Mutable extends Category, JsonBuilder<Category> {


### PR DESCRIPTION
The default implementation `Category#mutable` didn't actually return a mutable copy but a new "empty" mutable `Category` object.