### PR TITLE
Fix to run first example on vertx page

### DIFF
--- a/docs/src/main/asciidoc/vertx.adoc
+++ b/docs/src/main/asciidoc/vertx.adoc
@@ -115,9 +115,13 @@ In this file, copy the following code:
 ----
 package org.acme;
 
+import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.inject.Inject;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 @Path("/vertx")                        // <1>


### PR DESCRIPTION
Running through this tutorial I needed to add the following to the imports to get it to work.

import io.smallrye.mutiny.Uni;
import io.vertx.mutiny.core.Vertx;

import java.nio.charset.StandardCharsets;

import javax.inject.Inject;
import javax.ws.rs.GET;
import javax.ws.rs.Path;