### PR TITLE
Add osgi-core dependency for liquibase-core

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5395,6 +5395,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- liquibase-core has a dependency on org.osgi:osgi.core -->
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.core</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.liquibase.ext</groupId>
                 <artifactId>liquibase-mongodb</artifactId>

--- a/extensions/liquibase-mongodb/runtime/pom.xml
+++ b/extensions/liquibase-mongodb/runtime/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>

--- a/extensions/liquibase/runtime/pom.xml
+++ b/extensions/liquibase/runtime/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>


### PR DESCRIPTION
liquibase-core (optionally) depends on osgi-core for API classes that
the GraalVM CE native image generator detects.
Class.getDeclaredClass0() fails on some liquibase methods.  In
particular liquibase.Scope.getCurrentScope().

Add the dependency to the classpath so that it's available at image
generation time where everything is initialized at build time.

Closes #27232