### PR TITLE
Revert "Mark Quartz extension as stable"

### DIFF
--- a/docs/src/main/asciidoc/quartz.adoc
+++ b/docs/src/main/asciidoc/quartz.adoc
@@ -6,9 +6,12 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 = Scheduling Periodic Tasks with Quartz
 
 include::./attributes.adoc[]
+:extension-status: preview
 
 Modern applications often need to run specific tasks periodically.
 In this guide, you learn how to schedule periodic clustered tasks using the http://www.quartz-scheduler.org/[Quartz] extension.
+
+include::{includes}/extension-status.adoc[]
 
 TIP: If you only need to run in-memory scheduler use the xref:scheduler.adoc[Scheduler] extension.
 

--- a/extensions/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/quartz/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,6 @@ metadata:
   guide: "https://quarkus.io/guides/quartz"
   categories:
   - "miscellaneous"
-  status: "stable"
+  status: "preview"
   config:
   - "quarkus.quartz."


### PR DESCRIPTION
Reverts quarkusio/quarkus#26709

Quartz is using some javax packages that will need to be migrated to jakarta. There hasn't been any new Quartz version for a while so I think we should have a reassurance about this before marking this extension stable.