### PR TITLE
Load CodeGenProvider services once instead of once per module

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CodeGenWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CodeGenWatcher.java
@@ -1,0 +1,62 @@
+package io.quarkus.deployment.dev;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+import io.quarkus.deployment.CodeGenerator;
+import io.quarkus.deployment.codegen.CodeGenData;
+import io.quarkus.deployment.util.FSWatchUtil;
+import io.quarkus.runtime.LaunchMode;
+
+class CodeGenWatcher {
+
+    private static final Logger log = Logger.getLogger(CodeGenWatcher.class);
+
+    private final QuarkusClassLoader deploymentClassLoader;
+    private final FSWatchUtil fsWatchUtil;
+
+    CodeGenWatcher(CuratedApplication curatedApplication, DevModeContext context) throws CodeGenException {
+        final QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
+        final List<CodeGenData> codeGens = CodeGenerator.init(deploymentClassLoader, context.getAllModules());
+        if (codeGens.isEmpty()) {
+            fsWatchUtil = null;
+            this.deploymentClassLoader = null;
+            deploymentClassLoader.close();
+        } else {
+            final Collection<FSWatchUtil.Watcher> watchers = new ArrayList<>(codeGens.size());
+            final Properties properties = new Properties();
+            properties.putAll(context.getBuildSystemProperties());
+            for (CodeGenData codeGen : codeGens) {
+                watchers.add(new FSWatchUtil.Watcher(codeGen.sourceDir, codeGen.provider.inputExtension(),
+                        modifiedPaths -> {
+                            try {
+                                CodeGenerator.trigger(deploymentClassLoader,
+                                        codeGen,
+                                        curatedApplication.getApplicationModel(), properties, LaunchMode.DEVELOPMENT, false);
+                            } catch (Exception any) {
+                                log.warn("Code generation failed", any);
+                            }
+                        }));
+            }
+            fsWatchUtil = new FSWatchUtil();
+            fsWatchUtil.observe(watchers, 500);
+            this.deploymentClassLoader = deploymentClassLoader;
+        }
+    }
+
+    void shutdown() {
+        if (fsWatchUtil != null) {
+            fsWatchUtil.shutdown();
+        }
+        if (deploymentClassLoader != null) {
+            deploymentClassLoader.close();
+        }
+    }
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/JavaCompilationProvider.java
@@ -6,9 +6,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.tools.Diagnostic;
@@ -33,8 +31,8 @@ public class JavaCompilationProvider implements CompilationProvider {
     // -g is used to make the java compiler generate all debugging info
     // -parameters is used to generate metadata for reflection on method parameters
     // this is useful when people using debuggers against their hot-reloaded app
-    private static final Set<String> COMPILER_OPTIONS = new HashSet<>(Arrays.asList("-g", "-parameters"));
-    private static final Set<String> IGNORE_NAMESPACES = new HashSet<>(Collections.singletonList("org.osgi"));
+    private static final Set<String> COMPILER_OPTIONS = Set.of("-g", "-parameters");
+    private static final Set<String> IGNORE_NAMESPACES = Set.of("org.osgi");
 
     JavaCompiler compiler;
     StandardJavaFileManager fileManager;
@@ -47,7 +45,7 @@ public class JavaCompilationProvider implements CompilationProvider {
 
     @Override
     public Set<String> handledExtensions() {
-        return Collections.singleton(".java");
+        return Set.of(".java");
     }
 
     @Override
@@ -67,7 +65,7 @@ public class JavaCompilationProvider implements CompilationProvider {
 
             DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
             fileManager.setLocation(StandardLocation.CLASS_PATH, context.getClasspath());
-            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singleton(context.getOutputDirectory()));
+            fileManager.setLocation(StandardLocation.CLASS_OUTPUT, List.of(context.getOutputDirectory()));
 
             CompilerFlags compilerFlags = new CompilerFlags(COMPILER_OPTIONS, context.getCompilerOptions(getProviderKey()),
                     context.getReleaseJavaVersion(), context.getSourceJavaVersion(), context.getTargetJvmVersion());

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -101,7 +101,6 @@ import io.quarkus.maven.components.MavenVersionEnforcer;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.GACT;
-import io.quarkus.maven.dependency.GACTV;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
@@ -1056,7 +1055,7 @@ public class DevMojo extends AbstractMojo {
             appModel = new BootstrapAppModelResolver(resolverBuilder.build())
                     .setDevMode(true)
                     .setCollectReloadableDependencies(!noDeps)
-                    .resolveModel(GACTV.jar(project.getGroupId(), project.getArtifactId(), project.getVersion()));
+                    .resolveModel(ArtifactCoords.jar(project.getGroupId(), project.getArtifactId(), project.getVersion()));
         }
 
         // serialize the app model to avoid re-resolving it in the dev process

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -65,11 +65,10 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
 
         ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         CuratedApplication curatedApplication = null;
+        QuarkusClassLoader deploymentClassLoader = null;
         try {
-
             curatedApplication = bootstrapApplication(launchMode);
-
-            QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
+            deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
             final Class<?> codeGenerator = deploymentClassLoader.loadClass("io.quarkus.deployment.CodeGenerator");
@@ -90,6 +89,9 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
                 curatedApplication.close();
             }
             Thread.currentThread().setContextClassLoader(originalTccl);
+            if (deploymentClassLoader != null) {
+                deploymentClassLoader.close();
+            }
         }
     }
 

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/IoUtils.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/bootstrap/util/IoUtils.java
@@ -120,33 +120,34 @@ public class IoUtils {
     public static Path copy(Path source, Path target) throws IOException {
         if (Files.isDirectory(source)) {
             Files.createDirectories(target);
+            Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
+                    new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                                throws IOException {
+                            final Path targetDir = target.resolve(source.relativize(dir).toString());
+                            try {
+                                Files.copy(dir, targetDir);
+                            } catch (FileAlreadyExistsException e) {
+                                if (!Files.isDirectory(targetDir)) {
+                                    throw e;
+                                }
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                throws IOException {
+                            Files.copy(file, target.resolve(source.relativize(file).toString()),
+                                    StandardCopyOption.REPLACE_EXISTING);
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
         } else {
             Files.createDirectories(target.getParent());
+            Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
-        Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
-                new SimpleFileVisitor<Path>() {
-                    @Override
-                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                            throws IOException {
-                        final Path targetDir = target.resolve(source.relativize(dir).toString());
-                        try {
-                            Files.copy(dir, targetDir);
-                        } catch (FileAlreadyExistsException e) {
-                            if (!Files.isDirectory(targetDir)) {
-                                throw e;
-                            }
-                        }
-                        return FileVisitResult.CONTINUE;
-                    }
-
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        Files.copy(file, target.resolve(source.relativize(file).toString()),
-                                StandardCopyOption.REPLACE_EXISTING);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
         return target;
     }
 

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/app/CuratedApplication.java
@@ -409,6 +409,7 @@ public class CuratedApplication implements Serializable, AutoCloseable {
         if (baseRuntimeClassLoader != null) {
             baseRuntimeClassLoader.close();
         }
+        augmentationElements.clear();
     }
 
     /**


### PR DESCRIPTION
I noticed that we load `CodeGenProvider` services for each module in a multimodule project and we also never close the deployment classloader created to look for the `CodeGenProvider` implementations. This PR fixes both issues.