### PR TITLE
Helpers to instantiate empty config while taking @Config* annotations and defaults into account

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigInstantiator.java
@@ -108,8 +108,10 @@ public class ConfigInstantiator {
                     name = dashify(field.getName());
                 } else if (name.equals(ConfigItem.ELEMENT_NAME)) {
                     name = field.getName();
+                } else if (name.equals(ConfigItem.PARENT)) {
+                    name = null;
                 }
-                String fullName = prefix + "." + name;
+                String fullName = prefix + (name == null ? "" : "." + name);
                 if (fieldClass == Map.class) {
                     field.set(o, handleMap(fullName, genericType, config, quarkusPropertyNames));
                 } else if (configItem == null || fieldClass.isAnnotationPresent(ConfigGroup.class)) {

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
@@ -43,7 +43,12 @@ public class ConfigInstantiatorTestCase {
             entry("quarkus.named.value", "val"),
 
             entry("quarkus.named2.value", "val1"),
-            entry("quarkus.named2.group.value", "val2"));
+            entry("quarkus.named2.group.value", "val2"),
+
+            entry("quarkus.named3.value", "val3"),
+            entry("quarkus.named3.group.value", "val4"),
+            entry("quarkus.named3.map-of-groups.foo.value", "val5"),
+            entry("quarkus.named3.map-of-groups.bar.value", "val6"));
 
     private static Config testConfig;
     private static Config cfgToRestore;
@@ -126,6 +131,19 @@ public class ConfigInstantiatorTestCase {
         assertThat(config.group.value).isEqualTo("val2");
     }
 
