### PR TITLE
Support empty env var values in Kubernetes/Knative/OpenShift extensions

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvConverter.java
@@ -28,7 +28,7 @@ public class EnvConverter {
         e.secrets.ifPresent(sl -> sl.forEach(s -> envs.add(new EnvBuilder().withName(convertName(s)).withSecret(s).build())));
         e.configmaps
                 .ifPresent(cl -> cl.forEach(c -> envs.add(new EnvBuilder().withName(convertName(c)).withConfigmap(c).build())));
-        e.vars.forEach((k, v) -> envs.add(new EnvBuilder().withName(convertName(k)).withValue(v).build()));
+        e.vars.forEach((k, v) -> envs.add(new EnvBuilder().withName(convertName(k)).withValue(v.orElse("")).build()));
         e.fields.forEach((k, v) -> {
             // env vars from fields need to have their name set in addition to their field field :)
             final String field = convertName(k);

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarHolder.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarHolder.java
@@ -48,7 +48,7 @@ public interface EnvVarHolder {
 
         // override old-style with newer versions if present
         final EnvVarsConfig c = getEnv();
-        c.vars.forEach((k, v) -> validator.process(KubernetesEnvBuildItem.createSimpleVar(k, v, target)));
+        c.vars.forEach((k, v) -> validator.process(KubernetesEnvBuildItem.createSimpleVar(k, v.orElse(""), target)));
         c.fields.forEach((k, v) -> validator.process(KubernetesEnvBuildItem.createFromField(k, v, target)));
         c.configmaps
                 .ifPresent(cl -> cl.forEach(cm -> validator.process(KubernetesEnvBuildItem.createFromConfigMap(cm, target))));

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/EnvVarsConfig.java
@@ -34,7 +34,7 @@ public class EnvVarsConfig {
      * The map associating environment name to its associated value.
      */
     @ConfigItem
-    Map<String, String> vars;
+    Map<String, Optional<String>> vars;
 
     /**
      * The map recording the configuration of environment variable taking their value from resource (Secret or

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithNewStyleEnvTest.java
@@ -56,6 +56,9 @@ public class KubernetesWithNewStyleEnvTest {
                                     .filteredOn(env -> "ENVVAR".equals(env.getName()))
                                     .singleElement().satisfies(env -> assertThat(env.getValue()).isEqualTo("value"));
                             assertThat(container.getEnv())
+                                    .filteredOn(env -> "EMPTYVAR".equals(env.getName()))
+                                    .singleElement().satisfies(env -> assertThat(env.getValue()).isNullOrEmpty());
+                            assertThat(container.getEnv())
                                     .filteredOn(env -> "QUARKUS_KUBERNETES_CONFIG_ENABLED".equals(env.getName()))
                                     .singleElement().satisfies(env -> assertThat(env.getValue()).isEqualTo("true"));
                             assertThat(container.getEnv())

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-new-style-env.properties
@@ -1,5 +1,6 @@
 quarkus.kubernetes.env.fields.fromfield=metadata.name
 quarkus.kubernetes.env.vars.envvar=value
+quarkus.kubernetes.env.vars.emptyvar=
 quarkus.kubernetes.env.vars."quarkus.kubernetes-config.enabled"=true
 quarkus.kubernetes.env.configmaps=configName
 quarkus.kubernetes.env.secrets=secretName


### PR DESCRIPTION
This change allows setting env var with empty values: `quarkus.kubernetes.env.vars.TESTVAR=`

Fix https://github.com/quarkusio/quarkus/issues/27663