### PR TITLE
New config `quarkus.flyway.repair-at-start`

### DIFF
--- a/docs/src/main/asciidoc/flyway.adoc
+++ b/docs/src/main/asciidoc/flyway.adoc
@@ -146,6 +146,14 @@ advantage of this while developing and testing new migration scripts,
 you will want to set `%dev.quarkus.flyway.clean-at-start=true`, so that
 Flyway actually runs the modified migration.
 
+=== Repairing the Flyway schema history table
+
+There are different scenarios which may require _repairing_ the Flyway schema history table.
+One such scenario is when a migration fails in a database which doesn't support transactional DDL
+statements.
+
+In such situations the link:https://flywaydb.org/documentation/command/repair[Flyway repair command] comes in handy. In Quarkus this can either be executed automatically before the migration by setting `quarkus.flyway.repair-at-start=true` or manually by injecting the `Flyway` object and calling `Flyway#repair()`.
+
 == Multiple datasources
 
 Flyway can be configured for multiple datasources.

--- a/extensions/flyway/deployment/pom.xml
+++ b/extensions/flyway/deployment/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionRepairAtStartTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionRepairAtStartTest.java
@@ -1,0 +1,79 @@
+package io.quarkus.flyway.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.flywaydb.core.Flyway;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class FlywayExtensionRepairAtStartTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(FlywayResource.class)
+                    .addAsResource("db/migration/V1.0.0__Quarkus.sql")
+                    .addAsResource("migrate-at-start-config.properties", "application.properties"))
+            .setLogRecordPredicate(r -> true)
+            .setAllowFailedStart(true);
+
+    @Test
+    @DisplayName("Repair at start works correctly")
+    public void testRepairUsingDevMode() {
+        assertThat(RestAssured.get("/flyway/current-version").then().statusCode(200).extract().asString()).isEqualTo("1.0.0");
+
+        config.clearLogRecords();
+        config.modifyResourceFile("db/migration/V1.0.0__Quarkus.sql", s -> s + "\nNONSENSE STATEMENT CHANGING CHECKSUM;");
+        config.modifyResourceFile("application.properties", s -> s + "\nquarkus.flyway.validate-on-migrate=true");
+
+        // trigger application restart
+        RestAssured.get("/");
+
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(config.getLogRecords()).anySatisfy(r -> {
+                assertThat(r.getMessage()).contains("Failed to start application");
+                assertThat(r.getThrown().getMessage()).contains("Migration checksum mismatch for migration version 1.0.0");
+            });
+            RestAssured.get("/flyway/current-version").then().statusCode(500);
+        });
+
+        config.clearLogRecords();
+        config.modifyResourceFile("application.properties", s -> s + "\nquarkus.flyway.repair-at-start=true");
+
+        // trigger application restart
+        RestAssured.get("/");
+
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(config.getLogRecords()).anySatisfy(
+                    r -> assertThat(r.getMessage()).contains("Successfully repaired schema history table"));
+            assertThat(RestAssured.get("/flyway/current-version").then().statusCode(200).extract().asString())
+                    .isEqualTo("1.0.0");
+        });
+    }
+
+    @Path("flyway")
+    public static class FlywayResource {
+        @Inject
+        Flyway flyway;
+
+        @Path("current-version")
+        @GET
+        public String currentVersion() {
+            return flyway.info().current().getVersion().toString();
+        }
+    }
+
+}

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainer.java
@@ -7,16 +7,18 @@ public class FlywayContainer {
     private final Flyway flyway;
     private final boolean cleanAtStart;
     private final boolean migrateAtStart;
+    private final boolean repairAtStart;
     private final String dataSourceName;
     private final boolean hasMigrations;
     private final boolean createPossible;
     private final String id;
 
-    public FlywayContainer(Flyway flyway, boolean cleanAtStart, boolean migrateAtStart, String dataSourceName,
-            boolean hasMigrations, boolean createPossible) {
+    public FlywayContainer(Flyway flyway, boolean cleanAtStart, boolean migrateAtStart, boolean repairAtStart,
+            String dataSourceName, boolean hasMigrations, boolean createPossible) {
         this.flyway = flyway;
         this.cleanAtStart = cleanAtStart;
         this.migrateAtStart = migrateAtStart;
+        this.repairAtStart = repairAtStart;
         this.dataSourceName = dataSourceName;
         this.hasMigrations = hasMigrations;
         this.createPossible = createPossible;
@@ -33,6 +35,10 @@ public class FlywayContainer {
 
     public boolean isMigrateAtStart() {
         return migrateAtStart;
+    }
+
+    public boolean isRepairAtStart() {
+        return repairAtStart;
     }
 
     public String getDataSourceName() {

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducer.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayContainerProducer.java
@@ -36,6 +36,6 @@ public class FlywayContainerProducer {
         final Flyway flyway = new FlywayCreator(matchingRuntimeConfig, matchingBuildTimeConfig).withCallbacks(callbacks)
                 .createFlyway(dataSource);
         return new FlywayContainer(flyway, matchingRuntimeConfig.cleanAtStart, matchingRuntimeConfig.migrateAtStart,
-                dataSourceName, hasMigrations, createPossible);
+                matchingRuntimeConfig.repairAtStart, dataSourceName, hasMigrations, createPossible);
     }
 }

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayDataSourceRuntimeConfig.java
@@ -106,6 +106,13 @@ public final class FlywayDataSourceRuntimeConfig {
     public boolean migrateAtStart;
 
     /**
+     * true to execute a Flyway repair command when the application starts, false otherwise.
+     *
+     */
+    @ConfigItem
+    public boolean repairAtStart;
+
+    /**
      * Enable the creation of the history table if it does not exist already.
      */
     @ConfigItem

--- a/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRecorder.java
+++ b/extensions/flyway/runtime/src/main/java/io/quarkus/flyway/runtime/FlywayRecorder.java
@@ -72,6 +72,9 @@ public class FlywayRecorder {
             if (flywayContainer.isCleanAtStart()) {
                 flywayContainer.getFlyway().clean();
             }
+            if (flywayContainer.isRepairAtStart()) {
+                flywayContainer.getFlyway().repair();
+            }
             if (flywayContainer.isMigrateAtStart()) {
                 flywayContainer.getFlyway().migrate();
             }


### PR DESCRIPTION
Introduces a new config property `quarkus.flyway.repair-at-start` which when set to `true` will run Flyway `repair` (see https://flywaydb.org/documentation/command/repair) prior to executing `migrate`.

Fixes #27329