### PR TITLE
Ability to configure dependency exclusions when composing app modules programmatically

### DIFF
--- a/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BuildWithExclusionsWorkspaceModuleTest.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/runnerjar/BuildWithExclusionsWorkspaceModuleTest.java
@@ -1,0 +1,93 @@
+package io.quarkus.deployment.runnerjar;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.TsArtifact;
+import io.quarkus.bootstrap.resolver.TsQuarkusExt;
+import io.quarkus.bootstrap.workspace.ArtifactSources;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyBuilder;
+import io.quarkus.maven.dependency.ResolvedDependency;
+
+public class BuildWithExclusionsWorkspaceModuleTest extends BootstrapFromWorkspaceModuleTestBase {
+
+    @Override
+    protected WorkspaceModule composeApplication() throws Exception {
+
+        TsArtifact acmeLibA = TsArtifact.jar("acme-lib-a");
+
+        TsArtifact acmeLibB = TsArtifact.jar("acme-lib-b");
+        addToExpectedLib(acmeLibB);
+
+        // Acme Quarkus extension
+        final TsQuarkusExt acmeExt = new TsQuarkusExt("acme-ext");
+        acmeExt.getRuntime().addDependency(acmeLibA);
+        acmeExt.getRuntime().addDependency(acmeLibB);
+        install(acmeExt);
+        addToExpectedLib(acmeExt.getRuntime());
+
+        // Acme Quarkus platform BOM
+        final TsArtifact acmeBom = TsArtifact.pom("org.acme", "acme-bom", "1.0");
+        acmeBom.addManagedDependency(platformDescriptor());
+        acmeBom.addManagedDependency(platformProperties());
+        install(acmeBom);
+
+        final WorkspaceModule module = WorkspaceModule.builder()
+                .setModuleId(WorkspaceModuleId.of("org.acme", "acme-app", "1"))
+                .setModuleDir(mkdir("app-module"))
+                .setBuildDir(mkdir("target"))
+                .addArtifactSources(ArtifactSources.main(
+                        SourceDir.of(mkdir("app-module/main/java"), mkdir("main/classes")),
+                        SourceDir.of(mkdir("app-module/main/resources"), mkdir("main/classes"))))
+                .addArtifactSources(ArtifactSources.test(
+                        SourceDir.of(mkdir("app-module/test/java"), mkdir("test/classes")),
+                        SourceDir.of(mkdir("app-module/test/resources"), mkdir("test/classes"))))
+                .addDependencyConstraint(
+                        Dependency.pomImport(acmeBom.getGroupId(), acmeBom.getArtifactId(), acmeBom.getVersion()))
+                .addDependencyConstraint(
+                        DependencyBuilder.newInstance()
+                                .setGroupId(acmeExt.getRuntime().getGroupId())
+                                .setArtifactId(acmeExt.getRuntime().getArtifactId())
+                                .setVersion(acmeExt.getRuntime().getVersion())
+                                .addExclusion(TsArtifact.DEFAULT_GROUP_ID, "acme-lib-a")
+                                .build())
+                .addDependency(Dependency.of(acmeExt.getRuntime().getGroupId(), acmeExt.getRuntime().getArtifactId()))
+                .build();
+
+        return module;
+    }
+
+    @Override
+    protected void assertAppModel(ApplicationModel appModel) throws Exception {
+
+        final ResolvedDependency appArtifact = appModel.getAppArtifact();
+        assertThat(appArtifact.toCompactCoords()).isEqualTo("org.acme:acme-app:1");
+        assertThat(appArtifact.getResolvedPaths().getSinglePath()).isEqualTo(workDir.resolve("main/classes"));
+
+        // runtime classpath
+        assertThat(appModel.getDependencies().stream().filter(Dependency::isRuntimeCp).map(ArtifactCoords::getArtifactId)
+                .collect(Collectors.toList())).isEqualTo(List.of("acme-ext", "acme-lib-b"));
+
+        // deployment classpath
+        assertThat(appModel.getDependencies().stream().filter(Dependency::isDeploymentCp).map(ArtifactCoords::getArtifactId)
+                .collect(Collectors.toList()))
+                .isEqualTo(List.of("acme-ext", "acme-lib-b", "acme-ext-deployment"));
+    }
+
+    private Path mkdir(String path) throws IOException {
+        Path p = workDir.resolve(path);
+        Files.createDirectories(p);
+        return p;
+    }
+}

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependency.java
@@ -1,6 +1,8 @@
 package io.quarkus.maven.dependency;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 public class ArtifactDependency extends GACTV implements Dependency, Serializable {
@@ -13,12 +15,14 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
     }
 
     private final String scope;
