### PR TITLE
Bump slf4j-jboss-logmanager to 1.2.0.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -104,7 +104,7 @@
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.2.1.Final</jboss-logging-annotations.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
+        <slf4j-jboss-logmanager.version>1.2.0.Final</slf4j-jboss-logmanager.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
         <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>


### PR DESCRIPTION
Hello @gsmet @jamezp,

following the release https://github.com/jboss-logging/slf4j-jboss-logmanager/releases/tag/1.2.0.Final
here is the update for quarkus-bom.

(and, of course, I'm open to test pre-releases with this change)