### PR TITLE
CDI context propagation improvements for the reactive stack

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/Capability.java
@@ -39,6 +39,7 @@ public interface Capability {
 
     String REST = QUARKUS_PREFIX + "rest";
     String REST_CLIENT = REST + ".client";
+    String REST_CLIENT_REACTIVE = REST_CLIENT + ".reactive";
     String REST_JACKSON = REST + ".jackson";
     String REST_JSONB = REST + ".jsonb";
 

--- a/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
+++ b/extensions/narayana-lra/deployment/src/main/java/io/quarkus/narayana/lra/deployment/NarayanaLRAProcessor.java
@@ -45,7 +45,7 @@ class NarayanaLRAProcessor {
                     "'quarkus-narayana-lra' can only work if 'quarkus-resteasy-jackson' or 'quarkus-resteasy-reactive-jackson' is present");
         }
 
-        if (!capabilities.isPresent(Capability.REST_CLIENT)) {
+        if (!capabilities.isCapabilityWithPrefixPresent(Capability.REST_CLIENT)) {
             throw new IllegalStateException(
                     "'quarkus-narayana-lra' can only work if 'quarkus-rest-client' or 'quarkus-rest-client-reactive' is present");
         }

--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/QuarkusContextStorage.java
@@ -1,7 +1,6 @@
 package io.quarkus.opentelemetry.runtime;
 
 import static io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle.setContextSafe;
-import static io.smallrye.common.vertx.VertxContext.getOrCreateDuplicatedContext;
 import static io.smallrye.common.vertx.VertxContext.isDuplicatedContext;
 
 import org.jboss.logging.Logger;
@@ -9,6 +8,7 @@ import org.jboss.logging.Logger;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Vertx;
 
 /**
@@ -118,8 +118,10 @@ public enum QuarkusContextStorage implements ContextStorage {
      */
     public static io.vertx.core.Context getVertxContext() {
         io.vertx.core.Context context = Vertx.currentContext();
-        if (context != null) {
-            io.vertx.core.Context dc = getOrCreateDuplicatedContext(context);
+        if (context != null && VertxContext.isOnDuplicatedContext()) {
+            return context;
+        } else if (context != null) {
+            io.vertx.core.Context dc = VertxContext.createNewDuplicatedContext(context);
             setContextSafe(dc, true);
             return dc;
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RequestLeakDetectionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/RequestLeakDetectionTest.java
@@ -1,0 +1,192 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ResponseBody;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class RequestLeakDetectionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(MyRestAPI.class, MyRequestScopeBean.class, Barrier.class, Task.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Inject
+    Barrier barrier;
+
+    @Test
+    public void testWithConcurrentCalls() {
+        List<String> results = new CopyOnWriteArrayList<>();
+        int count = 100;
+        barrier.setMaxConcurrency(count);
+        for (int i = 0; i < count; i++) {
+            int c = i;
+            new Thread(() -> {
+                ResponseBody<?> body = RestAssured.given().pathParam("val", c).contentType(MediaType.APPLICATION_JSON)
+                        .get("/test/{val}").thenReturn().body();
+                String value = body.toString();
+                results.add(value);
+            }).start();
+        }
+        await().until(() -> results.size() == count);
+        Set<String> asSet = new HashSet<>(results);
+        Assertions.assertEquals(asSet.size(), count);
+    }
+
+    @Test
+    public void testWithConcurrentBlockingCalls() {
+        List<String> results = new CopyOnWriteArrayList<>();
+        int count = 100;
+        barrier.setMaxConcurrency(count);
+        for (int i = 0; i < count; i++) {
+            int c = i;
+            new Thread(() -> {
+                ResponseBody<?> body = RestAssured.given().pathParam("val", c).contentType(MediaType.APPLICATION_JSON)
+                        .get("/test/blocking/{val}").thenReturn().body();
+                String value = body.toString();
+                results.add(value);
+            }).start();
+        }
+        await().until(() -> results.size() == count);
+        Set<String> asSet = new HashSet<>(results);
+        Assertions.assertEquals(asSet.size(), count);
+    }
+
+    @ApplicationScoped
+    @Path("/test")
+    public static class MyRestAPI {
+
+        @Inject
+        MyRequestScopeBean bean;
+
+        @Inject
+        Barrier barrier;
+
+        @GET
+        @Path("/{val}")
+        public Uni<Foo> foo(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int r = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(r, val);
+                    e.complete(bean.getValue());
+                });
+            }).map(i -> new Foo(Integer.toString(i)));
+        }
+
+        @GET
+        @Path("/blocking/{val}")
+        public Foo blocking(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int r = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(r, val);
+                    e.complete(bean.getValue());
+                });
+            })
+                    .map(i -> new Foo(Integer.toString(i)))
+                    .await().indefinitely();
+        }
+    }
+
+    @ApplicationScoped
+    public static class Barrier {
+
+        private int level;
+
+        public void setMaxConcurrency(int level) {
+            this.level = level;
+        }
+
+        private final AtomicInteger counter = new AtomicInteger();
+        private final List<Task> tasks = new CopyOnWriteArrayList<>();
+
+        public void enqueue(Context context, Runnable runnable) {
+            Task task = new Task(context, runnable);
+            tasks.add(task);
+            if (counter.incrementAndGet() >= level) {
+                for (Task tbr : new ArrayList<>(tasks)) {
+                    tbr.run();
+                    tasks.remove(tbr);
+                }
+            }
+        }
+    }
+
+    private static class Task {
+        private final Context context;
+        private final Runnable runnable;
+
+        private Task(Context context, Runnable runnable) {
+            this.context = context;
+            this.runnable = runnable;
+        }
+
+        void run() {
+            context.runOnContext(x -> runnable.run());
+        }
+    }
+
+    @RequestScoped
+    public static class MyRequestScopeBean {
+
+        private int value = -1;
+
+        public void setValue(int v) {
+            if (value != -1) {
+                throw new IllegalStateException("Already initialized");
+            }
+            value = v;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+    }
+
+    public static class Foo {
+
+        public final String value;
+
+        public Foo(String value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -45,6 +45,13 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
         }
     }
 
+    @Override
+    protected void requestScopeDeactivated() {
+        // we intentionally don't call 'CurrentRequestManager.set(null)'
+        // because there is no need to clear the current request
+        // as that is backed by a DuplicatedContext and not accessible to other requests anyway
+    }
+
     protected SecurityContext createSecurityContext() {
         return new ResteasyReactiveSecurityContext(context);
     }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/RequestLeakDetectionTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/RequestLeakDetectionTest.java
@@ -1,0 +1,309 @@
+package io.quarkus.rest.client.reactive;
+
+import static io.quarkus.rest.client.reactive.RestClientTestUtil.setUrlForClass;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ResponseBody;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class RequestLeakDetectionTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyRestAPI.class, MyRequestScopeBean.class, Barrier.class, Task.class, RemoteClient.class,
+                            RemoteService.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                    .addAsResource(
+                            new StringAsset(setUrlForClass(RemoteClient.class)), "application.properties"));
+
+    @Inject
+    Barrier barrier;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "reactive-server-and-client",
+            "blocking-server-and-reactive-client",
+            "blocking-server-and-client",
+            "reactive-server-and-blocking-client"
+    })
+    public void testWithConcurrentCallsWithReactiveClientAndServer(String path) {
+        List<String> results = new CopyOnWriteArrayList<>();
+        int count = 100;
+        barrier.setMaxConcurrency(count);
+        for (int i = 0; i < count; i++) {
+            int c = i;
+            new Thread(() -> {
+                ResponseBody<?> body = RestAssured.given().pathParam("val", c).contentType(MediaType.APPLICATION_JSON)
+                        .get("/test/" + path + "/{val}").thenReturn().body();
+                String value = body.toString();
+                results.add(value);
+            }).start();
+        }
+        await().until(() -> results.size() == count);
+        Set<String> asSet = new HashSet<>(results);
+        Assertions.assertEquals(asSet.size(), count);
+    }
+
+    @ApplicationScoped
+    @Path("/test")
+    public static class MyRestAPI {
+
+        @Inject
+        MyRequestScopeBean bean;
+
+        @Inject
+        Barrier barrier;
+
+        @RestClient
+        RemoteClient client;
+
+        @GET
+        @Path("/reactive-server-and-client/{val}")
+        public Uni<Foo> reactiveServerAndClient(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    Assertions.assertEquals(bean.getValue(), val);
+                    int rBefore = Vertx.currentContext().getLocal("count");
+                    client.invokeReactive(Integer.toString(val))
+                            .invoke(s -> {
+                                Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                                int rAfter = Vertx.currentContext().getLocal("count");
+                                Assertions.assertEquals(s, "hello " + rAfter);
+                                Assertions.assertEquals(rBefore, rAfter);
+                                Assertions.assertEquals(rAfter, val);
+                                Assertions.assertEquals(bean.getValue(), val);
+                            }).subscribe().with(x -> e.complete(val), e::fail);
+                });
+            }).map(i -> {
+                Assertions.assertEquals(bean.getValue(), val);
+                return new Foo(Integer.toString(i));
+            });
+        }
+
+        @GET
+        @Path("/blocking-server-and-reactive-client/{val}")
+        public Foo blockingServerWithReactiveClient(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int rBefore = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(bean.getValue(), val);
+                    client.invokeReactive(Integer.toString(val))
+                            .invoke(s -> {
+                                Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                                int rAfter = Vertx.currentContext().getLocal("count");
+                                Assertions.assertEquals(s, "hello " + rAfter);
+                                Assertions.assertEquals(rBefore, rAfter);
+                                Assertions.assertEquals(rAfter, val);
+                                Assertions.assertEquals(bean.getValue(), val);
+                            }).subscribe().with(x -> e.complete(val), e::fail);
+                });
+            }).map(i -> {
+                Assertions.assertEquals(bean.getValue(), val);
+                return new Foo(Integer.toString(i));
+            })
+                    .await().indefinitely();
+        }
+
+        @GET
+        @Path("/blocking-server-and-client/{val}")
+        public Foo blockingServerAndBlockingClient(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int rBefore = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(bean.getValue(), val);
+                    String s = client.invokeBlocking(Integer.toString(val));
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int rAfter = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(s, "hello " + rAfter);
+                    Assertions.assertEquals(rBefore, rAfter);
+                    Assertions.assertEquals(rAfter, val);
+                    Assertions.assertEquals(bean.getValue(), val);
+                    e.complete(val);
+                }, true);
+            }).map(i -> {
+                Assertions.assertEquals(bean.getValue(), val);
+                return new Foo(Integer.toString(i));
+            })
+                    .await().indefinitely();
+        }
+
+        @GET
+        @Path("/reactive-server-and-blocking-client/{val}")
+        public Uni<Foo> reactiveServerWithBlockingClient(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int rBefore = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(bean.getValue(), val);
+                    String s = client.invokeBlocking(Integer.toString(val));
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int rAfter = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(s, "hello " + rAfter);
+                    Assertions.assertEquals(rBefore, rAfter);
+                    Assertions.assertEquals(rAfter, val);
+                    Assertions.assertEquals(bean.getValue(), val);
+                    e.complete(val);
+                }, true);
+            }).map(i -> {
+                Assertions.assertEquals(bean.getValue(), val);
+                return new Foo(Integer.toString(i));
+            });
+        }
+    }
+
+    @Path("/remote")
+    public static class RemoteService {
+
+        @GET
+        @Path("/reactive/{name}")
+        public Uni<String> hello(String name) {
+            return Uni.createFrom().item("hello " + name);
+        }
+
+        @GET
+        @Path("/blocking/{name}")
+        public String helloBlocking(String name) {
+            return "hello " + name;
+        }
+    }
+
+    @RegisterRestClient
+    @Path("/remote")
+    public interface RemoteClient {
+        @GET
+        @Path("/reactive/{name}")
+        Uni<String> invokeReactive(String name);
+
+        @GET
+        @Path("/blocking/{name}")
+        String invokeBlocking(String name);
+    }
+
+    @ApplicationScoped
+    public static class Barrier {
+
+        private int level;
+
+        public void setMaxConcurrency(int level) {
+            this.level = level;
+        }
+
+        private final AtomicInteger counter = new AtomicInteger();
+        private final List<Task> tasks = new CopyOnWriteArrayList<>();
+
+        public void enqueue(Context context, Runnable runnable) {
+            enqueue(context, runnable, false);
+        }
+
+        public void enqueue(Context context, Runnable runnable, boolean blocking) {
+            Task task = new Task(context, runnable, blocking);
+            tasks.add(task);
+            if (counter.incrementAndGet() >= level) {
+                for (Task tbr : new ArrayList<>(tasks)) {
+                    tbr.run();
+                    tasks.remove(tbr);
+                }
+            }
+        }
+    }
+
+    private static class Task {
+        private final Context context;
+        private final Runnable runnable;
+
+        private final boolean blocking;
+
+        private Task(Context context, Runnable runnable, boolean blocking) {
+            this.context = context;
+            this.runnable = runnable;
+            this.blocking = blocking;
+        }
+
+        void run() {
+            if (blocking) {
+                context.executeBlocking(p -> {
+                    runnable.run();
+                    p.complete();
+                });
+            } else {
+                context.runOnContext(x -> runnable.run());
+            }
+        }
+    }
+
+    @RequestScoped
+    public static class MyRequestScopeBean {
+
+        private int value = -1;
+
+        public void setValue(int v) {
+            if (value != -1) {
+                throw new IllegalStateException("Already initialized");
+            }
+            value = v;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+    }
+
+    public static class Foo {
+
+        public final String value;
+
+        public Foo(String value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <configuration>
                     <capabilities>
-                        <provides>io.quarkus.rest.client</provides>
+                        <provides>io.quarkus.rest.client.reactive</provides>
                     </capabilities>
                 </configuration>
                 <executions>

--- a/extensions/smallrye-graphql/deployment/pom.xml
+++ b/extensions/smallrye-graphql/deployment/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/RequestLeakDetectionTest.java
+++ b/extensions/smallrye-graphql/deployment/src/test/java/io/quarkus/smallrye/graphql/deployment/RequestLeakDetectionTest.java
@@ -1,0 +1,185 @@
+package io.quarkus.smallrye.graphql.deployment;
+
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ResponseBody;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class RequestLeakDetectionTest extends AbstractGraphQLTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().withApplicationRoot((jar) -> jar
+            .addClasses(RequestLeakDetectionTest.MyGraphQLApi.class, MyRequestScopeBean.class, Barrier.class, Task.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+    @Inject
+    Barrier barrier;
+
+    @Test
+    public void testWithConcurrentCalls() {
+        List<String> results = new CopyOnWriteArrayList<>();
+        List<String> nested = new CopyOnWriteArrayList<>();
+        List<String> nestedUni = new CopyOnWriteArrayList<>();
+        int count = 100;
+        barrier.setMaxConcurrency(count);
+        for (int i = 0; i < count; i++) {
+            int c = i;
+            new Thread(() -> {
+                String query = getPayload("{ foo(val:" + c + ") { value nested{ value } nestedUni { value } } }");
+                ResponseBody<?> body = RestAssured.given().body(query).contentType(MEDIATYPE_JSON).post("/graphql/")
+                        .thenReturn().body();
+                String value = body.path("data.foo.value");
+                String nestedValue = body.path("data.foo.nested.value");
+                String nestedUniValue = body.path("data.foo.nestedUni.value");
+                results.add(value);
+                nested.add(nestedValue);
+                nestedUni.add(nestedUniValue);
+            }).start();
+        }
+        await().until(() -> results.size() == count);
+        await().until(() -> nested.size() == count);
+        await().until(() -> nestedUni.size() == count);
+        Set<String> asSet = new HashSet<>(results);
+        Assertions.assertEquals(count, asSet.size());
+        asSet = new HashSet<>(nested);
+        Assertions.assertEquals(count, asSet.size());
+        asSet = new HashSet<>(nestedUni);
+        Assertions.assertEquals(count, asSet.size());
+    }
+
+    @ApplicationScoped
+    @GraphQLApi
+    public static class MyGraphQLApi {
+
+        @Inject
+        MyRequestScopeBean bean;
+
+        @Inject
+        Barrier barrier;
+
+        @Query
+        public Uni<Foo> foo(int val) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            Vertx.currentContext().putLocal("count", val);
+            bean.setValue(val);
+
+            return Uni.createFrom().<Integer> emitter(e -> {
+                barrier.enqueue(Vertx.currentContext(), () -> {
+                    Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+                    int r = Vertx.currentContext().getLocal("count");
+                    Assertions.assertEquals(r, val);
+                    e.complete(bean.getValue());
+                });
+            }).map(i -> new Foo(Integer.toString(i)));
+        }
+
+        public Foo nested(@Source Foo foo) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            int r = Vertx.currentContext().getLocal("count");
+            String rAsString = Integer.toString(r);
+            Assertions.assertEquals(rAsString, foo.value);
+            Assertions.assertEquals(bean.getValue(), r);
+            return new Foo("source field on foo " + foo.value);
+        }
+
+        public Uni<Foo> nestedUni(@Source Foo foo) {
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+            int r = Vertx.currentContext().getLocal("count");
+            String rAsString = Integer.toString(r);
+            Assertions.assertEquals(rAsString, foo.value);
+            Assertions.assertEquals(bean.getValue(), r);
+            return Uni.createFrom().item(new Foo("uni source field on foo " + foo.value));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class Barrier {
+
+        private int level;
+
+        public void setMaxConcurrency(int level) {
+            this.level = level;
+        }
+
+        private final AtomicInteger counter = new AtomicInteger();
+        private final List<Task> tasks = new CopyOnWriteArrayList<>();
+
+        public void enqueue(Context context, Runnable runnable) {
+            Task task = new Task(context, runnable);
+            tasks.add(task);
+            if (counter.incrementAndGet() >= level) {
+                for (Task tbr : new ArrayList<>(tasks)) {
+                    tbr.run();
+                    tasks.remove(tbr);
+                }
+            }
+        }
+    }
+
+    private static class Task {
+        private final Context context;
+        private final Runnable runnable;
+
+        private Task(Context context, Runnable runnable) {
+            this.context = context;
+            this.runnable = runnable;
+        }
+
+        void run() {
+            context.runOnContext(x -> runnable.run());
+        }
+    }
+
+    @RequestScoped
+    public static class MyRequestScopeBean {
+
+        private int value = -1;
+
+        public void setValue(int v) {
+            if (value != -1) {
+                throw new IllegalStateException("Already initialized");
+            }
+            value = v;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+    }
+
+    public static class Foo {
+
+        public final String value;
+
+        public Foo(String value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxBuildConfig.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxBuildConfig.java
@@ -1,0 +1,17 @@
+package io.quarkus.vertx.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "vertx", phase = ConfigPhase.BUILD_TIME)
+public class VertxBuildConfig {
+
+    /**
+     * If set to {@code true} then a customized current context factory (backed by a Vert.x duplicated local context) is used
+     * for normal scopes in ArC.
+     */
+    @ConfigItem(generateDocumentation = false, defaultValue = "true")
+    public boolean customizeArcContext;
+
+}

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -101,8 +101,11 @@ class VertxProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    CurrentContextFactoryBuildItem currentContextFactory(VertxRecorder recorder) {
-        return new CurrentContextFactoryBuildItem(recorder.currentContextFactory());
+    void currentContextFactory(BuildProducer<CurrentContextFactoryBuildItem> currentContextFactory,
+            VertxBuildConfig buildConfig, VertxRecorder recorder) {
+        if (buildConfig.customizeArcContext) {
+            currentContextFactory.produce(new CurrentContextFactoryBuildItem(recorder.currentContextFactory()));
+        }
     }
 
     @BuildStep

--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/VertxProcessor.java
@@ -20,6 +20,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.AutoAddScopeBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.BeanRegistrationPhaseBuildItem.BeanConfiguratorBuildItem;
+import io.quarkus.arc.deployment.CurrentContextFactoryBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem.BeanClassAnnotationExclusion;
 import io.quarkus.arc.processor.AnnotationStore;
@@ -96,6 +97,12 @@ class VertxProcessor {
                 shutdown, codecByClass);
         serviceStart.produce(new ServiceStartBuildItem("vertx"));
         return new VertxBuildItem(recorder.forceStart(vertx.getVertx()));
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.STATIC_INIT)
+    CurrentContextFactoryBuildItem currentContextFactory(VertxRecorder recorder) {
+        return new CurrentContextFactoryBuildItem(recorder.currentContextFactory());
     }
 
     @BuildStep

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/currentcontextfactory/VertxCurrentContextFactoryDisabledTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/deployment/currentcontextfactory/VertxCurrentContextFactoryDisabledTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.vertx.deployment.currentcontextfactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.runtime.VertxCurrentContextFactory;
+
+public class VertxCurrentContextFactoryDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.vertx.customize-arc-context", "false");
+
+    @Test
+    public void testCustomizedFactoryNotUsed() {
+        assertFalse(Arc.container().getCurrentContextFactory() instanceof VertxCurrentContextFactory);
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxCurrentContextFactory.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxCurrentContextFactory.java
@@ -1,0 +1,58 @@
+package io.quarkus.vertx.runtime;
+
+import java.lang.annotation.Annotation;
+
+import io.netty.util.concurrent.FastThreadLocal;
+import io.quarkus.arc.CurrentContext;
+import io.quarkus.arc.CurrentContextFactory;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.InjectableContext.ContextState;
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class VertxCurrentContextFactory implements CurrentContextFactory {
+
+    @Override
+    public <T extends InjectableContext.ContextState> CurrentContext<T> create(Class<? extends Annotation> scope) {
+        return new VertxCurrentContext<>();
+    }
+
+    private static final class VertxCurrentContext<T extends ContextState> implements CurrentContext<T> {
+
+        private final FastThreadLocal<T> fallback = new FastThreadLocal<>();
+
+        @Override
+        public T get() {
+            Context context = Vertx.currentContext();
+            if (context != null && VertxContext.isDuplicatedContext(context)) {
+                return context.getLocal(this);
+            }
+            return fallback.get();
+        }
+
+        @Override
+        public void set(T state) {
+            Context context = Vertx.currentContext();
+            if (context != null && VertxContext.isDuplicatedContext(context)) {
+                VertxContextSafetyToggle.setContextSafe(context, true);
+                context.putLocal(this, state);
+            } else {
+                fallback.set(state);
+            }
+        }
+
+        @Override
+        public void remove() {
+            Context context = Vertx.currentContext();
+            if (context != null && VertxContext.isDuplicatedContext(context)) {
+                // NOOP - the DC should not be shared.
+                //                context.removeLocal(this);
+            } else {
+                fallback.remove();
+            }
+        }
+
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/VertxRecorder.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
 
+import io.quarkus.arc.CurrentContextFactory;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
@@ -64,6 +65,10 @@ public class VertxRecorder {
                 }
             });
         }
+    }
+
+    public RuntimeValue<CurrentContextFactory> currentContextFactory() {
+        return new RuntimeValue<>(new VertxCurrentContextFactory());
     }
 
     public static Vertx getVertx() {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -527,4 +527,9 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
         }
         return defaultValue;
     }
+
+    @Override
+    protected boolean isRequestScopeManagementRequired() {
+        return false;
+    }
 }

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -130,7 +130,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         boolean processingSuspended = false;
         //if this is a blocking target we don't activate for the initial non-blocking part
         //unless there are pre-mapping filters as these may require CDI
-        boolean disasociateRequestScope = false;
+        boolean disassociateRequestScope = false;
         boolean aborted = false;
         try {
             while (position < handlers.length) {
@@ -146,7 +146,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
                             running = true;
                             if (isRequestScopeManagementRequired()) {
                                 if (requestScopeActivated) {
-                                    disasociateRequestScope = true;
+                                    disassociateRequestScope = true;
                                     requestScopeActivated = false;
                                 }
                             } else {
@@ -190,7 +190,7 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
                 }
                 close();
             } else {
-                if (disasociateRequestScope) {
+                if (disassociateRequestScope) {
                     requestScopeDeactivated();
                     currentRequestScope.deactivate();
                 }

--- a/integration-tests/opentelemetry-reactive/src/main/java/io/quarkus/it/opentelemetry/reactive/ReactiveResource.java
+++ b/integration-tests/opentelemetry-reactive/src/main/java/io/quarkus/it/opentelemetry/reactive/ReactiveResource.java
@@ -30,9 +30,18 @@ public class ReactiveResource {
     }
 
     @GET
-    @Path("/multiple")
-    public Uni<String> helloMultiple() {
-        return Uni.combine().all().unis(client.helloGet("Naruto"), client.helloGet("Goku"))
+    @Path("/multiple-chain")
+    public Uni<String> helloMultipleUsingChain() {
+        return client.helloGet("Naruto")
+                .chain(s1 -> client.helloGet("Goku").map(s2 -> s1 + " and " + s2));
+    }
+
+    @GET
+    @Path("/multiple-combine")
+    public Uni<String> helloMultipleUsingCombine() {
+        return Uni.combine().all().unis(
+                client.helloGet("Naruto"),
+                client.helloGet("Goku"))
                 .combinedWith((s, s2) -> s + " and " + s2);
     }
 

--- a/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveTest.java
+++ b/integration-tests/opentelemetry-reactive/src/test/java/io/quarkus/it/opentelemetry/reactive/OpenTelemetryReactiveTest.java
@@ -1,20 +1,29 @@
 package io.quarkus.it.opentelemetry.reactive;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.api.trace.SpanKind.SERVER;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
@@ -29,7 +38,6 @@ public class OpenTelemetryReactiveTest {
     @Test
     void get() {
         given()
-                .contentType("application/json")
                 .when()
                 .queryParam("name", "Naruto")
                 .get("/reactive")
@@ -46,7 +54,6 @@ public class OpenTelemetryReactiveTest {
     @Test
     void post() {
         given()
-                .contentType("application/json")
                 .when()
                 .body("Naruto")
                 .post("/reactive")
@@ -61,11 +68,10 @@ public class OpenTelemetryReactiveTest {
     }
 
     @Test
-    void multiple() {
+    void multipleUsingChain() {
         given()
-                .contentType("application/json")
                 .when()
-                .get("/reactive/multiple")
+                .get("/reactive/multiple-chain")
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello Naruto and Hello Goku"));
@@ -75,10 +81,106 @@ public class OpenTelemetryReactiveTest {
         List<Map<String, Object>> spans = getSpans();
         assertEquals(7, spans.size());
         assertEquals(1, spans.stream().map(map -> map.get("traceId")).collect(toSet()).size());
+
+        // First span is the call getting into the server. It does not have a parent span.
+        Map<String, Object> parent = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
+
+        // We should get 2 client spans originated by the server
+        List<Map<String, Object>> clientSpans = getSpansByKindAndParentId(spans, CLIENT, parent.get("spanId"));
+        assertEquals(2, clientSpans.size());
+
+        // Each client calls the server and programmatically create a span, so each have a server and an internal span
+
+        // Naruto Span
+        Optional<Map<String, Object>> narutoSpan = clientSpans.stream()
+                .filter(map -> ((String) ((Map<?, ?>) map.get("attributes")).get(HTTP_URL.getKey())).contains("Naruto"))
+                .findFirst();
+        assertTrue(narutoSpan.isPresent());
+        Map<String, Object> naruto = narutoSpan.get();
+
+        Map<String, Object> narutoServer = getSpanByKindAndParentId(spans, SERVER, naruto.get("spanId"));
+        assertEquals("/reactive?name=Naruto", ((Map<?, ?>) narutoServer.get("attributes")).get(HTTP_TARGET.getKey()));
+        Map<String, Object> narutoInternal = getSpanByKindAndParentId(spans, INTERNAL, narutoServer.get("spanId"));
+        assertEquals("helloGet", narutoInternal.get("name"));
+
+        // Goku Span
+        Optional<Map<String, Object>> gokuSpan = clientSpans.stream()
+                .filter(map -> ((String) ((Map<?, ?>) map.get("attributes")).get(HTTP_URL.getKey())).contains("Goku"))
+                .findFirst();
+        assertTrue(gokuSpan.isPresent());
+        Map<String, Object> goku = gokuSpan.get();
+
+        Map<String, Object> gokuServer = getSpanByKindAndParentId(spans, SERVER, goku.get("spanId"));
+        assertEquals("/reactive?name=Goku", ((Map<?, ?>) gokuServer.get("attributes")).get(HTTP_TARGET.getKey()));
+        Map<String, Object> gokuInternal = getSpanByKindAndParentId(spans, INTERNAL, gokuServer.get("spanId"));
+        assertEquals("helloGet", gokuInternal.get("name"));
+    }
+
+    @Test
+    void multipleUsingCombine() {
+        given()
+                .when()
+                .get("/reactive/multiple-combine")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello Naruto and Hello Goku"));
+
+        await().atMost(5, TimeUnit.SECONDS).until(() -> getSpans().size() == 7);
+
+        List<Map<String, Object>> spans = getSpans();
+        assertEquals(7, spans.size());
+        assertEquals(1, spans.stream().map(map -> map.get("traceId")).collect(toSet()).size());
+
+        // First span is the call getting into the server. It does not have a parent span.
+        Map<String, Object> parent = getSpanByKindAndParentId(spans, SERVER, "0000000000000000");
+
+        // We should get 2 client spans originated by the server
+        List<Map<String, Object>> clientSpans = getSpansByKindAndParentId(spans, CLIENT, parent.get("spanId"));
+        assertEquals(2, clientSpans.size());
+
+        // Each client calls the server and programmatically create a span, so each have a server and an internal span
+
+        // Naruto Span
+        Optional<Map<String, Object>> narutoSpan = clientSpans.stream()
+                .filter(map -> ((String) ((Map<?, ?>) map.get("attributes")).get(HTTP_URL.getKey())).contains("Naruto"))
+                .findFirst();
+        assertTrue(narutoSpan.isPresent());
+        Map<String, Object> naruto = narutoSpan.get();
+
+        Map<String, Object> narutoServer = getSpanByKindAndParentId(spans, SERVER, naruto.get("spanId"));
+        assertEquals("/reactive?name=Naruto", ((Map<?, ?>) narutoServer.get("attributes")).get(HTTP_TARGET.getKey()));
+        Map<String, Object> narutoInternal = getSpanByKindAndParentId(spans, INTERNAL, narutoServer.get("spanId"));
+        assertEquals("helloGet", narutoInternal.get("name"));
+
+        // Goku Span
+        Optional<Map<String, Object>> gokuSpan = clientSpans.stream()
+                .filter(map -> ((String) ((Map<?, ?>) map.get("attributes")).get(HTTP_URL.getKey())).contains("Goku"))
+                .findFirst();
+        assertTrue(gokuSpan.isPresent());
+        Map<String, Object> goku = gokuSpan.get();
+
+        Map<String, Object> gokuServer = getSpanByKindAndParentId(spans, SERVER, goku.get("spanId"));
+        assertEquals("/reactive?name=Goku", ((Map<?, ?>) gokuServer.get("attributes")).get(HTTP_TARGET.getKey()));
+        Map<String, Object> gokuInternal = getSpanByKindAndParentId(spans, INTERNAL, gokuServer.get("spanId"));
+        assertEquals("helloGet", gokuInternal.get("name"));
     }
 
     private static List<Map<String, Object>> getSpans() {
         return when().get("/export").body().as(new TypeRef<>() {
         });
+    }
+
+    private static Map<String, Object> getSpanByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
+            Object parentSpanId) {
+        List<Map<String, Object>> span = getSpansByKindAndParentId(spans, kind, parentSpanId);
+        assertEquals(1, span.size());
+        return span.get(0);
+    }
+
+    private static List<Map<String, Object>> getSpansByKindAndParentId(List<Map<String, Object>> spans, SpanKind kind,
+            Object parentSpanId) {
+        return spans.stream()
+                .filter(map -> map.get("kind").equals(kind.toString()))
+                .filter(map -> map.get("parentSpanId").equals(parentSpanId)).collect(toList());
     }
 }


### PR DESCRIPTION
This PR implements a new way to store the ArC _request scope_. Instead of storing that object in a `ThreadLocal` (which is problematic in an event loop-based architecture), the _request scope_ is stored in the _Vert.x duplicated context_ which is used for the whole reactive/async processing. If there is no duplicated context, it falls back to a thread-local.

This PR makes accessing request-scope beans a lot simpler in reactive applications. The request scope is available as soon as the _continuations_ are executed on the same duplicated context. We aware that if this access happens after the termination of the scope, an error is reported (as it's clearly misuing the concepts). 

### ArC
Introduce the `VertxCurrentContextFactory` so that the Vert.x duplicated context can be used to store the "current context" for normal scopes. If we're not on the Vert.x duplicated context we fallback to the `ThreadLocal` (or `FastThreadLocal` respectively).

### resteasy-reactive
Don't clear our CDI current request when suspending.

This was done to prevent subsequent requests running on the same thread as a suspended request from accessing the former's data. With the advent of DuplicatedContext-backed storage, there is no longer any chance of mixing data, so there is no need to clear it out.

Furthermore, by not clearing out current requests, the code that accesses the request scoped `CurrentVertxRequest`
that is executed while the request is suspended can now work even if context propagation is not in play.

### Tests
Add leak detection tests for resteasy reactive, graphql, and reactive rest client. Also, improve the OpenTelemetry reactive tests.

### OpenTelemetry
Only register the OpenTelemetryClientFilter for RESTEasy Client Classic. Use Capabilities to determine when to register the OpenTelemetryClientFilter.