### PR TITLE
Add CrossSite Request Forgery prevention filter

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -777,6 +777,16 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-csrf-reactive</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-csrf-reactive-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-oidc</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -397,6 +397,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-csrf-reactive</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-datasource</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -383,6 +383,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-csrf-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-datasource-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -1,0 +1,196 @@
+////
+This guide is maintained in the main Quarkus repository
+and pull requests should be submitted there:
+https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
+////
+= Cross-Site Request Forgery Prevention
+
+include::./attributes.adoc[]
+
+https://owasp.org/www-community/attacks/csrf[Cross-Site Request Forgery(CSRF)] is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated.
+
+Quarkus Security provides a CSRF prevention feature which consists of a xref:resteasy-reactive.adoc[Resteasy Reactive] server filter which creates and verifies CSRF tokens and an HTML form parameter provider which supports the xref:qute-reference.adoc#injecting-beans-directly-in-templates[injection of CSRF tokens in Qute templates].
+
+== Creating the Project
+
+First, we need a new project.
+Create a new project with the following command:
+
+:create-app-artifact-id: security-csrf-prevention
+:create-app-extensions: csrf-reactive
+include::{includes}/devtools/create-app.adoc[]
+
+This command generates a project which imports the `csrf-reactive` extension.
+
+If you already have your Quarkus project configured, you can add the `csrf-reactive` extension
+to your project by running the following command in your project base directory:
+
+:add-extension-extensions: csrf-reactive
+include::{includes}/devtools/extension-add.adoc[]
+
+This will add the following to your build file:
+
+[source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
+.pom.xml
+----
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-csrf-reactive</artifactId>
+</dependency>
+----
+
+[source,gradle,role="secondary asciidoc-tabs-target-sync-gradle"]
+.build.gradle
+----
+implementation("io.quarkus:quarkus-csrf-reactive")
+----
+
+Next lets add a Qute template producing an HTML form:
+
+[source,html]
+----
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>User Name Input</title> 
+</head>
+<body>
+    <h1>User Name Input</h1>
+
+    <form action="/service/csrfTokenForm" method="post">
+    	<input type="hidden" name="{inject:csrf.parameterName}" value="{inject:csrf.token}" />  <1>
+    	
+    	<p>Your Name: <input type="text" name="name" /></p>
+    	<p><input type="submit" name="submit"/></p>
+    </form>
+</body>
+</html>
+----
+
+<1> This expression is used to inject a CSRF token into a hidden form field. This token will be verified by the CSRF filter against a CSRF cookie.
+
+You can name the file containing this template as `csrfToken.html` and put it in a `src/main/resources/templates` folder.
+
+Now let's create a resource class which returns an HTML form and handles form POST requests:
+
+[source,java]
+----
+package io.quarkus.it.csrf;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("/service")
+public class UserNameResource {
+
+    @Inject
+    Template csrfToken; <1>
+
+    @GET
+    @Path("/csrfTokenForm")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getCsrfTokenForm() {
+        return csrfToken.instance(); <2>
+    }
+
+    @POST
+    @Path("/csrfTokenForm")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postCsrfTokenForm(@FormParam("name") String name) {
+        return userName; <3>
+    }
+}
+----
+
+<1> Inject the `csrfToken.html` as a `Template`.
+<2> Return HTML form with a hidden form field containing a CSRF token created by the CSRF filter.
+<3> Handle the form POST request, this method can only be invoked only if the CSRF filter has successfully verified the token.
+
+The form POST request will fail with HTTP status `400` if the filter finds the hidden CSRF form field is missing, the CSRF cookie is missing, or if the CSRF form field and CSRF cookie values do not match.
+
+At this stage no additional configuration is needed - by default the CSRF form field and cookie name will be set to `csrf_token`, and the filter will verify the token. But lets change these names:
+
+[source,properties]
+----
+quarkus.csrf-reactive.form-field-name=csrftoken
+quarkus.csrf-reactive.cookie-name=csrftoken
+----
+
+Note that the CSRF filter has to read the input stream in order to verify the token and then re-create the stream for the application code to read it as well. The filter performs this work on an event loop thread so for small form payloads such as the one shown in the example above it will have negligible peformance side-effects. However if you deal with large form payloads then it is recommended to compare the CSRF form field and cookie values in the application code:
+
+[source,java]
+----
+package io.quarkus.it.csrf;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("/service")
+public class UserNameResource {
+
+    @Inject
+    Template csrfToken;
+
+    @GET
+    @Path("/csrfTokenForm")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getCsrfTokenForm() {
+        return csrfToken.instance();
+    }
+
+    @POST
+    @Path("/csrfTokenForm")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postCsrfTokenForm(@CookieParam("csrf-token") csrfCookie, @FormParam("csrf-token") String formCsrfToken, @FormParam("name") String userName) {
+        if (!csrfCookie.getValue().equals(formCsrfToken)) { <1>
+            throw new BadRequestException();
+        }
+        return userName;
+    }
+}
+----
+
+<1> Compare the CSRF form field and cookie values and fail with HTTP status `400` if they don't match.
+
+Also disable the token verification in the filter:
+
+[source,properties]
+----
+quarkus.csrf-reactive.verify-token=false
+----
+
+
+[[csrf-reactive-configuration-reference]]
+== Configuration Reference
+
+include::{generated-dir}/config/quarkus-csrf-reactive.adoc[leveloffset=+1, opts=optional]
+
+== References
+
+* https://owasp.org/www-community/attacks/csrf[OWASP Cross-Site Request Forgery]
+* xref:resteasy-reactive.adoc[RESTEasy Reactive]
+* xref:qute-reference.adoc[Qute Reference]
+* xref:security.adoc[Quarkus Security]

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -263,6 +263,10 @@ See the xref:http-reference.adoc#ssl[Supporting secure connections with SSL] gui
 
 If you plan to make your Quarkus application accessible to another application running on a different domain, you will need to configure CORS (Cross-Origin Resource Sharing). Please read the xref:http-reference.adoc#cors-filter[HTTP CORS documentation] for more information.
 
+== Cross-Site Request Forgery Prevention
+
+Quarkus Security provides a RESTEasy Reactive filter which can help protect against a https://owasp.org/www-community/attacks/csrf[Cross-Site Request Forgery] attack. Please read the xref:csrf-prevention.adoc[Cross-Site Request Forgery Prevention] guide for more information.
+
 == SameSite cookies
 
 Please see xref:http-reference.adoc#same-site-cookie[SameSite cookies] for information about adding a https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite] cookie property to any of the cookies set by a Quarkus endpoint.

--- a/extensions/csrf-reactive/deployment/pom.xml
+++ b/extensions/csrf-reactive/deployment/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-csrf-reactive-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-csrf-reactive-deployment</artifactId>
+    <name>Quarkus - Cross-Site Request Forgery Filter Reactive - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-csrf-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-qute-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http-deployment</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveAlwaysEnabledProcessor.java
+++ b/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveAlwaysEnabledProcessor.java
@@ -1,0 +1,14 @@
+package io.quarkus.csrf.reactive;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+// Executed even if the extension is disabled, see https://github.com/quarkusio/quarkus/pull/26966/
+public class CsrfReactiveAlwaysEnabledProcessor {
+
+    @BuildStep
+    FeatureBuildItem featureBuildItem() {
+        return new FeatureBuildItem("csrf-reactive");
+    }
+
+}

--- a/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
+++ b/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildStep.java
@@ -1,0 +1,35 @@
+package io.quarkus.csrf.reactive;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.csrf.reactive.runtime.CsrfRequestResponseReactiveFilter;
+import io.quarkus.csrf.reactive.runtime.CsrfTokenParameterProvider;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+
+@BuildSteps(onlyIf = CsrfReactiveBuildStep.IsEnabled.class)
+public class CsrfReactiveBuildStep {
+
+    @BuildStep
+    void registerProvider(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexedClassesBuildItem) {
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfRequestResponseReactiveFilter.class));
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, CsrfRequestResponseReactiveFilter.class));
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(CsrfTokenParameterProvider.class));
+        additionalIndexedClassesBuildItem
+                .produce(new AdditionalIndexedClassesBuildItem(CsrfRequestResponseReactiveFilter.class.getName()));
+    }
+
+    public static class IsEnabled implements BooleanSupplier {
+        CsrfReactiveBuildTimeConfig config;
+
+        public boolean getAsBoolean() {
+            return config.enabled;
+        }
+    }
+}

