### PR TITLE
Reactive MongoDB Change Streams - Add Support for Databases using custom ChangeStreamOptions

### DIFF
--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/impl/ReactiveMongoDatabaseImpl.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/impl/ReactiveMongoDatabaseImpl.java
@@ -10,6 +10,7 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.reactivestreams.client.AggregatePublisher;
+import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher;
 import com.mongodb.reactivestreams.client.MongoDatabase;
@@ -217,7 +218,14 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
 
     @Override
     public <T> Multi<ChangeStreamDocument<T>> watch(Class<T> clazz, ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(clazz)));
+    }
+
+    private <D> ChangeStreamPublisher<D> apply(ChangeStreamOptions options, ChangeStreamPublisher<D> watch) {
+        if (options == null) {
+            return watch;
+        }
+        return options.apply(watch);
     }
 
     @Override
@@ -227,7 +235,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
 
     @Override
     public Multi<ChangeStreamDocument<Document>> watch(List<? extends Bson> pipeline, ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(pipeline)));
     }
 
     @Override
@@ -238,7 +246,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
     @Override
     public <T> Multi<ChangeStreamDocument<T>> watch(List<? extends Bson> pipeline, Class<T> clazz,
             ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(pipeline, clazz)));
     }
 
     @Override
@@ -248,7 +256,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
 
     @Override
     public Multi<ChangeStreamDocument<Document>> watch(ClientSession clientSession, ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(clientSession)));
     }
 
     @Override
@@ -259,7 +267,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
     @Override
     public <T> Multi<ChangeStreamDocument<T>> watch(ClientSession clientSession, Class<T> clazz,
             ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(clientSession, clazz)));
     }
 
     @Override
@@ -270,7 +278,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
     @Override
     public Multi<ChangeStreamDocument<Document>> watch(ClientSession clientSession, List<? extends Bson> pipeline,
             ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(clientSession, pipeline)));
     }
 
     @Override
@@ -282,7 +290,7 @@ public class ReactiveMongoDatabaseImpl implements ReactiveMongoDatabase {
     @Override
     public <T> Multi<ChangeStreamDocument<T>> watch(ClientSession clientSession, List<? extends Bson> pipeline,
             Class<T> clazz, ChangeStreamOptions options) {
-        return null;
+        return Wrappers.toMulti(apply(options, database.watch(clientSession, pipeline, clazz)));
     }
 
     @Override


### PR DESCRIPTION
Add support for watching databases using custom ChangeStreamOptions in Reactive Mongo change streams.

This follows the exact pattern used in ReactiveMongoCollectionImpl, applied to databases. 

Fixes #27549 