### PR TITLE
RestClient Reactive: Default conversion for basic types

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/FormParamTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/FormParamTest.java
@@ -24,7 +24,7 @@ public class FormParamTest {
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(FormClient.class, SubFormClient.class, Resource.class));
+                    .addClasses(FormClient.class, SubFormClient.class, Resource.class, Mode.class));
 
     @TestHTTPResource
     URI baseUri;
@@ -50,6 +50,13 @@ public class FormParamTest {
         assertThat(result).isEqualTo("sub rootParam1:par1,rootParam2:par 2,subParam1:spar1,subParam2:spar 2");
     }
 
+    @Test
+    void shouldSupportParsingDifferentTypes() {
+        FormClient formClient = RestClientBuilder.newBuilder().baseUri(baseUri).build(FormClient.class);
+        String result = formClient.withTypes("a", 1, 2, Mode.On);
+        assertThat(result).isEqualTo("root text:a,number:1,wrapNumber:2,mode:On");
+    }
+
     public interface FormClient {
         @POST
         @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
@@ -58,6 +65,13 @@ public class FormParamTest {
 
         @Path("/sub")
         SubFormClient subForm(@FormParam("rootParam1") String formParam1, @FormParam("rootParam2") String formParam2);
+
+        @POST
+        @Path("/types")
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Produces(MediaType.TEXT_PLAIN)
+        String withTypes(@FormParam("text") String text, @FormParam("number") int number,
+                @FormParam("wrapNumber") Integer wrapNumber, @FormParam("mode") Mode mode);
     }
 
     public interface SubFormClient {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/Mode.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/Mode.java
@@ -1,0 +1,6 @@
+package io.quarkus.rest.client.reactive.form;
+
+public enum Mode {
+    Off,
+    On
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/Resource.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/form/Resource.java
@@ -30,4 +30,12 @@ public class Resource {
         return Response.ok(String.format("sub rootParam1:%s,rootParam2:%s,subParam1:%s,subParam2:%s",
                 rootParam1, rootParam2, subParam1, subParam2)).build();
     }
+
+    @POST
+    @Path("/types")
+    public Response getWithTypes(@RestForm String text, @RestForm int number, @RestForm Integer wrapNumber,
+            @RestForm Mode mode) {
+        return Response.ok(String.format("root text:%s,number:%s,wrapNumber:%s,mode:%s", text, number, wrapNumber, mode))
+                .build();
+    }
 }


### PR DESCRIPTION
Default support for primitive and enum types. For the rest, a custom converter is necessary. 

Fix https://github.com/quarkusio/quarkus/issues/27430