### PR TITLE
Always instantiate Hibernate ORM collections in the default fetch group

### DIFF
--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessAssociationsTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessAssociationsTest.java
@@ -1,0 +1,282 @@
+package io.quarkus.hibernate.orm.applicationfieldaccess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Checks that access to public fields by the application is correctly replaced with getter/setter calls
+ * and works correctly for all association types.
+ */
+public class PublicFieldAccessAssociationsTest {
+
+    private static final String CONTAINED_VALUE = "someValue";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(ContainingEntity.class)
+                    .addClass(FieldAccessEnhancedDelegate.class))
+            .withConfigurationResource("application-fetch-max-depth-zero.properties");
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserTransaction transaction;
+
+    @Test
+    public void testFieldAccess()
+            throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException,
+            RollbackException {
+        // Ideally we'd write a @ParameterizedTest and pass the delegates as parameters,
+        // but we cannot do that due to JUnit using a different classloader than the test.
+        for (FieldAccessEnhancedDelegate delegate : FieldAccessEnhancedDelegate.values()) {
+            doTestFieldAccess(delegate);
+        }
+    }
+
+    private void doTestFieldAccess(FieldAccessEnhancedDelegate delegate)
+            throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException,
+            RollbackException {
+        ContainingEntity entity = new ContainingEntity();
+        ContainedEntity containedEntity = new ContainedEntity();
+        containedEntity.value = CONTAINED_VALUE;
+
+        transaction.begin();
+        em.persist(entity);
+        em.persist(containedEntity);
+        transaction.commit();
+
+        transaction.begin();
+        entity = em.getReference(ContainingEntity.class, entity.id);
+        containedEntity = em.getReference(ContainedEntity.class, containedEntity.id);
+        // Initially the assertion doesn't pass: the value was not set yet
+        AssertionError expected = null;
+        try {
+            delegate.assertValueAndLaziness(entity, containedEntity);
+        } catch (AssertionError e) {
+            expected = e;
+        }
+        if (expected == null) {
+            throw new IllegalStateException("This test is buggy: assertions should not pass at this point.");
+        }
+        transaction.rollback();
+
+        transaction.begin();
+        entity = em.getReference(ContainingEntity.class, entity.id);
+        containedEntity = em.getReference(ContainedEntity.class, containedEntity.id);
+        // Since field access is replaced with accessor calls,
+        // we expect this change to be detected by dirty tracking and persisted.
+        delegate.setValue(entity, containedEntity);
+        transaction.commit();
+
+        // Test getReference()
+        transaction.begin();
+        entity = em.getReference(ContainingEntity.class, entity.id);
+        containedEntity = em.getReference(ContainedEntity.class, containedEntity.id);
+        // We're working on an uninitialized proxy.
+        assertThat(entity).returns(false, Hibernate::isInitialized);
+        // The above should have persisted a value that passes the assertion.
+        delegate.assertValueAndLaziness(entity, containedEntity);
+        // Accessing the value should trigger initialization of the proxy.
+        assertThat(entity).returns(true, Hibernate::isInitialized);
+        transaction.commit();
+
+        // Test find()
+        transaction.begin();
+        entity = em.find(ContainingEntity.class, entity.id);
+        containedEntity = em.find(ContainedEntity.class, containedEntity.id);
+        // We're working on an actual entity instance (not a proxy).
+        assertThat(entity).returns(true, Hibernate::isInitialized);
+        // The above should have persisted a value that passes the assertion.
+        delegate.assertValueAndLaziness(entity, containedEntity);
+        transaction.commit();
+    }
+
+    @Entity
+    public static class ContainingEntity {
+
+        @Id
+        @GeneratedValue
+        public long id;
+
+        @OneToOne
+        public ContainedEntity oneToOne;
+
+        @ManyToOne
+        public ContainedEntity manyToOne;
+
+        @OneToMany
+        @JoinTable(name = "containing_oneToMany")
+        public List<ContainedEntity> oneToMany = new ArrayList<>();
+
+        @ManyToMany
+        @JoinTable(name = "containing_manyToMany")
+        public List<ContainedEntity> manyToMany = new ArrayList<>();
+
+        @OneToOne(mappedBy = "oneToOne")
+        public ContainedEntity oneToOneMappedBy;
+
+        @OneToMany(mappedBy = "manyToOne")
+        public List<ContainedEntity> oneToManyMappedBy = new ArrayList<>();
+
+        @ManyToMany(mappedBy = "manyToMany")
+        public List<ContainedEntity> manyToManyMappedBy = new ArrayList<>();
+
+    }
+
+    @Entity
+    public static class ContainedEntity {
+
+        @Id
+        @GeneratedValue
+        public long id;
+
+        @Column(name = "value_")
+        public String value;
+
+        @OneToOne
+        public ContainingEntity oneToOne;
+
+        @ManyToOne
+        public ContainingEntity manyToOne;
+
+        @ManyToMany
+        @JoinTable(name = "containing_manyToMany_mappedBy")
+        public List<ContainingEntity> manyToMany = new ArrayList<>();
+
+    }
+
+    private enum FieldAccessEnhancedDelegate {
+
+        ONE_TO_ONE {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.oneToOne = containedEntity;
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                // No expectations regarding laziness on ToOne associations
+                assertThat(entity.oneToOne).isEqualTo(containedEntity);
+                consumeValue(entity.oneToOne);
+            }
+        },
+        MANY_TO_ONE {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.manyToOne = containedEntity;
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                // No expectations regarding laziness on ToOne associations
+                assertThat(entity.manyToOne).isEqualTo(containedEntity);
+                consumeValue(entity.manyToOne);
+            }
+        },
+        ONE_TO_MANY {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.oneToMany.add(containedEntity);
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                assertThat((Object) entity.oneToMany).returns(false, Hibernate::isInitialized);
+                assertThat(entity.oneToMany).containsExactly(containedEntity);
+                assertThat((Object) entity.oneToMany).returns(true, Hibernate::isInitialized);
+            }
+        },
+        MANY_TO_MANY {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.manyToMany.add(containedEntity);
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                assertThat((Object) entity.manyToMany).returns(false, Hibernate::isInitialized);
+                assertThat(entity.manyToMany).containsExactly(containedEntity);
+                assertThat((Object) entity.manyToMany).returns(true, Hibernate::isInitialized);
+            }
+        },
+        ONE_TO_ONE_MAPPED_BY {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.oneToOneMappedBy = containedEntity;
+                containedEntity.oneToOne = entity;
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                // No expectations regarding laziness on ToOne associations
+                assertThat(entity.oneToOneMappedBy).isEqualTo(containedEntity);
+                consumeValue(entity.oneToOneMappedBy);
+            }
+        },
+        ONE_TO_MANY_MAPPED_BY {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.oneToManyMappedBy.add(containedEntity);
+                containedEntity.manyToOne = entity;
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                assertThat((Object) entity.oneToManyMappedBy).returns(false, Hibernate::isInitialized);
+                assertThat(entity.oneToManyMappedBy).containsExactly(containedEntity);
+                assertThat((Object) entity.oneToManyMappedBy).returns(true, Hibernate::isInitialized);
+            }
+        },
+        MANY_TO_MANY_MAPPED_BY {
+            @Override
+            public void setValue(ContainingEntity entity, ContainedEntity containedEntity) {
+                entity.manyToManyMappedBy.add(containedEntity);
+                containedEntity.manyToMany.add(entity);
+            }
+
+            @Override
+            public void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity) {
+                assertThat((Object) entity.manyToManyMappedBy).returns(false, Hibernate::isInitialized);
+                assertThat(entity.manyToManyMappedBy).containsExactly(containedEntity);
+                assertThat((Object) entity.manyToManyMappedBy).returns(true, Hibernate::isInitialized);
+            }
+        };
+
+        protected void consumeValue(ContainedEntity entity) {
+            assertThat(entity.value).isEqualTo(CONTAINED_VALUE);
+        }
+
+        public abstract void setValue(ContainingEntity entity, ContainedEntity containedEntity);
+
+        public abstract void assertValueAndLaziness(ContainingEntity entity, ContainedEntity containedEntity);
+
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessFieldTypesTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessFieldTypesTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.publicfields;
+package io.quarkus.hibernate.orm.applicationfieldaccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Checks that public field access is correctly replaced with getter/setter calls,
- * regardless of the field type.
+ * Checks that access to public fields by the application is correctly replaced with getter/setter calls
+ * and works correctly for all field types.
  */
 public class PublicFieldAccessFieldTypesTest {
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessFinalFieldTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessFinalFieldTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package io.quarkus.hibernate.orm.publicfields;
+package io.quarkus.hibernate.orm.applicationfieldaccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +30,7 @@ import io.quarkus.hibernate.orm.TransactionTestUtils;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Checks that public, final field access is correctly replaced with getter calls for reads,
+ * Checks that access to public, final fields by the application is correctly replaced with getter calls for reads,
  * but not replaced at all for writes (since writes to final fields can only occur from constructors).
  * <p>
  * See https://github.com/quarkusio/quarkus/issues/20186

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessInheritanceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldAccessInheritanceTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.hibernate.orm.publicfields;
+package io.quarkus.hibernate.orm.applicationfieldaccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 
 /**
- * Checks that public field access is correctly replaced with getter/setter calls,
- * regardless of where the field is declared in the class hierarchy.
+ * Checks that access to public fields by the application is correctly replaced with getter/setter calls
+ * and works correctly regardless of where the field is declared in the class hierarchy.
  */
 public class PublicFieldAccessInheritanceTest {
 

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldWithProxyAndLazyLoadingAndInheritanceTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/applicationfieldaccess/PublicFieldWithProxyAndLazyLoadingAndInheritanceTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package io.quarkus.hibernate.orm.publicfields;
+package io.quarkus.hibernate.orm.applicationfieldaccess;
 
 import static io.quarkus.hibernate.orm.TransactionTestUtils.inTransaction;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/batch/BatchFetchSizeTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/batch/BatchFetchSizeTest.java
@@ -45,20 +45,20 @@ public class BatchFetchSizeTest {
 
         transaction.begin();
         List<MainEntity> entities = session.createQuery("from MainEntity", MainEntity.class).list();
-        assertThat(entities).allSatisfy(e -> assertThat(Hibernate.isPropertyInitialized(e, "others"))
+        assertThat(entities).allSatisfy(e -> assertThat(Hibernate.isInitialized(e.others))
                 .as("'others' initialized for " + e).isFalse());
 
         MainEntity entity = entities.get(0);
         // Trigger initialization for the collection from one entity.
         entity.others.get(0);
-        assertThat(Hibernate.isPropertyInitialized(entity, "others"))
+        assertThat(Hibernate.isInitialized(entity.others))
                 .as("'others' initialized for " + entity).isTrue();
 
         // 20 entities were already in the session when the initialization above occurred,
         // so it should have triggered batch initialization of several 'others' collections.
         assertThat(entities).hasSize(20);
         assertThat(entities)
-                .filteredOn(e -> Hibernate.isPropertyInitialized(e, "others"))
+                .filteredOn(e -> Hibernate.isInitialized(e.others))
                 .hasSize(16); // Default batch fetch size is 16
         transaction.commit();
     }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootEntityManagerFactoryBuilder.java
@@ -121,7 +121,6 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
     }
 
     protected void populate(String persistenceUnitName, SessionFactoryOptionsBuilder options, StandardServiceRegistry ssr) {
-
         // will use user override value or default to false if not supplied to follow
         // JPA spec.
         final boolean jtaTransactionAccessEnabled = runtimeSettings.getBoolean(
@@ -157,6 +156,11 @@ public class FastBootEntityManagerFactoryBuilder implements EntityManagerFactory
         options.addSessionFactoryObservers(new ServiceRegistryCloser());
 
         options.applyEntityNotFoundDelegate(new JpaEntityNotFoundDelegate());
+
+        // This is necessary for Hibernate Reactive, see https://github.com/quarkusio/quarkus/issues/15814
+        // This is also necessary for Hibernate ORM if we want to prevent calls to getters on initialized entities
+        // outside of sessions from throwing exceptions, see https://github.com/quarkusio/quarkus/discussions/27657
+        options.enableCollectionInDefaultFetchGroup(true);
 
         if (this.validatorFactory != null) {
             options.applyValidatorFactory(validatorFactory);


### PR DESCRIPTION
... be it for Hibernate Reactive (as before) or for Hibernate ORM.

Fixes #27657
Fixes #4644 (according to https://github.com/quarkusio/quarkus/discussions/27657#discussioncomment-3580743)

Fixes problems such as https://github.com/quarkusio/quarkus/discussions/27657, where calling a getter to retrieve a collection on an initialized entity would throw a `LazyInitializationException`, whereas one would expect the exception to be thrown later, when accessing the collection itself (`.size()`, `.iterator()`, ...).

This sets defaults as suggested by @gavinking and @Sanne when the option was introduced some time ago: https://github.com/hibernate/hibernate-orm/pull/3558#issuecomment-695003875, https://github.com/hibernate/hibernate-orm/pull/3558#issuecomment-701440788