### PR TITLE
Upgrade to ANTLR 4.10.1 (for the ANTLR 4.x series)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -176,7 +176,7 @@
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <mockito.version>4.9.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
-        <antlr.version>4.9.2</antlr.version>
+        <antlr.version>4.10.1</antlr.version><!-- needs to align with same property in build-parent/pom.xml -->
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>
         <keycloak.version>19.0.3</keycloak.version>
         <logstash-gelf.version>1.15.0</logstash-gelf.version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -67,8 +67,8 @@
 
         <!-- MicroProfile TCK versions used to be defined here but have moved to the concrete tck modules -->
 
-        <!-- Antlr is used by the PanacheQL parser-->
-        <antlr.version>4.9.2</antlr.version>
+        <!-- Antlr 4 is used by the PanacheQL parser but also needs to match the requirements of Hibernate ORM 6.x-->
+        <antlr.version>4.10.1</antlr.version>
 
         <!-- SELinux access label, used when mounting local volumes into containers in tests -->
         <volume.access.modifier>:Z</volume.access.modifier>


### PR DESCRIPTION
This is in preparation of Hibernate ORM 6: we'll require this version, so might as well try to prepare for that, in case there's other projects that need to adapt.

N.B. versions v3 and v4 of ANTLR use a different package name, therefore this has no impact on users of ANTLR v3.x and previous.