### PR TITLE
Bump tags of Kafka-related Docker images

### DIFF
--- a/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
+++ b/docs/src/main/asciidoc/kafka-reactive-getting-started.adoc
@@ -404,7 +404,7 @@ version: '3.5'
 services:
 
   zookeeper:
-    image: quay.io/strimzi/kafka:0.23.0-kafka-2.8.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
       "sh", "-c",
       "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -417,7 +417,7 @@ services:
       - kafka-quickstart-network
 
   kafka:
-    image: quay.io/strimzi/kafka:0.23.0-kafka-2.8.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
       "sh", "-c",
       "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"

--- a/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
+++ b/docs/src/main/asciidoc/kafka-schema-registry-avro.adoc
@@ -321,7 +321,7 @@ version: '2'
 services:
 
   zookeeper:
-    image: quay.io/strimzi/kafka:0.22.1-kafka-2.7.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
         "sh", "-c",
         "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -332,7 +332,7 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: quay.io/strimzi/kafka:0.22.1-kafka-2.7.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
         "sh", "-c",
         "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
@@ -348,7 +348,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:2.1.5.Final
+    image: apicurio/apicurio-registry-mem:2.2.5.Final
     ports:
       - 8081:8080
     depends_on:
@@ -582,7 +582,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
     @Override
     public Map<String, String> start() {
         kafka.start();
-        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.1.5.Final")
+        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.2.5.Final")
                 .withExposedPorts(8080)
                 .withEnv("QUARKUS_PROFILE", "prod");
         registry.start();

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -491,7 +491,7 @@ version: '3.5'
 
 services:
   zookeeper:
-    image: strimzi/kafka:0.19.0-kafka-2.5.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
       "sh", "-c",
       "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -503,7 +503,7 @@ services:
     networks:
       - kafkastreams-network
   kafka:
-    image: strimzi/kafka:0.19.0-kafka-2.5.0
+    image: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
     command: [
       "sh", "-c",
       "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT} --override num.partitions=$${KAFKA_NUM_PARTITIONS}"

--- a/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
+++ b/extensions/schema-registry/devservice/deployment/src/main/java/io/quarkus/apicurio/registry/devservice/ApicurioRegistryDevServicesBuildTimeConfig.java
@@ -31,7 +31,7 @@ public class ApicurioRegistryDevServicesBuildTimeConfig {
      * Note that only Apicurio Registry 2.x images are supported.
      * Specifically, the image repository must end with {@code apicurio/apicurio-registry-mem}.
      */
-    @ConfigItem(defaultValue = "quay.io/apicurio/apicurio-registry-mem:2.2.3.Final")
+    @ConfigItem(defaultValue = "quay.io/apicurio/apicurio-registry-mem:2.2.5.Final")
     public String imageName;
 
     /**

--- a/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/KafkaAndSchemaRegistryTestResource.java
+++ b/integration-tests/kafka-avro/src/test/java/io/quarkus/it/kafka/KafkaAndSchemaRegistryTestResource.java
@@ -21,7 +21,7 @@ public class KafkaAndSchemaRegistryTestResource implements QuarkusTestResourceLi
 
     @Override
     public Map<String, String> start() {
-        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:1.2.2.Final")
+        registry = new GenericContainer<>("apicurio/apicurio-registry-mem:2.2.5.Final")
                 .withExposedPorts(8080)
                 .withEnv("QUARKUS_PROFILE", "prod");
         registry.start();


### PR DESCRIPTION
Use latest version of `quay.io/apicurio/apicurio-registry-mem` (2.2.5.Final), latest Kafka 2.x tag for `quay.io/strimzi/kafka` (0.27.0-kafka-2.8.1), and latest version of `docker.io/vectorized/redpanda` (v22.2.2).