### PR TITLE
BeanManager.getBeans() - assume the default qualifier if none specified

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -496,7 +496,11 @@ public class ArcContainerImpl implements ArcContainer {
         if (requiredType instanceof TypeVariable) {
             throw new IllegalArgumentException("The given type is a type variable: " + requiredType);
         }
-        Qualifiers.verify(qualifiers, qualifierNonbindingMembers.keySet());
+        if (qualifiers == null || qualifiers.length == 0) {
+            qualifiers = new Annotation[] { Default.Literal.INSTANCE };
+        } else {
+            Qualifiers.verify(qualifiers, qualifierNonbindingMembers.keySet());
+        }
         // This method does not cache the results
         return Set.of(getMatchingBeans(new Resolvable(requiredType, qualifiers)).toArray(new Bean<?>[] {}));
     }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/beanmanager/BeanManagerTest.java
@@ -61,7 +61,8 @@ public class BeanManagerTest {
 
     @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer.Builder()
-            .beanClasses(Legacy.class, AlternativeLegacy.class, Fool.class, DummyInterceptor.class, DummyBinding.class,
+            .beanClasses(Legacy.class, AlternativeLegacy.class, Fool.class, LowFool.class, DummyInterceptor.class,
+                    DummyBinding.class,
                     LowPriorityInterceptor.class, WithInjectionPointMetadata.class, High.class, Low.class, Observers.class,
                     BeanWithCustomQualifier.class)
             .qualifierRegistrars(new QualifierRegistrar() {
@@ -293,6 +294,12 @@ public class BeanManagerTest {
         String getId() {
             return id;
         }
+
+    }
+
+    @Low
+    @Dependent
+    static class LowFool extends Fool {
 
     }
 

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/builtin/beans/BuiltInBeansAreResolvableTest.java
@@ -44,7 +44,8 @@ public class BuiltInBeansAreResolvableTest {
         // basic BM is resolvable
         assertTrue(instance.select(BeanManager.class).isResolvable());
         // invoke something on the BM
-        assertEquals(1, instance.select(BeanManager.class).get().getBeans(DummyBean.class).size());
+        assertEquals(1,
+                instance.select(BeanManager.class).get().getBeans(DummyBean.class, new DummyQualifier.Literal()).size());
         // you shouldn't be able to select BM with qualifiers
         assertFalse(instance.select(BeanManager.class, new DummyQualifier.Literal()).isResolvable());
     }

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/InjectMockTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/InjectMockTest.java
@@ -3,6 +3,7 @@ package io.quarkus.it.rest.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -19,6 +20,7 @@ import io.restassured.RestAssured;
 public class InjectMockTest {
 
     @InjectMock
+    @RestClient
     ClientWithExceptionMapper mock;
 
     @BeforeEach

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/InjectMockWithInterceptorTest.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/InjectMockWithInterceptorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,7 @@ public class InjectMockWithInterceptorTest {
     CircuitBreakerMaintenance cb;
 
     @InjectMock
+    @RestClient
     FaultToleranceOnInterfaceClient mock;
 
     @BeforeEach


### PR DESCRIPTION
- this behavior is defined by the spec