### PR TITLE
Fix scheduler exclusion

### DIFF
--- a/extensions/scheduler/common/pom.xml
+++ b/extensions/scheduler/common/pom.xml
@@ -27,7 +27,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish</groupId>
-                    <artifactId>javax.el</artifactId>
+                    <artifactId>jakarta.el</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/extensions/scheduler/common/pom.xml
+++ b/extensions/scheduler/common/pom.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-scheduler-parent</artifactId>
-    <version>999-SNAPSHOT</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-scheduler-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>quarkus-scheduler-common</artifactId>
-  <name>Quarkus - Scheduler - Common</name>
+    <artifactId>quarkus-scheduler-common</artifactId>
+    <name>Quarkus - Scheduler - Common</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-scheduler-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.cronutils</groupId>
-      <artifactId>cron-utils</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish</groupId>
-          <artifactId>javax.el</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- TEST dependencies -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- TEST dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Commit with change is: https://github.com/quarkusio/quarkus/commit/36156ea7443707bef4de51bbfb3ca6572141d500

They switched from using javax.el to jakarta.el in cron-utils and it's in the way of the Jakarta migration.

I also created https://github.com/jmrozanec/cron-utils/pull/537 that should solve the issue once and for all.