### PR TITLE
Fix OTel JDBC URL override in dev mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/DevServicesAdditionalConfigBuildItem.java
@@ -1,7 +1,9 @@
 package io.quarkus.deployment.builditem;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import io.quarkus.builder.item.MultiBuildItem;
 
@@ -15,6 +17,7 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
 
+    private final DevServicesAdditionalConfigProvider configProvider;
     private final Collection<String> triggeringKeys;
     private final String key;
     private final String value;
@@ -22,7 +25,7 @@ public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
 
     /**
      * @deprecated Call
-     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(Collection, String, String, Runnable)}
+     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider)}
      *             instead.
      */
     @Deprecated
@@ -31,35 +34,85 @@ public final class DevServicesAdditionalConfigBuildItem extends MultiBuildItem {
         this(List.of(triggeringKey), key, value, callbackWhenEnabled);
     }
 
+    /**
+     * @deprecated Call
+     *             {@link DevServicesAdditionalConfigBuildItem#DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider)}
+     *             instead.
+     */
+    @Deprecated
     public DevServicesAdditionalConfigBuildItem(Collection<String> triggeringKeys,
             String key, String value, Runnable callbackWhenEnabled) {
         this.triggeringKeys = triggeringKeys;
         this.key = key;
         this.value = value;
         this.callbackWhenEnabled = callbackWhenEnabled;
+        this.configProvider = devServicesConfig -> {
+            if (triggeringKeys.stream().anyMatch(devServicesConfig::containsKey)) {
+                if (callbackWhenEnabled != null) {
+                    callbackWhenEnabled.run();
+                }
+                return Map.of(key, value);
+            } else {
+                return Map.of();
+            }
+        };
+    }
+
+    public DevServicesAdditionalConfigBuildItem(DevServicesAdditionalConfigProvider configProvider) {
+        this.triggeringKeys = Collections.emptyList();
+        this.key = null;
+        this.value = null;
+        this.callbackWhenEnabled = null;
+        this.configProvider = configProvider;
     }
 
     /**
-     * @deprecated Call {@link #getTriggeringKeys()} instead.
+     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
      */
     @Deprecated
     public String getTriggeringKey() {
         return getTriggeringKeys().iterator().next();
     }
 
+    /**
+     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
+     */
+    @Deprecated
     public Collection<String> getTriggeringKeys() {
         return triggeringKeys;
     }
 
+    /**
+     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
+     */
+    @Deprecated
     public String getKey() {
         return key;
     }
 
+    /**
+     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
+     */
+    @Deprecated
     public String getValue() {
         return value;
     }
 
