### PR TITLE
Correctly set default for `quarkus.flyway.validate-on-migrate`

### DIFF
--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -17,7 +17,7 @@ public final class FlywayDataSourceRuntimeConfig {
      *
      * @return {@link FlywayDataSourceRuntimeConfig}
      */
-    public static final FlywayDataSourceRuntimeConfig defaultConfig() {
+    public static FlywayDataSourceRuntimeConfig defaultConfig() {
         return new FlywayDataSourceRuntimeConfig();
     }
 
@@ -126,7 +126,7 @@ public final class FlywayDataSourceRuntimeConfig {
     /**
      * Whether to automatically call validate when performing a migration.
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = "true")
     public boolean validateOnMigrate = true;
 
     /**


### PR DESCRIPTION
The default value for `quarkus.flyway.validate-on-migrate` was incorrectly set using a plain field default value. While not validated by Quarkus, this actually doesn't have any effect. What is important is setting `ConfigItem#defaultValue`.