### PR TITLE
Corrected AUTH_SERVER_URL_PROP in KeycloakTestClient

### DIFF
--- a/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
+++ b/test-framework/keycloak-server/src/main/java/io/quarkus/test/keycloak/client/KeycloakTestClient.java
@@ -17,7 +17,7 @@ import io.restassured.specification.RequestSpecification;
 public class KeycloakTestClient implements DevServicesContext.ContextAware {
 
     private final static String CLIENT_AUTH_SERVER_URL_PROP = "client.quarkus.oidc.auth-server-url";
-    private final static String AUTH_SERVER_URL_PROP = "client.quarkus.oidc.auth-server-url";
+    private final static String AUTH_SERVER_URL_PROP = "quarkus.oidc.auth-server-url";
     private final static String CLIENT_ID_PROP = "quarkus.oidc.client-id";
     private final static String CLIENT_SECRET_PROP = "quarkus.oidc.credentials.secret";
 


### PR DESCRIPTION
Both `AUTH_SERVER_URL_PROP` and `CLIENT_AUTH_SERVER_URL_PROP` constants in `KeycloakTestClient` are set as `client.quarkus.oidc.auth-server-url` and it seems the idea is `client.quarkus.oidc.auth-server-url` takes the precedence and is used to override if we want to not to use the default `quarkus.oidc.auth-server-url` which will be set when using quarkus-oidc extension.