### PR TITLE
action-build-reporter - Disable main repo at the job level

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -786,7 +786,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build report
     needs: [build-jdk11,jvm-tests,maven-tests,gradle-tests,devtools-tests,quickstarts-tests,tcks-test,native-tests]
-    if: always()
+    if: always() && github.repository != 'quarkusio/quarkus'
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Just downloading the artifacts takes time so let's disable the run for
the main repository at the job level so nothing is executed.