### PR TITLE
Fix KafkaDevServicesContinuousTestingTestCase#testContinuousTestingScenario2

### DIFF
--- a/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
+++ b/extensions/smallrye-reactive-messaging-kafka/deployment/src/test/java/io/quarkus/smallrye/reactivemessaging/kafka/deployment/testing/KafkaDevServicesContinuousTestingTestCase.java
@@ -6,7 +6,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -67,7 +66,6 @@ public class KafkaDevServicesContinuousTestingTestCase {
     }
 
     @Test
-    @Disabled("Flaky, see https://github.com/quarkusio/quarkus/pull/27580#issuecomment-1230984624")
     public void testContinuousTestingScenario2() {
         ContinuousTestingTestUtils utils = new ContinuousTestingTestUtils();
         var result = utils.waitForNextCompletion();
@@ -77,7 +75,7 @@ public class KafkaDevServicesContinuousTestingTestCase {
         result = utils.waitForNextCompletion();
         Assertions.assertEquals(0, result.getTotalTestsPassed());
         Assertions.assertEquals(1, result.getTotalTestsFailed());
-        test.modifySourceFile(PriceConverter.class, s -> s.replaceAll("//", ""));
+        test.modifySourceFile(PriceResource.class, s -> s.replaceAll("//", ""));
         result = utils.waitForNextCompletion();
         Assertions.assertEquals(0, result.getTotalTestsPassed());
         Assertions.assertEquals(1, result.getTotalTestsFailed());
@@ -85,7 +83,7 @@ public class KafkaDevServicesContinuousTestingTestCase {
         result = utils.waitForNextCompletion();
         Assertions.assertEquals(0, result.getTotalTestsPassed());
         Assertions.assertEquals(1, result.getTotalTestsFailed());
-        test.modifySourceFile(PriceResource.class, s -> s.replaceAll("//", ""));
+        test.modifySourceFile(PriceConverter.class, s -> s.replaceAll("//", ""));
         result = utils.waitForNextCompletion();
         Assertions.assertEquals(1, result.getTotalTestsPassed());
         Assertions.assertEquals(0, result.getTotalTestsFailed());


### PR DESCRIPTION
The test is stable when we move the `PriceResource` as the first modified source file.

Fixes #27614