### PR TITLE
Switch Oracle DB container image to new 21-slim-faststart flavour

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -95,7 +95,7 @@
         <db2.image>docker.io/ibmcom/db2:11.5.7.0a</db2.image>
         <mssql.image>mcr.microsoft.com/mssql/server:2019-latest</mssql.image>
         <mysql.image>docker.io/mysql:8.0</mysql.image>
-        <oracle.image>docker.io/gvenzl/oracle-xe:21-slim</oracle.image>
+        <oracle.image>docker.io/gvenzl/oracle-xe:21-slim-faststart</oracle.image>
         <mongo.image>docker.io/mongo:4.4</mongo.image>
 
         <!-- Align various dependencies that are not really part of the bom-->

--- a/integration-tests/jpa-oracle/README.md
+++ b/integration-tests/jpa-oracle/README.md
@@ -22,7 +22,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-xe:21-slim-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.

--- a/integration-tests/reactive-oracle-client/README.md
+++ b/integration-tests/reactive-oracle-client/README.md
@@ -23,7 +23,7 @@ Authentication parameters might need to be changed in the Quarkus configuration 
 ### Starting Oracle via docker
 
 ```
-docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test gvenzl/oracle-xe:21-slim
+docker run --memory-swappiness=0 --rm=true --name=HibernateTestingOracle -p 1521:1521 -e ORACLE_PASSWORD=hibernate_orm_test docker.io/gvenzl/oracle-xe:21-slim-faststart
 ```
 
 This will start a local instance with the configuration matching the parameters used by the integration tests of this module.


### PR DESCRIPTION

@gvenzl is now publishing a new kind of Oracle DB container images called "faststart" - these are slighly larger to download but are sginificantly faster to bootstrap, making them more suitable for Quarkus dev-services.

With this PR I'm making them the new default for Quarkus; the change should be transparent to end users.

Also it would seem that the slightly larger file size has negligible impact on pull times (atlhough this will likely vary from system to system); see https://github.com/gvenzl/oci-oracle-xe/issues/36
