### PR TITLE
Make sending OIDC client id with introspection credentials optional

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -112,6 +112,12 @@ public class OidcTenantConfig extends OidcCommonConfig {
         @ConfigItem
         public Optional<String> secret = Optional.empty();
 
+        /**
+         * Include OpenId Connect Client ID configured with 'quarkus.oidc.client-id'
+         */
+        @ConfigItem(defaultValue = "true")
+        public boolean includeClientId = true;
+
         public Optional<String> getName() {
             return name;
         }
@@ -126,6 +132,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setSecret(String secret) {
             this.secret = Optional.of(secret);
+        }
+
+        public boolean isIncludeClientId() {
+            return includeClientId;
+        }
+
+        public void setIncludeClientId(boolean includeClientId) {
+            this.includeClientId = includeClientId;
         }
 
     }

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcProviderClient.java
@@ -126,7 +126,7 @@ public class OidcProviderClient implements Closeable {
         request.putHeader(ACCEPT_HEADER, APPLICATION_JSON);
         if (introspect && introspectionBasicAuthScheme != null) {
             request.putHeader(AUTHORIZATION_HEADER, introspectionBasicAuthScheme);
-            if (oidcConfig.clientId.isPresent()) {
+            if (oidcConfig.clientId.isPresent() && oidcConfig.introspectionCredentials.includeClientId) {
                 formBody.set(OidcConstants.CLIENT_ID, oidcConfig.clientId.get());
             }
         } else if (clientSecretBasicAuthScheme != null) {


### PR DESCRIPTION
Fixes #27442 

This PR adds a boolean configuration property making it possible to skip sending the OIDC client id when using the custom/basic introspection authentication. I haven't added a test as testing this case is quite involved (see #26917) so I'm not sure these PR changes need another test like the one added in #26917, but I can work on it if preferred