### PR TITLE
Jandex quarkus-bootstrap-app-model

### DIFF
--- a/independent-projects/bootstrap/app-model/pom.xml
+++ b/independent-projects/bootstrap/app-model/pom.xml
@@ -83,4 +83,20 @@
             </exclusions>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -36,6 +36,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
 
         <!-- Dependency versions -->
         <assertj.version>3.23.1</assertj.version>
@@ -81,6 +82,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.jboss.jandex</groupId>
+                    <artifactId>jandex-maven-plugin</artifactId>
+                    <version>${jandex-maven-plugin.version}</version>
+                </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>


### PR DESCRIPTION
This gets rid of the warning when compiling an app to native that depends on it:

```bash
[WARNING] [io.quarkus.deployment.steps.ReflectiveHierarchyStep] Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index:
    - io.quarkus.maven.dependency.ArtifactCoords (source: JacksonProcessor > io.quarkus.registry.config.RegistriesConfigImpl$Builder)
    - io.quarkus.maven.dependency.ArtifactKey (source: JacksonProcessor > io.quarkus.registry.json.JsonArtifactCoordsMixin)
Consider adding them to the index either by creating a Jandex index for your dependency via the Maven plugin, an empty META-INF/beans.xml or quarkus.index-dependency properties.
```