### PR TITLE
Allow HttpServerOptionsCustomizer to set KeyManager and TrustManager for HTTPS server

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/customizers/HttpServerOptionsCustomizerTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/customizers/HttpServerOptionsCustomizerTest.java
@@ -28,7 +28,7 @@ public class HttpServerOptionsCustomizerTest {
 
     @Test
     void test() {
-        Assertions.assertThat(customizer.count()).isEqualTo(1);
+        Assertions.assertThat(customizer.count()).isEqualTo(2);
         Assertions.assertThat(RestAssured.get("http://localhost:9998").body().asString()).isEqualTo("hello");
     }
 


### PR DESCRIPTION
This change allows the application to use the `HttpServerOptionsCustomizer` mechanism to set their own `KeyManager` and `TrustManager` to Vert.x. That is achieved by simply moving the check to disable TLS (in absense of server certificate & key) from before the customizer call to after the call.

Without this change the `HttpServerOptionsCustomizer.customizeHttpsServer()` method is not called unless certificate and key were already defined in `quarkus.http.ssl.certificate.*` config options. Setting the config option is not desirable when the application wants to customize the HTTPS server by setting its own `KeyManager`. In that case `quarkus.http.ssl.certificate.*` options are not applicable, since Quarkus is not in control of setting the server credentials.

Example use case that is enabled by this PR: Application sets custom `KeyManager` that supports certificate hot-reload without restarting the server (xref #15926).

Fixes #27481