### PR TITLE
Bump groovy for maven-invoker-plugin to support Java 19

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -771,7 +771,7 @@
                         <dependency>
                             <groupId>org.codehaus.groovy</groupId>
                             <artifactId>groovy</artifactId>
-                            <version>3.0.9</version>
+                            <version>3.0.12</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -96,7 +96,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>3.0.9</version>
+                        <version>3.0.12</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Relates to #24789 and should fix `maven-invoker-plugin` failures in the EA job.

https://issues.apache.org/jira/browse/GROOVY-10569