### PR TITLE
Add getDataSource accessor in the new Redis API

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisCommands.java
@@ -1,0 +1,12 @@
+package io.quarkus.redis.datasource;
+
+/**
+ * Interface implemented by <em>reactive</em> Redis command groups.
+ */
+public interface ReactiveRedisCommands {
+
+    /**
+     * @return the data source.
+     */
+    ReactiveRedisDataSource getDataSource();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveTransactionalRedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveTransactionalRedisCommands.java
@@ -1,0 +1,14 @@
+package io.quarkus.redis.datasource;
+
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+
+/**
+ * Interface implemented by <em>transactional and reactive</em> Redis command groups.
+ */
+public interface ReactiveTransactionalRedisCommands {
+
+    /**
+     * @return the data source.
+     */
+    ReactiveTransactionalRedisDataSource getDataSource();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisCommands.java
@@ -1,0 +1,12 @@
+package io.quarkus.redis.datasource;
+
+/**
+ * Interface implemented by <em>imperative</em> Redis command groups.
+ */
+public interface RedisCommands {
+
+    /**
+     * @return the data source.
+     */
+    RedisDataSource getDataSource();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/TransactionalRedisCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/TransactionalRedisCommands.java
@@ -1,0 +1,14 @@
+package io.quarkus.redis.datasource;
+
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+/**
+ * Interface implemented by <em>transactional and imperative</em> Redis command groups.
+ */
+public interface TransactionalRedisCommands {
+
+    /**
+     * @return the data source.
+     */
+    TransactionalRedisDataSource getDataSource();
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/BitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/BitMapCommands.java
@@ -2,6 +2,8 @@ package io.quarkus.redis.datasource.bitmap;
 
 import java.util.List;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing commands from the {@code bitmap} group.
  * See <a href="https://redis.io/commands/?group=bitmap">the bitmap command list</a> for further information about these
@@ -9,7 +11,7 @@ import java.util.List;
  *
  * @param <K> the type of the key
  */
-public interface BitMapCommands<K> {
+public interface BitMapCommands<K> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/bitcount">BITCOUNT</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/ReactiveBitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/ReactiveBitMapCommands.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.bitmap;
 
 import java.util.List;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -11,7 +12,7 @@ import io.smallrye.mutiny.Uni;
  *
  * @param <K> the type of the key
  */
-public interface ReactiveBitMapCommands<K> {
+public interface ReactiveBitMapCommands<K> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/bitcount">BITCOUNT</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/ReactiveTransactionalBitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/ReactiveTransactionalBitMapCommands.java
@@ -1,8 +1,9 @@
 package io.quarkus.redis.datasource.bitmap;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalBitMapCommands<K> {
+public interface ReactiveTransactionalBitMapCommands<K> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/bitcount">BITCOUNT</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/TransactionalBitMapCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bitmap/TransactionalBitMapCommands.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.datasource.bitmap;
 
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
 /**
  * Allows executing commands from the {@code bitmap} group in a Redis transaction ({@code Multi}).
  * See <a href="https://redis.io/commands/?group=bitmap">the bitmap command list</a> for further information about these
@@ -7,7 +9,7 @@ package io.quarkus.redis.datasource.bitmap;
  *
  * @param <K> the type of the key
  */
-public interface TransactionalBitMapCommands<K> {
+public interface TransactionalBitMapCommands<K> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/bitcount">BITCOUNT</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoCommands.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing commands from the {@code geo} group.
  * See <a href="https://redis.io/commands/?group=geo">the geo command list</a> for further information about these commands.
@@ -14,7 +16,7 @@ import java.util.Set;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public interface GeoCommands<K, V> {
+public interface GeoCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/geoadd">GEOADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/ReactiveGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/ReactiveGeoCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.geo;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -15,7 +16,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public interface ReactiveGeoCommands<K, V> {
+public interface ReactiveGeoCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/geoadd">GEOADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/ReactiveTransactionalGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/ReactiveTransactionalGeoCommands.java
@@ -1,8 +1,9 @@
 package io.quarkus.redis.datasource.geo;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalGeoCommands<K, V> {
+public interface ReactiveTransactionalGeoCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/geoadd">GEOADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/TransactionalGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/TransactionalGeoCommands.java
@@ -1,6 +1,8 @@
 package io.quarkus.redis.datasource.geo;
 
-public interface TransactionalGeoCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalGeoCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/geoadd">GEOADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.hash;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 
 /**
@@ -18,7 +19,7 @@ import io.quarkus.redis.datasource.ScanArgs;
  * @param <F> the type of the field
  * @param <V> the type of the value
  */
-public interface HashCommands<K, F, V> {
+public interface HashCommands<K, F, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/hdel">HDEL</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.hash;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.smallrye.mutiny.Uni;
 
@@ -19,7 +20,7 @@ import io.smallrye.mutiny.Uni;
  * @param <F> the type of the field
  * @param <V> the type of the value
  */
-public interface ReactiveHashCommands<K, F, V> {
+public interface ReactiveHashCommands<K, F, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/hdel">HDEL</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveTransactionalHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveTransactionalHashCommands.java
@@ -2,9 +2,10 @@ package io.quarkus.redis.datasource.hash;
 
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalHashCommands<K, F, V> {
+public interface ReactiveTransactionalHashCommands<K, F, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/hdel">HDEL</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/TransactionalHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/TransactionalHashCommands.java
@@ -2,7 +2,9 @@ package io.quarkus.redis.datasource.hash;
 
 import java.util.Map;
 
-public interface TransactionalHashCommands<K, F, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalHashCommands<K, F, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/hdel">HDEL</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/HyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/HyperLogLogCommands.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.datasource.hyperloglog;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing commands from the {@code hyperloglog} group.
  * See <a href="https://redis.io/commands/?group=hyperloglog">the hyperloglog command list</a> for further information about
@@ -9,7 +11,7 @@ package io.quarkus.redis.datasource.hyperloglog;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the sets
  */
-public interface HyperLogLogCommands<K, V> {
+public interface HyperLogLogCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/pfadd">PFADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveHyperLogLogCommands.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.datasource.hyperloglog;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -11,7 +12,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the sets
  */
-public interface ReactiveHyperLogLogCommands<K, V> {
+public interface ReactiveHyperLogLogCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/pfadd">PFADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveTransactionalHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveTransactionalHyperLogLogCommands.java
@@ -1,8 +1,9 @@
 package io.quarkus.redis.datasource.hyperloglog;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalHyperLogLogCommands<K, V> {
+public interface ReactiveTransactionalHyperLogLogCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/pfadd">PFADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/TransactionalHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/TransactionalHyperLogLogCommands.java
@@ -1,6 +1,8 @@
 package io.quarkus.redis.datasource.hyperloglog;
 
-public interface TransactionalHyperLogLogCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalHyperLogLogCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/pfadd">PFADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/KeyCommands.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing commands manipulating keys.
  * See <a href="https://redis.io/commands/?group=generic">the generic command list</a> for further information about these
@@ -13,7 +15,7 @@ import java.util.Set;
  *
  * @param <K> the type of the keys, often {@link String}
  */
-public interface KeyCommands<K> {
+public interface KeyCommands<K> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/copy">COPY</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveKeyCommands.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -15,7 +16,7 @@ import io.smallrye.mutiny.Uni;
  *
  * @param <K> the type of the keys, often {@link String}
  */
-public interface ReactiveKeyCommands<K> {
+public interface ReactiveKeyCommands<K> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/copy">COPY</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveTransactionalKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/ReactiveTransactionalKeyCommands.java
@@ -3,9 +3,10 @@ package io.quarkus.redis.datasource.keys;
 import java.time.Duration;
 import java.time.Instant;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalKeyCommands<K> {
+public interface ReactiveTransactionalKeyCommands<K> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/copy">COPY</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/TransactionalKeyCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/keys/TransactionalKeyCommands.java
@@ -3,7 +3,9 @@ package io.quarkus.redis.datasource.keys;
 import java.time.Duration;
 import java.time.Instant;
 
-public interface TransactionalKeyCommands<K> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalKeyCommands<K> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/copy">COPY</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ListCommands.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.OptionalLong;
 
+import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.SortArgs;
 
 /**
@@ -16,7 +17,7 @@ import io.quarkus.redis.datasource.SortArgs;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the lists
  */
-public interface ListCommands<K, V> {
+public interface ListCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/blmove">BLMOVE</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveListCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.list;
 import java.time.Duration;
 import java.util.List;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.SortArgs;
 import io.smallrye.mutiny.Uni;
 
@@ -16,7 +17,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the lists
  */
-public interface ReactiveListCommands<K, V> {
+public interface ReactiveListCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/blmove">BLMOVE</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveTransactionalListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/ReactiveTransactionalListCommands.java
@@ -2,9 +2,10 @@ package io.quarkus.redis.datasource.list;
 
 import java.time.Duration;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalListCommands<K, V> {
+public interface ReactiveTransactionalListCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/blmove">BLMOVE</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/TransactionalListCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/list/TransactionalListCommands.java
@@ -2,7 +2,9 @@ package io.quarkus.redis.datasource.list;
 
 import java.time.Duration;
 
-public interface TransactionalListCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalListCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/blmove">BLMOVE</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/PubSubCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/PubSubCommands.java
@@ -3,13 +3,15 @@ package io.quarkus.redis.datasource.pubsub;
 import java.util.List;
 import java.util.function.Consumer;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing Pub/Sub commands.
  * See <a href="https://redis.io/docs/manual/pubsub/">the pub/sub documentation</a>.
  *
  * @param <V> the class of the exchanged messages.
  */
-public interface PubSubCommands<V> {
+public interface PubSubCommands<V> extends RedisCommands {
 
     /**
      * Publishes a message to a given channel

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/ReactivePubSubCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/pubsub/ReactivePubSubCommands.java
@@ -3,10 +3,11 @@ package io.quarkus.redis.datasource.pubsub;
 import java.util.List;
 import java.util.function.Consumer;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactivePubSubCommands<V> {
+public interface ReactivePubSubCommands<V> extends ReactiveRedisCommands {
 
     /**
      * Publishes a message to a given channel

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveSetCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.set;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 import io.smallrye.mutiny.Uni;
@@ -16,7 +17,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the sets
  */
-public interface ReactiveSetCommands<K, V> {
+public interface ReactiveSetCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/sadd">SADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveTransactionalSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/ReactiveTransactionalSetCommands.java
@@ -1,8 +1,9 @@
 package io.quarkus.redis.datasource.set;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalSetCommands<K, V> {
+public interface ReactiveTransactionalSetCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/sadd">SADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/SetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/SetCommands.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.datasource.set;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 
@@ -15,7 +16,7 @@ import io.quarkus.redis.datasource.SortArgs;
  * @param <K> the type of the key
  * @param <V> the type of the value stored in the sets
  */
-public interface SetCommands<K, V> {
+public interface SetCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/sadd">SADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/TransactionalSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/set/TransactionalSetCommands.java
@@ -1,6 +1,8 @@
 package io.quarkus.redis.datasource.set;
 
-public interface TransactionalSetCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalSetCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/sadd">SADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveSortedSetCommands.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 import io.quarkus.redis.datasource.list.KeyValue;
@@ -22,7 +23,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the scored item
  */
-public interface ReactiveSortedSetCommands<K, V> {
+public interface ReactiveSortedSetCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/zadd">ZADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveTransactionalSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/ReactiveTransactionalSortedSetCommands.java
@@ -3,9 +3,10 @@ package io.quarkus.redis.datasource.sortedset;
 import java.time.Duration;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalSortedSetCommands<K, V> {
+public interface ReactiveTransactionalSortedSetCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/zadd">ZADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/SortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/SortedSetCommands.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
+import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 import io.quarkus.redis.datasource.list.KeyValue;
@@ -23,7 +24,7 @@ import io.quarkus.redis.datasource.list.KeyValue;
  * @param <K> the type of the key
  * @param <V> the type of the scored item
  */
-public interface SortedSetCommands<K, V> {
+public interface SortedSetCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/zadd">ZADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/TransactionalSortedSetCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/sortedset/TransactionalSortedSetCommands.java
@@ -3,7 +3,9 @@ package io.quarkus.redis.datasource.sortedset;
 import java.time.Duration;
 import java.util.Map;
 
-public interface TransactionalSortedSetCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalSortedSetCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/zadd">ZADD</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.string;
 
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -15,7 +16,7 @@ import io.smallrye.mutiny.Uni;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public interface ReactiveStringCommands<K, V> {
+public interface ReactiveStringCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveTransactionalStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveTransactionalStringCommands.java
@@ -2,9 +2,10 @@ package io.quarkus.redis.datasource.string;
 
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
-public interface ReactiveTransactionalStringCommands<K, V> {
+public interface ReactiveTransactionalStringCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
@@ -2,6 +2,8 @@ package io.quarkus.redis.datasource.string;
 
 import java.util.Map;
 
+import io.quarkus.redis.datasource.RedisCommands;
+
 /**
  * Allows executing commands from the {@code string} group.
  * See <a href="https://redis.io/commands/?group=string">the string command list</a> for further information
@@ -13,7 +15,7 @@ import java.util.Map;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public interface StringCommands<K, V> {
+public interface StringCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/TransactionalStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/TransactionalStringCommands.java
@@ -2,7 +2,9 @@ package io.quarkus.redis.datasource.string;
 
 import java.util.Map;
 
-public interface TransactionalStringCommands<K, V> {
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalStringCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommandGroup.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractRedisCommandGroup.java
@@ -1,0 +1,22 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.RedisCommands;
+import io.quarkus.redis.datasource.RedisDataSource;
+
+public class AbstractRedisCommandGroup implements RedisCommands {
+
+    protected final RedisDataSource ds;
+    protected final Duration timeout;
+
+    public AbstractRedisCommandGroup(RedisDataSource ds, Duration timeout) {
+        this.ds = ds;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public RedisDataSource getDataSource() {
+        return ds;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalCommands.java
@@ -1,12 +1,16 @@
 package io.quarkus.redis.runtime.datasource;
 
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.vertx.mutiny.redis.client.Response;
 
-public class AbstractTransactionalCommands {
+public class AbstractTransactionalCommands implements ReactiveTransactionalRedisCommands {
 
     protected final TransactionHolder tx;
+    private final ReactiveTransactionalRedisDataSource ds;
 
-    public AbstractTransactionalCommands(TransactionHolder tx) {
+    public AbstractTransactionalCommands(ReactiveTransactionalRedisDataSource ds, TransactionHolder tx) {
+        this.ds = ds;
         this.tx = tx;
     }
 
@@ -15,5 +19,10 @@ public class AbstractTransactionalCommands {
             this.tx.discard();
             throw new IllegalStateException("Unable to add command to the current transaction");
         }
+    }
+
+    @Override
+    public ReactiveTransactionalRedisDataSource getDataSource() {
+        return ds;
     }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalRedisCommandGroup.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTransactionalRedisCommandGroup.java
@@ -1,0 +1,22 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class AbstractTransactionalRedisCommandGroup implements TransactionalRedisCommands {
+
+    protected final TransactionalRedisDataSource ds;
+    protected final Duration timeout;
+
+    public AbstractTransactionalRedisCommandGroup(TransactionalRedisDataSource ds, Duration timeout) {
+        this.ds = ds;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public TransactionalRedisDataSource getDataSource() {
+        return ds;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingBitmapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingBitmapCommandsImpl.java
@@ -3,18 +3,18 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.util.List;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 
-public class BlockingBitmapCommandsImpl<K> implements BitMapCommands<K> {
+public class BlockingBitmapCommandsImpl<K> extends AbstractRedisCommandGroup implements BitMapCommands<K> {
 
     private final ReactiveBitMapCommands<K> reactive;
-    private final Duration timeout;
 
-    public BlockingBitmapCommandsImpl(ReactiveBitMapCommands<K> reactive, Duration timeout) {
+    public BlockingBitmapCommandsImpl(RedisDataSource ds, ReactiveBitMapCommands<K> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingGeoCommandsImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.OptionalDouble;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.geo.GeoAddArgs;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.geo.GeoItem;
@@ -17,14 +18,13 @@ import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.GeoValue;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 
-public class BlockingGeoCommandsImpl<K, V> implements GeoCommands<K, V> {
+public class BlockingGeoCommandsImpl<K, V> extends AbstractRedisCommandGroup implements GeoCommands<K, V> {
 
     private final ReactiveGeoCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingGeoCommandsImpl(ReactiveGeoCommands<K, V> reactive, Duration timeout) {
+    public BlockingGeoCommandsImpl(RedisDataSource ds, ReactiveGeoCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingHashCommandsImpl.java
@@ -4,19 +4,19 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hash.HashScanCursor;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 
-public class BlockingHashCommandsImpl<K, F, V> implements HashCommands<K, F, V> {
+public class BlockingHashCommandsImpl<K, F, V> extends AbstractRedisCommandGroup implements HashCommands<K, F, V> {
 
     private final ReactiveHashCommands<K, F, V> reactive;
-    private final Duration timeout;
 
-    public BlockingHashCommandsImpl(ReactiveHashCommands<K, F, V> reactive, Duration timeout) {
+    public BlockingHashCommandsImpl(RedisDataSource ds, ReactiveHashCommands<K, F, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingHyperLogLogCommandsImpl.java
@@ -2,17 +2,17 @@ package io.quarkus.redis.runtime.datasource;
 
 import java.time.Duration;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
 
-public class BlockingHyperLogLogCommandsImpl<K, V> implements HyperLogLogCommands<K, V> {
+public class BlockingHyperLogLogCommandsImpl<K, V> extends AbstractRedisCommandGroup implements HyperLogLogCommands<K, V> {
 
     private final ReactiveHyperLogLogCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingHyperLogLogCommandsImpl(ReactiveHyperLogLogCommands<K, V> reactive, Duration timeout) {
+    public BlockingHyperLogLogCommandsImpl(RedisDataSource ds, ReactiveHyperLogLogCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingKeyCommandsImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.KeyCommands;
@@ -12,14 +13,13 @@ import io.quarkus.redis.datasource.keys.KeyScanCursor;
 import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 
-public class BlockingKeyCommandsImpl<K> implements KeyCommands<K> {
+public class BlockingKeyCommandsImpl<K> extends AbstractRedisCommandGroup implements KeyCommands<K> {
 
     private final ReactiveKeyCommands<K> reactive;
-    private final Duration timeout;
 
-    public BlockingKeyCommandsImpl(ReactiveKeyCommands<K> reactive, Duration timeout) {
+    public BlockingKeyCommandsImpl(RedisDataSource ds, ReactiveKeyCommands<K> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingListCommandsImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.OptionalLong;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.SortArgs;
 import io.quarkus.redis.datasource.list.KeyValue;
 import io.quarkus.redis.datasource.list.LPosArgs;
@@ -11,14 +12,13 @@ import io.quarkus.redis.datasource.list.ListCommands;
 import io.quarkus.redis.datasource.list.Position;
 import io.quarkus.redis.datasource.list.ReactiveListCommands;
 
-public class BlockingListCommandsImpl<K, V> implements ListCommands<K, V> {
+public class BlockingListCommandsImpl<K, V> extends AbstractRedisCommandGroup implements ListCommands<K, V> {
 
     private final ReactiveListCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingListCommandsImpl(ReactiveListCommands<K, V> reactive, Duration timeout) {
+    public BlockingListCommandsImpl(RedisDataSource ds, ReactiveListCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingPubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingPubSubCommandsImpl.java
@@ -6,17 +6,17 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.pubsub.PubSubCommands;
 import io.quarkus.redis.datasource.pubsub.ReactivePubSubCommands;
 
-public class BlockingPubSubCommandsImpl<V> implements PubSubCommands<V> {
+public class BlockingPubSubCommandsImpl<V> extends AbstractRedisCommandGroup implements PubSubCommands<V> {
 
     private final ReactivePubSubCommands<V> reactive;
-    private final Duration timeout;
 
-    public BlockingPubSubCommandsImpl(ReactivePubSubCommands<V> reactive, Duration timeout) {
+    public BlockingPubSubCommandsImpl(RedisDataSource ds, ReactivePubSubCommands<V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -172,52 +172,52 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
 
     @Override
     public <K1, F, V1> HashCommands<K1, F, V1> hash(Class<K1> redisKeyType, Class<F> typeOfField, Class<V1> typeOfValue) {
-        return new BlockingHashCommandsImpl<>(reactive.hash(redisKeyType, typeOfField, typeOfValue), timeout);
+        return new BlockingHashCommandsImpl<>(this, reactive.hash(redisKeyType, typeOfField, typeOfValue), timeout);
     }
 
     @Override
     public <K1, V1> GeoCommands<K1, V1> geo(Class<K1> redisKeyType, Class<V1> memberType) {
-        return new BlockingGeoCommandsImpl<>(reactive.geo(redisKeyType, memberType), timeout);
+        return new BlockingGeoCommandsImpl<>(this, reactive.geo(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K1> KeyCommands<K1> key(Class<K1> redisKeyType) {
-        return new BlockingKeyCommandsImpl<>(reactive.key(redisKeyType), timeout);
+        return new BlockingKeyCommandsImpl<>(this, reactive.key(redisKeyType), timeout);
     }
 
     @Override
     public <K1, V1> SortedSetCommands<K1, V1> sortedSet(Class<K1> redisKeyType, Class<V1> valueType) {
-        return new BlockingSortedSetCommandsImpl<>(reactive.sortedSet(redisKeyType, valueType), timeout);
+        return new BlockingSortedSetCommandsImpl<>(this, reactive.sortedSet(redisKeyType, valueType), timeout);
     }
 
     @Override
     public <K1, V1> StringCommands<K1, V1> string(Class<K1> redisKeyType, Class<V1> valueType) {
-        return new BlockingStringCommandsImpl<>(reactive.string(redisKeyType, valueType), timeout);
+        return new BlockingStringCommandsImpl<>(this, reactive.string(redisKeyType, valueType), timeout);
     }
 
     @Override
     public <K1, V1> SetCommands<K1, V1> set(Class<K1> redisKeyType, Class<V1> memberType) {
-        return new BlockingSetCommandsImpl<>(reactive.set(redisKeyType, memberType), timeout);
+        return new BlockingSetCommandsImpl<>(this, reactive.set(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K1, V1> ListCommands<K1, V1> list(Class<K1> redisKeyType, Class<V1> memberType) {
-        return new BlockingListCommandsImpl<>(reactive.list(redisKeyType, memberType), timeout);
+        return new BlockingListCommandsImpl<>(this, reactive.list(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K1, V1> HyperLogLogCommands<K1, V1> hyperloglog(Class<K1> redisKeyType, Class<V1> memberType) {
-        return new BlockingHyperLogLogCommandsImpl<>(reactive.hyperloglog(redisKeyType, memberType), timeout);
+        return new BlockingHyperLogLogCommandsImpl<>(this, reactive.hyperloglog(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K> BitMapCommands<K> bitmap(Class<K> redisKeyType) {
-        return new BlockingBitmapCommandsImpl<>(reactive.bitmap(redisKeyType), timeout);
+        return new BlockingBitmapCommandsImpl<>(this, reactive.bitmap(redisKeyType), timeout);
     }
 
     @Override
     public <V> PubSubCommands<V> pubsub(Class<V> messageType) {
-        return new BlockingPubSubCommandsImpl<>(reactive.pubsub(messageType), timeout);
+        return new BlockingPubSubCommandsImpl<>(this, reactive.pubsub(messageType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingSetCommandsImpl.java
@@ -4,20 +4,20 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.quarkus.redis.datasource.set.SScanCursor;
 import io.quarkus.redis.datasource.set.SetCommands;
 
-public class BlockingSetCommandsImpl<K, V> implements SetCommands<K, V> {
+public class BlockingSetCommandsImpl<K, V> extends AbstractRedisCommandGroup implements SetCommands<K, V> {
 
     private final ReactiveSetCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingSetCommandsImpl(ReactiveSetCommands<K, V> reactive, Duration timeout) {
+    public BlockingSetCommandsImpl(RedisDataSource ds, ReactiveSetCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingSortedSetCommandsImpl.java
@@ -8,6 +8,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.SortArgs;
 import io.quarkus.redis.datasource.list.KeyValue;
@@ -21,14 +22,13 @@ import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
 import io.quarkus.redis.datasource.sortedset.ZScanCursor;
 
-public class BlockingSortedSetCommandsImpl<K, V> implements SortedSetCommands<K, V> {
+public class BlockingSortedSetCommandsImpl<K, V> extends AbstractRedisCommandGroup implements SortedSetCommands<K, V> {
 
     private final ReactiveSortedSetCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingSortedSetCommandsImpl(ReactiveSortedSetCommands<K, V> reactive, Duration timeout) {
+    public BlockingSortedSetCommandsImpl(RedisDataSource ds, ReactiveSortedSetCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
@@ -3,19 +3,19 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.StringCommands;
 
-public class BlockingStringCommandsImpl<K, V> implements StringCommands<K, V> {
+public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup implements StringCommands<K, V> {
 
     private final ReactiveStringCommands<K, V> reactive;
-    private final Duration timeout;
 
-    public BlockingStringCommandsImpl(ReactiveStringCommands<K, V> reactive, Duration timeout) {
+    public BlockingStringCommandsImpl(RedisDataSource ds, ReactiveStringCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalBitMapCommandsImpl.java
@@ -5,16 +5,17 @@ import java.time.Duration;
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalBitMapCommandsImpl<K> implements TransactionalBitMapCommands<K> {
+public class BlockingTransactionalBitMapCommandsImpl<K> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalBitMapCommands<K> {
 
     private final ReactiveTransactionalBitMapCommands<K> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalBitMapCommandsImpl(ReactiveTransactionalBitMapCommands<K> reactive, Duration timeout) {
+    public BlockingTransactionalBitMapCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalBitMapCommands<K> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalGeoCommandsImpl.java
@@ -12,16 +12,17 @@ import io.quarkus.redis.datasource.geo.GeoSearchStoreArgs;
 import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalGeoCommandsImpl<K, V> implements TransactionalGeoCommands<K, V> {
+public class BlockingTransactionalGeoCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalGeoCommands<K, V> {
 
     private final ReactiveTransactionalGeoCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalGeoCommandsImpl(ReactiveTransactionalGeoCommands<K, V> reactive, Duration timeout) {
+    public BlockingTransactionalGeoCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalGeoCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalHashCommandsImpl.java
@@ -5,16 +5,17 @@ import java.util.Map;
 
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalHashCommandsImpl<K, F, V> implements TransactionalHashCommands<K, F, V> {
+public class BlockingTransactionalHashCommandsImpl<K, F, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalHashCommands<K, F, V> {
 
     private final ReactiveTransactionalHashCommands<K, F, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalHashCommandsImpl(ReactiveTransactionalHashCommands<K, F, V> reactive, Duration timeout) {
+    public BlockingTransactionalHashCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalHashCommands<K, F, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalHyperLogLogCommandsImpl.java
@@ -4,17 +4,18 @@ import java.time.Duration;
 
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
 import io.quarkus.redis.datasource.hyperloglog.TransactionalHyperLogLogCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalHyperLogLogCommandsImpl<K, V> implements TransactionalHyperLogLogCommands<K, V> {
+public class BlockingTransactionalHyperLogLogCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalHyperLogLogCommands<K, V> {
 
     private final ReactiveTransactionalHyperLogLogCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalHyperLogLogCommandsImpl(ReactiveTransactionalHyperLogLogCommands<K, V> reactive,
+    public BlockingTransactionalHyperLogLogCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalHyperLogLogCommands<K, V> reactive,
             Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalKeyCommandsImpl.java
@@ -8,16 +8,17 @@ import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.ReactiveTransactionalKeyCommands;
 import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
 import io.quarkus.redis.datasource.keys.TransactionalKeyCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalKeyCommandsImpl<K> implements TransactionalKeyCommands<K> {
+public class BlockingTransactionalKeyCommandsImpl<K> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalKeyCommands<K> {
 
     private final ReactiveTransactionalKeyCommands<K> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalKeyCommandsImpl(ReactiveTransactionalKeyCommands<K> reactive, Duration timeout) {
+    public BlockingTransactionalKeyCommandsImpl(TransactionalRedisDataSource ds, ReactiveTransactionalKeyCommands<K> reactive,
+            Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalListCommandsImpl.java
@@ -6,16 +6,17 @@ import io.quarkus.redis.datasource.list.LPosArgs;
 import io.quarkus.redis.datasource.list.Position;
 import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
 import io.quarkus.redis.datasource.list.TransactionalListCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalListCommandsImpl<K, V> implements TransactionalListCommands<K, V> {
+public class BlockingTransactionalListCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalListCommands<K, V> {
 
     private final ReactiveTransactionalListCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalListCommandsImpl(ReactiveTransactionalListCommands<K, V> reactive, Duration timeout) {
+    public BlockingTransactionalListCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalListCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -38,47 +38,49 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K, F, V> TransactionalHashCommands<K, F, V> hash(Class<K> redisKeyType, Class<F> typeOfField,
             Class<V> typeOfValue) {
-        return new BlockingTransactionalHashCommandsImpl<>(reactive.hash(redisKeyType, typeOfField, typeOfValue), timeout);
+        return new BlockingTransactionalHashCommandsImpl<>(this, reactive.hash(redisKeyType, typeOfField, typeOfValue),
+                timeout);
     }
 
     @Override
     public <K, V> TransactionalGeoCommands<K, V> geo(Class<K> redisKeyType, Class<V> memberType) {
-        return new BlockingTransactionalGeoCommandsImpl<>(reactive.geo(redisKeyType, memberType), timeout);
+        return new BlockingTransactionalGeoCommandsImpl<>(this, reactive.geo(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K> TransactionalKeyCommands<K> key(Class<K> redisKeyType) {
-        return new BlockingTransactionalKeyCommandsImpl<>(reactive.key(redisKeyType), timeout);
+        return new BlockingTransactionalKeyCommandsImpl<>(this, reactive.key(redisKeyType), timeout);
     }
 
     @Override
     public <K, V> TransactionalSetCommands<K, V> set(Class<K> redisKeyType, Class<V> memberType) {
-        return new BlockingTransactionalSetCommandsImpl<>(reactive.set(redisKeyType, memberType), timeout);
+        return new BlockingTransactionalSetCommandsImpl<>(this, reactive.set(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K, V> TransactionalSortedSetCommands<K, V> sortedSet(Class<K> redisKeyType, Class<V> valueType) {
-        return new BlockingTransactionalSortedSetCommandsImpl<>(reactive.sortedSet(redisKeyType, valueType), timeout);
+        return new BlockingTransactionalSortedSetCommandsImpl<>(this, reactive.sortedSet(redisKeyType, valueType), timeout);
     }
 
     @Override
     public <K, V> TransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType) {
-        return new BlockingTransactionalStringCommandsImpl<>(reactive.string(redisKeyType, valueType), timeout);
+        return new BlockingTransactionalStringCommandsImpl<>(this, reactive.string(redisKeyType, valueType), timeout);
     }
 
     @Override
     public <K, V> TransactionalListCommands<K, V> list(Class<K> redisKeyType, Class<V> memberType) {
-        return new BlockingTransactionalListCommandsImpl<>(reactive.list(redisKeyType, memberType), timeout);
+        return new BlockingTransactionalListCommandsImpl<>(this, reactive.list(redisKeyType, memberType), timeout);
     }
 
     @Override
     public <K, V> TransactionalHyperLogLogCommands<K, V> hyperloglog(Class<K> redisKeyType, Class<V> memberType) {
-        return new BlockingTransactionalHyperLogLogCommandsImpl<>(reactive.hyperloglog(redisKeyType, memberType), timeout);
+        return new BlockingTransactionalHyperLogLogCommandsImpl<>(this, reactive.hyperloglog(redisKeyType, memberType),
+                timeout);
     }
 
     @Override
     public <K> TransactionalBitMapCommands<K> bitmap(Class<K> redisKeyType) {
-        return new BlockingTransactionalBitMapCommandsImpl<>(reactive.bitmap(redisKeyType), timeout);
+        return new BlockingTransactionalBitMapCommandsImpl<>(this, reactive.bitmap(redisKeyType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalSetCommandsImpl.java
@@ -4,16 +4,17 @@ import java.time.Duration;
 
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalSetCommandsImpl<K, V> implements TransactionalSetCommands<K, V> {
+public class BlockingTransactionalSetCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalSetCommands<K, V> {
 
     private final ReactiveTransactionalSetCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalSetCommandsImpl(ReactiveTransactionalSetCommands<K, V> reactive, Duration timeout) {
+    public BlockingTransactionalSetCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalSetCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalSortedSetCommandsImpl.java
@@ -11,16 +11,17 @@ import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.sortedset.ZAddArgs;
 import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalSortedSetCommandsImpl<K, V> implements TransactionalSortedSetCommands<K, V> {
+public class BlockingTransactionalSortedSetCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalSortedSetCommands<K, V> {
 
     private final ReactiveTransactionalSortedSetCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalSortedSetCommandsImpl(ReactiveTransactionalSortedSetCommands<K, V> reactive, Duration timeout) {
+    public BlockingTransactionalSortedSetCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalSortedSetCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
@@ -7,16 +7,17 @@ import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 
-public class BlockingTransactionalStringCommandsImpl<K, V> implements TransactionalStringCommands<K, V> {
+public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalStringCommands<K, V> {
 
     private final ReactiveTransactionalStringCommands<K, V> reactive;
 
-    private final Duration timeout;
-
-    public BlockingTransactionalStringCommandsImpl(ReactiveTransactionalStringCommands<K, V> reactive, Duration timeout) {
+    public BlockingTransactionalStringCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalStringCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
         this.reactive = reactive;
-        this.timeout = timeout;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBitMapCommandsImpl.java
@@ -2,16 +2,26 @@ package io.quarkus.redis.runtime.datasource;
 
 import java.util.List;
 
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveBitMapCommandsImpl<K> extends AbstractBitMapCommands<K>
-        implements ReactiveBitMapCommands<K> {
+        implements ReactiveBitMapCommands<K>, ReactiveRedisCommands {
 
-    public ReactiveBitMapCommandsImpl(RedisCommandExecutor redis, Class<K> k) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveBitMapCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
         super(redis, k);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveGeoCommandsImpl.java
@@ -5,6 +5,7 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.geo.GeoAddArgs;
 import io.quarkus.redis.datasource.geo.GeoItem;
 import io.quarkus.redis.datasource.geo.GeoPosition;
@@ -21,9 +22,16 @@ import io.vertx.mutiny.redis.client.Response;
 public class ReactiveGeoCommandsImpl<K, V> extends AbstractGeoCommands<K, V> implements ReactiveGeoCommands<K, V> {
 
     static final GeoAddArgs DEFAULT_INSTANCE = new GeoAddArgs();
+    private final ReactiveRedisDataSource reactive;
 
-    public ReactiveGeoCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    public ReactiveGeoCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHashCommandsImpl.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashScanCursor;
@@ -14,8 +15,16 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveHashCommandsImpl<K, F, V> extends AbstractHashCommands<K, F, V> implements ReactiveHashCommands<K, F, V> {
 
-    public ReactiveHashCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<F> f, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveHashCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<F> f, Class<V> v) {
         super(redis, k, f, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @SafeVarargs

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveHyperLogLogCommandsImpl.java
@@ -1,5 +1,6 @@
 package io.quarkus.redis.runtime.datasource;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
@@ -7,8 +8,16 @@ import io.vertx.mutiny.redis.client.Response;
 public class ReactiveHyperLogLogCommandsImpl<K, V> extends AbstractHyperLogLogCommands<K, V>
         implements ReactiveHyperLogLogCommands<K, V> {
 
-    public ReactiveHyperLogLogCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveHyperLogLogCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @SafeVarargs

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveKeyCommandsImpl.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.KeyScanArgs;
@@ -18,8 +19,16 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveKeyCommandsImpl<K> extends AbstractKeyCommands<K> implements ReactiveKeyCommands<K> {
 
-    public ReactiveKeyCommandsImpl(RedisCommandExecutor redis, Class<K> k) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveKeyCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k) {
         super(redis, k);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveListCommandsImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 import java.util.List;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.list.KeyValue;
 import io.quarkus.redis.datasource.list.LPosArgs;
 import io.quarkus.redis.datasource.list.Position;
@@ -12,8 +13,16 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveListCommandsImpl<K, V> extends AbstractListCommands<K, V> implements ReactiveListCommands<K, V> {
 
-    public ReactiveListCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveListCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactivePubSubCommandsImpl.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.pubsub.ReactivePubSubCommands;
 import io.smallrye.common.vertx.VertxContext;
 import io.smallrye.mutiny.Multi;
@@ -34,6 +35,11 @@ public class ReactivePubSubCommandsImpl<V> extends AbstractRedisCommands impleme
         this.client = ds.redis;
         this.datasource = ds;
         this.classOfMessage = classOfMessage;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return datasource;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSetCommandsImpl.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.set.ReactiveSScanCursor;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
@@ -14,8 +15,16 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveSetCommandsImpl<K, V> extends AbstractSetCommands<K, V> implements ReactiveSetCommands<K, V> {
 
-    public ReactiveSetCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveSortedSetCommandsImpl.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.ScanArgs;
 import io.quarkus.redis.datasource.list.KeyValue;
 import io.quarkus.redis.datasource.sortedset.Range;
@@ -24,8 +25,16 @@ import io.vertx.mutiny.redis.client.Response;
 public class ReactiveSortedSetCommandsImpl<K, V> extends AbstractSortedSetCommands<K, V>
         implements ReactiveSortedSetCommands<K, V> {
 
-    public ReactiveSortedSetCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveSortedSetCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import java.util.Map;
 
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
@@ -10,8 +11,16 @@ import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, V> implements ReactiveStringCommands<K, V> {
 
-    public ReactiveStringCommandsImpl(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveStringCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
         super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBitMapCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBitMapCommandsImpl.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.runtime.datasource;
 
 import io.quarkus.redis.datasource.bitmap.BitFieldArgs;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -10,8 +11,9 @@ public class ReactiveTransactionalBitMapCommandsImpl<K> extends AbstractTransact
 
     private final ReactiveBitMapCommandsImpl<K> reactive;
 
-    public ReactiveTransactionalBitMapCommandsImpl(ReactiveBitMapCommandsImpl<K> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalBitMapCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveBitMapCommandsImpl<K> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGeoCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalGeoCommandsImpl.java
@@ -12,6 +12,7 @@ import io.quarkus.redis.datasource.geo.GeoSearchArgs;
 import io.quarkus.redis.datasource.geo.GeoSearchStoreArgs;
 import io.quarkus.redis.datasource.geo.GeoUnit;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -20,8 +21,9 @@ public class ReactiveTransactionalGeoCommandsImpl<K, V> extends AbstractTransact
 
     private final ReactiveGeoCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalGeoCommandsImpl(ReactiveGeoCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalGeoCommandsImpl(ReactiveTransactionalRedisDataSource ds, ReactiveGeoCommandsImpl<K, V> reactive,
+            TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHashCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHashCommandsImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -11,8 +12,9 @@ public class ReactiveTransactionalHashCommandsImpl<K, F, V> extends AbstractTran
 
     private final ReactiveHashCommandsImpl<K, F, V> reactive;
 
-    public ReactiveTransactionalHashCommandsImpl(ReactiveHashCommandsImpl<K, F, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalHashCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveHashCommandsImpl<K, F, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHyperLogLogCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalHyperLogLogCommandsImpl.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.runtime.datasource;
 
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -9,8 +10,9 @@ public class ReactiveTransactionalHyperLogLogCommandsImpl<K, V> extends Abstract
 
     private final ReactiveHyperLogLogCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalHyperLogLogCommandsImpl(ReactiveHyperLogLogCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalHyperLogLogCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveHyperLogLogCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalKeyCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalKeyCommandsImpl.java
@@ -7,6 +7,7 @@ import io.quarkus.redis.datasource.keys.CopyArgs;
 import io.quarkus.redis.datasource.keys.ExpireArgs;
 import io.quarkus.redis.datasource.keys.ReactiveTransactionalKeyCommands;
 import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -15,8 +16,9 @@ public class ReactiveTransactionalKeyCommandsImpl<K> extends AbstractTransaction
 
     private final ReactiveKeyCommandsImpl<K> reactive;
 
-    public ReactiveTransactionalKeyCommandsImpl(ReactiveKeyCommandsImpl<K> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalKeyCommandsImpl(ReactiveTransactionalRedisDataSource ds, ReactiveKeyCommandsImpl<K> reactive,
+            TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalListCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalListCommandsImpl.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import io.quarkus.redis.datasource.list.LPosArgs;
 import io.quarkus.redis.datasource.list.Position;
 import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -13,8 +14,9 @@ public class ReactiveTransactionalListCommandsImpl<K, V> extends AbstractTransac
 
     private final ReactiveListCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalListCommandsImpl(ReactiveListCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalListCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveListCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -43,56 +43,56 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     @Override
     public <K, F, V> ReactiveTransactionalHashCommands<K, F, V> hash(Class<K> redisKeyType, Class<F> typeOfField,
             Class<V> typeOfValue) {
-        return new ReactiveTransactionalHashCommandsImpl<>(
+        return new ReactiveTransactionalHashCommandsImpl<>(this,
                 (ReactiveHashCommandsImpl<K, F, V>) this.reactive.hash(redisKeyType, typeOfField, typeOfValue),
                 tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalGeoCommands<K, V> geo(Class<K> redisKeyType, Class<V> memberType) {
-        return new ReactiveTransactionalGeoCommandsImpl<>(
+        return new ReactiveTransactionalGeoCommandsImpl<>(this,
                 (ReactiveGeoCommandsImpl<K, V>) this.reactive.geo(redisKeyType, memberType), tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalSortedSetCommands<K, V> sortedSet(Class<K> redisKeyType, Class<V> valueType) {
-        return new ReactiveTransactionalSortedSetCommandsImpl<>(
+        return new ReactiveTransactionalSortedSetCommandsImpl<>(this,
                 (ReactiveSortedSetCommandsImpl<K, V>) this.reactive.sortedSet(redisKeyType, valueType), tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType) {
-        return new ReactiveTransactionalStringCommandsImpl<>(
+        return new ReactiveTransactionalStringCommandsImpl<>(this,
                 (ReactiveStringCommandsImpl<K, V>) this.reactive.string(redisKeyType, valueType), tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalSetCommands<K, V> set(Class<K> redisKeyType, Class<V> memberType) {
-        return new ReactiveTransactionalSetCommandsImpl<>(
+        return new ReactiveTransactionalSetCommandsImpl<>(this,
                 (ReactiveSetCommandsImpl<K, V>) this.reactive.set(redisKeyType, memberType), tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalListCommands<K, V> list(Class<K> redisKeyType, Class<V> memberType) {
-        return new ReactiveTransactionalListCommandsImpl<>(
+        return new ReactiveTransactionalListCommandsImpl<>(this,
                 (ReactiveListCommandsImpl<K, V>) this.reactive.list(redisKeyType, memberType), tx);
     }
 
     @Override
     public <K, V> ReactiveTransactionalHyperLogLogCommands<K, V> hyperloglog(Class<K> redisKeyType, Class<V> memberType) {
-        return new ReactiveTransactionalHyperLogLogCommandsImpl<>(
+        return new ReactiveTransactionalHyperLogLogCommandsImpl<>(this,
                 (ReactiveHyperLogLogCommandsImpl<K, V>) this.reactive.hyperloglog(redisKeyType, memberType), tx);
     }
 
     @Override
     public <K> ReactiveTransactionalBitMapCommands<K> bitmap(Class<K> redisKeyType) {
-        return new ReactiveTransactionalBitMapCommandsImpl<>(
+        return new ReactiveTransactionalBitMapCommandsImpl<>(this,
                 (ReactiveBitMapCommandsImpl<K>) this.reactive.bitmap(redisKeyType), tx);
     }
 
     @Override
     public <K> ReactiveTransactionalKeyCommands<K> key(Class<K> redisKeyType) {
-        return new ReactiveTransactionalKeyCommandsImpl<>(
+        return new ReactiveTransactionalKeyCommandsImpl<>(this,
                 (ReactiveKeyCommandsImpl<K>) this.reactive.key(redisKeyType), tx);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSetCommandsImpl.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.runtime.datasource;
 
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -9,8 +10,9 @@ public class ReactiveTransactionalSetCommandsImpl<K, V> extends AbstractTransact
 
     private final ReactiveSetCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalSetCommandsImpl(ReactiveSetCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalSetCommandsImpl(ReactiveTransactionalRedisDataSource ds, ReactiveSetCommandsImpl<K, V> reactive,
+            TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSortedSetCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalSortedSetCommandsImpl.java
@@ -10,6 +10,7 @@ import io.quarkus.redis.datasource.sortedset.ScoredValue;
 import io.quarkus.redis.datasource.sortedset.ZAddArgs;
 import io.quarkus.redis.datasource.sortedset.ZAggregateArgs;
 import io.quarkus.redis.datasource.sortedset.ZRangeArgs;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -18,8 +19,9 @@ public class ReactiveTransactionalSortedSetCommandsImpl<K, V> extends AbstractTr
 
     private final ReactiveSortedSetCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalSortedSetCommandsImpl(ReactiveSortedSetCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalSortedSetCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveSortedSetCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -13,8 +14,9 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
 
     private final ReactiveStringCommandsImpl<K, V> reactive;
 
-    public ReactiveTransactionalStringCommandsImpl(ReactiveStringCommandsImpl<K, V> reactive, TransactionHolder tx) {
-        super(tx);
+    public ReactiveTransactionalStringCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveStringCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
         this.reactive = reactive;
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BitMapCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BitMapCommandsTest.java
@@ -37,6 +37,11 @@ public class BitMapCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(bitmap.getDataSource());
+    }
+
+    @Test
     void bitcount() {
         assertThat(bitmap.bitcount(key)).isEqualTo(0);
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
@@ -71,6 +71,11 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(geo.getDataSource());
+    }
+
+    @Test
     void geoadd() {
         boolean added = geo.geoadd(key, 44.9396, CRUSSOL_LATITUDE, Place.crussol);
         assertThat(added).isTrue();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
@@ -38,6 +38,11 @@ public class HashCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(hash.getDataSource());
+    }
+
+    @Test
     void simpleHset() {
         hash.hset("my-hash", "field1", Person.person1);
         Person person = hash.hget("my-hash", "field1");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HyperLogLogCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HyperLogLogCommandsTest.java
@@ -27,6 +27,11 @@ public class HyperLogLogCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(hll.getDataSource());
+    }
+
+    @Test
     void pfadd() {
         String k = getKey();
         assertThat(hll.pfadd(k, Person.person1, Person.person1)).isTrue();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -51,6 +51,11 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(keys.getDataSource());
+    }
+
+    @Test
     void del() {
         strings.set(key, Person.person7);
         assertThat((long) keys.del(key)).isEqualTo(1);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
@@ -36,6 +36,11 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(lists.getDataSource());
+    }
+
+    @Test
     void blpop() {
         lists.rpush("two", Person.person2, Person.person3);
         assertThat(lists.blpop(Duration.ofSeconds(1), "one", "two")).isEqualTo(KeyValue.of("two", Person.person2));

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/NumericCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/NumericCommandsTest.java
@@ -31,6 +31,11 @@ public class NumericCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(num.getDataSource());
+    }
+
+    @Test
     void decr() {
         assertThat(num.decr(key)).isEqualTo(-1);
         assertThat(num.decr(key)).isEqualTo(-2);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubCommandsTest.java
@@ -54,6 +54,11 @@ public class PubSubCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(pubsub.getDataSource());
+    }
+
+    @Test
     void testPubSub() {
 
         List<Person> people = new CopyOnWriteArrayList<>();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
@@ -35,6 +35,11 @@ public class PubSubTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(ps.getDataSource());
+    }
+
+    @Test
     void testWithSingleChannel() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(3);
         ReactivePubSubCommands.ReactiveRedisSubscriber subscriber = ps.subscribe("people",

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -42,6 +42,11 @@ public class SetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(sets.getDataSource());
+    }
+
+    @Test
     void sadd() {
         assertThat(sets.sadd(key, person1)).isEqualTo(1L);
         assertThat(sets.sadd(key, person1)).isEqualTo(0);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
@@ -43,7 +43,6 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
 
         setOfPlaces = ds.sortedSet(Place.class);
         setOfStrings = ds.sortedSet(String.class);
-
     }
 
     @AfterEach
@@ -53,6 +52,12 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
 
     private void populate() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0));
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(setOfStrings.getDataSource());
+        assertThat(ds).isEqualTo(setOfPlaces.getDataSource());
     }
 
     @Test

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
@@ -41,6 +41,11 @@ public class StringCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(strings.getDataSource());
+    }
+
+    @Test
     void append() {
         assertThat(strings.append(key, value)).isEqualTo(value.length());
         assertThat(strings.append(key, "X")).isEqualTo(value.length() + 1);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBitMapCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBitMapCommandsTest.java
@@ -37,6 +37,7 @@ public class TransactionalBitMapCommandsTest extends DatasourceTestBase {
     public void bitMapBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalBitMapCommands<String> bitmap = tx.bitmap(String.class);
+            assertThat(bitmap.getDataSource()).isEqualTo(tx);
             bitmap.bitcount(key); // 0 -> 0
             bitmap.setbit(key, 0L, 1); // 1 -> 1
             bitmap.setbit(key, 1L, 1); // 2 -> 2

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGeoCommandsTest.java
@@ -40,6 +40,7 @@ public class TransactionalGeoCommandsTest extends DatasourceTestBase {
     public void geoBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalGeoCommands<String, String> geo = tx.geo(String.class);
+            assertThat(geo.getDataSource()).isEqualTo(tx);
             geo.geoadd(key, 10, 10, "1"); // 0 - true
             geo.geoadd(key, GeoItem.of("2", GeoPosition.of(-1, -1))); // 1 - true
             geo.geoadd(key, GeoItem.of("3", -20, -20)); // 2 - true

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHashCommandsTest.java
@@ -36,6 +36,7 @@ public class TransactionalHashCommandsTest extends DatasourceTestBase {
     public void hgetBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalHashCommands<String, String, String> hash = tx.hash(String.class);
+            assertThat(hash.getDataSource()).isEqualTo(tx);
             hash.hget(KEY, "field"); // 0 -> null
             hash.hset(KEY, "field", "hello"); // 1 -> true
             hash.hget(KEY, "field"); // 2 -> "hello

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHyperLogLogCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHyperLogLogCommandsTest.java
@@ -34,6 +34,7 @@ public class TransactionalHyperLogLogCommandsTest extends DatasourceTestBase {
     public void hllBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalHyperLogLogCommands<String, String> hll = tx.hyperloglog(String.class);
+            assertThat(hll.getDataSource()).isEqualTo(tx);
             hll.pfadd(key, "a", "b", "c", "d"); // 0 -> true
             hll.pfcount(key); // 1 -> 4
             hll.pfadd(key, "a", "d", "e"); // 2 -> true

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalKeyTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalKeyTest.java
@@ -38,7 +38,9 @@ public class TransactionalKeyTest extends DatasourceTestBase {
     public void keyBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalKeyCommands<String> keys = tx.key();
+            assertThat(keys.getDataSource()).isEqualTo(tx);
             TransactionalHashCommands<String, String, String> hash = tx.hash(String.class);
+            assertThat(hash.getDataSource()).isEqualTo(tx);
             hash.hset("k1", Map.of("1", "a", "2", "b", "3", "c"));
             hash.hset("k2", "4", "d");
             keys.type("k1");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalListCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalListCommandsTest.java
@@ -34,6 +34,7 @@ public class TransactionalListCommandsTest extends DatasourceTestBase {
     public void listBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalListCommands<String, String> list = tx.list(String.class);
+            assertThat(list.getDataSource()).isEqualTo(tx);
             list.lpush(key, "a", "b", "c", "d");
             list.linsertBeforePivot(key, "c", "1");
             list.lpos(key, "c");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSetCommandsTest.java
@@ -34,6 +34,7 @@ public class TransactionalSetCommandsTest extends DatasourceTestBase {
     public void setBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalSetCommands<String, String> set = tx.set(String.class);
+            assertThat(set.getDataSource()).isEqualTo(tx);
             set.sadd(key, "a", "b", "c", "d");
             set.sadd(key, "c", "1");
             set.spop(key);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSortedSetCommandsTest.java
@@ -37,6 +37,7 @@ public class TransactionalSortedSetCommandsTest extends DatasourceTestBase {
     public void setBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalSortedSetCommands<String, String> set = tx.sortedSet(String.class);
+            assertThat(set.getDataSource()).isEqualTo(tx);
             set.zadd(key, Map.of("a", 1.0, "b", 2.0, "c", 3.0, "d", 4.0));
             set.zadd(key, 3.0, "e");
             set.zpopmin(key);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalStringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalStringCommandsTest.java
@@ -35,6 +35,7 @@ public class TransactionalStringCommandsTest extends DatasourceTestBase {
     public void setBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
             TransactionalStringCommands<String, String> string = tx.string(String.class);
+            assertThat(string.getDataSource()).isEqualTo(tx);
             string.set(key, "hello");
             string.setnx("k2", "bonjour");
             string.append(key, "-1");


### PR DESCRIPTION
This removes the need to keep a reference on the data source when later in the code, we need to initiate a transaction.
