### PR TITLE
Update the Redis dev service to Redis 7

### DIFF
--- a/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
+++ b/extensions/redis-client/deployment/src/main/java/io/quarkus/redis/client/deployment/DevServicesRedisProcessor.java
@@ -42,7 +42,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 @BuildSteps(onlyIfNot = IsNormal.class, onlyIf = { GlobalDevServicesConfig.Enabled.class })
 public class DevServicesRedisProcessor {
     private static final Logger log = Logger.getLogger(DevServicesRedisProcessor.class);
-    private static final String REDIS_6_ALPINE = "docker.io/redis:6-alpine";
+    private static final String REDIS_7_ALPINE = "docker.io/redis:7-alpine";
     private static final int REDIS_EXPOSED_PORT = 6379;
     private static final String REDIS_SCHEME = "redis://";
 
@@ -171,8 +171,8 @@ public class DevServicesRedisProcessor {
             return null;
         }
 
-        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(REDIS_6_ALPINE))
-                .asCompatibleSubstituteFor(REDIS_6_ALPINE);
+        DockerImageName dockerImageName = DockerImageName.parse(devServicesConfig.imageName.orElse(REDIS_7_ALPINE))
+                .asCompatibleSubstituteFor(REDIS_7_ALPINE);
 
         Supplier<RunningDevService> defaultRedisServerSupplier = () -> {
             QuarkusPortRedisContainer redisContainer = new QuarkusPortRedisContainer(dockerImageName, devServicesConfig.port,


### PR DESCRIPTION
The new API is using the Redis 7 commands, so without this, some commands do not work (geosearch for example) as the server does not handle them.
