### PR TITLE
Rework the BeanDefiningAnnotationBuildItem default scope

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDefiningAnnotation.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDefiningAnnotation.java
@@ -7,6 +7,10 @@ public class BeanDefiningAnnotation {
     private final DotName annotation;
     private final DotName defaultScope;
 
+    public BeanDefiningAnnotation(DotName annotation) {
+        this(annotation, null);
+    }
+
     public BeanDefiningAnnotation(DotName annotation, DotName defaultScope) {
         this.annotation = annotation;
         this.defaultScope = defaultScope;

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/StereotypeInfo.java
@@ -15,30 +15,39 @@ public class StereotypeInfo {
     private final boolean isInherited;
     private final List<AnnotationInstance> parentStereotypes;
     private final ClassInfo target;
-    // allows to differentiate between standard stereotype and one that is in fact additional bean defining annotation
-    private final boolean isAdditionalBeanDefiningAnnotation;
-    // allows to differentiate between standard stereotype and one that was added through StereotypeRegistrarBuildItem
+    // used to differentiate between standard stereotype and one that was added through StereotypeRegistrarBuildItem
     private final boolean isAdditionalStereotype;
 
+    /**
+     *
+     * @deprecated This constructor will be removed at some time after Quarkus 3.0
+     */
+    @Deprecated
     public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean alternative,
-            Integer alternativePriority,
-            boolean isNamed, boolean isAdditionalBeanDefiningAnnotation, boolean isAdditionalStereotype,
+            Integer alternativePriority, boolean isNamed, boolean isAdditionalBeanDefiningAnnotation,
+            boolean isAdditionalStereotype,
             ClassInfo target, boolean isInherited, List<AnnotationInstance> parentStereotypes) {
+        this(defaultScope, interceptorBindings, alternative, alternativePriority, isNamed, isAdditionalStereotype, target,
+                isInherited, parentStereotypes);
+    }
+
+    public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean alternative,
+            Integer alternativePriority, boolean isNamed, boolean isAdditionalStereotype, ClassInfo target, boolean isInherited,
+            List<AnnotationInstance> parentStereotypes) {
         this.defaultScope = defaultScope;
         this.interceptorBindings = interceptorBindings;
         this.alternative = alternative;
         this.alternativePriority = alternativePriority;
         this.isNamed = isNamed;
-        this.target = target;
-        this.isAdditionalBeanDefiningAnnotation = isAdditionalBeanDefiningAnnotation;
-        this.isAdditionalStereotype = isAdditionalStereotype;
         this.isInherited = isInherited;
         this.parentStereotypes = parentStereotypes;
+        this.target = target;
+        this.isAdditionalStereotype = isAdditionalStereotype;
     }
 
     public StereotypeInfo(ScopeInfo defaultScope, List<AnnotationInstance> interceptorBindings, boolean alternative,
-            Integer alternativePriority,
-            boolean isNamed, ClassInfo target, boolean isInherited, List<AnnotationInstance> parentStereotype) {
+            Integer alternativePriority, boolean isNamed, ClassInfo target, boolean isInherited,
+            List<AnnotationInstance> parentStereotype) {
         this(defaultScope, interceptorBindings, alternative, alternativePriority, isNamed, false, false, target, isInherited,
                 parentStereotype);
     }
@@ -75,8 +84,13 @@ public class StereotypeInfo {
         return target.name();
     }
 
+    /**
+     *
+     * @deprecated This method will be removed at some time after Quarkus 3.0
+     */
+    @Deprecated
     public boolean isAdditionalBeanDefiningAnnotation() {
-        return isAdditionalBeanDefiningAnnotation;
+        return false;
     }
 
     /**
@@ -93,7 +107,7 @@ public class StereotypeInfo {
     }
 
     public boolean isGenuine() {
-        return !isAdditionalBeanDefiningAnnotation && !isAdditionalStereotype;
+        return !isAdditionalStereotype;
     }
 
     public List<AnnotationInstance> getParentStereotypes() {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/ScopeInheritanceStereotypeTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/inheritance/ScopeInheritanceStereotypeTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.arc.test.inheritance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Model;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ScopeInheritanceStereotypeTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(SuperBean.class, SubBean.class);
+
+    @Test
+    public void testExplicitScopeTakesPrecedence() {
+        // Inheritance of type-level metadata: "A scope type explicitly declared by X and inherited by Y from X takes precedence over default scopes of stereotypes declared or inherited by Y."
+        InjectableBean<SubBean> bean = Arc.container().instance(SubBean.class).getBean();
+        assertEquals(ApplicationScoped.class, bean.getScope());
+    }
+
+    @ApplicationScoped
+    static class SuperBean {
+
+        public void ping() {
+        }
+    }
+
+    @Model
+    // should inherit @ApplicationScoped
+    static class SubBean extends SuperBean {
+
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/MultipleStereotypeScopesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/stereotypes/MultipleStereotypeScopesTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.arc.test.stereotypes;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.arc.test.ArcTestContainer;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Model;
+import javax.enterprise.inject.Stereotype;
+import javax.enterprise.inject.spi.DefinitionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class MultipleStereotypeScopesTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder().beanClasses(ModelBean.class, MyStereotype.class)
+            .shouldFail().build();
+
+    @Test
+    public void testFailure() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure() instanceof DefinitionException);
+    }
+
+    @MyStereotype
+    @Model
+    static class ModelBean {
+
+    }
+
+    @ApplicationScoped
+    @Stereotype
+    @Target({ TYPE, METHOD, FIELD })
+    @Retention(RUNTIME)
+    @interface MyStereotype {
+    }
+
+}


### PR DESCRIPTION
- it was previously implemented as a "synthetic" stereotype; the
downsides of this solution were (1) there was a need to distinguish
"real" and "bda" stereotypes so that the bda one can be ignored if a
real stereotype with a default scope is used (otherwise users might get
unexpected definition errors) and (2) it was not possible to define CDI
qualifier as a bean defining annotation with a default scope