+    // Not adding @ConfigItem to properties feels wrong, but it's supported,
+    // so ConfigInstantiator should support it too.
+    @Test
+    public void handleWithoutConfigItem() {
+        RootWithoutConfigItem config = new RootWithoutConfigItem();
+        ConfigInstantiator.handleObject(config);
+        assertThat(config.value).isEqualTo("val3");
+        assertThat(config.group.value).isEqualTo("val4");
+        assertThat(config.mapOfGroups).containsKeys("foo", "bar");
+        assertThat(config.mapOfGroups.get("foo").value).isEqualTo("val5");
+        assertThat(config.mapOfGroups.get("bar").value).isEqualTo("val6");
+    }
+
     private static class MapOfMapsConfig {
 
         @ConfigItem
@@ -197,6 +215,25 @@ public class ConfigInstantiatorTestCase {
     private static class GroupWithoutConfigSuffix {
 
         public GroupWithoutConfigSuffix() {
+        }
+
+        @ConfigItem
+        public String value;
+    }
+
+    @ConfigRoot(name = "named3")
+    private static class RootWithoutConfigItem {
+        @ConfigItem
+        public String value;
+
+        public GroupInRootWithoutConfigItem group;
+
+        public Map<String, GroupInRootWithoutConfigItem> mapOfGroups;
+    }
+
+    @ConfigGroup
+    private static class GroupInRootWithoutConfigItem {
+        public GroupInRootWithoutConfigItem() {
         }
 
         @ConfigItem

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
@@ -48,7 +48,9 @@ public class ConfigInstantiatorTestCase {
             entry("quarkus.named3.value", "val3"),
             entry("quarkus.named3.group.value", "val4"),
             entry("quarkus.named3.map-of-groups.foo.value", "val5"),
-            entry("quarkus.named3.map-of-groups.bar.value", "val6"));
+            entry("quarkus.named3.map-of-groups.bar.value", "val6"),
+
+            entry("quarkus.named4", "val7"));
 
     private static Config testConfig;
     private static Config cfgToRestore;
@@ -144,6 +146,15 @@ public class ConfigInstantiatorTestCase {
         assertThat(config.mapOfGroups.get("bar").value).isEqualTo("val6");
     }
 
+    // Not adding @ConfigItem to properties feels wrong, but it's supported,
+    // so ConfigInstantiator should support it too.
+    @Test
+    public void handleElementNameParent() {
+        RootWithElementNameParent config = new RootWithElementNameParent();
+        ConfigInstantiator.handleObject(config);
+        assertThat(config.value).isEqualTo("val7");
+    }
+
     private static class MapOfMapsConfig {
 
         @ConfigItem
@@ -237,6 +248,12 @@ public class ConfigInstantiatorTestCase {
         }
 
         @ConfigItem
+        public String value;
+    }
+
+    @ConfigRoot(name = "named4")
+    private static class RootWithElementNameParent {
+        @ConfigItem(name = ConfigItem.PARENT)
         public String value;
     }
 

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
@@ -40,7 +40,10 @@ public class ConfigInstantiatorTestCase {
             entry("quarkus.map-of-maps.map-of-maps.\"outer2.key\".inner1.value", "o2i1"),
             entry("quarkus.map-of-maps.map-of-maps.\"outer2.key\".\"inner2.key\".value", "o2i2"),
 
-            entry("quarkus.named.value", "val"));
+            entry("quarkus.named.value", "val"),
+
+            entry("quarkus.named2.value", "val1"),
+            entry("quarkus.named2.group.value", "val2"));
 
     private static Config testConfig;
     private static Config cfgToRestore;
@@ -115,6 +118,14 @@ public class ConfigInstantiatorTestCase {
         assertThat(config.value).isEqualTo("val");
     }
 
+    @Test
+    public void handleWithoutConfigSuffix() {
+        RootWithoutConfigSuffix config = new RootWithoutConfigSuffix();
+        ConfigInstantiator.handleObject(config);
+        assertThat(config.value).isEqualTo("val1");
+        assertThat(config.group.value).isEqualTo("val2");
+    }
+
     private static class MapOfMapsConfig {
 
         @ConfigItem
@@ -167,6 +178,26 @@ public class ConfigInstantiatorTestCase {
 
     @ConfigRoot(name = "named")
     private static class WithNameConfig {
+
+        @ConfigItem
+        public String value;
+    }
+
+    @ConfigRoot(name = "named2")
+    private static class RootWithoutConfigSuffix {
+
+        @ConfigItem
+        public String value;
+
+        @ConfigItem
+        public GroupWithoutConfigSuffix group;
+    }
+
+    @ConfigGroup
+    private static class GroupWithoutConfigSuffix {
+
+        public GroupWithoutConfigSuffix() {
+        }
 
         @ConfigItem
         public String value;

--- a/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
+++ b/core/runtime/src/test/java/io/quarkus/runtime/configuration/ConfigInstantiatorTestCase.java
@@ -3,8 +3,10 @@ package io.quarkus.runtime.configuration;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.Config;
@@ -155,6 +157,34 @@ public class ConfigInstantiatorTestCase {
         assertThat(config.value).isEqualTo("val7");
     }
 
+    @Test
+    public void createEmptyObjectWithConfigIgnored() {
+        LogConfig logConfig = ConfigInstantiator.createEmptyObject(LogConfig.class);
+
+        // On contrary to the test "handleLogConfig" above,
+        // here we expect configuration to be ignored:
+        // we only want the defaults.
+        // This is arguably more useful for config groups than for config roots.
+        assertThat(logConfig.level).isEqualTo(Level.INFO);
+        assertThat(logConfig.categories).isEmpty();
+    }
+
+    @Test
+    public void createEmptyObjectWithDefaults() {
+        WithDefaultsConfig config = ConfigInstantiator.createEmptyObject(WithDefaultsConfig.class);
+
+        assertThat(config.noDefaultStringValue).isNull();
+        assertThat(config.withDefaultStringValue).isEqualTo("someDefault");
+        assertThat(config.noDefaultConvertedValue).isNull();
+        assertThat(config.withDefaultConvertedValue).isEqualTo(42);
+        assertThat(config.optionalStringValue).isNotNull().isEmpty();
+        assertThat(config.optionalConvertedValue).isNotNull().isEmpty();
+        assertThat(config.listOfStringsValue).isNull();
+        assertThat(config.listOfConvertedValue).isNull();
+        assertThat(config.mapOfStringsValue).isNotNull().isEmpty();
+        assertThat(config.mapOfGroupsValue).isNotNull().isEmpty();
+    }
+
     private static class MapOfMapsConfig {
 
         @ConfigItem
@@ -274,5 +304,39 @@ public class ConfigInstantiatorTestCase {
         public String getName() {
             return "ConfigInstantiatorTestCase config source";
         }
+    }
+
+    @ConfigGroup
+    public static class WithDefaultsConfig {
+
+        @ConfigItem
+        public String noDefaultStringValue;
+
+        @ConfigItem(defaultValue = "someDefault")
+        public String withDefaultStringValue;
+
+        @ConfigItem
+        public Integer noDefaultConvertedValue;
+
+        @ConfigItem(defaultValue = "42")
+        public Integer withDefaultConvertedValue;
+
+        @ConfigItem
+        public Optional<String> optionalStringValue;
+
+        @ConfigItem
+        public Optional<Integer> optionalConvertedValue;
+
+        @ConfigItem
+        public List<String> listOfStringsValue;
+
+        @ConfigItem
+        public List<Integer> listOfConvertedValue;
+
+        @ConfigItem
+        public Map<String, String> mapOfStringsValue;
+
+        @ConfigItem
+        public Map<String, MapValueConfig> mapOfGroupsValue;
     }
 }

--- a/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
+++ b/extensions/agroal/deployment/src/main/java/io/quarkus/agroal/deployment/AgroalProcessor.java
@@ -48,6 +48,7 @@ import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
@@ -295,7 +296,7 @@ class AgroalProcessor {
         for (Entry<String, DataSourceBuildTimeConfig> entry : dataSourcesBuildTimeConfig.namedDataSources.entrySet()) {
             DataSourceJdbcBuildTimeConfig jdbcBuildTimeConfig = dataSourcesJdbcBuildTimeConfig.namedDataSources
                     .containsKey(entry.getKey()) ? dataSourcesJdbcBuildTimeConfig.namedDataSources.get(entry.getKey()).jdbc
-                            : new DataSourceJdbcBuildTimeConfig();
+                            : ConfigInstantiator.createEmptyObject(DataSourceJdbcBuildTimeConfig.class);
             if (!jdbcBuildTimeConfig.enabled) {
                 continue;
             }

--- a/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoRuntimeConfigNamedDataSourceTest.java
+++ b/extensions/agroal/deployment/src/test/java/io/quarkus/agroal/test/NoRuntimeConfigNamedDataSourceTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.agroal.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.agroal.DataSource;
+import io.quarkus.agroal.runtime.DataSourcesJdbcRuntimeConfig;
+import io.quarkus.agroal.runtime.UnconfiguredDataSource;
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that Agroal is able to install a named datasource,
+ * even when there is no runtime configuration for that datasource.
+ * <p>
+ * This case is interesting mainly because it would most likely lead to an NPE
+ * unless we take extra care to avoid it.
+ */
+public class NoRuntimeConfigNamedDataSourceTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            // For Agroal, provide only build-time config; rely on defaults for everything else.
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            // Disable dev services, since they could interfere with runtime config (in particular the JDBC URL setting).
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Test
+    public void test() {
+        // Check that runtime config for our datasource is indeed missing.
+        DataSourcesJdbcRuntimeConfig config = Arc.container().instance(DataSourcesJdbcRuntimeConfig.class).get();
+        assertThat(config.namedDataSources).isNullOrEmpty();
+        // Test that the datasource was installed correctly regardless.
+        AgroalDataSource dataSource = Arc.container()
+                .instance(AgroalDataSource.class, new DataSource.DataSourceLiteral("ds-1")).get();
+        assertThat(dataSource).isNotNull();
+        // Though of course, the datasource cannot be used.
+        assertThat(dataSource).isInstanceOf(UnconfiguredDataSource.class);
+        assertThatThrownBy(() -> {
+            try (Connection connection = dataSource.getConnection()) {
+            }
+        })
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessage("quarkus.datasource.ds-1.jdbc.url has not been defined");
+    }
+}

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcBuildTimeConfig.java
@@ -14,14 +14,14 @@ public class DataSourceJdbcBuildTimeConfig {
      * If we create a JDBC datasource for this datasource.
      */
     @ConfigItem(name = ConfigItem.PARENT, defaultValue = "true")
-    public boolean enabled = true;
+    public boolean enabled;
 
     /**
      * The datasource driver class name
      */
     @ConfigItem
     @ConvertWith(TrimmedStringConverter.class)
-    public Optional<String> driver = Optional.empty();
+    public Optional<String> driver;
 
     /**
      * Whether we want to use regular JDBC transactions, XA, or disable all transactional capabilities.
@@ -29,18 +29,18 @@ public class DataSourceJdbcBuildTimeConfig {
      * When enabling XA you will need a driver implementing {@link javax.sql.XADataSource}.
      */
     @ConfigItem(defaultValue = "enabled")
-    public TransactionIntegration transactions = TransactionIntegration.ENABLED;
+    public TransactionIntegration transactions;
 
     /**
      * Enable datasource metrics collection. If unspecified, collecting metrics will be enabled by default if
      * a metrics extension is active.
      */
     @ConfigItem
-    public Optional<Boolean> enableMetrics = Optional.empty();
+    public Optional<Boolean> enableMetrics;
 
     /**
      * Enable JDBC tracing. Disabled by default.
      */
     @ConfigItem(defaultValue = "false")
-    public boolean tracing = false;
+    public boolean tracing;
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.agroal.runtime;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -18,7 +17,7 @@ public class DataSourceJdbcRuntimeConfig {
      * The datasource URL
      */
     @ConfigItem
-    public Optional<String> url = Optional.empty();
+    public Optional<String> url;
 
     /**
      * The initial size of the pool. Usually you will want to set the initial size to match at least the
@@ -26,19 +25,19 @@ public class DataSourceJdbcRuntimeConfig {
      * of the connections on boot, while being able to sustain a minimal pool size after boot.
      */
     @ConfigItem
-    public OptionalInt initialSize = OptionalInt.empty();
+    public OptionalInt initialSize;
 
     /**
      * The datasource pool minimum size
      */
     @ConfigItem
-    public int minSize = 0;
+    public int minSize;
 
     /**
      * The datasource pool maximum size
      */
     @ConfigItem(defaultValue = "20")
-    public int maxSize = 20;
+    public int maxSize;
 
     /**
      * The interval at which we validate idle connections in the background.
@@ -46,43 +45,43 @@ public class DataSourceJdbcRuntimeConfig {
      * Set to {@code 0} to disable background validation.
      */
     @ConfigItem(defaultValue = "2M")
-    public Optional<Duration> backgroundValidationInterval = Optional.of(Duration.ofMinutes(2));
+    public Optional<Duration> backgroundValidationInterval;
 
     /**
      * Perform foreground validation on connections that have been idle for longer than the specified interval.
      */
     @ConfigItem
-    public Optional<Duration> foregroundValidationInterval = Optional.empty();
+    public Optional<Duration> foregroundValidationInterval;
 
     /**
      * The timeout before cancelling the acquisition of a new connection
      */
     @ConfigItem(defaultValue = "5")
-    public Optional<Duration> acquisitionTimeout = Optional.of(Duration.ofSeconds(5));
+    public Optional<Duration> acquisitionTimeout;
 
     /**
      * The interval at which we check for connection leaks.
      */
     @ConfigItem
-    public Optional<Duration> leakDetectionInterval = Optional.empty();
+    public Optional<Duration> leakDetectionInterval;
 
     /**
      * The interval at which we try to remove idle connections.
      */
     @ConfigItem(defaultValue = "5M")
-    public Optional<Duration> idleRemovalInterval = Optional.of(Duration.ofMinutes(5));
+    public Optional<Duration> idleRemovalInterval;
 
     /**
      * The max lifetime of a connection.
      */
     @ConfigItem
-    public Optional<Duration> maxLifetime = Optional.empty();
+    public Optional<Duration> maxLifetime;
 
     /**
      * The transaction isolation level.
      */
     @ConfigItem
-    public Optional<AgroalConnectionFactoryConfiguration.TransactionIsolation> transactionIsolationLevel = Optional.empty();
+    public Optional<AgroalConnectionFactoryConfiguration.TransactionIsolation> transactionIsolationLevel;
 
     /**
      * Collect and display extra troubleshooting info on leaked connections.
@@ -104,26 +103,26 @@ public class DataSourceJdbcRuntimeConfig {
      * no leaks are happening.
      */
     @ConfigItem(defaultValue = "true")
-    public boolean detectStatementLeaks = true;
+    public boolean detectStatementLeaks;
 
     /**
      * Query executed when first using a connection.
      */
     @ConfigItem
-    public Optional<String> newConnectionSql = Optional.empty();
+    public Optional<String> newConnectionSql;
 
     /**
      * Query executed to validate a connection.
      */
     @ConfigItem
-    public Optional<String> validationQuerySql = Optional.empty();
+    public Optional<String> validationQuerySql;
 
     /**
      * Disable pooling to prevent reuse of Connections. Use this with when an external pool manages the life-cycle
      * of Connections.
      */
     @ConfigItem(defaultValue = "true")
-    public boolean poolingEnabled = true;
+    public boolean poolingEnabled;
 
     /**
      * Require an active transaction when acquiring a connection. Recommended for production.
@@ -131,18 +130,18 @@ public class DataSourceJdbcRuntimeConfig {
      * validation. Setting this setting to STRICT may lead to failures in those cases.
      */
     @ConfigItem
-    public Optional<AgroalConnectionPoolConfiguration.TransactionRequirement> transactionRequirement = Optional.empty();
+    public Optional<AgroalConnectionPoolConfiguration.TransactionRequirement> transactionRequirement;
 
     /**
      * Other unspecified properties to be passed to the JDBC driver when creating new connections.
      */
     @ConfigItem
-    public Map<String, String> additionalJdbcProperties = Collections.emptyMap();
+    public Map<String, String> additionalJdbcProperties;
 
     /**
      * Enable JDBC tracing.
      */
     @ConfigItem
-    public DataSourceJdbcTracingRuntimeConfig tracing = new DataSourceJdbcTracingRuntimeConfig();
+    public DataSourceJdbcTracingRuntimeConfig tracing;
 
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcTracingRuntimeConfig.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcTracingRuntimeConfig.java
@@ -12,18 +12,18 @@ public class DataSourceJdbcTracingRuntimeConfig {
      * Enable JDBC tracing.
      */
     @ConfigItem(defaultValueDocumentation = "false if quarkus.datasource.jdbc.tracing=false and true if quarkus.datasource.jdbc.tracing=true")
-    public Optional<Boolean> enabled = Optional.empty();
+    public Optional<Boolean> enabled;
 
     /**
      * Trace calls with active Spans only
      */
     @ConfigItem(defaultValue = "false")
-    public boolean traceWithActiveSpanOnly = false;
+    public boolean traceWithActiveSpanOnly;
 
     /**
      * Ignore specific queries from being traced
      */
     @ConfigItem(defaultValueDocumentation = "Ignore specific queries from being traced, multiple queries can be specified separated by semicolon, double quotes should be escaped with \\")
-    public Optional<String> ignoreForTracing = Optional.empty();
+    public Optional<String> ignoreForTracing;
 
 }

--- a/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
+++ b/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSources.java
@@ -48,6 +48,7 @@ import io.quarkus.datasource.runtime.DataSourceBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourceRuntimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.datasource.runtime.DataSourcesRuntimeConfig;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 /**
  * This class is sort of a producer for {@link AgroalDataSource}.
@@ -366,7 +367,7 @@ public class DataSources {
 
         DataSourceBuildTimeConfig namedConfig = dataSourcesBuildTimeConfig.namedDataSources.get(dataSourceName);
 
-        return namedConfig != null ? namedConfig : new DataSourceBuildTimeConfig();
+        return namedConfig != null ? namedConfig : ConfigInstantiator.createEmptyObject(DataSourceBuildTimeConfig.class);
     }
 
     public DataSourceJdbcBuildTimeConfig getDataSourceJdbcBuildTimeConfig(String dataSourceName) {
@@ -377,7 +378,8 @@ public class DataSources {
         DataSourceJdbcOuterNamedBuildTimeConfig namedOuterConfig = dataSourcesJdbcBuildTimeConfig.namedDataSources
                 .get(dataSourceName);
 
-        return namedOuterConfig != null ? namedOuterConfig.jdbc : new DataSourceJdbcBuildTimeConfig();
+        return namedOuterConfig != null ? namedOuterConfig.jdbc
+                : ConfigInstantiator.createEmptyObject(DataSourceJdbcBuildTimeConfig.class);
     }
 
     public DataSourceRuntimeConfig getDataSourceRuntimeConfig(String dataSourceName) {
@@ -387,7 +389,7 @@ public class DataSources {
 
         DataSourceRuntimeConfig namedConfig = dataSourcesRuntimeConfig.namedDataSources.get(dataSourceName);
 
-        return namedConfig != null ? namedConfig : new DataSourceRuntimeConfig();
+        return namedConfig != null ? namedConfig : ConfigInstantiator.createEmptyObject(DataSourceRuntimeConfig.class);
     }
 
     public DataSourceJdbcRuntimeConfig getDataSourceJdbcRuntimeConfig(String dataSourceName) {
@@ -398,7 +400,8 @@ public class DataSources {
         DataSourceJdbcOuterNamedRuntimeConfig namedOuterConfig = dataSourcesJdbcRuntimeConfig.namedDataSources
                 .get(dataSourceName);
 
-        return namedOuterConfig != null ? namedOuterConfig.jdbc : new DataSourceJdbcRuntimeConfig();
+        return namedOuterConfig != null ? namedOuterConfig.jdbc
+                : ConfigInstantiator.createEmptyObject(DataSourceJdbcRuntimeConfig.class);
     }
 
     /**

--- a/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/NoBuildTimeConfigNamedPUTest.java
+++ b/extensions/hibernate-envers/deployment/src/test/java/io/quarkus/hibernate/orm/envers/config/NoBuildTimeConfigNamedPUTest.java
@@ -1,0 +1,55 @@
+package io.quarkus.hibernate.orm.envers.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.Bindable;
+
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.envers.HibernateEnversBuildTimeConfig;
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.hibernate.orm.envers.MyAuditedEntity;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that Hibernate Envers is able to start in a named PU,
+ * even when there is no build-time configuration for that PU.
+ * <p>
+ * This case is interesting mainly because it would most likely lead to an NPE
+ * unless we take extra care to avoid it.
+ */
+public class NoBuildTimeConfigNamedPUTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(MyAuditedEntity.class))
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".jdbc.url", "jdbc:h2:mem:test")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".datasource", "ds-1")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".packages",
+                    MyAuditedEntity.class.getPackage().getName())
+            // For Hibernate Envers, do not provide any build-time config; rely on defaults for everything.
+
+            // Disable dev services, since they could interfere with runtime config (in particular the schema generation settings).
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            // Make build-time config accessible through CDI
+            .overrideConfigKey("quarkus.arc.unremovable-types", HibernateEnversBuildTimeConfig.class.getName());
+
+    @Test
+    public void test() {
+        // Check that build-time config for our PU is indeed missing.
+        HibernateEnversBuildTimeConfig config = Arc.container()
+                .instance(HibernateEnversBuildTimeConfig.class).get();
+        assertThat(config.persistenceUnits).isNullOrEmpty();
+        // Test that Hibernate Envers was started correctly regardless.
+        EntityManagerFactory entityManagerFactory = Arc.container()
+                .instance(EntityManagerFactory.class, new PersistenceUnitLiteral("pu-1")).get();
+        assertThat(entityManagerFactory.getMetamodel().getEntities())
+                .extracting(Bindable::getBindableJavaType)
+                .contains((Class) DefaultRevisionEntity.class);
+    }
+}

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversBuildTimeConfig.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.envers;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -10,6 +9,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class HibernateEnversBuildTimeConfig {
@@ -41,13 +41,17 @@ public class HibernateEnversBuildTimeConfig {
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, HibernateEnversBuildTimeConfigPersistenceUnit> persistenceUnits;
 
-    public Map<String, HibernateEnversBuildTimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateEnversBuildTimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
+    public HibernateEnversBuildTimeConfigPersistenceUnit getPersistenceUnitConfig(String name) {
+        HibernateEnversBuildTimeConfigPersistenceUnit result;
+        if (PersistenceUnitUtil.isDefaultPersistenceUnit(name)) {
+            result = defaultPersistenceUnit;
+        } else {
+            result = persistenceUnits.get(name);
         }
-        map.putAll(persistenceUnits);
-        return map;
+        if (result == null) {
+            result = ConfigInstantiator.createEmptyObject(HibernateEnversBuildTimeConfigPersistenceUnit.class);
+        }
+        return result;
     }
 
     /**

--- a/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
+++ b/extensions/hibernate-envers/runtime/src/main/java/io/quarkus/hibernate/envers/HibernateEnversRecorder.java
@@ -31,8 +31,8 @@ public class HibernateEnversRecorder {
 
         @Override
         public void contributeBootProperties(BiConsumer<String, Object> propertyCollector) {
-            var puConfig = buildTimeConfig.getAllPersistenceUnitConfigsAsMap().get(puName);
-            if (puConfig != null && puConfig.active.isPresent() && !puConfig.active.get()) {
+            var puConfig = buildTimeConfig.getPersistenceUnitConfig(puName);
+            if (puConfig.active.isPresent() && !puConfig.active.get()) {
                 propertyCollector.accept(EnversService.INTEGRATION_ENABLED, "false");
                 // Do not process other properties: Hibernate Envers is inactive anyway.
                 return;

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmDisabledProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmDisabledProcessor.java
@@ -1,5 +1,9 @@
 package io.quarkus.hibernate.orm.deployment;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
@@ -12,12 +16,16 @@ class HibernateOrmDisabledProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    public void disableHibernateOrm(HibernateOrmDisabledRecorder recorder, HibernateOrmRuntimeConfig runtimeConfig) {
+    public void disableHibernateOrm(HibernateOrmDisabledRecorder recorder, HibernateOrmRuntimeConfig runtimeConfig,
+            List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptors) {
         // The disabling itself is done through conditions on build steps (see uses of HibernateOrmEnabled.class)
 
         // We still want to check that nobody tries to set quarkus.hibernate-orm.active = true at runtime
         // if Hibernate ORM is disabled, though:
-        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        Set<String> persistenceUnitNames = persistenceUnitDescriptors.stream()
+                .map(PersistenceUnitDescriptorBuildItem::getConfigurationName)
+                .collect(Collectors.toSet());
+        recorder.checkNoExplicitActiveTrue(runtimeConfig, persistenceUnitNames);
     }
 
 }

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -214,15 +214,9 @@ public final class HibernateOrmProcessor {
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)
-    void handleMoveSql(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> runtimeInfoProducer,
+    void handleGenerateSql(BuildProducer<DevConsoleRuntimeTemplateInfoBuildItem> runtimeInfoProducer,
             BuildProducer<JdbcInitialSQLGeneratorBuildItem> initialSQLGeneratorBuildItemBuildProducer,
             HibernateOrmConfig config, CurateOutcomeBuildItem curateOutcomeBuildItem) {
-
-        DevConsoleRuntimeTemplateInfoBuildItem devConsoleRuntimeTemplateInfoBuildItem = new DevConsoleRuntimeTemplateInfoBuildItem(
-                "create-ddl." + PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME,
-                new HibernateOrmDevConsoleCreateDDLSupplier(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME), this.getClass(),
-                curateOutcomeBuildItem);
-        runtimeInfoProducer.produce(devConsoleRuntimeTemplateInfoBuildItem);
         for (Entry<String, HibernateOrmConfigPersistenceUnit> entry : config.getAllPersistenceUnitConfigsAsMap().entrySet()) {
             handleGenerateSqlForPu(runtimeInfoProducer, initialSQLGeneratorBuildItemBuildProducer, entry.getKey(),
                     entry.getValue().datasource.orElse(DataSourceUtil.DEFAULT_DATASOURCE_NAME), curateOutcomeBuildItem);

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/PersistenceUnitDescriptorBuildItem.java
@@ -25,9 +25,11 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
     private final ParsedPersistenceXmlDescriptor descriptor;
 
     // The default PU in Hibernate Reactive is named "default-reactive" instead of "<default>",
-    // but everything related to configuration (e.g. getAllPersistenceUnitConfigsAsMap() still
+    // but everything related to configuration (e.g. getAllPersistenceUnitConfigsAsMap()) still
     // use the name "<default>", so we need to convert between those.
     private final String configurationName;
+    // This config is missing when (and only when) configuring through persistence.xml (see fromPersistenceXml).
+    private final Optional<HibernateOrmConfigPersistenceUnit> buildTimeConfig;
     private final Optional<String> dataSource;
     private final MultiTenancyStrategy multiTenancyStrategy;
     private final String multiTenancySchemaDataSource;
@@ -37,15 +39,17 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
     private final boolean fromPersistenceXml;
 
     public PersistenceUnitDescriptorBuildItem(ParsedPersistenceXmlDescriptor descriptor, String configurationName,
+            Optional<HibernateOrmConfigPersistenceUnit> buildTimeConfig,
             List<RecordableXmlMapping> xmlMappings,
             Map<String, String> quarkusConfigUnsupportedProperties,
             boolean isReactive, boolean fromPersistenceXml) {
-        this(descriptor, configurationName,
+        this(descriptor, configurationName, buildTimeConfig,
                 Optional.of(DataSourceUtil.DEFAULT_DATASOURCE_NAME), MultiTenancyStrategy.NONE, null,
                 xmlMappings, quarkusConfigUnsupportedProperties, isReactive, fromPersistenceXml);
     }
 
     public PersistenceUnitDescriptorBuildItem(ParsedPersistenceXmlDescriptor descriptor, String configurationName,
+            Optional<HibernateOrmConfigPersistenceUnit> buildTimeConfig,
             Optional<String> dataSource,
             MultiTenancyStrategy multiTenancyStrategy, String multiTenancySchemaDataSource,
             List<RecordableXmlMapping> xmlMappings,
@@ -53,6 +57,7 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
             boolean isReactive, boolean fromPersistenceXml) {
         this.descriptor = descriptor;
         this.configurationName = configurationName;
+        this.buildTimeConfig = buildTimeConfig;
         this.dataSource = dataSource;
         this.multiTenancyStrategy = multiTenancyStrategy;
         this.multiTenancySchemaDataSource = multiTenancySchemaDataSource;
@@ -72,6 +77,14 @@ public final class PersistenceUnitDescriptorBuildItem extends MultiBuildItem {
 
     public String getPersistenceUnitName() {
         return descriptor.getName();
+    }
+
+    public String getConfigurationName() {
+        return configurationName;
+    }
+
+    public Optional<HibernateOrmConfigPersistenceUnit> getBuildTimeConfig() {
+        return buildTimeConfig;
     }
 
     public Optional<String> getDataSource() {

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/namedpu/NoRuntimeConfigNamedPUTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/config/namedpu/NoRuntimeConfigNamedPUTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.hibernate.orm.config.namedpu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.Bindable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.hibernate.orm.runtime.HibernateOrmRuntimeConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that Hibernate ORM is able to start a named PU,
+ * even when there is no runtime configuration for that PU.
+ * <p>
+ * This case is interesting mainly because it would most likely lead to an NPE
+ * unless we take extra care to avoid it.
+ */
+public class NoRuntimeConfigNamedPUTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addPackage(MyEntity.class.getPackage().getName()))
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".jdbc.url", "jdbc:h2:mem:test")
+            // For Hibernate ORM, provide only build-time config; rely on defaults for everything else.
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".datasource", "ds-1")
+            // Disable dev services, since they could interfere with runtime config (in particular the schema generation settings).
+            .overrideConfigKey("quarkus.devservices.enabled", "false");
+
+    @Test
+    public void test() {
+        // Check that runtime config for our PU is indeed missing.
+        HibernateOrmRuntimeConfig config = Arc.container().instance(HibernateOrmRuntimeConfig.class).get();
+        assertThat(config.persistenceUnits).isNullOrEmpty();
+        // Test that Hibernate ORM was started correctly regardless.
+        EntityManagerFactory entityManagerFactory = Arc.container()
+                .instance(EntityManagerFactory.class, new PersistenceUnitLiteral("pu-1")).get();
+        assertThat(entityManagerFactory).isNotNull();
+        assertThat(entityManagerFactory.getMetamodel().getEntities())
+                .extracting(Bindable::getBindableJavaType)
+                .containsExactlyInAnyOrder((Class) MyEntity.class);
+    }
+}

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java
@@ -147,8 +147,6 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
             throw new PersistenceException("No name provided and multiple persistence units found");
         }
 
