### PR TITLE
Make it more obvious how to do propagation

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -424,10 +424,11 @@ we are able to propagate the span into the Kafka Record with:
 
 [source,java]
 ----
-Metadata.of(TracingMetadata.withPrevious(Context.current()));
+TracingMetadata tm = TracingMetadata.withPrevious(Context.current();
+Message out = Message.of(...).withMetadata(tm);
 ----
 
-The above creates a `Metadata` object we can add to the `Message` being produced,
+The above creates a `TracingMetadata` object we can add to the `Message` being produced,
 which retrieves the OpenTelemetry `Context` to extract the current span for propagation.
 
 [[configuration-reference]]


### PR DESCRIPTION
The example itself is misleading as one would not want to `Message.addMetadata(<example code>)`, as in this case the `TracingMetadata` would be wrapped inside a `Metadata` object, which does not allow to find it on incoming messages.

TODO: I am not convinced that the `.withPrevious()` is correct, as in my case https://itnext.io/distributed-tracing-with-quarkus-python-open-telemetry-and-jaeger-part-3-79137543b2c5 it would not take the current traceId, which we just got from the incoming message, but rather use a different one that then breaks the continuation (and effectively creates two separate traces)

@brunobat 