### PR TITLE
Do not set 'realm=Quarkus' in Basic auth challenge

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CombinedFormBasicAuthTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/CombinedFormBasicAuthTestCase.java
@@ -23,6 +23,7 @@ public class CombinedFormBasicAuthTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.realm=TestRealm\n" +
             "quarkus.http.auth.form.enabled=true\n" +
             "quarkus.http.auth.form.login-page=login\n" +
             "quarkus.http.auth.form.error-page=error\n" +
@@ -154,7 +155,7 @@ public class CombinedFormBasicAuthTestCase {
                 .then()
                 .assertThat()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
+                .header("WWW-Authenticate", equalTo("basic realm=\"TestRealm\""));
 
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AuthConfig.java
@@ -29,8 +29,8 @@ public class AuthConfig {
     /**
      * The authentication realm
      */
-    @ConfigItem(defaultValue = "Quarkus")
-    public String realm;
+    @ConfigItem
+    public Optional<String> realm;
 
     /**
      * The HTTP permissions

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/BasicAuthenticationMechanism.java
@@ -95,7 +95,7 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
 
     public BasicAuthenticationMechanism(final String realmName, final boolean silent,
             Charset charset, Map<Pattern, Charset> userAgentCharsets) {
-        this.challenge = BASIC_PREFIX + "realm=\"" + realmName + "\"";
+        this.challenge = realmName == null ? BASIC : BASIC_PREFIX + "realm=\"" + realmName + "\"";
         this.silent = silent;
         this.charset = charset;
         this.userAgentCharsets = Collections.unmodifiableMap(new LinkedHashMap<>(userAgentCharsets));

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -279,7 +279,8 @@ public class HttpSecurityRecorder {
         return new Supplier<BasicAuthenticationMechanism>() {
             @Override
             public BasicAuthenticationMechanism get() {
-                return new BasicAuthenticationMechanism(buildTimeConfig.auth.realm, buildTimeConfig.auth.form.enabled);
+                return new BasicAuthenticationMechanism(buildTimeConfig.auth.realm.orElse(null),
+                        buildTimeConfig.auth.form.enabled);
             }
         };
     }

--- a/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -75,7 +75,7 @@ public class BearerTokenAuthorizationTest {
                 .when().get("/api/users/me")
                 .then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
+                .header("WWW-Authenticate", equalTo("basic"));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class BearerTokenAuthorizationTest {
         RestAssured.given()
                 .when().get("/api/users/me").then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
+                .header("WWW-Authenticate", equalTo("basic"));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class BearerTokenAuthorizationTest {
                 .when().get("/basic-only")
                 .then()
                 .statusCode(401)
-                .header("WWW-Authenticate", equalTo("basic realm=\"Quarkus\""));
+                .header("WWW-Authenticate", equalTo("basic"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #27291 

Currently, reporting an optional `realm` property in the Basic auth chalenge `WWW-Authenticate: Basic realm="Quarkus"` by default has 2 problems: 1) it affects the clients which are not prepared/expect a `realm` property as reported on Zulip and 2) it leaks an implementation detail, a minor case of the information exposure.

So this PR simply makes a `quarkus.http.realm` property optional for the `realm` reported only if it is required. It is really a bug fix so proposing a backport as well