### PR TITLE
Re-enable `ParseOnce` starting with GraalVM / Mandrel 22.2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -677,19 +677,21 @@ public class NativeImageBuildStep {
                 }
                 nativeImageArgs.add("--features=" + String.join(",", featuresList));
 
-                /*
-                 * Instruct GraalVM / Mandrel parse compiler graphs twice, once for the static analysis and once again
-                 * for the AOT compilation.
-                 *
-                 * We do this because single parsing significantly increases memory usage at build time
-                 * see https://github.com/oracle/graal/issues/3435 and
-                 * https://github.com/graalvm/mandrel/issues/304#issuecomment-952070568 for more details.
-                 *
-                 * Note: This option must come before the invocation of
-                 * {@code handleAdditionalProperties(nativeImageArgs)} to ensure that devs and advanced users can
-                 * override it by passing -Dquarkus.native.additional-build-args=-H:+ParseOnce
-                 */
-                nativeImageArgs.add("-H:-ParseOnce");
+                if (graalVMVersion.isOlderThan(GraalVM.Version.VERSION_22_2_0)) {
+                    /*
+                     * Instruct GraalVM / Mandrel parse compiler graphs twice, once for the static analysis and once again
+                     * for the AOT compilation.
+                     *
+                     * We do this because single parsing significantly increases memory usage at build time
+                     * see https://github.com/oracle/graal/issues/3435 and
+                     * https://github.com/graalvm/mandrel/issues/304#issuecomment-952070568 for more details.
+                     *
+                     * Note: This option must come before the invocation of
+                     * {@code handleAdditionalProperties(nativeImageArgs)} to ensure that devs and advanced users can
+                     * override it by passing -Dquarkus.native.additional-build-args=-H:+ParseOnce
+                     */
+                    nativeImageArgs.add("-H:-ParseOnce");
+                }
 
                 /**
                  * This makes sure the Kerberos integration module is made available in case any library


### PR DESCRIPTION
We no longer need to disable `ParseOnce` as memory usage with it enabled
has improved in GraalVM 22.2.

See
https://docs.google.com/spreadsheets/d/15PJ1Qd7kgneuP61N1T2_AyJ3WBsbXpVHIPKbxgH1qfM/edit#gid=1672873268
for a comparison between using and not using `ParseOnce` with 22.2.

Relates to https://github.com/oracle/graal/issues/3435 and
https://github.com/graalvm/mandrel/issues/316

Fixes #25944