### PR TITLE
Replace usages of `@DisabledOnNativeImage` and `@NativeImageTest`

### DIFF
--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/native-test/java/org/acme/lambda/LambdaHandlerTestIT.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/amazon-lambda-example/java/src/native-test/java/org/acme/lambda/LambdaHandlerTestIT.java
@@ -1,8 +1,8 @@
 package org.acme.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LambdaHandlerTestIT extends LambdaHandlerTest {
 
     // Execute the same tests but in native mode.

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-amazon-lambda-example/java/src/native-test/java/org/acme/funqy/FunqyIT.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-amazon-lambda-example/java/src/native-test/java/org/acme/funqy/FunqyIT.java
@@ -1,8 +1,8 @@
 package org.acme.funqy;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class FunqyIT extends FunqyTest {
 
     // Run the same tests

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-knative-events-example/java/src/native-test/java/org/acme/funqy/cloudevent/FunqyIT.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/examples/funqy-knative-events-example/java/src/native-test/java/org/acme/funqy/cloudevent/FunqyIT.java
@@ -1,8 +1,8 @@
 package org.acme.funqy.cloudevent;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class FunqyIT extends FunqyTest {
 
     // Run the same tests

--- a/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/funqy-http-codestart/java/src/native-test/java/org/acme/MyFunctionsIT.java
+++ b/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/funqy-http-codestart/java/src/native-test/java/org/acme/MyFunctionsIT.java
@@ -1,8 +1,8 @@
 package org.acme;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MyFunctionsIT extends MyFunctionsTest {
     // Run the same tests in native
 }

--- a/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
+++ b/extensions/amazon-lambda-http/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
@@ -1,7 +1,7 @@
 package ${package};
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class GreetingIT extends GreetingTest {
 }

--- a/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
+++ b/extensions/amazon-lambda-rest/maven-archetype/src/main/resources/archetype-resources/src/test/java/GreetingIT.java
@@ -1,7 +1,7 @@
 package ${package};
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class GreetingIT extends GreetingTest {
 }

--- a/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerIT.java
+++ b/extensions/amazon-lambda/maven-archetype/src/main/resources/archetype-resources/src/test/java/LambdaHandlerIT.java
@@ -1,7 +1,7 @@
 package ${package};
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LambdaHandlerIT extends LambdaHandlerTest {
 }

--- a/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-http-resteasy-reactive/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-http-resteasy/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-http/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/amazon-lambda-rest/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaV1SimpleIT.java
+++ b/integration-tests/amazon-lambda-rest/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaV1SimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaV1SimpleIT extends AmazonLambdaV1SimpleTestCase {
 }

--- a/integration-tests/amazon-lambda-s3event/src/test/java/io/quarkus/it/amazon/lambda/S3EventIT.java
+++ b/integration-tests/amazon-lambda-s3event/src/test/java/io/quarkus/it/amazon/lambda/S3EventIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class S3EventIT extends S3EventTestCase {
 }

--- a/integration-tests/amazon-lambda-stream-handler/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda-stream-handler/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
+++ b/integration-tests/amazon-lambda/src/test/java/io/quarkus/it/amazon/lambda/AmazonLambdaSimpleIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.amazon.lambda;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class AmazonLambdaSimpleIT extends AmazonLambdaSimpleTestCase {
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageDecodersIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.awt.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ImageDecodersIT extends ImageDecodersTest {
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageEncodersIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.awt.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ImageEncodersIT extends ImageEncodersTest {
 }

--- a/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsIT.java
+++ b/integration-tests/awt/src/test/java/io/quarkus/awt/it/ImageGeometryFontsIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.awt.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ImageGeometryFontsIT extends ImageGeometryFontsTest {
 }

--- a/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseITCase.java
+++ b/integration-tests/bouncycastle-fips-jsse/src/test/java/io/quarkus/it/bouncycastle/BouncyCastleFipsJsseITCase.java
@@ -2,14 +2,14 @@ package io.quarkus.it.bouncycastle;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
 public class BouncyCastleFipsJsseITCase extends BouncyCastleFipsJsseTestCase {
 
     @Test
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Override
     public void testListProviders() throws Exception {
         doTestListProviders();

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-kafka/src/test/java/org/acme/kafka/KafkaClientTest.java
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-build-jib-with-kafka/src/test/java/org/acme/kafka/KafkaClientTest.java
@@ -1,6 +1,5 @@
 package org.acme.kafka;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 

--- a/integration-tests/devtools/src/test/resources/__snapshots__/FunqyHttpCodestartTest/testContent/src_test_java_ilove_quark_us_MyFunctionsIT.java
+++ b/integration-tests/devtools/src/test/resources/__snapshots__/FunqyHttpCodestartTest/testContent/src_test_java_ilove_quark_us_MyFunctionsIT.java
@@ -1,8 +1,8 @@
 package ilove.quark.us;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MyFunctionsIT extends MyFunctionsTest {
     // Run the same tests in native
 }

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
@@ -1,8 +1,8 @@
 package org.acme;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeExampleResourceIT extends ExampleResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/native-test/java/org/acme/NativeExampleResourceIT.java
@@ -1,8 +1,8 @@
 package org.acme;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeExampleResourceIT extends ExampleResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/src/native-test/java/org/acme/ExampleResourceNativeTest.java
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/src/native-test/java/org/acme/ExampleResourceNativeTest.java
@@ -1,6 +1,6 @@
 package org.acme;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ExampleResourceNativeTest extends ExampleResourceTest {}

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
@@ -1,6 +1,6 @@
 package org.acme
 
-import io.quarkus.test.junit.NativeImageTest
+import io.quarkus.test.junit.QuarkusIntegrationTest
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NativeExampleResourceIT : ExampleResourceTest()

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/native-test/java/io/quarkus/reproducer/NativeExampleResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/native-test/java/io/quarkus/reproducer/NativeExampleResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.reproducer;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeExampleResourceIT extends ExampleResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/modB/src/native-test/java/org/acme/NativeGreetingResourceIT.java
+++ b/integration-tests/gradle/src/main/resources/multi-module-with-empty-module/modB/src/native-test/java/org/acme/NativeGreetingResourceIT.java
@@ -1,8 +1,8 @@
 package org.acme;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeGreetingResourceIT extends GreetingResourceTest {
 
     // Execute the same tests but in native mode.

--- a/integration-tests/gradle/src/main/resources/multi-source-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/src/native-test/kotlin/org/acme/NativeExampleResourceIT.kt
@@ -1,6 +1,6 @@
 package org.acme
 
-import io.quarkus.test.junit.NativeImageTest
+import io.quarkus.test.junit.QuarkusIntegrationTest
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class NativeExampleResourceIT : ExampleResourceTest()

--- a/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityTest.kt
+++ b/integration-tests/hibernate-orm-panache-kotlin/src/test/kotlin/io/quarkus/it/panache/KotlinPanacheFunctionalityTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.quarkus.it.panache.kotlin.Dog
 import io.quarkus.it.panache.kotlin.Person
-import io.quarkus.test.junit.DisabledOnNativeImage
+import io.quarkus.test.junit.DisabledOnIntegrationTest
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
@@ -41,7 +41,7 @@ open class KotlinPanacheFunctionalityTest {
      * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
      */
     @Test
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Throws(JsonProcessingException::class)
     fun jacksonDeserializationIgnoresPersistentAttribute() { // set Up
         val person = Person()
@@ -62,7 +62,7 @@ open class KotlinPanacheFunctionalityTest {
     }
 
     @Test
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     fun entityManagerIsInjected() {
         assertNotNull(Dog.getEntityManager())
     }

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.test.junit.DisabledOnIntegrationTest;
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -64,7 +63,7 @@ public class PanacheFunctionalityTest {
                         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><person><id>666</id><name>Eddie</name><serialisationTrick>1</serialisationTrick><status>DECEASED</status></person>"));
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void testPanacheInTest() {
         Assertions.assertEquals(0, Person.count());
@@ -105,7 +104,7 @@ public class PanacheFunctionalityTest {
      * This test does not interact with the Quarkus application itself. It is just using the Jackson ObjectMapper with a
      * PanacheEntity. Thus this test is disabled in native mode. The test code runs the JVM and not native.
      */
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void jacksonDeserializationIgnoresPersistentAttribute() throws JsonProcessingException {
         // set Up
@@ -126,7 +125,7 @@ public class PanacheFunctionalityTest {
     /**
      * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
      */
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void jaxbDeserializationHasAllFields() throws JsonProcessingException, JAXBException {
         // set Up
@@ -198,14 +197,14 @@ public class PanacheFunctionalityTest {
                         + PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME + "\",result=\"miss\"}"));
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Transactional
     @Test
     void testBug7102InOneTransaction() {
         testBug7102();
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void testBug7102() {
         Person person = createBug7102();

--- a/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-reactive-panache/src/test/java/io/quarkus/it/panache/reactive/PanacheFunctionalityTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.hibernate.reactive.panache.common.runtime.ReactiveTransactional;
 import io.quarkus.test.TestReactiveTransaction;
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
@@ -64,7 +64,7 @@ public class PanacheFunctionalityTest {
                 .body(is("{\"id\":666,\"dogs\":[],\"name\":\"Eddie\",\"serialisationTrick\":1,\"status\":\"DECEASED\"}"));
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void testPanacheInTest() {
         Assertions.assertEquals(0, Person.count().await().indefinitely());
@@ -87,7 +87,7 @@ public class PanacheFunctionalityTest {
      * This test does not interact with the Quarkus application itself. It is just using the Jackson ObjectMapper with a
      * PanacheEntity. Thus this test is disabled in native mode. The test code runs the JVM and not native.
      */
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void jacksonDeserializationIgnoresPersistentAttribute() throws JsonProcessingException {
         // set Up
@@ -108,7 +108,7 @@ public class PanacheFunctionalityTest {
     /**
      * This test is disabled in native mode as there is no interaction with the quarkus integration test endpoint.
      */
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void jsonbDeserializationHasAllFields() throws JsonProcessingException {
         // set Up
@@ -156,7 +156,7 @@ public class PanacheFunctionalityTest {
         RestAssured.when().get("/test/testSortByNullPrecedence").then().body(is("OK"));
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @ReactiveTransactional
     @Test
     Uni<Void> testTransaction() {
@@ -165,14 +165,14 @@ public class PanacheFunctionalityTest {
         return Uni.createFrom().nullItem();
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     void testNoTransaction() {
         Transaction transaction = Panache.currentTransaction().await().indefinitely();
         Assertions.assertNull(transaction);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @Test
     public void testBug7102() {
         createBug7102()
@@ -212,7 +212,7 @@ public class PanacheFunctionalityTest {
         return Person.findById(id);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @TestReactiveTransaction
     @Test
     @Order(100)
@@ -223,7 +223,7 @@ public class PanacheFunctionalityTest {
         asserter.assertEquals(() -> Person.count(), 1l);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @TestReactiveTransaction
     @Test
     @Order(101)
@@ -233,7 +233,7 @@ public class PanacheFunctionalityTest {
         asserter.assertEquals(() -> Person.count(), 0l);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @ReactiveTransactional
     @Test
     @Order(200)
@@ -244,7 +244,7 @@ public class PanacheFunctionalityTest {
         asserter.assertEquals(() -> Person.count(), 1l);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @ReactiveTransactional
     @Test
     @Order(201)
@@ -257,7 +257,7 @@ public class PanacheFunctionalityTest {
         asserter.execute(() -> Panache.currentTransaction().invoke(tx -> tx.markForRollback()));
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @ReactiveTransactional
     @Test
     @Order(202)
@@ -269,7 +269,7 @@ public class PanacheFunctionalityTest {
         asserter.assertEquals(() -> Person.deleteAll(), 1l);
     }
 
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     @RunOnVertxContext
     @Test
     @Order(300)

--- a/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/JPAFunctionalityInGraalITCase.java
+++ b/integration-tests/jpa-db2/src/test/java/io/quarkus/it/jpa/db2/JPAFunctionalityInGraalITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jpa.db2;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class JPAFunctionalityInGraalITCase extends JPAFunctionalityTest {
 }

--- a/integration-tests/jpa-mapping-xml/modern-app/src/test/java/io/quarkus/it/jpa/mapping/xml/modern/app/XmlMappingOnlyAttributeConverterITCase.java
+++ b/integration-tests/jpa-mapping-xml/modern-app/src/test/java/io/quarkus/it/jpa/mapping/xml/modern/app/XmlMappingOnlyAttributeConverterITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jpa.mapping.xml.modern.app;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class XmlMappingOnlyAttributeConverterITCase extends XmlMappingOnlyAttributeConverterTest {
 }

--- a/integration-tests/jpa-mapping-xml/modern-app/src/test/java/io/quarkus/it/jpa/mapping/xml/modern/app/XmlMappingOnlyEntityListenerITCase.java
+++ b/integration-tests/jpa-mapping-xml/modern-app/src/test/java/io/quarkus/it/jpa/mapping/xml/modern/app/XmlMappingOnlyEntityListenerITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jpa.mapping.xml.modern.app;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class XmlMappingOnlyEntityListenerITCase extends XmlMappingOnlyEntityListenerTest {
 }

--- a/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/entitylistener/EntityListenerInGraalITCase.java
+++ b/integration-tests/jpa/src/test/java/io/quarkus/it/jpa/entitylistener/EntityListenerInGraalITCase.java
@@ -1,7 +1,7 @@
 package io.quarkus.it.jpa.entitylistener;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class EntityListenerInGraalITCase extends EntityListenerTest {
 }

--- a/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
+++ b/integration-tests/locales/src/test/java/io/quarkus/locales/it/LocalesIT.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 
 /**
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
  * glibc-all-langpacks
  *
  */
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LocalesIT {
 
     private static final Logger LOG = Logger.getLogger(LocalesIT.class);

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/HealthCheckTestCase.java
@@ -6,12 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.wildfly.common.Assert;
 
 import io.quarkus.it.health.SimpleHealthCheck;
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@DisabledOnNativeImage("This test is not meant to be ran in native mode as Quarkus does not yet support injection " +
-        "in native " + "tests - see https://quarkus.io/guides/getting-started-testing#native-executable-testing")
+@DisabledOnIntegrationTest("This test is not meant to be ran in native mode as Quarkus does not yet support injection " +
+        "in native tests - see https://quarkus.io/guides/getting-started-testing#native-executable-testing")
 public class HealthCheckTestCase {
 
     final SimpleHealthCheck simpleHealthCheck;

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/JaxRSTestCase.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.it.rest.TestResource;
 import io.quarkus.it.rest.TestResourceWithVariable;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
@@ -37,7 +37,7 @@ public class JaxRSTestCase {
     }
 
     @Test
-    @DisabledOnNativeImage //the native image tests will bind to 0.0.0.0 as the image is a production image, but the test datasource in the JVM will want to use localhost
+    @DisabledOnIntegrationTest //the native image tests will bind to 0.0.0.0 as the image is a production image, but the test datasource in the JVM will want to use localhost
     public void testConfigInjectionOfPort() {
         String host = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class).orElse("0.0.0.0");
         RestAssured.when().get("/test/config/host").then().body(is(host));

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/ResourcesTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/ResourcesTestCase.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
@@ -21,7 +21,7 @@ public class ResourcesTestCase {
     }
 
     @Test
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     public void excludedJvm() {
         RestAssured.when()
                 .get("/resources/test-resources/file.adoc")

--- a/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
+++ b/integration-tests/no-awt/src/test/java/io/quarkus/awt/it/GraphicsIT.java
@@ -19,10 +19,10 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.RestAssured;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class GraphicsIT {
 
     private static final Logger LOG = Logger.getLogger(GraphicsIT.class);

--- a/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsIT.java
+++ b/integration-tests/reactive-messaging-rabbitmq-dyn/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorDynCredsIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.rabbitmq;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class RabbitMQConnectorDynCredsIT extends RabbitMQConnectorDynCredsTest {
 
 }

--- a/integration-tests/reactive-messaging-rabbitmq/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorIT.java
+++ b/integration-tests/reactive-messaging-rabbitmq/src/test/java/io/quarkus/it/rabbitmq/RabbitMQConnectorIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.it.rabbitmq;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class RabbitMQConnectorIT extends RabbitMQConnectorTest {
 
 }

--- a/integration-tests/rest-client-reactive-kotlin-serialization/src/test/kotlin/io/quarkus/it/rest/client/BasicTestIT.kt
+++ b/integration-tests/rest-client-reactive-kotlin-serialization/src/test/kotlin/io/quarkus/it/rest/client/BasicTestIT.kt
@@ -1,6 +1,6 @@
 package io.quarkus.it.rest.client
 
-import io.quarkus.test.junit.NativeImageTest
+import io.quarkus.test.junit.QuarkusIntegrationTest
 
-@NativeImageTest
+@QuarkusIntegrationTest
 class BasicTestIT : BasicTest()

--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ClasspathTestCase.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnNativeImage;
+import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
@@ -34,7 +34,7 @@ public class ClasspathTestCase {
     @Test
     // Static init may happen in a container when testing a native image,
     // in which case we don't have any classpath record to check.
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     public void testStaticInitMainClassNoDuplicate() {
         given().param("resourceName", CLASS_FILE)
                 .param("phase", "static_init")
@@ -45,7 +45,7 @@ public class ClasspathTestCase {
     @Test
     // Static init may happen in a container when testing a native image,
     // in which case we don't have any classpath record to check.
-    @DisabledOnNativeImage
+    @DisabledOnIntegrationTest
     public void testStaticInitMainResourceNoDuplicate() {
         given().param("resourceName", RESOURCE_FILE)
                 .param("phase", "static_init")


### PR DESCRIPTION
`@DisabledOnNativeImage` and `@NativeImageTest` are deprecated, using `@DisabledOnIntegrationTest` and `@QuarkusIntegrationTest` instead.