### PR TITLE
Add global rest-client config properties

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/deployment/src/main/java/io/quarkus/restclient/config/deployment/RestClientConfigUtils.java
+++ b/extensions/resteasy-classic/rest-client-config/deployment/src/main/java/io/quarkus/restclient/config/deployment/RestClientConfigUtils.java
@@ -1,5 +1,6 @@
 package io.quarkus.restclient.config.deployment;
 
+import static io.quarkus.restclient.config.Constants.GLOBAL_REST_SCOPE_FORMAT;
 import static io.quarkus.restclient.config.Constants.MP_REST_SCOPE_FORMAT;
 import static io.quarkus.restclient.config.Constants.QUARKUS_REST_SCOPE_FORMAT;
 
@@ -30,6 +31,10 @@ public final class RestClientConfigUtils {
             scopeConfig = config.getOptionalValue(String.format(QUARKUS_REST_SCOPE_FORMAT, configKeyOptional.get()),
                     String.class);
         }
+        if (scopeConfig.isEmpty() && configKeyOptional.isPresent()) { // quarkus style config; quoted configKey
+            scopeConfig = config.getOptionalValue(String.format(QUARKUS_REST_SCOPE_FORMAT, '"' + configKeyOptional.get() + '"'),
+                    String.class);
+        }
         if (scopeConfig.isEmpty() && configKeyOptional.isPresent()) { // microprofile style config; configKey
             scopeConfig = config.getOptionalValue(String.format(MP_REST_SCOPE_FORMAT, configKeyOptional.get()), String.class);
         }
@@ -37,6 +42,9 @@ public final class RestClientConfigUtils {
             scopeConfig = config.getOptionalValue(
                     String.format(QUARKUS_REST_SCOPE_FORMAT, restClientInterface.simpleName()),
                     String.class);
+        }
+        if (scopeConfig.isEmpty()) { // "global" rest-config property as a fallback
+            scopeConfig = config.getOptionalValue(GLOBAL_REST_SCOPE_FORMAT, String.class);
         }
         return scopeConfig;
     }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/Constants.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/Constants.java