+    /**
+     * @deprecated Don't call this method, use {@link #getConfigProvider()} instead.
+     */
+    @Deprecated
     public Runnable getCallbackWhenEnabled() {
         return callbackWhenEnabled;
+    }
+
+    public DevServicesAdditionalConfigProvider getConfigProvider() {
+        return configProvider;
+    }
+
+    public interface DevServicesAdditionalConfigProvider {
+
+        Map<String, String> provide(Map<String, String> devServicesConfig);
+
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/DevServicesConfigBuildStep.java
@@ -65,16 +65,11 @@ class DevServicesConfigBuildStep {
         oldConfig = newProperties;
 
         Map<String, String> newPropertiesWithAdditionalConfig = new HashMap<>(newProperties);
+        var unmodifiableNewProperties = Collections.unmodifiableMap(newProperties);
         // On contrary to dev services config, "additional" config build items are
         // produced on each restart, so we don't want to remember them from one restart to the next.
         for (DevServicesAdditionalConfigBuildItem item : devServicesAdditionalConfigBuildItems) {
-            if (item.getTriggeringKeys().stream().anyMatch(newProperties::containsKey)) {
-                var callback = item.getCallbackWhenEnabled();
-                if (callback != null) {
-                    callback.run(); // This generally involves logging
-                }
-                newPropertiesWithAdditionalConfig.put(item.getKey(), item.getValue());
-            }
+            newPropertiesWithAdditionalConfig.putAll(item.getConfigProvider().provide(unmodifiableNewProperties));
         }
 
         for (Map.Entry<String, String> entry : newPropertiesWithAdditionalConfig.entrySet()) {

--- a/extensions/opentelemetry/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/opentelemetry/deployment/pom.xml
@@ -37,6 +37,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-deployment-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-spi</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/dev/DevServicesOpenTelemetryProcessor.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/dev/DevServicesOpenTelemetryProcessor.java
@@ -51,9 +51,13 @@ public class DevServicesOpenTelemetryProcessor {
                     ConfigValue driverValue = ConfigProvider.getConfig().getConfigValue(driverKey);
                     if (driverValue.getValue() != null
                             && driverValue.getValue().equals("io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver")) {
-                        devServicesAdditionalConfig.produce(new DevServicesAdditionalConfigBuildItem(key, key,
-                                value.replaceFirst("jdbc:", "jdbc:otel:"), () -> {
-                                }));
+                        devServicesAdditionalConfig.produce(new DevServicesAdditionalConfigBuildItem(devServicesConfig -> {
+                            if (devServicesConfig.containsKey(key)) {
+                                return Map.of(key, value.replaceFirst("jdbc:", "jdbc:otel:"));
+                            } else {
+                                return Map.of();
+                            }
+                        }));
                     }
                 }
             }

--- a/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevServicesDatasourcesTest.java
+++ b/extensions/opentelemetry/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/OpenTelemetryDevServicesDatasourcesTest.java
@@ -32,11 +32,18 @@ public class OpenTelemetryDevServicesDatasourcesTest {
                 .statusCode(200)
                 .body(Matchers.startsWith("jdbc:otel:h2"));
 
+        // Test a change in resources that disables OTEL
         TEST.modifyResourceFile("application.properties", s -> "quarkus.datasource.db-kind=h2\n");
-
         RestAssured.when().get("/config/{name}", "quarkus.datasource.jdbc.url").then()
                 .statusCode(200)
                 .body(Matchers.startsWith("jdbc:h2"));
+
+        // Test a change in resources that enables OTEL
+        TEST.modifyResourceFile("application.properties", s -> "quarkus.datasource.db-kind=h2\n" +
+                "quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver");
+        RestAssured.when().get("/config/{name}", "quarkus.datasource.jdbc.url").then()
+                .statusCode(200)
+                .body(Matchers.startsWith("jdbc:otel:h2"));
     }
 
     @Path("/config")


### PR DESCRIPTION
#26449 [changed](https://github.com/quarkusio/quarkus/pull/26449/files#diff-6f71f219fd6868080defc0f53705a894b5208e8ca5674db855fb79de166c35e4L58-L71) how the dev service configuration is altered by the OTel extension.

A result of that change is that instead relying on configuration persisted on the first startup, we now rely on `DevServicesAdditionalConfigBuildItem`, which means that datasource configuration override is re-generated on each restart, instead of being persisted on the first startup.

That's a good thing, because that means we'll automatically adapt to any change in dev service configuration.

However, the configuration override by the OTel extension will now _only_ work when dev service configuration change, because it is only executed when `DevServicesDatasourceResultBuildItem` is produced:

https://github.com/quarkusio/quarkus/blob/7ebfc266c12f51716bf2879a03f470cb3dd482ad/extensions/opentelemetry/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/dev/DevServicesOpenTelemetryProcessor.java

As a reminder, `DevServicesDatasourceResultBuildItem` is only produced when dev services need to be started/restarted. If the app restarts but dev services don't need to restart, `DevServicesDatasourceResultBuildItem` won't be there, and then we won't generate the OTel config override for datasources.

So the current code will work if we're using the OTel JDBC driver on the first startup, and also if we remove that driver and the app restarts.
But it won't work if the OTel JDBC driver is not set on the first startup, and we later change configuration to set `quarkus.datasource.jdbc.driver` to the OTel JDBC driver: since that change doesn't involve a dev service restart, we won't generate the necessary configuration override. That's demonstrated by the test in the last commit.

This problem was detected while working on #26760, which needs this PR to fix `OpenTelemetryDevServicesDatasourcesTest`.

/cc @brunobat 