-        Map<String, HibernateOrmRuntimeConfigPersistenceUnit> puConfigMap = hibernateOrmRuntimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
         for (RuntimePersistenceUnitDescriptor persistenceUnit : units) {
             log.debugf(
                     "Checking persistence-unit [name=%s, explicit-provider=%s] against incoming persistence unit name [%s]",
@@ -174,8 +172,8 @@ public final class FastBootHibernatePersistenceProvider implements PersistencePr
                         "Attempting to boot a blocking Hibernate ORM instance on a reactive RecordedState");
             }
             final PrevalidatedQuarkusMetadata metadata = recordedState.getMetadata();
-            var puConfig = puConfigMap.getOrDefault(persistenceUnit.getConfigurationName(),
-                    new HibernateOrmRuntimeConfigPersistenceUnit());
+            var puConfig = hibernateOrmRuntimeConfig.getPersistenceUnitConfig(
+                    persistenceUnit.getConfigurationName());
             if (puConfig.active.isPresent() && !puConfig.active.get()) {
                 throw new IllegalStateException(
                         "Attempting to boot a deactivated Hibernate ORM persistence unit");

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmDisabledRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmDisabledRecorder.java
@@ -8,11 +8,10 @@ import io.quarkus.runtime.configuration.ConfigurationException;
 @Recorder
 public class HibernateOrmDisabledRecorder {
 
-    public void checkNoExplicitActiveTrue(HibernateOrmRuntimeConfig runtimeConfig) {
-        for (var entry : runtimeConfig.getAllPersistenceUnitConfigsAsMap().entrySet()) {
-            var config = entry.getValue();
+    public void checkNoExplicitActiveTrue(HibernateOrmRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
+        for (String puName : persistenceUnitNames) {
+            var config = runtimeConfig.getPersistenceUnitConfig(puName);
             if (config.active.isPresent() && config.active.get()) {
-                var puName = entry.getKey();
                 String enabledPropertyKey = HibernateOrmRuntimeConfig.extensionPropertyKey("enabled");
                 String activePropertyKey = HibernateOrmRuntimeConfig.puPropertyKey(puName, "active");
                 throw new ConfigurationException(

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
@@ -45,9 +45,4 @@ public class HibernateOrmRuntimeConfig {
                 : "quarkus.hibernate-orm.\"" + puName + "\".";
         return prefix + radical;
     }
-
-    public boolean isAnyPropertySet() {
-        return defaultPersistenceUnit.isAnyPropertySet() ||
-                !persistenceUnits.isEmpty();
-    }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java
@@ -1,13 +1,13 @@
 package io.quarkus.hibernate.orm.runtime;
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public class HibernateOrmRuntimeConfig {
@@ -26,13 +26,17 @@ public class HibernateOrmRuntimeConfig {
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, HibernateOrmRuntimeConfigPersistenceUnit> persistenceUnits;
 
-    public Map<String, HibernateOrmRuntimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateOrmRuntimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
+    public HibernateOrmRuntimeConfigPersistenceUnit getPersistenceUnitConfig(String name) {
+        HibernateOrmRuntimeConfigPersistenceUnit result;
+        if (PersistenceUnitUtil.isDefaultPersistenceUnit(name)) {
+            result = defaultPersistenceUnit;
+        } else {
+            result = persistenceUnits.get(name);
         }
-        map.putAll(persistenceUnits);
-        return map;
+        if (result == null) {
+            result = ConfigInstantiator.createEmptyObject(HibernateOrmRuntimeConfigPersistenceUnit.class);
+        }
+        return result;
     }
 
     public static String extensionPropertyKey(String radical) {

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -74,13 +74,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
     @ConfigDocMapKey("full-property-key")
     public Map<String, String> unsupportedProperties = new HashMap<>();
 
-    public boolean isAnyPropertySet() {
-        return database.isAnyPropertySet() ||
-                scripts.isAnyPropertySet() ||
-                log.isAnyPropertySet() ||
-                !unsupportedProperties.isEmpty();
-    }
-
     @ConfigGroup
     public static class HibernateOrmConfigPersistenceUnitDatabase {
 
@@ -103,12 +96,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
         public Optional<String> defaultSchema = Optional.empty();
-
-        public boolean isAnyPropertySet() {
-            return generation.isAnyPropertySet()
-                    || defaultCatalog.isPresent()
-                    || defaultSchema.isPresent();
-        }
     }
 
     @ConfigGroup
@@ -119,10 +106,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem
         public HibernateOrmConfigPersistenceUnitScriptGeneration generation = new HibernateOrmConfigPersistenceUnitScriptGeneration();
-
-        public boolean isAnyPropertySet() {
-            return generation.isAnyPropertySet();
-        }
     }
 
     @ConfigGroup
@@ -153,12 +136,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem
         public boolean haltOnError = false;
-
-        public boolean isAnyPropertySet() {
-            return !"none".equals(generation)
-                    || createSchemas
-                    || haltOnError;
-        }
     }
 
     @ConfigGroup
@@ -186,12 +163,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
         public Optional<String> dropTarget = Optional.empty();
-
-        public boolean isAnyPropertySet() {
-            return !"none".equals(generation)
-                    || createTarget.isPresent()
-                    || dropTarget.isPresent();
-        }
     }
 
     @ConfigGroup
@@ -222,10 +193,6 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem
         public Optional<Long> queriesSlowerThanMs = Optional.empty();
-
-        public boolean isAnyPropertySet() {
-            return sql || !formatSql || jdbcWarnings.isPresent() || queriesSlowerThanMs.isPresent();
-        }
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfigPersistenceUnit.java
@@ -1,6 +1,5 @@
 package io.quarkus.hibernate.orm.runtime;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,28 +26,28 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
      * @asciidoclet
      */
     @ConfigItem(defaultValueDocumentation = "`true` if Hibernate ORM is enabled; `false` otherwise")
-    public Optional<Boolean> active = Optional.empty();
+    public Optional<Boolean> active;
 
     /**
      * Database related configuration.
      */
     @ConfigItem
     @ConfigDocSection
-    public HibernateOrmConfigPersistenceUnitDatabase database = new HibernateOrmConfigPersistenceUnitDatabase();
+    public HibernateOrmConfigPersistenceUnitDatabase database;
 
     /**
      * Database scripts related configuration.
      */
     @ConfigItem
     @ConfigDocSection
-    public HibernateOrmConfigPersistenceUnitScripts scripts = new HibernateOrmConfigPersistenceUnitScripts();
+    public HibernateOrmConfigPersistenceUnitScripts scripts;
 
     /**
      * Logging configuration.
      */
     @ConfigItem
     @ConfigDocSection
-    public HibernateOrmConfigPersistenceUnitLog log = new HibernateOrmConfigPersistenceUnitLog();
+    public HibernateOrmConfigPersistenceUnitLog log;
 
     /**
      * Properties that should be passed on directly to Hibernate ORM.
@@ -72,7 +71,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
      */
     @ConfigItem
     @ConfigDocMapKey("full-property-key")
-    public Map<String, String> unsupportedProperties = new HashMap<>();
+    public Map<String, String> unsupportedProperties;
 
     @ConfigGroup
     public static class HibernateOrmConfigPersistenceUnitDatabase {
@@ -81,21 +80,21 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          * Schema generation configuration.
          */
         @ConfigItem
-        public HibernateOrmConfigPersistenceUnitDatabaseGeneration generation = new HibernateOrmConfigPersistenceUnitDatabaseGeneration();
+        public HibernateOrmConfigPersistenceUnitDatabaseGeneration generation;
 
         /**
          * The default catalog to use for the database objects.
          */
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
-        public Optional<String> defaultCatalog = Optional.empty();
+        public Optional<String> defaultCatalog;
 
         /**
          * The default schema to use for the database objects.
          */
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
-        public Optional<String> defaultSchema = Optional.empty();
+        public Optional<String> defaultSchema;
     }
 
     @ConfigGroup
@@ -105,7 +104,7 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          * Schema generation configuration.
          */
         @ConfigItem
-        public HibernateOrmConfigPersistenceUnitScriptGeneration generation = new HibernateOrmConfigPersistenceUnitScriptGeneration();
+        public HibernateOrmConfigPersistenceUnitScriptGeneration generation;
     }
 
     @ConfigGroup
@@ -123,19 +122,19 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem(name = ConfigItem.PARENT, defaultValue = "none")
         @ConvertWith(TrimmedStringConverter.class)
-        public String generation = "none";
+        public String generation;
 
         /**
          * If Hibernate ORM should create the schemas automatically (for databases supporting them).
          */
         @ConfigItem
-        public boolean createSchemas = false;
+        public boolean createSchemas;
 
         /**
          * Whether we should stop on the first error when applying the schema.
          */
         @ConfigItem
-        public boolean haltOnError = false;
+        public boolean haltOnError;
     }
 
     @ConfigGroup
@@ -148,21 +147,21 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          */
         @ConfigItem(name = ConfigItem.PARENT, defaultValue = "none")
         @ConvertWith(TrimmedStringConverter.class)
-        public String generation = "none";
+        public String generation;
 
         /**
          * Filename or URL where the database create DDL file should be generated.
          */
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
-        public Optional<String> createTarget = Optional.empty();
+        public Optional<String> createTarget;
 
         /**
          * Filename or URL where the database drop DDL file should be generated.
          */
         @ConfigItem
         @ConvertWith(TrimmedStringConverter.class)
-        public Optional<String> dropTarget = Optional.empty();
+        public Optional<String> dropTarget;
     }
 
     @ConfigGroup
@@ -174,25 +173,25 @@ public class HibernateOrmRuntimeConfigPersistenceUnit {
          * Setting it to true is obviously not recommended in production.
          */
         @ConfigItem
-        public boolean sql = false;
+        public boolean sql;
 
         /**
          * Format the SQL logs if SQL log is enabled
          */
         @ConfigItem(defaultValue = "true")
-        public boolean formatSql = true;
+        public boolean formatSql;
 
         /**
          * Whether JDBC warnings should be collected and logged.
          */
         @ConfigItem(defaultValueDocumentation = "depends on dialect")
-        public Optional<Boolean> jdbcWarnings = Optional.empty();
+        public Optional<Boolean> jdbcWarnings;
 
         /**
          * If set, Hibernate will log queries that took more than specified number of milliseconds to execute.
          */
         @ConfigItem
-        public Optional<Long> queriesSlowerThanMs = Optional.empty();
+        public Optional<Long> queriesSlowerThanMs;
     }
 
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/JPAConfig.java
@@ -33,12 +33,9 @@ public class JPAConfig {
 
     @Inject
     public JPAConfig(HibernateOrmRuntimeConfig hibernateOrmRuntimeConfig) {
-        Map<String, HibernateOrmRuntimeConfigPersistenceUnit> puConfigMap = hibernateOrmRuntimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
         for (RuntimePersistenceUnitDescriptor descriptor : PersistenceUnitsHolder.getPersistenceUnitDescriptors()) {
             String puName = descriptor.getName();
-            var puConfig = puConfigMap.getOrDefault(descriptor.getConfigurationName(),
-                    new HibernateOrmRuntimeConfigPersistenceUnit());
+            var puConfig = hibernateOrmRuntimeConfig.getPersistenceUnitConfig(descriptor.getConfigurationName());
             if (puConfig.active.isPresent() && !puConfig.active.get()) {
                 LOGGER.infof("Hibernate ORM persistence unit '%s' was deactivated through configuration properties",
                         puName);

--- a/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
+++ b/extensions/hibernate-reactive/deployment/src/main/java/io/quarkus/hibernate/reactive/deployment/HibernateReactiveProcessor.java
@@ -163,7 +163,7 @@ public final class HibernateReactiveProcessor {
             // - we don't support starting Hibernate Reactive from a persistence.xml
             // - we don't support Hibernate Envers with Hibernate Reactive
             persistenceUnitDescriptors.produce(new PersistenceUnitDescriptorBuildItem(reactivePU,
-                    PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME,
+                    PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, Optional.of(persistenceUnitConfig),
                     jpaModel.getXmlMappings(reactivePU.getName()),
                     persistenceUnitConfig.unsupportedProperties,
                     true, false));

--- a/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
+++ b/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/FastBootHibernateReactivePersistenceProvider.java
@@ -121,8 +121,6 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             throw new PersistenceException("No name provided and multiple persistence units found");
         }
 
-        Map<String, HibernateOrmRuntimeConfigPersistenceUnit> puConfigMap = hibernateOrmRuntimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
         for (RuntimePersistenceUnitDescriptor persistenceUnit : units) {
             log.debugf(
                     "Checking persistence-unit [name=%s, explicit-provider=%s] against incoming persistence unit name [%s]",
@@ -149,8 +147,7 @@ public final class FastBootHibernateReactivePersistenceProvider implements Persi
             RuntimeSettings.Builder runtimeSettingsBuilder = new RuntimeSettings.Builder(buildTimeSettings,
                     integrationSettings);
 
-            var puConfig = puConfigMap.getOrDefault(persistenceUnit.getConfigurationName(),
-                    new HibernateOrmRuntimeConfigPersistenceUnit());
+            var puConfig = hibernateOrmRuntimeConfig.getPersistenceUnitConfig(persistenceUnit.getConfigurationName());
             if (puConfig.active.isPresent() && !puConfig.active.get()) {
                 throw new IllegalStateException(
                         "Attempting to boot a deactivated Hibernate Reactive persistence unit");

--- a/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
+++ b/extensions/hibernate-search-orm-coordination-outbox-polling/deployment/src/main/java/io/quarkus/hibernate/search/orm/coordination/outboxpolling/deployment/HibernateSearchOutboxPollingProcessor.java
@@ -77,9 +77,6 @@ class HibernateSearchOutboxPollingProcessor {
 
     private boolean isUsingOutboxPolling(HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem persistenceUnit) {
         HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit puConfig = persistenceUnit.getBuildTimeConfig();
-        if (puConfig == null) {
-            return false;
-        }
         Optional<String> configuredStrategy = puConfig.coordination.strategy;
         return configuredStrategy.isPresent()
                 && configuredStrategy.get().equals(HibernateOrmMapperOutboxPollingSettings.COORDINATION_STRATEGY_NAME);

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchDisabledProcessor.java
@@ -3,6 +3,8 @@ package io.quarkus.hibernate.search.orm.elasticsearch.deployment;
 import static io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchProcessor.HIBERNATE_SEARCH_ELASTICSEARCH;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -36,7 +38,10 @@ class HibernateSearchElasticsearchDisabledProcessor {
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig,
             List<PersistenceUnitDescriptorBuildItem> persistenceUnitDescriptorBuildItems,
             BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeIntegrations) {
-        recorder.checkNoExplicitActiveTrue(runtimeConfig);
+        Set<String> persistenceUnitNames = persistenceUnitDescriptorBuildItems.stream()
+                .map(PersistenceUnitDescriptorBuildItem::getPersistenceUnitName)
+                .collect(Collectors.toSet());
+        recorder.checkNoExplicitActiveTrue(runtimeConfig, persistenceUnitNames);
         for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
             String puName = puDescriptor.getPersistenceUnitName();
             runtimeIntegrations.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem(HIBERNATE_SEARCH_ELASTICSEARCH,

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/deployment/HibernateSearchElasticsearchProcessor.java
@@ -87,9 +87,6 @@ class HibernateSearchElasticsearchProcessor {
         Map<String, Map<String, Set<String>>> persistenceUnitAndBackendAndIndexNamesForSearchExtensions = collectPersistenceUnitAndBackendAndIndexNamesForSearchExtensions(
                 index);
 
-        Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> configByPU = buildTimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
-
         for (PersistenceUnitDescriptorBuildItem puDescriptor : persistenceUnitDescriptorBuildItems) {
             Collection<AnnotationInstance> indexedAnnotationsForPU = new ArrayList<>();
             for (AnnotationInstance indexedAnnotation : indexedAnnotations) {
@@ -101,7 +98,7 @@ class HibernateSearchElasticsearchProcessor {
             Map<String, Set<String>> backendAndIndexNamesForSearchExtensions = persistenceUnitAndBackendAndIndexNamesForSearchExtensions
                     .getOrDefault(puDescriptor.getPersistenceUnitName(), Collections.emptyMap());
             String puName = puDescriptor.getPersistenceUnitName();
-            buildForPersistenceUnit(recorder, indexedAnnotationsForPU, puName, configByPU.get(puName),
+            buildForPersistenceUnit(recorder, indexedAnnotationsForPU, puName, buildTimeConfig.getPersistenceUnitConfig(puName),
                     backendAndIndexNamesForSearchExtensions,
                     configuredPersistenceUnits, staticIntegrations, runtimeIntegrations);
         }
@@ -255,9 +252,7 @@ class HibernateSearchElasticsearchProcessor {
                 .getBuildTimeConfig();
 
         Set<String> propertyKeysWithNoVersion = new LinkedHashSet<>();
-        Map<String, ElasticsearchBackendBuildTimeConfig> backends = buildTimeConfig != null
-                ? buildTimeConfig.getAllBackendConfigsAsMap()
-                : Collections.emptyMap();
+        Map<String, ElasticsearchBackendBuildTimeConfig> backends = buildTimeConfig.getAllBackendConfigsAsMap();
 
         Set<String> allBackendNames = new LinkedHashSet<>(configuredPersistenceUnit.getBackendNamesForIndexedEntities());
         allBackendNames.addAll(backends.keySet());

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUNamedBackendTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUNamedBackendTest.java
@@ -1,0 +1,58 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.Bindable;
+
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that Hibernate Search is able to start in a named PU with a named backend,
+ * even when there is no runtime configuration for that backend.
+ * <p>
+ * This case is interesting mainly because it would most likely lead to an NPE
+ * unless we take extra care to avoid it.
+ */
+@Disabled("The (build-time) 'version' property is not detected for some reason; I suspect a bug in Quarkus Config when there are two levels of maps in the config.")
+public class NoRuntimeConfigNamedPUNamedBackendTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(IndexedEntityInNamedBackend.class))
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".jdbc.url", "jdbc:h2:mem:test")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".datasource", "ds-1")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".packages",
+                    IndexedEntityInNamedBackend.class.getPackage().getName())
+            // For Hibernate Search, provide only build-time config; rely on defaults for everything else.
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu-1\".elasticsearch.\"mybackend\".version", "7")
+            // Disable dev services, since they could interfere with runtime config (in particular the schema management settings).
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            // Make runtime config accessible through CDI
+            .overrideConfigKey("quarkus.arc.unremovable-types", HibernateSearchElasticsearchRuntimeConfig.class.getName());
+
+    @Test
+    public void test() {
+        // Check that runtime config for our PU is indeed missing.
+        HibernateSearchElasticsearchRuntimeConfig config = Arc.container()
+                .instance(HibernateSearchElasticsearchRuntimeConfig.class).get();
+        assertThat(config.persistenceUnits).isNullOrEmpty();
+        // Test that Hibernate Search was started correctly regardless.
+        SearchMapping mapping = Arc.container()
+                .instance(SearchMapping.class, new PersistenceUnitLiteral("pu-1")).get();
+        assertThat(mapping).isNotNull();
+        assertThat(mapping.allIndexedEntities())
+                .extracting(SearchIndexedEntity::javaClass)
+                .containsExactlyInAnyOrder((Class) IndexedEntityInNamedBackend.class);
+    }
+}

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUNamedBackendTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUNamedBackendTest.java
@@ -2,10 +2,6 @@ package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.metamodel.Bindable;
-
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.junit.jupiter.api.Disabled;
@@ -14,6 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**

--- a/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUTest.java
+++ b/extensions/hibernate-search-orm-elasticsearch/deployment/src/test/java/io/quarkus/hibernate/search/orm/elasticsearch/test/configuration/NoRuntimeConfigNamedPUTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.hibernate.search.orm.elasticsearch.test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.PersistenceUnit.PersistenceUnitLiteral;
+import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Test that Hibernate Search is able to start in a named PU,
+ * even when there is no runtime configuration for that PU.
+ * <p>
+ * This case is interesting mainly because it would most likely lead to an NPE
+ * unless we take extra care to avoid it.
+ */
+public class NoRuntimeConfigNamedPUTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClass(IndexedEntity.class))
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".db-kind", "h2")
+            .overrideConfigKey("quarkus.datasource.\"ds-1\".jdbc.url", "jdbc:h2:mem:test")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".datasource", "ds-1")
+            .overrideConfigKey("quarkus.hibernate-orm.\"pu-1\".packages",
+                    IndexedEntity.class.getPackage().getName())
+            // For Hibernate Search, provide only build-time config; rely on defaults for everything else.
+            .overrideConfigKey("quarkus.hibernate-search-orm.\"pu-1\".elasticsearch.version", "7")
+            // Disable dev services, since they could interfere with runtime config (in particular the schema management settings).
+            .overrideConfigKey("quarkus.devservices.enabled", "false")
+            // Make runtime config accessible through CDI
+            .overrideConfigKey("quarkus.arc.unremovable-types", HibernateSearchElasticsearchRuntimeConfig.class.getName());
+
+    @Test
+    public void test() {
+        // Check that runtime config for our PU is indeed missing.
+        HibernateSearchElasticsearchRuntimeConfig config = Arc.container()
+                .instance(HibernateSearchElasticsearchRuntimeConfig.class).get();
+        assertThat(config.persistenceUnits).isNullOrEmpty();
+        // Test that Hibernate Search was started correctly regardless.
+        SearchMapping mapping = Arc.container()
+                .instance(SearchMapping.class, new PersistenceUnitLiteral("pu-1")).get();
+        assertThat(mapping).isNotNull();
+        assertThat(mapping.allIndexedEntities())
+                .extracting(SearchIndexedEntity::javaClass)
+                .containsExactlyInAnyOrder((Class) IndexedEntity.class);
+    }
+}

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchBuildTimeConfig.java
@@ -1,7 +1,6 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -9,6 +8,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 @ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class HibernateSearchElasticsearchBuildTimeConfig {
@@ -39,13 +39,17 @@ public class HibernateSearchElasticsearchBuildTimeConfig {
     @ConfigItem(name = ConfigItem.PARENT)
     Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> persistenceUnits;
 
-    public Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
+    public HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit getPersistenceUnitConfig(String name) {
+        HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit result;
+        if (PersistenceUnitUtil.isDefaultPersistenceUnit(name)) {
+            result = defaultPersistenceUnit;
+        } else {
+            result = persistenceUnits.get(name);
         }
-        map.putAll(persistenceUnits);
-        return map;
+        if (result == null) {
+            result = ConfigInstantiator.createEmptyObject(HibernateSearchElasticsearchBuildTimeConfigPersistenceUnit.class);
+        }
+        return result;
     }
 
 }

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfig.java
@@ -2,7 +2,6 @@ package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -10,6 +9,7 @@ import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 @ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.RUN_TIME)
 public class HibernateSearchElasticsearchRuntimeConfig {
@@ -28,13 +28,17 @@ public class HibernateSearchElasticsearchRuntimeConfig {
     @ConfigItem(name = ConfigItem.PARENT)
     public Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> persistenceUnits;
 
-    public Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> getAllPersistenceUnitConfigsAsMap() {
-        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> map = new TreeMap<>();
-        if (defaultPersistenceUnit != null) {
-            map.put(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME, defaultPersistenceUnit);
+    public HibernateSearchElasticsearchRuntimeConfigPersistenceUnit getPersistenceUnitConfig(String name) {
+        HibernateSearchElasticsearchRuntimeConfigPersistenceUnit result;
+        if (PersistenceUnitUtil.isDefaultPersistenceUnit(name)) {
+            result = defaultPersistenceUnit;
+        } else {
+            result = persistenceUnits.get(name);
         }
-        map.putAll(persistenceUnits);
-        return map;
+        if (result == null) {
+            result = ConfigInstantiator.createEmptyObject(HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.class);
+        }
+        return result;
     }
 
     public static String elasticsearchVersionPropertyKey(String persistenceUnitName, String backendName) {

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/HibernateSearchElasticsearchRuntimeConfigPersistenceUnit.java
@@ -1,12 +1,13 @@
 package io.quarkus.hibernate.search.orm.elasticsearch.runtime;
 
 import java.time.Duration;
-import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.engine.cfg.spi.ParseUtils;
@@ -18,6 +19,7 @@ import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.configuration.ConfigInstantiator;
 
 @ConfigGroup
 public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
@@ -76,15 +78,28 @@ public class HibernateSearchElasticsearchRuntimeConfigPersistenceUnit {
     @ConfigItem
     MultiTenancyConfig multiTenancy;
 
-    Map<String, ElasticsearchBackendRuntimeConfig> getAllBackendConfigsAsMap() {
-        Map<String, ElasticsearchBackendRuntimeConfig> map = new LinkedHashMap<>();
+    Set<String> getConfiguredBackendNames() {
+        Set<String> names = new LinkedHashSet<>();
         if (defaultBackend != null) {
-            map.put(null, defaultBackend);
+            names.add(null);
         }
         if (namedBackends != null) {
-            map.putAll(namedBackends.backends);
+            names.addAll(namedBackends.backends.keySet());
         }
-        return map;
+        return names;
+    }
+
+    ElasticsearchBackendRuntimeConfig getBackendConfig(String name) {
+        ElasticsearchBackendRuntimeConfig result;
+        if (name == null) {
+            result = defaultBackend;
+        } else {
+            result = namedBackends == null ? null : namedBackends.backends.get(name);
+        }
+        if (result == null) {
+            result = ConfigInstantiator.createEmptyObject(ElasticsearchBackendRuntimeConfig.class);
+        }
+        return result;
     }
 
     @ConfigGroup

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/runtime/devconsole/HibernateSearchDevConsoleRecorder.java
@@ -14,7 +14,6 @@ import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import io.quarkus.devconsole.runtime.spi.DevConsolePostHandler;
 import io.quarkus.devconsole.runtime.spi.FlashScopeUtil;
 import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfig;
-import io.quarkus.hibernate.search.orm.elasticsearch.runtime.HibernateSearchElasticsearchRuntimeConfigPersistenceUnit;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -25,10 +24,8 @@ public class HibernateSearchDevConsoleRecorder {
 
     public Supplier<HibernateSearchSupplier.IndexedPersistenceUnits> infoSupplier(
             HibernateSearchElasticsearchRuntimeConfig runtimeConfig, Set<String> persistenceUnitNames) {
-        Map<String, HibernateSearchElasticsearchRuntimeConfigPersistenceUnit> puConfigs = runtimeConfig
-                .getAllPersistenceUnitConfigsAsMap();
         Set<String> activePersistenceUnitNames = persistenceUnitNames.stream()
-                .filter(name -> puConfigs.get(name).active.orElse(true))
+                .filter(name -> runtimeConfig.getPersistenceUnitConfig(name).active.orElse(true))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         return new HibernateSearchSupplier(activePersistenceUnitNames);
     }


### PR DESCRIPTION
NOTE: This is not code that we can merge right now. This is a proof of concept, intended to demonstrate a problem and the value of solving it, and to start a discussion as to *how* we will solve it. 

## The problem

In several extensions, we have named config groups, represented as maps, e.g. in the Hibernate ORM extension:

https://github.com/quarkusio/quarkus/blob/56ab22e70cee3a6abd95b345490aa65728f37d1f/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRuntimeConfig.java#L21-L27

It sometimes happens that we need to access the configuration group for a given name, and it's not there: all configuration properties in that group are optional, and the user didn't set any. The code processing the configuration group thus needs to handle the case where that group is null.

I've seen several ad-hoc solutions, but none seems satisfying to me:

1. Don't do anything if the group is null: `if (group != null) { ...process...  }`
That's possible when the group is simply meant to be passed to an underlying library, but this means we  rely on the defaults from that underlying library.
We run the risk of those defaults becoming out of sync with `@ConfigItem(defaultValue = ...)`.
2. Hardcode the defaults in the processor: `var value = group == null ? <some default>`
We run the risk of those defaults becoming out of sync with `@ConfigItem(defaultValue = ...)`.
3. Hardcode the defaults as initial field values in the group class, and simply call `new MyGroup()` manually when we encounter null in the config processor.
Making sure new patches that introduce new fields also initialize that field requires a lot of rigor, since the lack of initialization may only show up at runtime with very specific configuration.
On top of that, we also run the risk of the initial field value becoming out of sync with `@ConfigItem(defaultValue = ...)`

When the "risks" mentioned above materialize, we either get an NPE, or a different behavior depending on whether at least one property in the group is set or not. We've had to fix bugs like that in the past, so I know it's not just a theoretical risk.

## The solution in this PR

I think a better solution would be one that relies on Quarkus' knowledge of the default for every single property; have some component directly instantiate an empty instance of the ConfigGroup class we need, with all fields initialized to the proper defaults defined in annotations (`@ConfigItem`, ...).

In this PR, I improved `ConfigInstantiator` in an (early) attempt to do so. That class is quite simple: it processes `@ConfigSection`/`@ConfigItem` annotations and interprets them on the fly.

According to the tests I added, this works.

However, there are still limitations:

* It does reflection at runtime. It won't work in native mode unless we add reflection information for config classes (which we don't want to do).
* It does reflection on each and every call to `ConfigInstatiator#createEmptyObject`. That won't perform well; we would need some cache, at least.

## The solution we'll want before we can merge anything

I think that we'll need to ditch `ConfigInstantiator` for this feature, and leverage build-time/runtime config reading code instead. I'm willing to do it, but I will need some guidance as to what's the best way of doing it.

As far as I can tell:

* We will probably need two separate "empty config group instantiation" APIs: one for build-time config, and one for runtime config.
* At build-time, the config reading is implemented in `io.quarkus.deployment.configuration.BuildTimeConfigurationReader`. That class processes annotations and builds metadata in its constructor. We may be able to reuse the metadata to implement an "empty config group instantiator" based on that metadata, but personally I'd favor reusing the existing code and simulating the reading of a config group from an empty config source -- even if that means changing the existing code.
* At runtime, the config reading seems to be implemented in `io.quarkus.deployment.configuration.RunTimeConfigurationGenerator`. That class generates bytecode that will run at runtime init. I suspect some of the methods in there could be used as-is to generate an empty config group. But worst case, we can generate some more.