@@ -6,6 +6,7 @@ public final class Constants {
     public static final String MP_REST = "/mp-rest/";
     public static final String MP_REST_SCOPE_FORMAT = "%s" + MP_REST + "scope";
     public static final String QUARKUS_REST_SCOPE_FORMAT = QUARKUS_CONFIG_PREFIX + "%s.scope";
+    public static final String GLOBAL_REST_SCOPE_FORMAT = QUARKUS_CONFIG_PREFIX + "scope";
 
     private Constants() {
     }

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -199,6 +199,8 @@ public class RestClientConfig {
 
     /**
      * The HTTP headers that should be applied to all requests of the rest client.
+     *
+     * This property is applicable to reactive REST clients only.
      */
     @ConfigItem
     public Map<String, String> headers;

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -6,6 +6,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.enterprise.inject.CreationException;
 
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -60,8 +62,9 @@ public class RestClientsConfig {
 
     /**
      * A string value in the form of `<proxyHost>:<proxyPort>` that specifies the HTTP proxy server hostname
-     * (or IP address) and port for requests of clients to use. Can be overwritten by client-specific settings
+     * (or IP address) and port for requests of clients to use.
      *
+     * Can be overwritten by client-specific settings.
      *
      * This property is applicable to reactive REST clients only.
      */
@@ -71,6 +74,8 @@ public class RestClientsConfig {
     /**
      * Proxy username, equivalent to the http.proxy or https.proxy JVM settings.
      *
+     * Can be overwritten by client-specific settings.
+     *
      * This property is applicable to reactive REST clients only.
      */
     @ConfigItem
@@ -79,6 +84,8 @@ public class RestClientsConfig {
     /**
      * Proxy password, equivalent to the http.proxyPassword or https.proxyPassword JVM settings.
      *
+     * Can be overwritten by client-specific settings.
+     *
      * This property is applicable to reactive REST clients only.
      */
     @ConfigItem
@@ -86,7 +93,9 @@ public class RestClientsConfig {
 
     /**
      * Hosts to access without proxy, similar to the http.nonProxyHosts or https.nonProxyHosts JVM settings.
-     * Please note that unlike the JVM settings, this property is empty by default
+     * Please note that unlike the JVM settings, this property is empty by default.
+     *
+     * Can be overwritten by client-specific settings.
      *
      * This property is applicable to reactive REST clients only.
      */
@@ -96,33 +105,167 @@ public class RestClientsConfig {
     public RestClientLoggingConfig logging;
 
     /**
-     * Global default connect timeout for automatically generated REST Clients. The attribute specifies a timeout
-     * in milliseconds that a client should wait to connect to the remote endpoint.
+     * A timeout in milliseconds that REST clients should wait to connect to the remote endpoint.
+     *
+     * Can be overwritten by client-specific settings.
      */
     @ConfigItem(defaultValue = "15000", defaultValueDocumentation = "15000 ms")
     public Long connectTimeout;
 
     /**
-     * Global default read timeout for automatically generated REST clients. The attribute specifies a timeout
-     * in milliseconds that a client should wait for a response from the remote endpoint.
+     * A timeout in milliseconds that REST clients should wait for a response from the remote endpoint.
+     *
+     * Can be overwritten by client-specific settings.
      */
     @ConfigItem(defaultValue = "30000", defaultValueDocumentation = "30000 ms")
     public Long readTimeout;
 
     /**
-     * If true, the reactive REST clients will not provide additional contextual information (like REST client class and method
+     * If true, the REST clients will not provide additional contextual information (like REST client class and method
      * names) when exception occurs during a client invocation.
+     *
+     * This property is applicable to reactive REST clients only.
      */
     @ConfigItem(defaultValue = "false")
     public boolean disableContextualErrorMessages;
 
     /**
-     * Configure the HTTP user-agent header to use.
+     * Default configuration for the HTTP user-agent header to use in all REST clients.
+     *
+     * Can be overwritten by client-specific settings.
      *
      * This property is applicable to reactive REST clients only.
      */
     @ConfigItem
     public Optional<String> userAgent;
+
+    /**
+     * The HTTP headers that should be applied to all requests of the rest client.
+     */
+    @ConfigItem
+    public Map<String, String> headers;
+
+    /**
+     * The class name of the host name verifier. The class must have a public no-argument constructor.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> hostnameVerifier;
+
+    /**
+     * The time in ms for which a connection remains unused in the connection pool before being evicted and closed.
+     * A timeout of {@code 0} means there is no timeout.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<Integer> connectionTTL;
+
+    /**
+     * The size of the connection pool for this client.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<Integer> connectionPoolSize;
+
+    /**
+     * The maximum number of redirection a request can follow.
+     *
+     * Can be overwritten by client-specific settings.
+     *
+     * This property is applicable to reactive REST clients only.
+     */
+    @ConfigItem
+    public Optional<Integer> maxRedirects;
+
+    /**
+     * A boolean value used to determine whether the client should follow HTTP redirect responses.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<Boolean> followRedirects;
+
+    /**
+     * Map where keys are fully-qualified provider classnames to include in the client, and values are their integer
+     * priorities. The equivalent of the `@RegisterProvider` annotation.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> providers;
+
+    /**
+     * The CDI scope to use for injections of REST client instances. Value can be either a fully qualified class name of a CDI
+     * scope annotation (such as "javax.enterprise.context.ApplicationScoped") or its simple name (such as"ApplicationScoped").
+     *
+     * Default scope for the rest-client extension is "Dependent" (which is the spec-compliant behavior).
+     *
+     * Default scope for the rest-client-reactive extension is "ApplicationScoped".
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> scope;
+
+    /**
+     * An enumerated type string value with possible values of "MULTI_PAIRS" (default), "COMMA_SEPARATED",
+     * or "ARRAY_PAIRS" that specifies the format in which multiple values for the same query parameter is used.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<QueryParamStyle> queryParamStyle;
+
+    /**
+     * The trust store location. Can point to either a classpath resource or a file.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> trustStore;
+
+    /**
+     * The trust store password.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> trustStorePassword;
+
+    /**
+     * The type of the trust store. Defaults to "JKS".
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> trustStoreType;
+
+    /**
+     * The key store location. Can point to either a classpath resource or a file.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> keyStore;
+
+    /**
+     * The key store password.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> keyStorePassword;
+
+    /**
+     * The type of the key store. Defaults to "JKS".
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<String> keyStoreType;
 
     public RestClientConfig getClientConfig(String configKey) {
         if (configKey == null) {

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/GlobalConfigurationTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/GlobalConfigurationTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.restclient.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GlobalConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(EchoClient.class, EchoResource.class, MyResponseFilter.class,
+                    MyHostnameVerifier.class))
+            .withConfigurationResource("global-configuration-test-application.properties");
+
+    @Inject
+    RestClientsConfig configRoot;
+
+    @RestClient
+    EchoClient client;
+
+    @Test
+    void shouldHaveSingletonScope() {
+        BeanManager beanManager = Arc.container().beanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(EchoClient.class, RestClient.LITERAL);
+        Bean<?> resolvedBean = beanManager.resolve(beans);
+        assertThat(resolvedBean.getScope()).isEqualTo(Singleton.class);
+    }
+
+    @Test
+    void shouldRespond() {
+        assertThat(client.echo("world")).contains("world");
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    void checkGlobalConfigValues() {
+        // global properties:
+        assertThat(configRoot.disableSmartProduces.get()).isTrue();
+        assertThat(configRoot.multipartPostEncoderMode.get()).isEqualTo("HTML5");
+        assertThat(configRoot.disableContextualErrorMessages).isTrue();
+
+        // global defaults for client specific properties:
+        assertThat(configRoot.scope.get()).isEqualTo("Singleton");
+        assertThat(configRoot.proxyAddress.get()).isEqualTo("host:123");
+        assertThat(configRoot.proxyUser.get()).isEqualTo("proxyUser");
+        assertThat(configRoot.proxyPassword.get()).isEqualTo("proxyPassword");
+        assertThat(configRoot.nonProxyHosts.get()).isEqualTo("nonProxyHosts");
+        assertThat(configRoot.connectTimeout).isEqualTo(2000);
+        assertThat(configRoot.readTimeout).isEqualTo(2001);
+        assertThat(configRoot.userAgent.get()).isEqualTo("agent");
+        assertThat(configRoot.headers).isEqualTo(Collections.singletonMap("foo", "bar"));
+        assertThat(configRoot.hostnameVerifier.get())
+                .isEqualTo("io.quarkus.restclient.configuration.MyHostnameVerifier");
+        assertThat(configRoot.connectionTTL.get()).isEqualTo(20000); // value in ms, will be converted to seconds
+        assertThat(configRoot.connectionPoolSize.get()).isEqualTo(2);
+        assertThat(configRoot.maxRedirects.get()).isEqualTo(2);
+        assertThat(configRoot.followRedirects.get()).isTrue();
+        assertThat(configRoot.providers.get())
+                .isEqualTo("io.quarkus.restclient.configuration.MyResponseFilter");
+        assertThat(configRoot.queryParamStyle.get()).isEqualTo(QueryParamStyle.MULTI_PAIRS);
+
+        assertThat(configRoot.trustStore.get()).isEqualTo("/path");
+        assertThat(configRoot.trustStorePassword.get()).isEqualTo("password");
+        assertThat(configRoot.trustStoreType.get()).isEqualTo("JKS");
+        assertThat(configRoot.keyStore.get()).isEqualTo("/path");
+        assertThat(configRoot.keyStorePassword.get()).isEqualTo("password");
+        assertThat(configRoot.keyStoreType.get()).isEqualTo("JKS");
+    }
+
+}

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/resources/global-configuration-test-application.properties
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/resources/global-configuration-test-application.properties
@@ -1,0 +1,41 @@
+# Legacy reactive rest client configs
+quarkus.rest-client-reactive.disable-smart-produces=true
+quarkus.rest-client-reactive.scope=InvalidScope
+quarkus.rest-client-reactive.provider-autodiscovery=false
+
+# Global configs
+quarkus.rest-client.multipart-post-encoder-mode=HTML5
+quarkus.rest-client.disable-contextual-error-messages=true
+quarkus.rest-client.disable-smart-produces=true
+
+# Global configs that can be overridden by client-specific configs
+quarkus.rest-client.scope=Singleton
+quarkus.rest-client.proxy-address=host:123
+quarkus.rest-client.proxy-user=proxyUser
+quarkus.rest-client.proxy-password=proxyPassword
+quarkus.rest-client.non-proxy-hosts=nonProxyHosts
+quarkus.rest-client.connect-timeout=2000
+quarkus.rest-client.read-timeout=2001
+quarkus.rest-client.user-agent=agent
+quarkus.rest-client.headers.foo=bar
+quarkus.rest-client.hostname-verifier=io.quarkus.restclient.configuration.MyHostnameVerifier
+quarkus.rest-client.connection-ttl=20000
+quarkus.rest-client.connection-pool-size=2
+quarkus.rest-client.max-redirects=2
+quarkus.rest-client.follow-redirects=true
+quarkus.rest-client.providers=io.quarkus.restclient.configuration.MyResponseFilter
+quarkus.rest-client.query-param-style=MULTI_PAIRS
+
+quarkus.rest-client.trust-store=/path
+quarkus.rest-client.trust-store-password=password
+quarkus.rest-client.trust-store-type=JKS
+quarkus.rest-client.key-store=/path
+quarkus.rest-client.key-store-password=password
+quarkus.rest-client.key-store-type=JKS
+
+# Specific client configuration, this is to allow for the client to be successfully created.
+# Override proxy, trust store and key store, as they don't exist.
+quarkus.rest-client.EchoClient.url=http://localhost:${quarkus.http.test-port:8081}
+quarkus.rest-client.EchoClient.proxy-address=none
+quarkus.rest-client.EchoClient.trust-store=none
+quarkus.rest-client.EchoClient.key-store=none

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/resources/quarkus-restclients-test-application.properties
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/resources/quarkus-restclients-test-application.properties
@@ -11,3 +11,6 @@ quarkus.rest-client."io.quarkus.restclient.configuration.EchoClient".scope=Singl
 # client identified by a simple class name
 quarkus.rest-client.ShortNameEchoClient.url=http://localhost:${quarkus.http.test-port:8081}
 quarkus.rest-client.ShortNameEchoClient.scope=Singleton
+
+# default client scope, should be overridden by client specific settings above
+quarkus.rest-client.scope=ApplicationScoped

--- a/extensions/resteasy-classic/rest-client/runtime/src/test/java/io/quarkus/restclient/runtime/RestClientBaseTest.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/test/java/io/quarkus/restclient/runtime/RestClientBaseTest.java
@@ -3,6 +3,7 @@ package io.quarkus.restclient.runtime;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -68,88 +69,121 @@ public class RestClientBaseTest {
     }
 
     @Test
-    public void testQuarkusConfig() throws Exception {
-        RestClientsConfig configRoot = createSampleConfiguration();
+    public void testClientSpecificConfigs() throws Exception {
+        // given
+
+        RestClientsConfig configRoot = createSampleConfigRoot();
+        configRoot.putClientConfig("test-client", createSampleClientConfig());
+
+        // when
+
         RestClientBuilder restClientBuilderMock = Mockito.mock(RestClientBuilder.class);
         RestClientBase restClientBase = new RestClientBase(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
                 null,
                 configRoot);
-        restClientBase.configureBaseUrl(restClientBuilderMock);
-        restClientBase.configureTimeouts(restClientBuilderMock);
-        restClientBase.configureProviders(restClientBuilderMock);
-        restClientBase.configureSsl(restClientBuilderMock);
-        restClientBase.configureProxy(restClientBuilderMock);
-        restClientBase.configureRedirects(restClientBuilderMock);
-        restClientBase.configureQueryParamStyle(restClientBuilderMock);
-        restClientBase.configureCustomProperties(restClientBuilderMock);
+        restClientBase.configureBuilder(restClientBuilderMock);
+
+        // then
 
         Mockito.verify(restClientBuilderMock).baseUrl(new URL("http://localhost"));
-        Mockito.verify(restClientBuilderMock).register(MyResponseFilter1.class);
+        Mockito.verify(restClientBuilderMock).proxyAddress("host1", 123);
         Mockito.verify(restClientBuilderMock).connectTimeout(100, TimeUnit.MILLISECONDS);
         Mockito.verify(restClientBuilderMock).readTimeout(101, TimeUnit.MILLISECONDS);
-        Mockito.verify(restClientBuilderMock).followRedirects(true);
-        Mockito.verify(restClientBuilderMock).proxyAddress("localhost", 1234);
-        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.COMMA_SEPARATED);
-        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
-        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
         Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier1.class));
         Mockito.verify(restClientBuilderMock).property("resteasy.connectionTTL", Arrays.asList(102, TimeUnit.MILLISECONDS));
         Mockito.verify(restClientBuilderMock).property("resteasy.connectionPoolSize", 103);
+        Mockito.verify(restClientBuilderMock).followRedirects(true);
+        Mockito.verify(restClientBuilderMock).register(MyResponseFilter1.class);
+        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.COMMA_SEPARATED);
+
+        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
+        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
     }
 
     @Test
-    public void testGlobalTimeouts() {
-        RestClientsConfig configRoot = new RestClientsConfig();
-        configRoot.connectTimeout = 5000L;
-        configRoot.readTimeout = 10000L;
+    public void testGlobalConfigs() throws MalformedURLException {
+        // given
+
+        RestClientsConfig configRoot = createSampleConfigRoot();
+
+        // when
+
         RestClientBuilder restClientBuilderMock = Mockito.mock(RestClientBuilder.class);
         RestClientBase restClientBase = new RestClientBase(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
                 null,
                 configRoot);
-        restClientBase.configureTimeouts(restClientBuilderMock);
+        restClientBase.configureBuilder(restClientBuilderMock);
 
-        Mockito.verify(restClientBuilderMock).connectTimeout(5000, TimeUnit.MILLISECONDS);
-        Mockito.verify(restClientBuilderMock).readTimeout(10000, TimeUnit.MILLISECONDS);
+        // then
+
+        Mockito.verify(restClientBuilderMock).baseUrl(new URL("http://localhost:8080"));
+        Mockito.verify(restClientBuilderMock).proxyAddress("host2", 123);
+        Mockito.verify(restClientBuilderMock).connectTimeout(200, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).readTimeout(201, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier2.class));
+        Mockito.verify(restClientBuilderMock).property("resteasy.connectionTTL", Arrays.asList(202, TimeUnit.MILLISECONDS));
+        Mockito.verify(restClientBuilderMock).property("resteasy.connectionPoolSize", 203);
+        Mockito.verify(restClientBuilderMock).followRedirects(true);
+        Mockito.verify(restClientBuilderMock).register(MyResponseFilter2.class);
+        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.MULTI_PAIRS);
+
+        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
+        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
     }
 
-    /**
-     * This method creates a Quarkus style configuration object (which would normally be created based on the MP config
-     * properties, but it's easier to instantiate it directly here).
-     */
-    private static RestClientsConfig createSampleConfiguration() {
+    private static RestClientsConfig createSampleConfigRoot() {
+        RestClientsConfig configRoot = new RestClientsConfig();
+
+        configRoot.proxyAddress = Optional.of("host2:123");
+        configRoot.connectTimeout = 200L;
+        configRoot.readTimeout = 201L;
+        configRoot.hostnameVerifier = Optional.of("io.quarkus.restclient.runtime.RestClientBaseTest$MyHostnameVerifier2");
+        configRoot.connectionTTL = Optional.of(202);
+        configRoot.connectionPoolSize = Optional.of(203);
+        configRoot.followRedirects = Optional.of(true);
+        configRoot.providers = Optional.of("io.quarkus.restclient.runtime.RestClientBaseTest$MyResponseFilter2");
+        configRoot.queryParamStyle = Optional.of(QueryParamStyle.MULTI_PAIRS);
+
+        configRoot.trustStore = Optional.of(truststoreFile.getAbsolutePath());
+        configRoot.trustStorePassword = Optional.of("truststorePassword");
+        configRoot.trustStoreType = Optional.of("JKS");
+        configRoot.keyStore = Optional.of(keystoreFile.getAbsolutePath());
+        configRoot.keyStorePassword = Optional.of("keystorePassword");
+        configRoot.keyStoreType = Optional.of("JKS");
+
+        return configRoot;
+    }
+
+    private static RestClientConfig createSampleClientConfig() {
         RestClientConfig clientConfig = new RestClientConfig();
+
+        // properties only configurable via client config
         clientConfig.url = Optional.of("http://localhost");
         clientConfig.uri = Optional.empty();
-        clientConfig.scope = Optional.of("Singleton");
-        clientConfig.providers = Optional
-                .of("io.quarkus.restclient.runtime.RestClientBaseTest$MyResponseFilter1");
+
+        // properties that override configRoot counterparts
+        clientConfig.proxyAddress = Optional.of("host1:123");
         clientConfig.connectTimeout = Optional.of(100L);
         clientConfig.readTimeout = Optional.of(101L);
+        clientConfig.hostnameVerifier = Optional.of("io.quarkus.restclient.runtime.RestClientBaseTest$MyHostnameVerifier1");
+        clientConfig.connectionTTL = Optional.of(102);
+        clientConfig.connectionPoolSize = Optional.of(103);
         clientConfig.followRedirects = Optional.of(true);
-        clientConfig.proxyAddress = Optional.of("localhost:1234");
+        clientConfig.providers = Optional.of("io.quarkus.restclient.runtime.RestClientBaseTest$MyResponseFilter1");
         clientConfig.queryParamStyle = Optional.of(QueryParamStyle.COMMA_SEPARATED);
+
         clientConfig.trustStore = Optional.of(truststoreFile.getAbsolutePath());
         clientConfig.trustStorePassword = Optional.of("truststorePassword");
         clientConfig.trustStoreType = Optional.of("JKS");
         clientConfig.keyStore = Optional.of(keystoreFile.getAbsolutePath());
         clientConfig.keyStorePassword = Optional.of("keystorePassword");
         clientConfig.keyStoreType = Optional.of("JKS");
-        clientConfig.hostnameVerifier = Optional
-                .of("io.quarkus.restclient.runtime.RestClientBaseTest$MyHostnameVerifier1");
-        clientConfig.connectionTTL = Optional.of(102);
-        clientConfig.connectionPoolSize = Optional.of(103);
-        clientConfig.maxRedirects = Optional.of(104);
 
-        RestClientsConfig configRoot = new RestClientsConfig();
-        configRoot.multipartPostEncoderMode = Optional.of("HTML5");
-        configRoot.disableSmartProduces = Optional.of(true);
-        configRoot.putClientConfig("test-client", clientConfig);
-
-        return configRoot;
+        return clientConfig;
     }
 
     @RegisterRestClient

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ConfigurationTest.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
@@ -18,22 +17,17 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.arc.Arc;
 import io.quarkus.rest.client.reactive.configuration.EchoResource;
 import io.quarkus.restclient.config.RestClientConfig;
-import io.quarkus.restclient.config.RestClientsConfig;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ConfigurationTest {
 
     @RegisterExtension
     static final QuarkusUnitTest TEST = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(HelloClientWithBaseUri.class, EchoResource.class))
+            .withApplicationRoot(jar -> jar.addClasses(HelloClientWithBaseUri.class, EchoResource.class))
             .withConfigurationResource("configuration-test-application.properties");
 
     @RestClient
     HelloClientWithBaseUri client;
-
-    @Inject
-    RestClientsConfig configRoot;
 
     @Test
     void shouldHaveSingletonScope() {
@@ -49,12 +43,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    void configurationShouldBeLoaded() {
-        assertThat(configRoot.disableSmartProduces).isPresent();
-        assertThat(configRoot.disableSmartProduces.get()).isTrue();
-        assertThat(configRoot.multipartPostEncoderMode).isPresent();
-        assertThat(configRoot.multipartPostEncoderMode.get()).isEqualTo("HTML5");
-
+    void checkClientSpecificConfigs() {
         RestClientConfig clientConfig = RestClientConfig.load(io.quarkus.rest.client.reactive.HelloClientWithBaseUri.class);
         verifyClientConfig(clientConfig, true);
 
@@ -71,8 +60,6 @@ public class ConfigurationTest {
 
         clientConfig = RestClientConfig.load("mp-client-prefix");
         verifyClientConfig(clientConfig, false);
-        assertThat(clientConfig.maxRedirects.isPresent()).isTrue();
-        assertThat(clientConfig.maxRedirects.get()).isEqualTo(4);
     }
 
     private void verifyClientConfig(RestClientConfig clientConfig, boolean checkExtraProperties) {

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/GlobalConfigurationTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.rest.client.reactive.configuration.EchoResource;
+import io.quarkus.restclient.config.RestClientsConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GlobalConfigurationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot(jar -> jar.addClasses(HelloClientWithBaseUri.class, EchoResource.class))
+            .withConfigurationResource("global-configuration-test-application.properties");
+
+    @Inject
+    RestClientsConfig configRoot;
+
+    @RestClient
+    HelloClientWithBaseUri client;
+
+    @Test
+    void shouldHaveSingletonScope() {
+        BeanManager beanManager = Arc.container().beanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(HelloClientWithBaseUri.class, RestClient.LITERAL);
+        Bean<?> resolvedBean = beanManager.resolve(beans);
+        assertThat(resolvedBean.getScope()).isEqualTo(Singleton.class);
+    }
+
+    @Test
+    void shouldRespond() {
+        assertThat(client.echo("world")).contains("world");
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    void checkGlobalConfigValues() {
+        // global properties:
+        assertThat(configRoot.disableSmartProduces.get()).isTrue();
+        assertThat(configRoot.multipartPostEncoderMode.get()).isEqualTo("HTML5");
+        assertThat(configRoot.disableContextualErrorMessages).isTrue();
+
+        // global defaults for client specific properties:
+        assertThat(configRoot.scope.get()).isEqualTo("Singleton");
+        assertThat(configRoot.proxyAddress.get()).isEqualTo("host:123");
+        assertThat(configRoot.proxyUser.get()).isEqualTo("proxyUser");
+        assertThat(configRoot.proxyPassword.get()).isEqualTo("proxyPassword");
+        assertThat(configRoot.nonProxyHosts.get()).isEqualTo("nonProxyHosts");
+        assertThat(configRoot.connectTimeout).isEqualTo(2000);
+        assertThat(configRoot.readTimeout).isEqualTo(2001);
+        assertThat(configRoot.userAgent.get()).isEqualTo("agent");
+        assertThat(configRoot.headers).isEqualTo(Collections.singletonMap("foo", "bar"));
+        assertThat(configRoot.hostnameVerifier.get())
+                .isEqualTo("io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier");
+        assertThat(configRoot.connectionTTL.get()).isEqualTo(20000); // value in ms, will be converted to seconds
+        assertThat(configRoot.connectionPoolSize.get()).isEqualTo(2);
+        assertThat(configRoot.maxRedirects.get()).isEqualTo(2);
+        assertThat(configRoot.followRedirects.get()).isTrue();
+        assertThat(configRoot.providers.get())
+                .isEqualTo("io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyResponseFilter");
+        assertThat(configRoot.queryParamStyle.get()).isEqualTo(QueryParamStyle.MULTI_PAIRS);
+
+        assertThat(configRoot.trustStore.get()).isEqualTo("/path");
+        assertThat(configRoot.trustStorePassword.get()).isEqualTo("password");
+        assertThat(configRoot.trustStoreType.get()).isEqualTo("JKS");
+        assertThat(configRoot.keyStore.get()).isEqualTo("/path");
+        assertThat(configRoot.keyStorePassword.get()).isEqualTo("password");
+        assertThat(configRoot.keyStoreType.get()).isEqualTo("JKS");
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/configuration-test-application.properties
@@ -3,15 +3,6 @@ io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/url=http://localh
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/scope=InvalidScope
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/providers=InvalidProvider
 io.quarkus.rest.client.reactive.HelloClientWithBaseUri/mp-rest/hostnameVerifier=InvalidVerifier
-quarkus.rest-client-reactive.scope=InvalidScope
-quarkus.rest-client-reactive.disable-smart-produces=false
-quarkus.rest.client.max-redirects=4
-quarkus.rest.client.multipart-post-encoder-mode=RFC3986
-
-# quarkus style configurations
-
-quarkus.rest-client.disable-smart-produces=true
-quarkus.rest-client.multipart-post-encoder-mode=HTML5
 
 # client identified by class name
 quarkus.rest-client."io.quarkus.rest.client.reactive.HelloClientWithBaseUri".url=http://localhost:${quarkus.http.test-port:8081}/hello

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/global-configuration-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/global-configuration-test-application.properties
@@ -1,0 +1,41 @@
+# Legacy reactive rest client configs
+quarkus.rest-client-reactive.disable-smart-produces=true
+quarkus.rest-client-reactive.scope=InvalidScope
+quarkus.rest-client-reactive.provider-autodiscovery=false
+
+# Global configs
+quarkus.rest-client.multipart-post-encoder-mode=HTML5
+quarkus.rest-client.disable-contextual-error-messages=true
+quarkus.rest-client.disable-smart-produces=true
+
+# Global configs that can be overridden by client-specific configs
+quarkus.rest-client.scope=Singleton
+quarkus.rest-client.proxy-address=host:123
+quarkus.rest-client.proxy-user=proxyUser
+quarkus.rest-client.proxy-password=proxyPassword
+quarkus.rest-client.non-proxy-hosts=nonProxyHosts
+quarkus.rest-client.connect-timeout=2000
+quarkus.rest-client.read-timeout=2001
+quarkus.rest-client.user-agent=agent
+quarkus.rest-client.headers.foo=bar
+quarkus.rest-client.hostname-verifier=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyHostnameVerifier
+quarkus.rest-client.connection-ttl=20000
+quarkus.rest-client.connection-pool-size=2
+quarkus.rest-client.max-redirects=2
+quarkus.rest-client.follow-redirects=true
+quarkus.rest-client.providers=io.quarkus.rest.client.reactive.HelloClientWithBaseUri$MyResponseFilter
+quarkus.rest-client.query-param-style=MULTI_PAIRS
+
+quarkus.rest-client.trust-store=/path
+quarkus.rest-client.trust-store-password=password
+quarkus.rest-client.trust-store-type=JKS
+quarkus.rest-client.key-store=/path
+quarkus.rest-client.key-store-password=password
+quarkus.rest-client.key-store-type=JKS
+
+# Specific client configuration, this is to allow for the client to be successfully created.
+# Override proxy, trust store and key store, as they don't exist.
+quarkus.rest-client.HelloClientWithBaseUri.url=http://localhost:${quarkus.http.test-port:8081}/hello
+quarkus.rest-client.HelloClientWithBaseUri.proxy-address=none
+quarkus.rest-client.HelloClientWithBaseUri.trust-store=none
+quarkus.rest-client.HelloClientWithBaseUri.key-store=none

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientReactiveConfig.java
@@ -17,6 +17,7 @@ public class RestClientReactiveConfig {
     /**
      * Default scope for Rest Client Reactive. Use `javax.enterprise.context.Dependent` for spec-compliant behavior
      */
+    @Deprecated // Deprecated in favour of RestClientsConfig.scope
     @ConfigItem(name = "scope", defaultValue = "javax.enterprise.context.ApplicationScoped")
     public String scope;
 
@@ -27,6 +28,7 @@ public class RestClientReactiveConfig {
      * MicroProfile Rest Client spec requires the implementations to always default to application/json.
      * This build item disables the "smart" behavior of RESTEasy Reactive to comply to the spec
      */
+    @Deprecated // Deprecated in favour of RestClientsConfig.disableSmartProduces
     @ConfigItem(name = "disable-smart-produces", defaultValue = "false")
     public boolean disableSmartProduces;
 

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -70,87 +70,163 @@ public class RestClientCDIDelegateBuilderTest {
     }
 
     @Test
-    public void testQuarkusConfig() {
-        RestClientsConfig configRoot = createSampleConfiguration();
+    public void testClientSpecificConfigs() {
+        // given
+
+        RestClientsConfig configRoot = createSampleConfigRoot();
+        configRoot.putClientConfig("test-client", createSampleClientConfig());
+
+        // when
+
         RestClientBuilderImpl restClientBuilderMock = Mockito.mock(RestClientBuilderImpl.class);
         new RestClientCDIDelegateBuilder<>(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
                 configRoot).build(restClientBuilderMock);
 
+        // then
+
         Mockito.verify(restClientBuilderMock).baseUri(URI.create("http://localhost"));
-        Mockito.verify(restClientBuilderMock).register(MyResponseFilter1.class);
-        Mockito.verify(restClientBuilderMock).connectTimeout(100, TimeUnit.MILLISECONDS);
-        Mockito.verify(restClientBuilderMock).readTimeout(101, TimeUnit.MILLISECONDS);
-        Mockito.verify(restClientBuilderMock).followRedirects(true);
-        Mockito.verify(restClientBuilderMock).proxyAddress("localhost", 1234);
-        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.COMMA_SEPARATED);
-        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
-        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
-        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier1.class));
-        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 30); // value in seconds
-        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 103);
-        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MAX_REDIRECTS, 104);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.SHARED, true);
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.NAME, "my-client");
         Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE,
                 HttpPostRequestEncoder.EncoderMode.HTML5);
+
+        Mockito.verify(restClientBuilderMock).proxyAddress("host1", 123);
+        Mockito.verify(restClientBuilderMock).proxyUser("proxyUser1");
+        Mockito.verify(restClientBuilderMock).proxyPassword("proxyPassword1");
+        Mockito.verify(restClientBuilderMock).nonProxyHosts("nonProxyHosts1");
+        Mockito.verify(restClientBuilderMock).connectTimeout(100, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).readTimeout(101, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.USER_AGENT, "agent1");
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.STATIC_HEADERS,
+                Collections.singletonMap("header1", "value"));
+        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier1.class));
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 10); // value converted to seconds
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 103);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MAX_REDIRECTS, 104);
+        Mockito.verify(restClientBuilderMock).followRedirects(true);
+        Mockito.verify(restClientBuilderMock).register(MyResponseFilter1.class);
+        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.COMMA_SEPARATED);
+
+        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
+        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
     }
 
     @Test
-    public void testGlobalTimeouts() {
-        RestClientsConfig configRoot = new RestClientsConfig();
-        configRoot.connectTimeout = 5000L;
-        configRoot.readTimeout = 10000L;
-        configRoot.multipartPostEncoderMode = Optional.empty();
-        configRoot.userAgent = Optional.empty();
+    public void testGlobalConfigs() {
+        // given
+
+        RestClientsConfig configRoot = createSampleConfigRoot();
+
+        // when
+
         RestClientBuilderImpl restClientBuilderMock = Mockito.mock(RestClientBuilderImpl.class);
         new RestClientCDIDelegateBuilder<>(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
                 configRoot).build(restClientBuilderMock);
 
-        Mockito.verify(restClientBuilderMock).connectTimeout(5000, TimeUnit.MILLISECONDS);
-        Mockito.verify(restClientBuilderMock).readTimeout(10000, TimeUnit.MILLISECONDS);
+        // then
+
+        Mockito.verify(restClientBuilderMock).baseUri(URI.create("http://localhost:8080"));
+        Mockito.verify(restClientBuilderMock)
+                .property(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE, HttpPostRequestEncoder.EncoderMode.HTML5);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.DISABLE_CONTEXTUAL_ERROR_MESSAGES, true);
+
+        Mockito.verify(restClientBuilderMock).proxyAddress("host2", 123);
+        Mockito.verify(restClientBuilderMock).proxyUser("proxyUser2");
+        Mockito.verify(restClientBuilderMock).proxyPassword("proxyPassword2");
+        Mockito.verify(restClientBuilderMock).nonProxyHosts("nonProxyHosts2");
+        Mockito.verify(restClientBuilderMock).connectTimeout(200, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).readTimeout(201, TimeUnit.MILLISECONDS);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.USER_AGENT, "agent2");
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.STATIC_HEADERS,
+                Collections.singletonMap("header2", "value"));
+        Mockito.verify(restClientBuilderMock).hostnameVerifier(Mockito.any(MyHostnameVerifier2.class));
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_TTL, 20);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.CONNECTION_POOL_SIZE, 203);
+        Mockito.verify(restClientBuilderMock).property(QuarkusRestClientProperties.MAX_REDIRECTS, 204);
+        Mockito.verify(restClientBuilderMock).followRedirects(true);
+        Mockito.verify(restClientBuilderMock).register(MyResponseFilter2.class);
+        Mockito.verify(restClientBuilderMock).queryParamStyle(QueryParamStyle.MULTI_PAIRS);
+
+        Mockito.verify(restClientBuilderMock).trustStore(Mockito.any());
+        Mockito.verify(restClientBuilderMock).keyStore(Mockito.any(), Mockito.anyString());
     }
 
