### PR TITLE
Fix streaming of JSON strings in RESTEasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/StreamingTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jackson/deployment/src/test/java/io/quarkus/resteasy/reactive/jackson/deployment/test/StreamingTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.jackson.deployment.test;
+
+import static io.restassured.RestAssured.when;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class StreamingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamingResource.class));
+
+    @Test
+    public void testSseMultiJsonString() {
+        when().get("/test/multi")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is("[\"Hello\",\"Hola\"]"));
+    }
+
+    @Path("/test")
+    public static class StreamingResource {
+
+        @GET
+        @Path("multi")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Multi<String> multi() {
+            return Multi.createFrom().items("Hello", "Hola");
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/StreamingTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-jsonb/deployment/src/test/java/io/quarkus/resteasy/reactive/jsonb/deployment/test/StreamingTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.resteasy.reactive.jsonb.deployment.test;
+
+import static io.restassured.RestAssured.when;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Multi;
+
+public class StreamingTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(StreamingResource.class));
+
+    @Test
+    public void testSseMultiJsonString() {
+        when().get("/test/multi")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.is("[\"Hello\",\"Hola\"]"));
+    }
+
+    @Path("/test")
+    public static class StreamingResource {
+
+        @GET
+        @Path("multi")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Multi<String> multi() {
+            return Multi.createFrom().items("Hello", "Hola");
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/MultiNdjsonTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/MultiNdjsonTest.java
@@ -55,7 +55,7 @@ public class MultiNdjsonTest {
             fail("Streaming did not complete in time");
         }
         assertThat(collected).hasSize(4)
-                .contains("one", "two", "three", "four");
+                .contains("\"one\"", "\"two\"", "\"three\"", "\"four\"");
     }
 
     @Test

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/StreamJsonTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/StreamJsonTest.java
@@ -55,7 +55,7 @@ public class StreamJsonTest {
             fail("Streaming did not complete in time");
         }
         assertThat(collected).hasSize(4)
-                .contains("one", "two", "3", "four");
+                .contains("\"one\"", "\"two\"", "\"3\"", "\"four\"");
     }
 
     @Test

--- a/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
+++ b/independent-projects/resteasy-reactive/server/jackson/src/main/java/org/jboss/resteasy/reactive/server/jackson/JacksonMessageBodyWriterUtil.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
 import javax.ws.rs.core.MultivaluedMap;
+import org.jboss.resteasy.reactive.server.StreamingOutputStream;
 
 public final class JacksonMessageBodyWriterUtil {
 
@@ -43,7 +44,8 @@ public final class JacksonMessageBodyWriterUtil {
     public static void doLegacyWrite(Object o, Annotation[] annotations, MultivaluedMap<String, Object> httpHeaders,
             OutputStream entityStream, ObjectWriter defaultWriter) throws IOException {
         setContentTypeIfNecessary(httpHeaders);
-        if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
+        if ((o instanceof String) && (!(entityStream instanceof StreamingOutputStream))) {
+            // YUK: done in order to avoid adding extra quotes... when we are not streaming a result
             entityStream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             if (annotations != null) {

--- a/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
@@ -11,6 +11,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import org.jboss.resteasy.reactive.common.providers.serialisers.JsonMessageBodyWriterUtil;
+import org.jboss.resteasy.reactive.server.StreamingOutputStream;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
@@ -27,7 +28,8 @@ public class JsonbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteable
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         JsonMessageBodyWriterUtil.setContentTypeIfNecessary(httpHeaders);
-        if (o instanceof String) { // YUK: done in order to avoid adding extra quotes...
+        if ((o instanceof String) && (!(entityStream instanceof StreamingOutputStream))) {
+            // YUK: done in order to avoid adding extra quotes... when we are not streaming a result
             entityStream.write(((String) o).getBytes(StandardCharsets.UTF_8));
         } else {
             json.toJson(o, type, entityStream);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/StreamingOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/StreamingOutputStream.java
@@ -1,0 +1,10 @@
+package org.jboss.resteasy.reactive.server;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * The only reason we use this is to give MessageBodyWriter classes the ability to tell
+ * if they are being called in a streaming context
+ */
+public class StreamingOutputStream extends ByteArrayOutputStream {
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/StreamingUtil.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/StreamingUtil.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.server.core;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
@@ -13,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyWriter;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
+import org.jboss.resteasy.reactive.server.StreamingOutputStream;
 import org.jboss.resteasy.reactive.server.handlers.PublisherResponseHandler;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 
@@ -56,7 +56,7 @@ public class StreamingUtil {
         MessageBodyWriter<Object>[] writers = (MessageBodyWriter<Object>[]) serialisers
                 .findWriters(null, entityClass, mediaType, RuntimeType.SERVER)
                 .toArray(ServerSerialisers.NO_WRITER);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        StreamingOutputStream baos = new StreamingOutputStream();
         boolean wrote = false;
         for (MessageBodyWriter<Object> writer : writers) {
             // Spec(API) says we should use class/type/mediaType but doesn't talk about annotations


### PR DESCRIPTION
Fixes: #18043

P.S. I am definitely not proud of how this is fixed, but we don't have many options given how mismatched the `MessageBodyWriter` API is with streaming results. This way also avoid trying to manually escape characters which was attempted in https://github.com/quarkusio/quarkus/pull/18401