### PR TITLE
Attempt to fix intermittent failure in SimpleContextPropagationTest caused by possible race condition

### DIFF
--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/RequestBean.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/RequestBean.java
@@ -1,5 +1,7 @@
 package io.quarkus.context.test;
 
+import java.util.concurrent.CountDownLatch;
+
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.RequestScoped;
 
@@ -7,6 +9,7 @@ import javax.enterprise.context.RequestScoped;
 public class RequestBean {
 
     public static volatile int DESTROY_INVOKED = 0;
+    public static volatile CountDownLatch LATCH;
 
     public String callMe() {
         return "Hello " + System.identityHashCode(this);
@@ -15,5 +18,14 @@ public class RequestBean {
     @PreDestroy
     public void destroy() {
         DESTROY_INVOKED++;
+        // bean is also used in tests where there is no latch
+        if (LATCH != null) {
+            LATCH.countDown();
+        }
+    }
+
+    public static void initState() {
+        LATCH = new CountDownLatch(2);
+        DESTROY_INVOKED = 0;
     }
 }

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -75,20 +75,22 @@ public class SimpleContextPropagationTest {
     }
 
     @Test()
-    public void testArcMEContextPropagationDisabled() {
+    public void testArcMEContextPropagationDisabled() throws InterruptedException {
         // reset state
-        RequestBean.DESTROY_INVOKED = 0;
+        RequestBean.initState();
         RestAssured.when().get("/context/noarc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
+        Assertions.assertTrue(RequestBean.LATCH.await(3, TimeUnit.SECONDS));
         Assertions.assertEquals(2, RequestBean.DESTROY_INVOKED);
     }
 
     @Test()
-    public void testArcTCContextPropagationDisabled() {
+    public void testArcTCContextPropagationDisabled() throws InterruptedException {
         // reset state
-        RequestBean.DESTROY_INVOKED = 0;
+        RequestBean.initState();
         RestAssured.when().get("/context/noarc-tc").then()
                 .statusCode(Response.Status.OK.getStatusCode());
+        Assertions.assertTrue(RequestBean.LATCH.await(3, TimeUnit.SECONDS));
         Assertions.assertEquals(2, RequestBean.DESTROY_INVOKED);
     }
 


### PR DESCRIPTION
As per comment in https://github.com/quarkusio/quarkus/pull/27159#issuecomment-1207800338, one of the CP tests can have a race condition. Using `CountDownLatch` to force await for bean destruction should fix this.