### PR TITLE
Jakarta - Simplify classloader-linkage-error

### DIFF
--- a/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classloader-linkage-error/pom.xml
@@ -13,8 +13,6 @@
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>11</maven.compiler.target>
-    <jaxb.version>2.3.1</jaxb.version>
-    <jaxb-core.version>2.3.0.1</jaxb-core.version>
     <stax-api.version>1.0.1</stax-api.version>
   </properties>
   <dependencyManagement>
@@ -36,19 +34,8 @@
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>${jaxb.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>${jaxb.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>${jaxb-core.version}</version>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jaxb</artifactId>
     </dependency>
     <dependency>
       <groupId>stax</groupId>


### PR DESCRIPTION
This makes the migration automatic and I confirmed the issue is still
present if we use quarkus-jaxb directly (removing the parent first
config gets us a LinkageError).

Fixes #27508