-    private int flags;
+    private final int flags;
+    private final Collection<ArtifactKey> exclusions;
 
     public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version) {
         super(groupId, artifactId, classifier, type, version);
         this.scope = SCOPE_COMPILE;
         flags = 0;
+        this.exclusions = List.of();
     }
 
     public ArtifactDependency(String groupId, String artifactId, String classifier, String type, String version, String scope,
@@ -26,6 +30,7 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
         super(groupId, artifactId, classifier, type, version);
         this.scope = scope;
         flags = optional ? DependencyFlags.OPTIONAL : 0;
+        this.exclusions = List.of();
     }
 
     public ArtifactDependency(ArtifactCoords coords, int... flags) {
@@ -41,18 +46,21 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
             allFlags |= f;
         }
         this.flags = allFlags;
+        this.exclusions = List.of();
     }
 
     public ArtifactDependency(Dependency d) {
         super(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion());
         this.scope = d.getScope();
         this.flags = d.getFlags();
+        this.exclusions = d.getExclusions();
     }
 
     public ArtifactDependency(AbstractDependencyBuilder<?, ?> builder) {
         super(builder.getGroupId(), builder.getArtifactId(), builder.getClassifier(), builder.getType(), builder.getVersion());
         this.scope = builder.getScope();
         this.flags = builder.getFlags();
+        this.exclusions = builder.exclusions.isEmpty() ? builder.exclusions : List.copyOf(builder.exclusions);
     }
 
     @Override
@@ -66,10 +74,15 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
     }
 
     @Override
+    public Collection<ArtifactKey> getExclusions() {
+        return exclusions;
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hash(flags, scope);
+        result = prime * result + Objects.hash(exclusions, flags, scope);
         return result;
     }
 
@@ -82,7 +95,7 @@ public class ArtifactDependency extends GACTV implements Dependency, Serializabl
         if (!(obj instanceof ArtifactDependency))
             return false;
         ArtifactDependency other = (ArtifactDependency) obj;
-        return flags == other.flags && Objects.equals(scope, other.scope);
+        return flags == other.flags && Objects.equals(scope, other.scope) && exclusions.equals(other.exclusions);
     }
 
     @Override

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ArtifactDependencyBuilder.java
@@ -1,5 +1,9 @@
 package io.quarkus.maven.dependency;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, T>, T> {
 
     String groupId;
@@ -7,8 +11,9 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
     String classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
     String type = ArtifactCoords.TYPE_JAR;
     String version;
-    String scope = "compile";
+    String scope = Dependency.SCOPE_COMPILE;
     int flags;
+    Collection<ArtifactKey> exclusions = List.of();
 
     @SuppressWarnings("unchecked")
     public B setCoords(ArtifactCoords coords) {
@@ -122,6 +127,19 @@ abstract class AbstractDependencyBuilder<B extends AbstractDependencyBuilder<B, 
         if ((flags & flag) > 0) {
             flags ^= flag;
         }
+    }
+
+    public B addExclusion(String groupId, String artifactId) {
+        return addExclusion(ArtifactKey.ga(groupId, artifactId));
+    }
+
+    @SuppressWarnings("unchecked")
+    public B addExclusion(ArtifactKey key) {
+        if (exclusions.isEmpty()) {
+            exclusions = new ArrayList<>();
+        }
+        exclusions.add(key);
+        return (B) this;
     }
 
     public String getGroupId() {

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/Dependency.java
@@ -1,5 +1,8 @@
 package io.quarkus.maven.dependency;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface Dependency extends ArtifactCoords {
 
     String SCOPE_COMPILE = "compile";
@@ -18,6 +21,10 @@ public interface Dependency extends ArtifactCoords {
     }
 
     String getScope();
+
+    default Collection<ArtifactKey> getExclusions() {
+        return List.of();
+    }
 
     int getFlags();
 


### PR DESCRIPTION
This allows excluding dependencies when bootstrapping (or building) applications that are assembled with some config, other than Maven or Gradle project. This is a use-case of custom application installers/builders.