### PR TITLE
Make sure methods annotated with `@Funq` are declared as public

### DIFF
--- a/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/main/java/io/quarkus/funqy/deployment/FunctionScannerBuildStep.java
@@ -63,6 +63,13 @@ public class FunctionScannerBuildStep {
             classNames.add(className);
             classes.add(method.declaringClass());
             String methodName = method.name();
+
+            if (!Modifier.isPublic(method.flags())) {
+                throw new RuntimeException(
+                        String.format("Method '%s' annotated with '@Funq' declared in the class '%s' is not public.",
+                                methodName, className));
+            }
+
             String functionName = null;
             if (funqMethod.value() != null) {
                 functionName = funqMethod.value().asString();

--- a/extensions/funqy/funqy-server-common/deployment/src/test/java/io/quarkus/funqy/deployment/DependencyInjectionTest.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/test/java/io/quarkus/funqy/deployment/DependencyInjectionTest.java
@@ -53,7 +53,7 @@ public class DependencyInjectionTest {
         GreetingService greetingService;
 
         @Funq
-        String greeting() {
+        public String greeting() {
             return greetingService.sayHello();
         }
 
@@ -68,7 +68,7 @@ public class DependencyInjectionTest {
         }
 
         @Funq
-        String farewell() {
+        public String farewell() {
             return greetingService.sayGoodbye();
         }
 
@@ -81,7 +81,7 @@ public class DependencyInjectionTest {
         GreetingService greetingService;
 
         @Funq
-        String bye() {
+        public String bye() {
             return greetingService.sayBye();
         }
 
@@ -97,7 +97,7 @@ public class DependencyInjectionTest {
         }
 
         @Funq
-        String hi() {
+        public String hi() {
             return greetingService.sayHi();
         }
 

--- a/extensions/funqy/funqy-server-common/deployment/src/test/java/io/quarkus/funqy/deployment/FunqMethodVisibilityTest.java
+++ b/extensions/funqy/funqy-server-common/deployment/src/test/java/io/quarkus/funqy/deployment/FunqMethodVisibilityTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.funqy.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.runtime.util.ExceptionUtil;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class FunqMethodVisibilityTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Hello.class))
+            .assertException(t -> {
+                Throwable rootCause = ExceptionUtil.getRootCause(t);
+                if (rootCause instanceof RuntimeException) {
+                    assertTrue(rootCause.getMessage().contains("Method 'greet' annotated with '@Funq'"));
+                    assertTrue(rootCause.getMessage().contains("is not public"));
+                } else {
+                    fail("Non-public method `greet` annotated with `@Funq` wasn't detected: " + t);
+                }
+            });
+
+    @Test
+    public void test() {
+        Assertions.fail();
+    }
+
+    public static class Hello {
+
+        @Funq
+        void greet() {
+            // do nothing
+        }
+    }
+
+}


### PR DESCRIPTION
fixes: #27669

Throw an exception and break the build when non-public methods are annotated with `@Funq` as only public methods are registered as functions. This will give developer the information he made mistake during the build as there is no good reason to declare methods with `@Funq` and don't use them as Funq functions.