### PR TITLE
Custom OIDC claim verification

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -10,6 +11,7 @@ import java.util.OptionalInt;
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.oidc.runtime.OidcConfig;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -951,6 +953,17 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public Optional<List<String>> audience = Optional.empty();
 
         /**
+         * A map of required claims and their expected values.
+         * For example, `quarkus.oidc.token.required-claims.org_id = org_xyz` would require tokens to have the `org_id` claim to
+         * be present and set to `org_xyz`.
+         * Strings are the only supported types. Use {@linkplain SecurityIdentityAugmentor} to verify claims of other types or
+         * complex claims.
+         */
+        @ConfigItem
+        @ConfigDocMapKey("claim-name")
+        public Map<String, String> requiredClaims = new HashMap<>();
+
+        /**
          * Expected token type
          */
         @ConfigItem
@@ -1166,6 +1179,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setDecryptionKeyLocation(String decryptionKeyLocation) {
             this.decryptionKeyLocation = Optional.of(decryptionKeyLocation);
+        }
+
+        public Map<String, String> getRequiredClaims() {
+            return requiredClaims;
+        }
+
+        public void setRequiredClaims(Map<String, String> requiredClaims) {
+            this.requiredClaims = requiredClaims;
         }
     }
 

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -95,6 +95,10 @@ quarkus.oidc.tenant-customheader.credentials.secret=secret
 quarkus.oidc.tenant-customheader.token.header=X-Forwarded-Authorization
 quarkus.oidc.tenant-customheader.application-type=service
 
+# Required claim (Uses tenant-b settings as it has multiple clients)
+quarkus.oidc.tenant-requiredclaim.auth-server-url=${keycloak.url}/realms/quarkus-b
+quarkus.oidc.tenant-requiredclaim.application-type=service
+quarkus.oidc.tenant-requiredclaim.token.required-claims.azp=quarkus-app-b
 
 quarkus.oidc.tenant-public-key.client-id=test
 quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -499,6 +499,24 @@ public class BearerTokenAuthorizationTest {
         }
     }
 
+    @Test
+    public void testRequiredClaimPass() {
+        //Client id should match the required azp claim
+        RestAssured.given().auth().oauth2(getAccessToken("alice", "b", "b"))
+                .when().get("/tenant/tenant-requiredclaim/api/user")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testRequiredClaimFail() {
+        //Client id does not match required azp claim
+        RestAssured.given().auth().oauth2(getAccessToken("alice", "b", "b2"))
+                .when().get("/tenant/tenant-requiredclaim/api/user")
+                .then()
+                .statusCode(401);
+    }
+
     private String getAccessToken(String userName, String clientId) {
         return getAccessToken(userName, clientId, clientId);
     }


### PR DESCRIPTION
This PR adds a new configuration property for specifying claims that should be present and matching in an OIDC token.

Fixes #27138.

Also Fixes #17292.