### PR TITLE
Exclude com.microsoft.azure:msal4j from the application BOM

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4955,6 +4955,12 @@
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
                 <version>${mssql-jdbc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.microsoft.azure</groupId>
+                        <artifactId>msal4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>


### PR DESCRIPTION
Fixes #27358 

Beyond us not actually needing this dependency, it was also transitively pulling in a dependency on com.nimbusds:oauth2-oidc-sdk which in turns enables additional Maven repositories on the project.

We really don't want that to happen: people might not trust it, it slows the build, and complicates project builds when they need offline/proxy definitions for each repository.