### PR TITLE
Upgrade to Hibernate ORM 5.6.11.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.10.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>5.6.11.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.7.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.4.Final</hibernate-validator.version>


### PR DESCRIPTION
https://in.relation.to/2022/08/30/hibernate-orm-5611-final/

Minor maintenance, and pre-requisite to allow Quarkus to be upgraded to Jandex 3.0

Also interesting: 
 - avoid a parser performance issue that could manifest on very complex models (>1000 different entities)
 - a bugfix to allow selecting an id of a composite type mapped with `@NotFound`

