### PR TITLE
Add support for optimistic locking / check-and-set in the new Redis API

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -573,6 +573,55 @@ TransactionResult result = ds.withTransaction(tx -> {
 
 IMPORTANT: You cannot use the pub/sub feature from within a transaction.
 
+==== Using optimistic locking
+
+To use optimistic locking, you need to use a variant of the `withTransaction` method, allowing the execution of code before the transaction starts.
+In other words, it will be executed as follows:
+
+[source]
+----
+WATCH key
+
+// Pre-transaction block
+// ....
+// Produce a result
+
+MULTI
+  // In transaction code, receive the result produced by the pre-transaction block.
+EXEC
+----
+
+For example, if you need to update a value in a hash only if the field exists, you will use the following API:
+
+[source, java]
+----
+OptimisticLockingTransactionResult<Boolean> result = blocking.withTransaction(ds -> {
+    // The pre-transaction block:
+    HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+    return hashCommands.hexists(key, "field"); // Produce a result (boolean in this case)
+},
+ (exists, tx) -> { // The transactional block, receives the result and the transactional data source
+        if (exists) {
+            tx.hash(String.class).hset(key, "field", "new value");
+        } else {
+            tx.discard();
+        }
+ },
+  key); // The watched key
+----
+
+If one of the watched keys is touched before or during the execution of the pre-transaction or transactional blocks, the transaction is aborted.
+The pre-transactional block produces a result that the transactional block can use.
+This construct is necessary because, within a transaction, the commands do not produce a result.
+Results can only be retrieved after the execution of the transaction.
+
+The pre-transaction and transactional blocks are invoked on the same Redis connection.
+Consequently, the pre-transaction block must use the passed data source to execute commands.
+Thus, the commands are emitted from that connection.
+These commands must not modify the watched keys.
+
+The transaction is aborted if the pre-transaction block throws an exception (or produces a failure when using the reactive API).
+
 ==== Executing custom commands
 
 To execute a custom command, or a command not supported by the API, use the following approach:

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/OptimisticLockingTransactionResult.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/OptimisticLockingTransactionResult.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.datasource.transactions;
+
+/**
+ * A structure holding the result of the commands executed in a transaction. Note that the result are ordered, and the
+ * (0-based) index of the command must be used to retrieve the result of a specific command.
+ *
+ * In addition, it provides the rerult from the pre-transaction block.
+ */
+public interface OptimisticLockingTransactionResult<I> extends TransactionResult {
+
+    /**
+     * Retrieves the result from the pre-transaction block
+     *
+     * @return the value produces by the pre-transaction block
+     */
+    I getPreTransactionResult();
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/OptimisticLockingTransactionResultImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/OptimisticLockingTransactionResultImpl.java
@@ -1,0 +1,56 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
+
+public class OptimisticLockingTransactionResultImpl<I> implements OptimisticLockingTransactionResult<I> {
+
+    private final List<Object> results = new ArrayList<>();
+    private final boolean discarded;
+    private final I input;
+
+    public OptimisticLockingTransactionResultImpl(boolean discarded, I input, List<Object> res) {
+        this.results.addAll(res);
+        this.discarded = discarded;
+        this.input = input;
+    }
+
+    public static <I> OptimisticLockingTransactionResult<I> discarded(I input) {
+        return new OptimisticLockingTransactionResultImpl<>(true, input, Collections.emptyList());
+    }
+
+    @Override
+    public boolean discarded() {
+        return discarded;
+    }
+
+    @Override
+    public int size() {
+        return results.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return results.isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(int index) {
+        return (T) results.get(index);
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return results.iterator();
+    }
+
+    @Override
+    public I getPreTransactionResult() {
+        return input;
+    }
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/OptimisticLockingTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/OptimisticLockingTest.java
@@ -1,0 +1,350 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.hash.HashCommands;
+import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+import io.smallrye.mutiny.Uni;
+
+public class OptimisticLockingTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void hashPutIfPresent() {
+        OptimisticLockingTransactionResult<Boolean> result = blocking.withTransaction(ds -> {
+            HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        tx.hash(String.class).hset(key, "field", "Bar");
+                    } else {
+                        tx.discard();
+                    }
+                },
+                key);
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isFalse();
+
+        blocking.hash(String.class).hset(key, "field", "Foo");
+
+        result = blocking.withTransaction(ds -> {
+            HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        tx.hash(String.class).hset(key, "field", "Bar");
+                    } else {
+                        tx.discard();
+                    }
+                },
+                key);
+
+        assertThat(result.isEmpty()).isFalse();
+        assertThat(result.discarded()).isFalse();
+        assertThat(result.getPreTransactionResult()).isTrue();
+
+        assertThat(blocking.hash(String.class).hget(key, "field")).isEqualTo("Bar");
+
+    }
+
+    @Test
+    public void hashPutIfPresentReactive() {
+        OptimisticLockingTransactionResult<Boolean> result = reactive.withTransaction(ds -> {
+            var hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely();
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isFalse();
+
+        blocking.hash(String.class).hset(key, "field", "Foo");
+
+        result = reactive.withTransaction(ds -> {
+            var hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely();
+
+        assertThat(result.isEmpty()).isFalse();
+        assertThat(result.discarded()).isFalse();
+        assertThat(result.getPreTransactionResult()).isTrue();
+
+        assertThat(blocking.hash(String.class).hget(key, "field")).isEqualTo("Bar");
+
+    }
+
+    @Test
+    public void hashPutIfPresentWithModificationOfTheWatchKey() {
+        OptimisticLockingTransactionResult<Boolean> result = blocking.withTransaction(ds -> {
+
+            // Using another connection - update the key
+            blocking.hash(String.class).hset(key, "another", "hello");
+
+            HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        tx.hash(String.class).hset(key, "field", "Bar");
+                    } else {
+                        tx.discard();
+                    }
+                },
+                key);
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isFalse();
+
+        blocking.hash(String.class).hset(key, "field", "Foo");
+
+        result = blocking.withTransaction(ds -> {
+            // Using another connection - update the key
+            blocking.hash(String.class).hset(key, "yet-another", "hello");
+
+            HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        tx.hash(String.class).hset(key, "field", "Bar");
+                    } else {
+                        tx.discard();
+                    }
+                },
+                key);
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isTrue();
+
+        assertThat(blocking.hash(String.class).hget(key, "field")).isEqualTo("Foo");
+
+    }
+
+    @Test
+    public void hashPutIfPresentReactiveWithModificationOfTheWatchKey() {
+        OptimisticLockingTransactionResult<Boolean> result = reactive.withTransaction(ds -> {
+            // Using another connection - update the key
+            return reactive.hash(String.class).hset(key, "another", "hello")
+                    .chain(() -> {
+                        var hashCommands = ds.hash(String.class);
+                        return hashCommands.hexists(key, "field");
+                    });
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely();
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isFalse();
+
+        blocking.hash(String.class).hset(key, "field", "Foo");
+
+        result = reactive.withTransaction(ds -> {
+            // Using another connection - update the key
+            return reactive.hash(String.class).hset(key, "another", "hello")
+                    .chain(() -> {
+                        var hashCommands = ds.hash(String.class);
+                        return hashCommands.hexists(key, "field");
+                    });
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely();
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.discarded()).isTrue();
+        assertThat(result.getPreTransactionResult()).isTrue();
+
+        assertThat(blocking.hash(String.class).hget(key, "field")).isEqualTo("Foo");
+
+    }
+
+    @Test
+    public void hashPutIfPresentPreBlockFailing() {
+        assertThatThrownBy(() -> blocking.withTransaction(ds -> {
+            Assertions.fail("expected");
+            HashCommands<String, String, String> hashCommands = ds.hash(String.class);
+            return hashCommands.hexists(key, "field");
+        },
+                (i, tx) -> {
+                    if (i) {
+                        tx.hash(String.class).hset(key, "field", "Bar");
+                    } else {
+                        tx.discard();
+                    }
+                },
+                key)).hasMessageContaining("expected");
+    }
+
+    @Test
+    public void hashPutIfPresentPreBlockProducingAFailure() {
+        assertThatThrownBy(() -> reactive.<Boolean> withTransaction(ds -> {
+            return Uni.createFrom().failure(new RuntimeException("expected"));
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely()).hasMessageContaining("expected");
+    }
+
+    @Test
+    public void hashPutIfPresentPreBlockThrowingAnException() {
+        assertThatThrownBy(() -> reactive.withTransaction(ds -> {
+            Assertions.fail("expected");
+            return Uni.createFrom().item(true);
+        },
+                (i, tx) -> {
+                    if (i) {
+                        return tx.hash(String.class).hset(key, "field", "Bar")
+                                .replaceWithVoid();
+                    } else {
+                        return tx.discard();
+                    }
+                },
+                key).await().indefinitely()).hasMessageContaining("expected");
+    }
+
+    @Test
+    public void testZpop() {
+        var list = blocking.sortedSet(String.class);
+        list.zadd(key, 1.0, "a");
+        list.zadd(key, 2.0, "b");
+        list.zadd(key, 3.0, "c");
+
+        var res = blocking.withTransaction(ds -> {
+            var elements = ds.sortedSet(String.class).zrange(key, 0, 0);
+            if (!elements.isEmpty()) {
+                return elements.get(0);
+            }
+            return null;
+        }, (element, tx) -> {
+            if (element == null) {
+                tx.discard();
+            } else {
+                tx.sortedSet(String.class).zrem(key, element);
+            }
+        }, key);
+
+        assertThat(res.discarded()).isFalse();
+        assertThat(res.getPreTransactionResult()).isEqualTo("a");
+    }
+
+    @Test
+    public void testZpopReactive() {
+        var list = blocking.sortedSet(String.class);
+        list.zadd(key, 1.0, "a");
+        list.zadd(key, 2.0, "b");
+        list.zadd(key, 3.0, "c");
+
+        var res = reactive.withTransaction(ds -> {
+            return ds.sortedSet(String.class).zrange(key, 0, 0)
+                    .map(elements -> {
+                        if (elements.isEmpty()) {
+                            return null;
+                        }
+                        return elements.get(0);
+                    });
+        }, (element, tx) -> {
+            if (element == null) {
+                return tx.discard();
+            } else {
+                return tx.sortedSet(String.class).zrem(key, element);
+            }
+        }, key).await().indefinitely();
+
+        assertThat(res.discarded()).isFalse();
+        assertThat(res.getPreTransactionResult()).isEqualTo("a");
+    }
+
+    @Test
+    public void testZpopWithKeyModification() {
+        var list = blocking.sortedSet(String.class);
+        list.zadd(key, 1.0, "a");
+        list.zadd(key, 2.0, "b");
+        list.zadd(key, 3.0, "c");
+
+        var res = blocking.withTransaction(ds -> {
+            blocking.sortedSet(String.class).zadd(key, 4.0, "d");
+            var elements = ds.sortedSet(String.class).zrange(key, 0, 0);
+            if (!elements.isEmpty()) {
+                return elements.get(0);
+            }
+            return null;
+        }, (element, tx) -> {
+            if (element == null) {
+                tx.discard();
+            } else {
+                tx.sortedSet(String.class).zrem(key, element);
+            }
+        }, key);
+
+        assertThat(res.discarded()).isTrue();
+        assertThat(res.getPreTransactionResult()).isEqualTo("a");
+    }
+
+}


### PR DESCRIPTION
This PR adds a new variant of the `withTransaction` method allowing optimistic locking patterns such as `updateIfExist`, or a `zpop` implementation. More details on https://redis.io/docs/manual/transactions/#optimistic-locking-using-check-and-set