-    private static RestClientsConfig createSampleConfiguration() {
+    private static RestClientsConfig createSampleConfigRoot() {
+        RestClientsConfig configRoot = new RestClientsConfig();
+
+        // global properties:
+        configRoot.multipartPostEncoderMode = Optional.of("HTML5");
+        configRoot.disableContextualErrorMessages = true;
+
+        // global defaults for client specific properties:
+        configRoot.proxyAddress = Optional.of("host2:123");
+        configRoot.proxyUser = Optional.of("proxyUser2");
+        configRoot.proxyPassword = Optional.of("proxyPassword2");
+        configRoot.nonProxyHosts = Optional.of("nonProxyHosts2");
+        configRoot.connectTimeout = 200L;
+        configRoot.readTimeout = 201L;
+        configRoot.userAgent = Optional.of("agent2");
+        configRoot.headers = Collections.singletonMap("header2", "value");
+        configRoot.hostnameVerifier = Optional
+                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyHostnameVerifier2");
+        configRoot.connectionTTL = Optional.of(20000); // value in ms, will be converted to seconds
+        configRoot.connectionPoolSize = Optional.of(203);
+        configRoot.maxRedirects = Optional.of(204);
+        configRoot.followRedirects = Optional.of(true);
+        configRoot.providers = Optional
+                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter2");
+        configRoot.queryParamStyle = Optional.of(QueryParamStyle.MULTI_PAIRS);
+
+        configRoot.trustStore = Optional.of(truststoreFile.getAbsolutePath());
+        configRoot.trustStorePassword = Optional.of("truststorePassword");
+        configRoot.trustStoreType = Optional.of("JKS");
+        configRoot.keyStore = Optional.of(keystoreFile.getAbsolutePath());
+        configRoot.keyStorePassword = Optional.of("keystorePassword");
+        configRoot.keyStoreType = Optional.of("JKS");
+
+        return configRoot;
+    }
+
+    private static RestClientConfig createSampleClientConfig() {
         RestClientConfig clientConfig = new RestClientConfig();
+
+        // properties only configurable via client config
         clientConfig.url = Optional.of("http://localhost");
         clientConfig.uri = Optional.empty();
-        clientConfig.scope = Optional.of("Singleton");
-        clientConfig.providers = Optional
-                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter1");
+        clientConfig.shared = Optional.of(true);
+        clientConfig.name = Optional.of("my-client");
+
+        // properties that override configRoot counterparts
+        clientConfig.proxyAddress = Optional.of("host1:123");
+        clientConfig.proxyUser = Optional.of("proxyUser1");
+        clientConfig.proxyPassword = Optional.of("proxyPassword1");
+        clientConfig.nonProxyHosts = Optional.of("nonProxyHosts1");
         clientConfig.connectTimeout = Optional.of(100L);
         clientConfig.readTimeout = Optional.of(101L);
+        clientConfig.userAgent = Optional.of("agent1");
+        clientConfig.headers = Collections.singletonMap("header1", "value");
+        clientConfig.hostnameVerifier = Optional
+                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyHostnameVerifier1");
+        clientConfig.connectionTTL = Optional.of(10000); // value in milliseconds, will be converted to seconds
+        clientConfig.connectionPoolSize = Optional.of(103);
+        clientConfig.maxRedirects = Optional.of(104);
         clientConfig.followRedirects = Optional.of(true);
-        clientConfig.proxyAddress = Optional.of("localhost:1234");
-        clientConfig.proxyUser = Optional.of("admin");
-        clientConfig.proxyPassword = Optional.of("adm1n");
-        clientConfig.nonProxyHosts = Optional.empty();
+        clientConfig.providers = Optional
+                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyResponseFilter1");
         clientConfig.queryParamStyle = Optional.of(QueryParamStyle.COMMA_SEPARATED);
+
         clientConfig.trustStore = Optional.of(truststoreFile.getAbsolutePath());
         clientConfig.trustStorePassword = Optional.of("truststorePassword");
         clientConfig.trustStoreType = Optional.of("JKS");
         clientConfig.keyStore = Optional.of(keystoreFile.getAbsolutePath());
         clientConfig.keyStorePassword = Optional.of("keystorePassword");
         clientConfig.keyStoreType = Optional.of("JKS");
-        clientConfig.hostnameVerifier = Optional
-                .of("io.quarkus.rest.client.reactive.runtime.RestClientCDIDelegateBuilderTest$MyHostnameVerifier1");
-        clientConfig.connectionTTL = Optional.of(30000); // value in milliseconds
-        clientConfig.connectionPoolSize = Optional.of(103);
-        clientConfig.maxRedirects = Optional.of(104);
-        clientConfig.headers = Collections.emptyMap();
-        clientConfig.shared = Optional.of(true);
-        clientConfig.name = Optional.of("my-client");
-        clientConfig.userAgent = Optional.of("rest-client");
 
-        RestClientsConfig configRoot = new RestClientsConfig();
-        configRoot.multipartPostEncoderMode = Optional.of("HTML5");
-        configRoot.disableSmartProduces = Optional.of(true);
-        configRoot.putClientConfig("test-client", clientConfig);
-
-        return configRoot;
+        return clientConfig;
     }
 
     @RegisterRestClient(configKey = "test-client")


### PR DESCRIPTION
Resolves https://github.com/quarkusio/quarkus/issues/27635

This commit adds global properties for most of configuration options
that can be set to individual REST client instances. E.g. the scope
property, that previously could only be set for specific client with:

`quarkus.rest-client.client-key.scope=Singleton`

can now be set globally with:

`quarkus.rest-client.scope=Singleton`

In this case the scope configuration would be applied to all REST client
instances unless it is overridden by client-specific configuration.

Following properties were added to the global scope:

```
scope
providers
follow-redirects
query-param-style
hostname-verifier
connection-ttl
connection-pool-size
max-redirects
headers

trust-store
trust-store-password
trust-store-type

key-store
key-store-password
key-store-type
```