### PR TITLE
SmallRye CP - introduce ThreadContextProviderBuildItem 

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1372,6 +1372,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1372,7 +1372,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
+                <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/extensions/arc/deployment/pom.xml
+++ b/extensions/arc/deployment/pom.xml
@@ -19,6 +19,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
         </dependency>
         <dependency>

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcConfig.java
@@ -203,6 +203,12 @@ public class ArcConfig {
     @ConfigItem
     public Optional<List<String>> ignoredSplitPackages;
 
+    /**
+     * Context propagation configuration.
+     */
+    @ConfigItem
+    public ArcContextPropagationConfig contextPropagation;
+
     public final boolean isRemoveUnusedBeansFieldValid() {
         return ALLOWED_REMOVE_UNUSED_BEANS_VALUES.contains(removeUnusedBeans.toLowerCase());
     }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ArcContextPropagationConfig {
+
+    /**
+     * If set to true and SmallRye Context Propagation extension is present then enable the context propagation for CDI
+     * contexts.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -81,6 +81,7 @@ import io.quarkus.arc.runtime.ArcRecorder;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.arc.runtime.LaunchModeProducer;
 import io.quarkus.arc.runtime.LoggerProducer;
+import io.quarkus.arc.runtime.context.ArcContextProvider;
 import io.quarkus.arc.runtime.test.PreloadedTestApplicationClassPredicate;
 import io.quarkus.bootstrap.BootstrapDebug;
 import io.quarkus.deployment.Capabilities;
@@ -114,6 +115,7 @@ import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.quarkus.runtime.test.TestApplicationClassPredicate;
 import io.quarkus.runtime.util.HashUtil;
+import io.quarkus.smallrye.context.deployment.spi.ThreadContextProviderBuildItem;
 
 /**
  * This class contains build steps that trigger various phases of the bean processing.
@@ -810,6 +812,13 @@ public class ArcProcessor {
             }
         } catch (AmbiguousResolutionException e) {
             errors.produce(new ValidationErrorBuildItem(e));
+        }
+    }
+
+    @BuildStep
+    void registerContextPropagation(ArcConfig config, BuildProducer<ThreadContextProviderBuildItem> threadContextProvider) {
+        if (config.contextPropagation.enabled) {
+            threadContextProvider.produce(new ThreadContextProviderBuildItem(ArcContextProvider.class));
         }
     }
 

--- a/extensions/arc/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
+++ b/extensions/arc/runtime/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
@@ -1,1 +1,0 @@
-io.quarkus.arc.runtime.context.ArcContextProvider

--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-context-propagation</artifactId>
         </dependency>
         <dependency>

--- a/extensions/smallrye-context-propagation/deployment/pom.xml
+++ b/extensions/smallrye-context-propagation/deployment/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
+            <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
 import io.quarkus.deployment.util.ServiceUtil;
+import io.quarkus.smallrye.context.deployment.spi.ThreadContextProviderBuildItem;
 import io.quarkus.smallrye.context.runtime.SmallRyeContextPropagationProvider;
 import io.quarkus.smallrye.context.runtime.SmallRyeContextPropagationRecorder;
 import io.smallrye.context.SmallRyeManagedExecutor;
@@ -59,12 +60,15 @@ class SmallRyeContextPropagationProcessor {
 
     @BuildStep
     @Record(ExecutionTime.STATIC_INIT)
-    void buildStatic(SmallRyeContextPropagationRecorder recorder)
+    void buildStatic(SmallRyeContextPropagationRecorder recorder, List<ThreadContextProviderBuildItem> threadContextProviders)
             throws ClassNotFoundException, IOException {
         List<ThreadContextProvider> discoveredProviders = new ArrayList<>();
         List<ContextManagerExtension> discoveredExtensions = new ArrayList<>();
-        for (Class<?> provider : ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
-                "META-INF/services/" + ThreadContextProvider.class.getName())) {
+        List<Class<?>> providers = threadContextProviders.stream().map(ThreadContextProviderBuildItem::getProvider)
+                .collect(Collectors.toList());
+        ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
+                "META-INF/services/" + ThreadContextProvider.class.getName()).forEach(providers::add);
+        for (Class<?> provider : providers) {
             try {
                 discoveredProviders.add((ThreadContextProvider) provider.getDeclaredConstructor().newInstance());
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {

--- a/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
+++ b/extensions/smallrye-context-propagation/deployment/src/main/java/io/quarkus/smallrye/context/deployment/SmallRyeContextPropagationProcessor.java
@@ -65,7 +65,7 @@ class SmallRyeContextPropagationProcessor {
         List<ThreadContextProvider> discoveredProviders = new ArrayList<>();
         List<ContextManagerExtension> discoveredExtensions = new ArrayList<>();
         List<Class<?>> providers = threadContextProviders.stream().map(ThreadContextProviderBuildItem::getProvider)
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
         ServiceUtil.classesNamedIn(Thread.currentThread().getContextClassLoader(),
                 "META-INF/services/" + ThreadContextProvider.class.getName()).forEach(providers::add);
         for (Class<?> provider : providers) {

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ContextProviderDisabledTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ContextProviderDisabledTest.java
@@ -1,0 +1,75 @@
+package io.quarkus.smallrye.context.deployment.test.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ContextNotActiveException;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ContextProviderDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().overrideConfigKey("quarkus.arc.context-propagation.enabled",
+            "false");
+
+    @Inject
+    ManagedExecutor all;
+
+    @Inject
+    MyRequestBean bean;
+
+    @Test
+    public void testPropagationDisabled() throws InterruptedException, ExecutionException, TimeoutException {
+        ManagedContext requestContext = Arc.container().requestContext();
+
+        requestContext.activate();
+        assertEquals("FOO", bean.getId());
+        try {
+            assertEquals("OK",
+                    all.completedFuture("OK").thenApplyAsync(text -> {
+                        // Assertion error would result in an ExecutionException thrown from the CompletableFuture.get()
+                        assertFalse(requestContext.isActive());
+                        try {
+                            bean.getId();
+                            fail();
+                        } catch (ContextNotActiveException expected) {
+                        }
+                        return text;
+                    }).toCompletableFuture().get(5, TimeUnit.SECONDS));
+        } finally {
+            requestContext.terminate();
+        }
+    }
+
+    @RequestScoped
+    public static class MyRequestBean {
+
+        String id;
+
+        @PostConstruct
+        void init() {
+            id = "FOO";
+        }
+
+        public String getId() {
+            return id;
+        }
+
+    }
+
+}

--- a/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ContextProviderEnabledTest.java
+++ b/extensions/smallrye-context-propagation/deployment/src/test/java/io/quarkus/smallrye/context/deployment/test/cdi/ContextProviderEnabledTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.smallrye.context.deployment.test.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ContextProviderEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest().overrideConfigKey("quarkus.arc.context-propagation.enabled",
+            "true");
+
+    @Inject
+    ManagedExecutor all;
+
+    @Inject
+    MyRequestBean bean;
+
+    @Test
+    public void testPropagationEnabled() throws InterruptedException, ExecutionException, TimeoutException {
+        ManagedContext requestContext = Arc.container().requestContext();
+
+        requestContext.activate();
+        assertEquals("FOO", bean.getId());
+        try {
+            assertEquals("OK",
+                    all.completedFuture("OK").thenApplyAsync(text -> {
+                        // Assertion error would result in an ExecutionException thrown from the CompletableFuture.get()
+                        assertTrue(requestContext.isActive());
+                        assertEquals("FOO", bean.getId());
+                        return text;
+                    }).toCompletableFuture().get(5, TimeUnit.SECONDS));
+            ;
+        } finally {
+            requestContext.terminate();
+        }
+    }
+
+    @RequestScoped
+    public static class MyRequestBean {
+
+        String id;
+
+        @PostConstruct
+        void init() {
+            id = "FOO";
+        }
+
+        public String getId() {
+            return id;
+        }
+
+    }
+
+}

--- a/extensions/smallrye-context-propagation/pom.xml
+++ b/extensions/smallrye-context-propagation/pom.xml
@@ -17,5 +17,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>spi</module>
     </modules>
 </project>

--- a/extensions/smallrye-context-propagation/spi/pom.xml
+++ b/extensions/smallrye-context-propagation/spi/pom.xml
@@ -10,8 +10,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
-    <name>Quarkus - SmallRye Context Propagation - Deployment - SPI</name>
+    <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
+    <name>Quarkus - SmallRye Context Propagation - SPI</name>
 
     <dependencies>
         <dependency>

--- a/extensions/smallrye-context-propagation/spi/pom.xml
+++ b/extensions/smallrye-context-propagation/spi/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-smallrye-context-propagation-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-smallrye-context-propagation-deployment-spi</artifactId>
+    <name>Quarkus - SmallRye Context Propagation - Deployment - SPI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.context-propagation</groupId>
+            <artifactId>microprofile-context-propagation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/extensions/smallrye-context-propagation/spi/src/main/java/io/quarkus/smallrye/context/deployment/spi/ThreadContextProviderBuildItem.java
+++ b/extensions/smallrye-context-propagation/spi/src/main/java/io/quarkus/smallrye/context/deployment/spi/ThreadContextProviderBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.smallrye.context.deployment.spi;
+
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * This build item can be used to register a {@link ThreadContextProvider}.
+ */
+public final class ThreadContextProviderBuildItem extends MultiBuildItem {
+
+    private final Class<? extends ThreadContextProvider> provider;
+
+    public ThreadContextProviderBuildItem(Class<? extends ThreadContextProvider> provider) {
+        this.provider = provider;
+    }
+
+    public Class<? extends ThreadContextProvider> getProvider() {
+        return provider;
+    }
+
+}


### PR DESCRIPTION
This PR introduces the `ThreadContextProviderBuildItem` so that it's possible to register a CP `ThreadContextProvider` via build item (in addition to the current service loader facility). Furhtermore, a new ArC config property is introduced - `quarkus.arc.context-propagation.enabled`. This property is a temporary solution, i.e. the property itself could be removed in the future or the default value may be subject of change.