### PR TITLE
Ensure that quarkus.native.reuse-existing=true does not fail if GraalVM is not present

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/NativeImageBuildItem.java
@@ -50,5 +50,9 @@ public final class NativeImageBuildItem extends SimpleBuildItem {
         public String getDistribution() {
             return distribution;
         }
+
+        public static GraalVMVersion unknown() {
+            return new GraalVMVersion("unknown", "unknown", -1, "unknown");
+        }
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -202,6 +202,12 @@ public class NativeImageBuildStep {
         String resultingExecutableName = getResultingExecutableName(nativeImageName, isContainerBuild);
         Path generatedExecutablePath = outputDir.resolve(resultingExecutableName);
         Path finalExecutablePath = outputTargetBuildItem.getOutputDirectory().resolve(resultingExecutableName);
+        if (nativeConfig.reuseExisting) {
+            if (Files.exists(finalExecutablePath)) {
+                return new NativeImageBuildItem(finalExecutablePath,
+                        NativeImageBuildItem.GraalVMVersion.unknown());
+            }
+        }
 
         NativeImageBuildRunner buildRunner = getNativeImageBuildRunner(nativeConfig, outputDir,
                 nativeImageName, resultingExecutableName);
@@ -212,15 +218,6 @@ public class NativeImageBuildStep {
             checkGraalVMVersion(graalVMVersion);
         } else {
             log.error("Unable to get GraalVM version from the native-image binary.");
-        }
-        if (nativeConfig.reuseExisting) {
-            if (Files.exists(finalExecutablePath)) {
-                return new NativeImageBuildItem(finalExecutablePath,
-                        new NativeImageBuildItem.GraalVMVersion(graalVMVersion.fullVersion,
-                                graalVMVersion.version.toString(),
-                                graalVMVersion.javaFeatureVersion,
-                                graalVMVersion.distribution.name()));
-            }
         }
 
         try {


### PR DESCRIPTION
Fixes: #27479