### PR TITLE
Validate that synthetic beans are defined with known scope annotations

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Beans.java
@@ -582,7 +582,6 @@ public final class Beans {
 
     static void validateBean(BeanInfo bean, List<Throwable> errors, Consumer<BytecodeTransformer> bytecodeTransformerConsumer,
             Set<DotName> classesReceivingNoArgsCtor) {
-
         if (bean.isClassBean()) {
             ClassInfo beanClass = bean.getTarget().get().asClass();
             String classifier = bean.getScope().isNormal() ? "Normal scoped" : null;
@@ -708,6 +707,12 @@ public final class Beans {
                 }
             }
         } else if (bean.isSynthetic()) {
+            // synth beans can accidentally be defined with a non-existing scope, throw exception in such case
+            DotName scopeName = bean.getScope().getDotName();
+            if (bean.getDeployment().getScope(scopeName) == null) {
+                throw new IllegalArgumentException("A synthetic bean " + bean + " was defined with invalid scope annotation - "
+                        + scopeName + ". Please use one of the built-in scopes or a valid, registered custom scope.");
+            }
             // this is for synthetic beans that need to be proxied but their classes don't have no-args constructor
             ClassInfo beanClass = getClassByName(bean.getDeployment().getBeanArchiveIndex(), bean.getBeanClass());
             MethodInfo noArgsConstructor = beanClass.method(Methods.INIT);

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SynthBeanWithWrongScopeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/buildextension/beans/SynthBeanWithWrongScopeTest.java
@@ -1,0 +1,65 @@
+package io.quarkus.arc.test.buildextension.beans;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.BeanCreator;
+import io.quarkus.arc.processor.BeanRegistrar;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Map;
+import javax.enterprise.context.spi.CreationalContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SynthBeanWithWrongScopeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanRegistrars(new TestRegistrar()).shouldFail().build();
+
+    @Test
+    public void testInvalidScopeWasDetectedAtBuildTime() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure().getMessage().contains("was defined with invalid scope annotation"),
+                container.getFailure().getMessage());
+    }
+
+    // no bean defining annotation; registered synthetically
+    static class BeanifyMe {
+
+    }
+
+    public static class MyBeanCreator implements BeanCreator<BeanifyMe> {
+
+        @Override
+        public BeanifyMe create(CreationalContext<BeanifyMe> creationalContext, Map<String, Object> params) {
+            return new BeanifyMe();
+        }
+    }
+
+    static class TestRegistrar implements BeanRegistrar {
+
+        @Override
+        public void register(RegistrationContext context) {
+            context.configure(BeanifyMe.class).unremovable()
+                    .types(BeanifyMe.class)
+                    // assign annotation that isn't a known scope - this should lead to sensible exception
+                    .scope(NotAScope.class)
+                    .creator(MyBeanCreator.class).done();
+        }
+
+    }
+
+    @Target({ TYPE, METHOD, FIELD, PARAMETER })
+    @Retention(RUNTIME)
+    public @interface NotAScope {
+
+    }
+}


### PR DESCRIPTION
Fixes #27510 