### PR TITLE
Make it easy to copy environment variables in config tables - add button

### DIFF
--- a/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
+++ b/core/processor/src/main/java/io/quarkus/annotation/processor/generate_doc/SummaryTableDocFormatter.java
@@ -75,7 +75,12 @@ final class SummaryTableDocFormatter implements DocFormatter {
         String doc = configDocKey.getConfigDoc();
 
         // Convert a property name to an environment variable name and show it in the config description
-        final var envVarExample = String.format("Environment variable: `+++%s+++`", toEnvVarName(configDocKey.getKey()));
+        final String envVarExample = String.format("ifdef::add-copy-button-to-env-var[]\n" +
+                "Environment variable: env_var_with_copy_button:+++%1$s+++[]\n" +
+                "endif::add-copy-button-to-env-var[]\n" +
+                "ifndef::add-copy-button-to-env-var[]\n" +
+                "Environment variable: `+++%1$s+++`\n" +
+                "endif::add-copy-button-to-env-var[]", toEnvVarName(configDocKey.getKey()));
         if (configDocKey.getConfigDoc().isEmpty()) {
             doc = envVarExample;
         } else {


### PR DESCRIPTION
related to https://github.com/quarkusio/quarkusio.github.io/pull/1510

When AsciiDoc attribute `add-copy-button-to-env-var` is defined, environment variable name is shown via inline macro, which allows to add a copy button (and prevent description from collapsing 'on copy') as discussed here https://github.com/quarkusio/quarkus/pull/26408#issuecomment-1198304829 without any JavaScript.