### PR TITLE
Fix service binding for SqlServer and Oracle

### DIFF
--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLServiceBindingConverter.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/MsSQLServiceBindingConverter.java
@@ -13,6 +13,6 @@ public class MsSQLServiceBindingConverter implements ServiceBindingConverter {
     @Override
     public Optional<ServiceBindingConfigSource> convert(List<ServiceBinding> serviceBindings) {
         return ServiceBinding.singleMatchingByType("sqlserver", serviceBindings)
-                .map(new DatasourceServiceBindingConfigSourceFactory.Jdbc());
+                .map(new DatasourceServiceBindingConfigSourceFactory.Jdbc("jdbc:%s://%s%s;databaseName=%s"));
     }
 }

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleServiceBindingConverter.java
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/java/io/quarkus/jdbc/oracle/runtime/OracleServiceBindingConverter.java
@@ -13,7 +13,7 @@ public class OracleServiceBindingConverter implements ServiceBindingConverter {
     @Override
     public Optional<ServiceBindingConfigSource> convert(List<ServiceBinding> serviceBindings) {
         return ServiceBinding.singleMatchingByType("oracle", serviceBindings)
-                .map(new DatasourceServiceBindingConfigSourceFactory.Jdbc());
+                .map(new DatasourceServiceBindingConfigSourceFactory.Jdbc("jdbc:%s:thin:@%s%s/%s"));
     }
 
 }

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/services/io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/services/io.quarkus.kubernetes.service.binding.runtime.ServiceBindingConverter
@@ -1,0 +1,1 @@
+io.quarkus.jdbc.oracle.runtime.OracleServiceBindingConverter

--- a/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/DatasourceServiceBindingConfigSourceFactory.java
+++ b/extensions/kubernetes-service-binding/runtime/src/main/java/io/quarkus/kubernetes/service/binding/runtime/DatasourceServiceBindingConfigSourceFactory.java
@@ -47,6 +47,12 @@ public abstract class DatasourceServiceBindingConfigSourceFactory
             log.debugf("Property 'password' was not found for datasource of type %s", serviceBinding.getType());
         }
 
+        String url = bindingProperties.get("jdbc-url");
+        if (url != null) {
+            properties.put(urlPropertyName, url);
+            return properties;
+        }
+
         String host = bindingProperties.get("host");
         String port = bindingProperties.get("port");
         String database = bindingProperties.get("database");
@@ -72,11 +78,19 @@ public abstract class DatasourceServiceBindingConfigSourceFactory
         public Jdbc() {
             super("jdbc", "quarkus.datasource.jdbc.url", "jdbc:%s://%s%s/%s");
         }
+
+        public Jdbc(String urlFormat) {
+            super("jdbc", "quarkus.datasource.jdbc.url", urlFormat);
+        }
     }
 
     public static class Reactive extends DatasourceServiceBindingConfigSourceFactory {
         public Reactive() {
             super("reactive", "quarkus.datasource.reactive.url", "%s://%s%s/%s");
+        }
+
+        public Reactive(String urlFormat) {
+            super("reactive", "quarkus.datasource.reactive.url", urlFormat);
         }
     }
 }

--- a/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OracleServiceBindingConverter.java
+++ b/extensions/reactive-oracle-client/runtime/src/main/java/io/quarkus/reactive/oracle/client/runtime/OracleServiceBindingConverter.java
@@ -13,7 +13,7 @@ public class OracleServiceBindingConverter implements ServiceBindingConverter {
     @Override
     public Optional<ServiceBindingConfigSource> convert(List<ServiceBinding> serviceBindings) {
         return ServiceBinding.singleMatchingByType("oracle", serviceBindings)
-                .map(new DatasourceServiceBindingConfigSourceFactory.Reactive());
+                .map(new DatasourceServiceBindingConfigSourceFactory.Reactive("%s:thin:@%s%s/%s"));
     }
 
 }


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/27461
1. Update the connection url for Oracle and SqlServer that is generated by the `kubernetes-service-binding` extension.
2. Add a new service binding configuration option `jdbc-url` to allow user to customize connection url for service binding. This is similar to what [spring-service-binding](https://github.com/spring-cloud/spring-cloud-bindings/pull/56) supports.