### PR TITLE
Deprecate OidcSession#expiresIn and add new methods

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcSession.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcSession.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -18,9 +19,30 @@ public interface OidcSession {
     /**
      * Return an {@linkplain:Instant} indicating how long will it take for the current session to expire.
      *
-     * @return
+     * @deprecated This method shouldn't be used as it provides an instant corresponding to 1970-01-01T0:0:0Z plus the duration
+     *             of the validity of the token, which is impractical. Please use either {@link #expiresAt()} or
+     *             {@link #validFor()} depending on your requirements. This method will be removed in a later version of
+     *             Quarkus.
+     *
+     * @return Instant
      */
+    @Deprecated(forRemoval = true, since = "2.12.0")
     Instant expiresIn();
+
+    /**
+     * Return an {@linkplain Instant} representing the current session's expiration time.
+     *
+     * @return Instant
+     */
+    Instant expiresAt();
+
+    /**
+     * Return a {@linkplain Duration} indicating how long the current session will remain valid for
+     * starting from this method's invocation time.
+     *
+     * @return Duration
+     */
+    Duration validFor();
 
     /**
      * Perform a local logout without a redirect to the OpenId Connect provider.

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcSessionImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.oidc.runtime;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Function;
 
@@ -57,8 +58,18 @@ public class OidcSessionImpl implements OidcSession {
     }
 
     @Override
+    public Instant expiresAt() {
+        return Instant.ofEpochSecond(idToken.getExpirationTime());
+    }
+
+    @Override
+    public Duration validFor() {
+        final long nowSecs = System.currentTimeMillis() / 1000;
+        return Duration.ofSeconds(idToken.getExpirationTime() - nowSecs);
+    }
+
+    @Override
     public JsonWebToken getIdToken() {
         return idToken;
     }
-
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -27,7 +27,8 @@ public class TenantHttps {
     @Path("query")
     @Authenticated
     public String getTenantWithQuery(@QueryParam("code") String value) {
-        return getTenant() + "?code=" + value;
+        return getTenant() + "?code=" + value + "&expiresAt=" + session.expiresAt().getEpochSecond()
+                + "&expiresInDuration=" + session.validFor().getSeconds();
     }
 
     @GET


### PR DESCRIPTION
Fixes #27122.

This PR:
- Fixes OidcSession#expiresIn to return a correct `Instant` representation of the token expiration time
- Adds a new method which will help users check how long, starting from now, the session will remain valid for.

Testing for a precise duration value is not easy, it is 3 secs (id token lifespan), but I'd like to avoid some random test failures, I think allowing for a ">1 && < 5" margin is reasonable, even for practical purposes. 

@geoand Have a look please when you are back :-).