### PR TITLE
Use ClassPathElement.getDependencyKey() for dev ui template paths

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsole.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/console/DevConsole.java
@@ -184,7 +184,10 @@ public class DevConsole implements Handler<RoutingContext> {
     }
 
     private void sendMainPage(RoutingContext event) {
-        Template devTemplate = engine.getTemplate("index");
+        final Template devTemplate = engine.getTemplate("index");
+        if (devTemplate == null) {
+            throw new RuntimeException("Failed to locate the `index` template");
+        }
         List<Map<String, Object>> actionableExtensions = new ArrayList<>();
         List<Map<String, Object>> nonActionableExtensions = new ArrayList<>();
         for (Entry<String, Map<String, Object>> entry : this.extensions.entrySet()) {


### PR DESCRIPTION
This simplifies the code figuring out the group and artifact IDs a template belongs to. It also does not rely on `maven-archive` dir to be present for not yet packaged modules.