### PR TITLE
Close event handling on reactive SseBroadcaster

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseBroadcasterImpl.java
@@ -72,7 +72,9 @@ public class SseBroadcasterImpl implements SseBroadcaster {
 
     synchronized void fireClose(SseEventSinkImpl sseEventSink) {
         for (Consumer<SseEventSink> listener : onCloseListeners) {
-            listener.accept(sseEventSink);
+            if (sinks.remove(sseEventSink)) {
+                listener.accept(sseEventSink);
+            }
         }
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
@@ -75,7 +75,13 @@ public class SseEventSinkImpl implements SseEventSink {
                     // I don't think we should be firing the exception on the broadcaster here
                 }
             });
-            response.addCloseHandler(this::close);
+            response.addCloseHandler(() -> {
+                if (broadcaster != null) {
+                    broadcaster.fireClose(this);
+                }
+                // Not sure if this call is necessary, as the sink results already closed when executing this handler
+                close();
+            });
         }
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/jaxrs/SseEventSinkImpl.java
@@ -75,10 +75,7 @@ public class SseEventSinkImpl implements SseEventSink {
                     // I don't think we should be firing the exception on the broadcaster here
                 }
             });
-            //            response.closeHandler(v -> {
-            //                // FIXME: notify of client closing
-            //                System.err.println("Server connection closed");
-            //            });
+            response.addCloseHandler(this::close);
         }
     }
 


### PR DESCRIPTION
Added the necessary handling on SseBroadcasterImpl, since it's method onClose() was never called in the case it was the client to close the response. 