### PR TITLE
Fix treatment of recursive bean types

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TypeVariableImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TypeVariableImpl.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringJoiner;
 
 public class TypeVariableImpl<D extends GenericDeclaration> implements TypeVariable<D> {
 
@@ -54,4 +55,17 @@ public class TypeVariableImpl<D extends GenericDeclaration> implements TypeVaria
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(" & ", " extends ", "");
+        joiner.setEmptyValue("");
+        for (Type bound : bounds) {
+            if (bound instanceof Class) {
+                joiner.add(((Class<?>) bound).getName());
+            } else {
+                joiner.add(bound.toString());
+            }
+        }
+        return name + joiner;
+    }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TypeVariableReferenceImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/TypeVariableReferenceImpl.java
@@ -1,0 +1,60 @@
+package io.quarkus.arc.impl;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+public class TypeVariableReferenceImpl<D extends GenericDeclaration> implements TypeVariable<D> {
+    private final String name;
+    private TypeVariableImpl<D> delegate;
+
+    public TypeVariableReferenceImpl(String name) {
+        this.name = name;
+    }
+
+    public void setDelegate(TypeVariableImpl<D> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        return delegate.getAnnotation(annotationClass);
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        return delegate.getAnnotations();
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        return delegate.getDeclaredAnnotations();
+    }
+
+    @Override
+    public Type[] getBounds() {
+        return delegate.getBounds();
+    }
+
+    @Override
+    public D getGenericDeclaration() {
+        return delegate.getGenericDeclaration();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public AnnotatedType[] getAnnotatedBounds() {
+        return delegate.getAnnotatedBounds();
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/EnumBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/EnumBeanTypesTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.arc.test.bean.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class EnumBeanTypesTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(ExtendedBooleanProducer.class);
+
+    @Test
+    public void test() {
+        InjectableBean<ExtendedBoolean> bean = Arc.container().instance(ExtendedBoolean.class).getBean();
+        Set<Type> types = bean.getTypes();
+
+        assertEquals(5, types.size());
+        assertTrue(types.contains(Object.class));
+        assertTrue(types.contains(Serializable.class));
+        assertTrue(types.contains(ExtendedBoolean.class));
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                Type genericClass = ((ParameterizedType) type).getRawType();
+                assertTrue(Enum.class.equals(genericClass) || Comparable.class.equals(genericClass));
+
+                assertEquals(1, ((ParameterizedType) type).getActualTypeArguments().length);
+                Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+                assertEquals(ExtendedBoolean.class, typeArg);
+            }
+        }
+    }
+
+    enum ExtendedBoolean {
+        TRUE,
+        FALSE,
+        FILE_NOT_FOUND,
+    }
+
+    @Dependent
+    static class ExtendedBooleanProducer {
+        @Produces
+        ExtendedBoolean produce() {
+            return null;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/GenericBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/GenericBeanTypesTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.arc.test.bean.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Iterator;
+import java.util.Set;
+import javax.enterprise.context.Dependent;
+import javax.inject.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class GenericBeanTypesTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(MyBean.class);
+
+    @Test
+    public void customGenericBean() {
+        InjectableBean<Object> bean = Arc.container().instance("myBean").getBean();
+        Set<Type> types = bean.getTypes();
+
+        assertEquals(3, types.size());
+        assertTrue(types.contains(Object.class));
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                Type genericClass = ((ParameterizedType) type).getRawType();
+                assertTrue(MyBean.class.equals(genericClass) || Iterable.class.equals(genericClass));
+
+                assertEquals(1, ((ParameterizedType) type).getActualTypeArguments().length);
+                Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("T", ((TypeVariable) typeArg).getName());
+
+                assertEquals(1, ((TypeVariable) typeArg).getBounds().length);
+                Type bound = ((TypeVariable) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(Comparable.class, ((ParameterizedType) bound).getRawType());
+
+                assertEquals(1, ((ParameterizedType) bound).getActualTypeArguments().length);
+                Type boundTypeArg = ((ParameterizedType) bound).getActualTypeArguments()[0];
+                assertTrue(boundTypeArg instanceof TypeVariable);
+                assertEquals("T", ((TypeVariable) boundTypeArg).getName());
+                // recursive
+            }
+        }
+    }
+
+    @Dependent
+    @Named("myBean")
+    static class MyBean<T extends Comparable<T>> implements Iterable<T> {
+        @Override
+        public Iterator<T> iterator() {
+            return null;
+        }
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/SimpleBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/SimpleBeanTypesTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.arc.test.bean.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+import javax.enterprise.context.Dependent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SimpleBeanTypesTest {
+    @RegisterExtension
+    ArcTestContainer container = new ArcTestContainer(MyBean.class);
+
+    @Test
+    public void test() {
+        InjectableBean<MyBean> bean = Arc.container().instance(MyBean.class).getBean();
+        Set<Type> types = bean.getTypes();
+
+        assertEquals(3, types.size());
+        assertTrue(types.contains(Object.class));
+        assertTrue(types.contains(MyBean.class));
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                Type genericClass = ((ParameterizedType) type).getRawType();
+                assertEquals(MyInterface.class, genericClass);
+
+                assertEquals(1, ((ParameterizedType) type).getActualTypeArguments().length);
+                Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+                assertEquals(String.class, typeArg);
+            }
+        }
+    }
+
+    interface MyInterface<T> {
+    }
+
+    @Dependent
+    static class MyBean implements MyInterface<String> {
+    }
+}


### PR DESCRIPTION
ArC used to pretty much not care about recursive bean types, because
they are very rare. However, per the CDI specification, `@Dependent`
beans may declare type parameters, and those can easily be recursive.

This commit fixes the bytecode generator that instantiates the set
of bean types. Bean types are, at runtime, represented using the common
`java.lang.reflect.Type` hierarchy, which represents recursive types
as an infinite path through the object graph of types. We clearly can't
generate a bytecode sequence to instantiate an infinite number of types,
but we can use a trick inspired by Jandex 3.0: add a notion of type
variable references.

For example, in `<T extends Comparable<T>>`, the first occurence of `T`
is represented by a `TypeVariableImpl`, which has a parameterized type
as its bound. The type argument of that parameterized type, which is
the second occurence of `T`, is represeted by `TypeVariableReferenceImpl`.
In the generated bytecode, the types are instantiated from inside, so
the reference is instantiated first, and when the containing type variable
is instantiated, the reference is patched to delegate to it.