### PR TITLE
Introduce `CaffeineCache#put(Object,CompletableFuture)`

### DIFF
--- a/docs/src/main/asciidoc/cache.adoc
+++ b/docs/src/main/asciidoc/cache.adoc
@@ -597,6 +597,36 @@ public class CacheKeysService {
 }
 ----
 
+=== Populating a `CaffeineCache`
+
+You can populate a `CaffeineCache` using the `CaffeineCache#put(Object, CompletableFuture)` method.
+This method associates the `CompletableFuture` with the given key in the cache. If the cache previously contained a value associated with the key, the old value is replaced by this `CompletableFuture`. If the asynchronous computation fails, the entry will be automatically removed.
+
+[source,java]
+----
+package org.acme.cache;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
+import io.quarkus.cache.CaffeineCache;
+
+import java.util.concurrent.CompletableFuture;
+
+@ApplicationScoped
+public class CacheService {
+
+    @CacheName("my-cache")
+    Cache cache;
+
+    @PostConstruct
+    public void initialize() {
+        cache.as(CaffeineCache.class).put("foo", CompletableFuture.completedFuture("bar"));
+    }
+}
+----
+
 === Retrieving a value if a key is present from a `CaffeineCache`
 
 The cache value from a specific `CaffeineCache` can be retrieved if present as shown below.

--- a/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
+++ b/extensions/cache/deployment/src/test/java/io/quarkus/cache/test/runtime/ProgrammaticApiTest.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -197,6 +198,18 @@ public class ProgrammaticApiTest {
         assertSame(thrown, result);
         assertKeySetContains();
         assertGetIfPresentMissingKey(key);
+    }
+
+    @Test
+    public void testPutShouldPopulateCache() {
+        CaffeineCache caffeineCache = cache.as(CaffeineCache.class);
+        try {
+            caffeineCache.put("foo", CompletableFuture.completedFuture("bar"));
+            assertEquals("bar", caffeineCache.get("foo", Function.identity()).await().indefinitely());
+        } finally {
+            // invalidate to remove side effects in other tests
+            cache.invalidate("foo").await().indefinitely();
+        }
     }
 
     private void assertKeySetContains(Object... expectedKeys) {

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/CaffeineCache.java
@@ -2,6 +2,7 @@ package io.quarkus.cache;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 public interface CaffeineCache extends Cache {
 
@@ -26,4 +27,18 @@ public interface CaffeineCache extends Cache {
      * @see com.github.benmanes.caffeine.cache.AsyncCache#getIfPresent(Object)
      */
     <V> CompletableFuture<V> getIfPresent(Object key);
+
+    /**
+     * Associates {@code value} with {@code key} in this cache. If the cache previously contained a
+     * value associated with {@code key}, the old value is replaced by {@code value}. If the
+     * asynchronous computation fails, the entry will be automatically removed.
+     * <p>
+     * Prefer {@link #get(Object, Function)} when using the conventional "if cached, return; otherwise
+     * create, cache and return" pattern.
+     *
+     * @param key key with which the specified value is to be associated
+     * @param valueFuture value to be associated with the specified key
+     * @throws NullPointerException if the specified key or value is null
+     */
+    <V> void put(Object key, CompletableFuture<V> valueFuture);
 }

--- a/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
+++ b/extensions/cache/runtime/src/main/java/io/quarkus/cache/runtime/caffeine/CaffeineCacheImpl.java
@@ -218,6 +218,11 @@ public class CaffeineCacheImpl extends AbstractCache implements CaffeineCache {
         return Collections.unmodifiableSet(new HashSet<>(cache.asMap().keySet()));
     }
 
+    @Override
+    public <V> void put(Object key, CompletableFuture<V> valueFuture) {
+        cache.put(key, (CompletableFuture<Object>) valueFuture);
+    }
+
     // For testing purposes only.
     public CaffeineCacheInfo getCacheInfo() {
         return cacheInfo;


### PR DESCRIPTION
This introduces a new method in CaffeineCache to allow manual population of the managed Caffeine cache.

From the Zulip conversation: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Manually.20populating.20a.20caffeine.20cache