### PR TITLE
Disallow mixing @QuarkusTest and @QuarkusMainTest

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -2,6 +2,7 @@ package io.quarkus.test.junit;
 
 import static io.quarkus.test.junit.IntegrationTestUtil.activateLogging;
 import static io.quarkus.test.junit.IntegrationTestUtil.getAdditionalTestResources;
+import static io.quarkus.test.junit.QuarkusTestExtension.IO_QUARKUS_TESTING_TYPE;
 
 import java.io.Closeable;
 import java.util.*;
@@ -31,6 +32,7 @@ import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 import io.quarkus.test.junit.main.QuarkusMainIntegrationTest;
 import io.quarkus.test.junit.main.QuarkusMainLauncher;
+import io.quarkus.test.junit.main.QuarkusMainTest;
 
 public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
         implements BeforeEachCallback, AfterEachCallback, ParameterResolver, BeforeAllCallback, AfterAllCallback {
@@ -64,6 +66,17 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
     private void ensurePrepared(ExtensionContext extensionContext, Class<? extends QuarkusTestProfile> profile)
             throws Exception {
         ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+        Class<?> testType = store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
+        if (testType != null) {
+            if (testType != QuarkusMainTest.class) {
+                throw new IllegalStateException(
+                        "Cannot mix both @QuarkusMainTest based tests and " + testType.getName()
+                                + " based tests in the same run");
+            }
+        } else {
+            store.put(IO_QUARKUS_TESTING_TYPE, QuarkusMainTest.class);
+        }
+
         QuarkusTestExtension.ExtensionState state = store.get(QuarkusTestExtension.ExtensionState.class.getName(),
                 QuarkusTestExtension.ExtensionState.class);
         boolean wrongProfile = !Objects.equals(profile, quarkusTestProfile);


### PR DESCRIPTION
These two can step on each other's toes too easily
(and lead to hard to diagnose errors), so let's make
the failure explicit

Relates to: #27247