### PR TITLE
Jakarta - Remove integration-tests/kafka-avro when migrating

### DIFF
--- a/integration-tests/kafka-avro-apicurio2/pom.xml
+++ b/integration-tests/kafka-avro-apicurio2/pom.xml
@@ -57,12 +57,8 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>7.0.0</version>
+            <version>7.2.1</version>
             <exclusions>
-                <exclusion>
-                    <groupId>jakarta.ws.rs</groupId>
-                    <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -578,10 +578,8 @@ recipeList:
   - org.openrewrite.maven.ChangePropertyValue:
       key: testng.version
       newValue: 7.4.0
-# In progress, these ones need a change:
+# TODO, these ones probably still need a change:
 #        <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
-#        <microprofile-lra.version>1.0</microprofile-lra.version>
-#        <smallrye-graphql.version>1.4.3</smallrye-graphql.version>
 #        <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
 #        <smallrye-reactive-types-converter.version>2.6.0</smallrye-reactive-types-converter.version>
 #        <smallrye-mutiny-vertx-binding.version>2.19.0</smallrye-mutiny-vertx-binding.version>

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -332,11 +332,17 @@ git checkout -- extensions/kubernetes-service-binding/runtime/src/test/resources
 
 # Disable non-compilable ITs
 # - Confluent registry client doesn't have a version supporting Jakarta packages
-sed -i 's@<module>kafka-avro</module>@<!-- <module>kafka-avro</module> -->@g' integration-tests/pom.xml
 
 # Commit what we have before cherry-picking stuff
 git add .
 git commit -m 'Transform sources to Jakarta'
+
+# Remove integration-tests/kafka-avro as it's testing old versions
+# We have a new module for newer versions that work with Jakarta
+sed -i '/<module>kafka-avro<\/module>/d' integration-tests/pom.xml
+rm -rf integration-tests/kafka-avro
+git add .
+git commit -m 'Remove integration-tests/kafka-avro - see kafka-avro-apicurio2 instead'
 
 # Apply EE 10 updates
 


### PR DESCRIPTION
Upgrade Confluent kafka-avro-serializer to 7.2.1 for integration-tests/kafka-avro-apicurio2

Fixes #26992