--- a/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildTimeConfig.java
+++ b/extensions/csrf-reactive/deployment/src/main/java/io/quarkus/csrf/reactive/CsrfReactiveBuildTimeConfig.java
@@ -1,0 +1,16 @@
+package io.quarkus.csrf.reactive;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Build time configuration for CSRF Reactive Filter.
+ */
+@ConfigRoot
+public class CsrfReactiveBuildTimeConfig {
+    /**
+     * If filter is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+}

--- a/extensions/csrf-reactive/pom.xml
+++ b/extensions/csrf-reactive/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-extensions-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-csrf-reactive-parent</artifactId>
+    <name>Quarkus - Cross-Site Request Forgery Prevention Filter Reactive</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/extensions/csrf-reactive/runtime/pom.xml
+++ b/extensions/csrf-reactive/runtime/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-csrf-reactive-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-csrf-reactive</artifactId>
+    <name>Quarkus - Cross-Site Request Forgery Prevention Filter - Runtime</name>
+    <description>Use Reactive REST Server filters to prevent the risk of Cross-Site Request Forgery</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
@@ -1,0 +1,91 @@
+package io.quarkus.csrf.reactive.runtime;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Runtime configuration for CSRF Reactive Filter.
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class CsrfReactiveConfig {
+    /**
+     * Form field name which keeps a CSRF token.
+     */
+    @ConfigItem(defaultValue = "csrf-token")
+    public String formFieldName;
+
+    /**
+     * CSRF cookie name.
+     */
+    @ConfigItem(defaultValue = "csrf-token")
+    public String cookieName;
+
+    /**
+     * CSRF cookie max age.
+     */
+    @ConfigItem(defaultValue = "10M")
+    public Duration cookieMaxAge;
+
+    /**
+     * CSRF cookie path.
+     */
+    @ConfigItem(defaultValue = "/")
+    public String cookiePath;
+
+    /**
+     * CSRF cookie domain.
+     */
+    @ConfigItem
+    public Optional<String> cookieDomain;
+
+    /**
+     * If enabled the CSRF cookie will have its 'secure' parameter set to 'true'
+     * when HTTP is used. It may be necessary when running behind an SSL terminating reverse proxy.
+     * The cookie will always be secure if HTTPS is used even if this property is set to false.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean cookieForceSecure;
+
+    /**
+     * Create CSRF token only if the HTTP GET relative request path is the same as the one configured with this property.
+     *
+     */
+    @ConfigItem
+    public Optional<String> createTokenPath;
+
+    /**
+     * The random CSRF token size in bytes.
+     */
+    @ConfigItem(defaultValue = "16")
+    public int tokenSize;
+
+    /**
+     * Verify CSRF token in the CSRF filter.
+     * If this property is enabled then the input stream will be read by the CSRF filter to verify the token
+     * and recreated for the application code to read the data correctly.
+     *
+     * Therefore, it is recommended to disable this property when dealing with the large form payloads and instead compare
+     * CSRF form and cookie parameters in the application code using JAX-RS {@linkplain FormParam} which refers to the
+     * {@link #formFieldName}
+     * form property and {@linkplain CookieParam} which refers to the {@link CsrfReactiveConfig#cookieName} cookie.
+     *
+     * Note that even if the CSRF token verification in the CSRF filter is disabled, the filter will still perform checks to
+     * ensure the token
+     * is available, has the correct {@linkplain #tokenSize} in bytes and that the Content-Type HTTP header is
+     * 'application/x-www-form-urlencoded'.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean verifyToken;
+
+    /**
+     * Require that only 'application/x-www-form-urlencoded' body is accepted for the token verification to proceed.
+     * Disable this property for the CSRF filter to avoid verifying the token for POST requests with other content types.
+     * This property is only effective if {@link #verifyToken} property is enabled.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean requireFormUrlEncoded;
+}

--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
@@ -1,0 +1,264 @@
+package io.quarkus.csrf.reactive.runtime;
+
+import java.io.ByteArrayInputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.CookieImpl;
+import io.vertx.core.http.impl.ServerCookie;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.mutiny.core.buffer.Buffer;
+
+public class CsrfRequestResponseReactiveFilter {
+    private static final Logger LOG = Logger.getLogger(CsrfRequestResponseReactiveFilter.class);
+
+    /**
+     * CSRF token key.
+     */
+    private static final String CSRF_TOKEN_KEY = "csrf_token";
+
+    /**
+     * CSRF token verification status.
+     */
+    private static final String CSRF_TOKEN_VERIFIED = "csrf_token_verified";
+
+    @Inject
+    Instance<CsrfReactiveConfig> configInstance;
+
+    public CsrfRequestResponseReactiveFilter() {
+    }
+
+    /**
+     * If the request method is safe ({@code GET}, {@code HEAD} or {@code OPTIONS}):
+     * <ul>
+     * <li>Sets a {@link RoutingContext} key by the name {@value #CSRF_TOKEN_KEY} that contains a randomly generated Base64
+     * encoded string, unless such a cookie was already sent in the incoming request.</li>
+     * </ul>
+     * If the request method is unsafe, requires the following:
+     * <ul>
+     * <li>The request contains a valid CSRF token cookie set in response to a previous request (see above).</li>
+     * <li>A request entity is present.</li>
+     * <li>The request {@code Content-Type} is {@value MediaType#APPLICATION_FORM_URLENCODED}.</li>
+     * <li>The request entity contains a form parameter with the name
+     * {@value #CSRF_TOKEN_KEY} and value that is equal to the one supplied in the cookie.</li>
+     * </ul>
+     */
+    @ServerRequestFilter(preMatching = true)
+    public Uni<Response> filter(ContainerRequestContext requestContext, RoutingContext routing) {
+        final CsrfReactiveConfig config = this.configInstance.get();
+
+        String cookieToken = getCookieToken(routing, config);
+        if (cookieToken != null) {
+            routing.put(CSRF_TOKEN_KEY, cookieToken);
+
+            try {
+                int suppliedTokenSize = Base64.getUrlDecoder().decode(cookieToken).length;
+
+                if (suppliedTokenSize != config.tokenSize) {
+                    LOG.debugf("Invalid CSRF token cookie size: expected %d, got %d", config.tokenSize,
+                            suppliedTokenSize);
+                    return Uni.createFrom().item(badClientRequest());
+                }
+            } catch (IllegalArgumentException e) {
+                LOG.debugf("Invalid CSRF token cookie: %s", cookieToken);
+                return Uni.createFrom().item(badClientRequest());
+            }
+        }
+
+        if (requestMethodIsSafe(requestContext)) {
+            // safe HTTP method, tolerate the absence of a token
+            if (cookieToken == null && isCsrfTokenRequired(routing, config)) {
+                // Set the CSRF cookie with a randomly generated value
+                byte[] token = new byte[config.tokenSize];
+                new SecureRandom().nextBytes(token);
+                routing.put(CSRF_TOKEN_KEY, Base64.getUrlEncoder().withoutPadding().encodeToString(token));
+            }
+        } else if (config.verifyToken) {
+            // unsafe HTTP method, token is required
+
+            if (!requestContext.getMediaType().getType().equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE.getType())
+                    || !requestContext.getMediaType().getSubtype()
+                            .equals(MediaType.APPLICATION_FORM_URLENCODED_TYPE.getSubtype())) {
+                if (config.requireFormUrlEncoded) {
+                    LOG.debugf("Request has the wrong media type: %s", requestContext.getMediaType().toString());
+                    return Uni.createFrom().item(badClientRequest());
+                } else {
+                    LOG.debugf("Request has the  media type: %s, skipping the token verification",
+                            requestContext.getMediaType().toString());
+                    return Uni.createFrom().nullItem();
+                }
+            }
+
+            if (!requestContext.hasEntity()) {
+                LOG.debug("Request has no entity");
+                return Uni.createFrom().item(badClientRequest());
+            }
+
+            if (cookieToken == null) {
+                LOG.debug("CSRF cookie is not found");
+                return Uni.createFrom().item(badClientRequest());
+            }
+
+            return getFormUrlEncodedData(routing.request())
+                    .flatMap(new Function<MultiMap, Uni<? extends Response>>() {
+                        @Override
+                        public Uni<Response> apply(MultiMap form) {
+
+                            String csrfToken = form.get(config.formFieldName);
+                            if (csrfToken == null) {
+                                LOG.debug("CSRF token is not found");
+                                return Uni.createFrom().item(badClientRequest());
+                            } else if (!csrfToken.equals(cookieToken)) {
+                                LOG.debug("CSRF token value is wrong");
+                                return Uni.createFrom().item(badClientRequest());
+                            } else {
+                                routing.put(CSRF_TOKEN_VERIFIED, true);
+                                requestContext.setEntityStream(new ByteArrayInputStream(encodeForm(form).getBytes()));
+                            }
+                            return Uni.createFrom().nullItem();
+                        }
+                    });
+        } else if (cookieToken == null) {
+            LOG.debug("CSRF token is not found");
+            return Uni.createFrom().item(badClientRequest());
+        }
+
+        return null;
+    }
+
+    private static Response badClientRequest() {
+        return Response.status(400).build();
+    }
+
+    /**
+     * If the requirements below are true, sets a cookie by the name {@value #CSRF_TOKEN_KEY} that contains a CSRF token.
+     * <ul>
+     * <li>The request method is {@code GET}.</li>
+     * <li>The request does not contain a valid CSRF token cookie.</li>
+     * </ul>
+     *
+     * @throws IllegalStateException if the {@link RoutingContext} does not have a value for the key {@value #CSRF_TOKEN_KEY}
+     *         and a cookie needs to be set.
+     */
+    @ServerResponseFilter
+    public void filter(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext, RoutingContext routing) {
+        final CsrfReactiveConfig config = configInstance.get();
+        if (requestContext.getMethod().equals("GET") && isCsrfTokenRequired(routing, config)
+                && getCookieToken(routing, config) == null) {
+            String token = (String) routing.get(CSRF_TOKEN_KEY);
+
+            if (token == null) {
+                throw new IllegalStateException(
+                        "CSRF Filter should have set the property " + CSRF_TOKEN_KEY + ", but it is null");
+            }
+
+            createCookie(token, routing, config);
+        }
+
+    }
+
+    /**
+     * Gets the CSRF token from the CSRF cookie from the current {@code RoutingContext}.
+     *
+     * @return An Optional containing the token, or an empty Optional if the token cookie is not present or is invalid
+     */
+    private String getCookieToken(RoutingContext routing, CsrfReactiveConfig config) {
+        Cookie cookie = routing.getCookie(config.cookieName);
+
+        if (cookie == null) {
+            LOG.debug("CSRF token cookie is not set");
+            return null;
+        }
+
+        return cookie.getValue();
+    }
+
+    private boolean isCsrfTokenRequired(RoutingContext routing, CsrfReactiveConfig config) {
+        LOG.error("**************Request path: " + routing.request().path());
+        LOG.error("**************Token path: " + config.createTokenPath.get());
+        return config.createTokenPath.isPresent() ? config.createTokenPath.get().equals(routing.request().path()) : true;
+    }
+
+    private void createCookie(String csrfToken, RoutingContext routing, CsrfReactiveConfig config) {
+        ServerCookie cookie = new CookieImpl(config.cookieName, csrfToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(config.cookieForceSecure || routing.request().isSSL());
+        cookie.setMaxAge(config.cookieMaxAge.toSeconds());
+        cookie.setPath(config.cookiePath);
+        if (config.cookieDomain.isPresent()) {
+            cookie.setDomain(config.cookieDomain.get());
+        }
+        routing.response().addCookie(cookie);
+    }
+
+    private static boolean requestMethodIsSafe(ContainerRequestContext context) {
+        switch (context.getMethod()) {
+            case "GET":
+            case "HEAD":
+            case "OPTIONS":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static Uni<MultiMap> getFormUrlEncodedData(HttpServerRequest request) {
+        request.setExpectMultipart(true);
+        return Uni.createFrom().emitter(new Consumer<UniEmitter<? super MultiMap>>() {
+            @Override
+            public void accept(UniEmitter<? super MultiMap> t) {
+                request.endHandler(new Handler<Void>() {
+                    @Override
+                    public void handle(Void event) {
+                        t.complete(request.formAttributes());
+                    }
+                });
+                request.resume();
+            }
+        });
+    }
+
+    private static Buffer encodeForm(MultiMap form) {
+        Buffer buffer = Buffer.buffer();
+        for (Map.Entry<String, String> entry : form) {
+            if (buffer.length() != 0) {
+                buffer.appendByte((byte) '&');
+            }
+            buffer.appendString(entry.getKey());
+            buffer.appendByte((byte) '=');
+            buffer.appendString(urlEncode(entry.getValue()));
+        }
+        return buffer;
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenParameterProvider.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenParameterProvider.java
@@ -1,0 +1,51 @@
+package io.quarkus.csrf.reactive.runtime;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * CSRF token form parameter provider which supports the injection of the CSRF token in Qute templates.
+ */
+@ApplicationScoped
+@Named("csrf")
+public class CsrfTokenParameterProvider {
+    /**
+     * CSRF token key.
+     */
+    private static final String CSRF_TOKEN_KEY = "csrf_token";
+
+    @Inject
+    RoutingContext context;
+
+    private final String csrfFormFieldName;
+
+    public CsrfTokenParameterProvider(CsrfReactiveConfig config) {
+        this.csrfFormFieldName = config.formFieldName;
+    }
+
+    /**
+     * Gets the CSRF token value.
+     *
+     * @throws IllegalStateException if the {@link RoutingContext} does not contain a CSRF token value.
+     */
+    public String getToken() {
+        String token = (String) context.get(CSRF_TOKEN_KEY);
+
+        if (token == null) {
+            throw new IllegalStateException(
+                    "CSRFFilter should have set the attribute " + csrfFormFieldName + ", but it is null");
+        }
+
+        return token;
+    }
+
+    /**
+     * Gets the name of the form parameter that is to contain the value returned by {@link #getToken()}.
+     */
+    public String getParameterName() {
+        return csrfFormFieldName;
+    }
+}

--- a/extensions/csrf-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/csrf-reactive/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,11 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "Cross-Site Request Forgery Prevention Filter Reactive"
+metadata:
+  keywords:
+  - "csrf"
+  categories:
+  - "security"
+  status: "preview"
+  config:
+  - "quarkus.csrf-reactive."

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -140,6 +140,7 @@
         <module>keycloak-admin-client</module>
         <module>keycloak-admin-client-reactive</module>
         <module>credentials</module>
+        <module>csrf-reactive</module>
 
         <!-- Infinispan -->
         <module>infinispan-client</module>

--- a/integration-tests/csrf-reactive/pom.xml
+++ b/integration-tests/csrf-reactive/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <groupId>io.quarkus</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-integration-test-csrf-reactive</artifactId>
+    <name>Quarkus - Integration Tests - Cross-Site Request Forgery Filter Reactive</name>
+    <description>Module that contains Cross-Site Request Forgery Filter Reactive tests</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-csrf-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-csrf-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
+++ b/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
@@ -1,0 +1,46 @@
+package io.quarkus.it.csrf;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/service")
+public class TestResource {
+
+    @Inject
+    Template csrfToken;
+
+    @Inject
+    RoutingContext routingContext;
+
+    @GET
+    @Path("/csrfTokenForm")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getCsrfTokenForm() {
+        return csrfToken.instance();
+    }
+
+    @POST
+    @Path("/csrfTokenForm")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postCsrfTokenForm(@FormParam("name") String name) {
+        return name + ":" + routingContext.get("csrf_token_verified", false);
+    }
+
+    @GET
+    @Path("/hello")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getSimpleGet() {
+        return "hello";
+    }
+}

--- a/integration-tests/csrf-reactive/src/main/resources/application.properties
+++ b/integration-tests/csrf-reactive/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.csrf-reactive.cookie-name=csrftoken
+quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm

--- a/integration-tests/csrf-reactive/src/main/resources/templates/csrfToken.html
+++ b/integration-tests/csrf-reactive/src/main/resources/templates/csrfToken.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSRF Token Test</title> 
+</head>
+<body>
+    <h1>CSRF Test</h1>
+
+    <form action="/service/csrfTokenForm" method="post">
+    	<input type="hidden" name="{inject:csrf.parameterName}" value="{inject:csrf.token}" />
+    	
+    	<p>Your Name: <input type="text" name="name" /></p>
+    	<p><input type="submit" name="submit"/></p>
+    </form>
+</body>
+</html>

--- a/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveITCase.java
+++ b/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveITCase.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.csrf;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class CsrfReactiveITCase extends CsrfReactiveTest {
+}

--- a/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
+++ b/integration-tests/csrf-reactive/src/test/java/io/quarkus/it/csrf/CsrfReactiveTest.java
@@ -1,0 +1,130 @@
+package io.quarkus.it.csrf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.util.Cookie;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class CsrfReactiveTest {
+
+    @Test
+    public void testCsrfToken() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage htmlPage = webClient.getPage("http://localhost:8081/service/csrfTokenForm");
+
+            assertEquals("CSRF Token Test", htmlPage.getTitleText());
+
+            HtmlForm loginForm = htmlPage.getForms().get(0);
+
+            loginForm.getInputByName("name").setValueAttribute("alice");
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            TextPage textPage = loginForm.getInputByName("submit").click();
+
+            assertEquals("alice:true", textPage.getContent());
+
+            textPage = webClient.getPage("http://localhost:8081/service/hello");
+            assertEquals("hello", textPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testCsrfTokenInFormButNoCookie() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage htmlPage = webClient.getPage("http://localhost:8081/service/csrfTokenForm");
+
+            assertEquals("CSRF Token Test", htmlPage.getTitleText());
+
+            HtmlForm loginForm = htmlPage.getForms().get(0);
+
+            loginForm.getInputByName("name").setValueAttribute("alice");
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            webClient.getCookieManager().clearCookies();
+
+            assertNull(webClient.getCookieManager().getCookie("csrftoken"));
+            try {
+                loginForm.getInputByName("submit").click();
+                fail("400 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(400, ex.getStatusCode());
+            }
+            webClient.getCookieManager().clearCookies();
+
+        }
+    }
+
+    @Test
+    public void testWrongCsrfTokenCookieValue() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage htmlPage = webClient.getPage("http://localhost:8081/service/csrfTokenForm");
+
+            assertEquals("CSRF Token Test", htmlPage.getTitleText());
+
+            HtmlForm loginForm = htmlPage.getForms().get(0);
+
+            loginForm.getInputByName("name").setValueAttribute("alice");
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            webClient.getCookieManager().clearCookies();
+
+            assertNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            webClient.getCookieManager().addCookie(new Cookie("localhost", "csrftoken", "wrongvalue"));
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+            try {
+                loginForm.getInputByName("submit").click();
+                fail("400 status error is expected");
+            } catch (FailingHttpStatusCodeException ex) {
+                assertEquals(400, ex.getStatusCode());
+            }
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testWrongCsrfTokenFormValue() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage htmlPage = webClient.getPage("http://localhost:8081/service/csrfTokenForm");
+
+            assertEquals("CSRF Token Test", htmlPage.getTitleText());
+
+            assertNotNull(webClient.getCookieManager().getCookie("csrftoken"));
+
+            RestAssured.given().urlEncodingEnabled(true)
+                    .param("csrf-token", "wrong-value")
+                    .post("/service/csrfTokenForm")
+                    .then().statusCode(400);
+
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -228,6 +228,7 @@
                 <module>oidc-tenancy</module>
                 <module>oidc-wiremock</module>
                 <module>keycloak-authorization</module>
+                <module>csrf-reactive</module>
                 <module>reactive-db2-client</module>
                 <module>reactive-pg-client</module>
                 <module>reactive-mysql-client</module>


### PR DESCRIPTION
Fixes #8399.

This PR is based on the ideas shown by @kekbur  in the code shared at #8399 but with some modifications:
- It is a RESTEasy Reactive implementation of a `preMatching` (implicitly non-blocking) server request filter
-  `RoutingContext`'s way of checking the form fields is used and the `InputStream` is recreated
- Token verification in the filter is optional - documentation shows how to easily compare the values in the application code when dealing with the large payloads
- the filter is configurable (various cookie properties, form field name, etc).

However I've not managed to resolve 2 problems yet which might be related:
* I could not make `CsrfReactiveConfig` runtime init - the test is failing if it is runtime init saying that `CsrfReactiveConfig` has not been initialized at the time of `CsrfRequestResponseReactiveFilter`'s construction ( `CsrfReactiveConfig` is injected into the `CsrfRequestResponseReactiveFilter` constructor). I tried initializing the filter it at the runtime init time - by injecting an empty recorder which did not really help...
* I could not create an internal `non-static` `SecureRandom` field in `CsrfRequestResponseReactiveFilter` - the native test buid is failing in this case - looks like RESTEasy Reactive filters are kept in a `static` field in `RESTEasy Reactive`? So a new `SecureRandom` is created directly in the request filter method implementation right now - not a big problem as the token creation should not happen often but I wonder if it can be optimized

@geoand @mkouba Can you please review and advise on resolving these 2 issues ?