### PR TITLE
Add exports for built-time init and Resources

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -28,7 +28,7 @@ public final class GraalVM {
         static final Version VERSION_22_3_0 = new Version("GraalVM 22.3.0", "22.3.0", Distribution.ORACLE);
 
         public static final Version VERSION_22_1_0 = new Version("GraalVM 22.1.0", "22.1.0", Distribution.ORACLE);
-        static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
+        public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_21_3;
         public static final Version CURRENT = VERSION_22_2_0;

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -285,6 +285,9 @@ public class NativeImageFeatureStep {
             // Needed to access LOOKUP_METHOD
             exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.base", "com.oracle.svm.util",
                     GraalVM.Version.VERSION_22_1_0));
+            // Needed to access com.oracle.svm.core.jdk.Resources.registerResource
+            exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk",
+                    GraalVM.Version.VERSION_22_2_0));
 
             ResultHandle resourcesRegistrySingleton = overallCatch.invokeStaticMethod(IMAGE_SINGLETONS_LOOKUP,
                     overallCatch.loadClassFromTCCL("com.oracle.svm.core.configure.ResourcesRegistry"));
@@ -341,6 +344,10 @@ public class NativeImageFeatureStep {
             overallCatch.invokeStaticMethod(ofMethod(ResourceHelper.class, "registerResources", void.class, String.class),
                     overallCatch.load(i.serviceDescriptorFile()));
         }
+
+        // Needed to access BUILD_TIME_INITIALIZATION
+        exports.produce(new JPMSExportBuildItem("org.graalvm.sdk", "org.graalvm.nativeimage.impl",
+                GraalVM.Version.VERSION_22_2_0));
 
         if (!resourceBundles.isEmpty()) {
             // Needed to access LOCALIZATION_FEATURE


### PR DESCRIPTION
Affects native builds with 22.3.0-dev builds of Graal.

`org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk` and
`org.graalvm.sdk/org.graalvm.nativeimage.impl` no longer exported
to the `UNNAMED` module. Add explicit exports.

Prior patch I'm seeing for `liquibase` integration-test:
```
Java version info: '17.0.4-beta+7-202206282316'
 C compiler: gcc (redhat, x86_64, 12.1.1)
 Garbage collector: Serial GC
 4 user-specific feature(s)
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase for the [org.jboss.threads] categories
 - io.quarkus.runtime.graal.ResourcesFeature: Register each line in META-INF/quarkus-native-resources.txt as a resource on Substrate VM
 - org.graalvm.home.HomeFinderFeature: Finds GraalVM paths and its version number
java.lang.IllegalAccessError: class io.quarkus.runner.Feature (in unnamed module @0x650a1aff) cannot access class org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport (in module org.graalvm.sdk) because module org.graalvm.sdk does not export org.graalvm.nativeimage.impl to unnamed module @0x650a1aff
	at io.quarkus.runner.Feature.beforeAnalysis(Unknown Source)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$9(NativeImageGenerator.java:734)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:78)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:734)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:576)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:533)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:403)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:580)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)

Fatal error: java.lang.RuntimeException: Failed to load resource META-INF/services/org.jboss.logmanager.MDCProvider
	at io.quarkus.runtime.ResourceHelper.registerResources(ResourceHelper.java:25)
	at io.quarkus.runtime.graal.ResourcesFeature.beforeAnalysis(ResourcesFeature.java:24)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$9(NativeImageGenerator.java:734)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:78)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:734)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:576)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:533)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:403)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:580)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
Caused by: java.lang.RuntimeException: Failed to register resource META-INF/services/org.jboss.logmanager.MDCProvider
	at io.quarkus.runtime.ResourceHelper.lambda$registerResources$0(ResourceHelper.java:21)
	at io.quarkus.runtime.util.ClassPathUtils.lambda$consumeStream$1(ClassPathUtils.java:180)
	at io.quarkus.runtime.util.ClassPathUtils.readStream(ClassPathUtils.java:201)
	at io.quarkus.runtime.util.ClassPathUtils.consumeStream(ClassPathUtils.java:179)
	at io.quarkus.runtime.util.ClassPathUtils.consumeAsStreams(ClassPathUtils.java:71)
	at io.quarkus.runtime.ResourceHelper.registerResources(ResourceHelper.java:17)
	... 9 more
Caused by: java.lang.IllegalAccessException: class io.quarkus.runtime.ResourceHelper cannot access class com.oracle.svm.core.jdk.Resources (in module org.graalvm.nativeimage.builder) because module org.graalvm.nativeimage.builder does not export com.oracle.svm.core.jdk to unnamed module @650a1aff
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
	at java.base/java.lang.reflect.Method.invoke(Method.java:560)
	at io.quarkus.runtime.ResourceHelper.lambda$registerResources$0(ResourceHelper.java:19)
	... 14 more

```