### PR TITLE
Set MP JWT TCK version to 2.0

### DIFF
--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -604,7 +604,7 @@ recipeList:
       newValue: 4.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-jwt-auth-tck.version
-      newValue: 2.1-RC2
+      newValue: 2.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-lra-tck.version
       newValue: 2.0-RC1


### PR DESCRIPTION
Fixes #27512.

Quarkus/smallrye-jwt have not been updated yet to depend on MP JWT 2.1