### PR TITLE
Unclutter test resource start error message

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/TestResourceManager.java
@@ -473,7 +473,8 @@ public class TestResourceManager implements Closeable {
                         allProps.putAll(start);
                     }
                 } catch (Exception e) {
-                    throw new RuntimeException("Unable to start Quarkus test resource " + entry.getTestResource(), e);
+                    throw new RuntimeException(
+                            "Unable to start Quarkus test resource " + entry.getTestResource().getClass().toString(), e);
                 }
             }
         }


### PR DESCRIPTION
This change leads for example from this:

```
Unable to start Quarkus test resource io.quarkus.test.mongodb.MongoTestResource@11d234c7
```

to

```
Unable to start Quarkus test resource class io.quarkus.test.mongodb.MongoTestResource
```

