### PR TITLE
Don't create an ArchivePathTree for non-JAR dependencies

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
@@ -38,7 +38,7 @@ public interface ResolvedDependency extends Dependency {
         }
         if (paths.isSinglePath()) {
             final Path p = paths.getSinglePath();
-            return PathTree.ofDirectoryOrArchive(p);
+            return isJar() ? PathTree.ofDirectoryOrArchive(p) : PathTree.ofDirectoryOrFile(p);
         }
         final PathTree[] trees = new PathTree[paths.size()];
         int i = 0;


### PR DESCRIPTION
Do not create `ArchivePathTree` for dependencies whose type isn't `JAR`. E.g. it may happen there will be `POM` artifacts among application dependencies.
FYI @knutwannheden