### PR TITLE
Ensure test resources are not restarted for nested classes

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/QuarkusTestResource.java
@@ -18,6 +18,8 @@ import io.quarkus.test.common.QuarkusTestResource.List;
  * and their corresponding {@code QuarkusTestResourceLifecycleManager}
  * started <b>before</b> <b>any</b> test is run.
  *
+ * Note that test resources are never restarted when running {@code @Nested} test classes.
+ *
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
I think regardless of the value of restrictToAnnotatedClass, the resources should never be restarted for nested classes.

Fix https://github.com/quarkusio/quarkus/issues/27400