### PR TITLE
Add explicit dependency on smallrye-context-propagation-propagators-rxjava2 for SR CP integration tests

### DIFF
--- a/integration-tests/smallrye-context-propagation/pom.xml
+++ b/integration-tests/smallrye-context-propagation/pom.xml
@@ -62,6 +62,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-context-propagation-propagators-rxjava2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fixes #27507 

This isn't needed in current `main` but will be needed for `jakarta` variant because newer RESTeasy doesn't transitively bring this dependency.