### PR TITLE
Make typesafe GraphQL clients ApplicationScoped

### DIFF
--- a/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
+++ b/extensions/smallrye-graphql-client/deployment/src/main/java/io/quarkus/smallrye/graphql/client/deployment/SmallRyeGraphQLClientProcessor.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -110,7 +111,7 @@ public class SmallRyeGraphQLClientProcessor {
             // an equivalent of io.smallrye.graphql.client.typesafe.impl.cdi.GraphQlClientBean that produces typesafe client instances
             SyntheticBeanBuildItem bean = SyntheticBeanBuildItem.configure(apiClassInfo.name())
                     .addType(apiClassInfo.name())
-                    .scope(Singleton.class)
+                    .scope(ApplicationScoped.class)
                     .supplier(recorder.typesafeClientSupplier(apiClass))
                     .unremovable()
                     .done();


### PR DESCRIPTION
The plan for later is to make the scope configurable (for typesafe as well as dynamic clients), but for now at least let's make it ApplicationScoped, because Singleton scope prevents mocking. This allows the clients to be mocked, but shouldn't significantly change any runtime behavior.