### PR TITLE
Disable KafkaDevServicesContinuousTestingTestCase#testContinuousTestingScenario2

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
@@ -6,6 +6,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -66,6 +67,7 @@ public class KafkaDevServicesContinuousTestingTestCase {
     }
 
     @Test
+    @Disabled("Flaky, see https://github.com/quarkusio/quarkus/pull/27580#issuecomment-1230984624")
     public void testContinuousTestingScenario2() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         var result = utils.waitForNextCompletion();


### PR DESCRIPTION
It has been flaky for months.

See for instance:
https://github.com/quarkusio/quarkus/pull/27580#issuecomment-1230984624

@cescoffier I let you create an issue to fix the test and reenable it and affect it to the appropriate person? Thanks.