### PR TITLE
Upgrade to version 42.5.0 of the PostgreSQL JDBC driver

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -117,7 +117,7 @@
         <cronutils.version>9.2.0</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
         <h2.version>2.1.214</h2.version>
-        <postgresql-jdbc.version>42.4.2</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <mariadb-jdbc.version>3.0.7</mariadb-jdbc.version>
         <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
         <mssql-jdbc.version>11.2.0.jre11</mssql-jdbc.version>


### PR DESCRIPTION
Needs CI opinion; we also want to check if this works flawlessly:
 - https://github.com/hibernate/hibernate-orm/pull/5236

Rationale: Hibernate ORM 6 already upgraded.