### PR TITLE
Drop -H:+JNI option from nativeImageArgs

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -733,7 +733,6 @@ public class NativeImageBuildStep {
 
                 nativeImageArgs.add(
                         "-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime"); //the default collection policy results in full GC's 50% of the time
-                nativeImageArgs.add("-H:+JNI");
                 nativeImageArgs.add("-H:+AllowFoldMethods");
 
                 if (nativeConfig.headless) {


### PR DESCRIPTION
`-H:+JNI` is the default since GraalVM 19.0.0
( https://github.com/oracle/graal/commit/6346801d0b129355dfd95a8f7cb112ed0a8155a4 )