### PR TITLE
Enable Keycloak Admin Client injection by default and minor doc updates

### DIFF
--- a/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
+++ b/docs/src/main/asciidoc/security-keycloak-admin-client.adoc
@@ -7,8 +7,10 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 
 include::./attributes.adoc[]
 
-The Quarkus Keycloak Admin Client and its reactive twin facilitate running the Keycloak Admin Client in a native mode.
-This guide demonstrates how you can leverage the xref:cdi-reference.adoc[Quarkus ArC] and inject the admin client to your Quarkus application.
+The Quarkus Keycloak Admin Client and its reactive twin support Keycloak Admin Client which can be used to configure a running Keycloak server.
+
+This guide demonstrates how you can leverage the xref:cdi-reference.adoc[Quarkus ArC] and inject the admin client to your Quarkus application, as well as how to create it directly in the application code.
+
 To learn more about the Keycloak Admin Client, please refer to its https://www.keycloak.org/docs/latest/server_development/#example-using-java[reference guide].
 
 == Prerequisites
@@ -74,7 +76,66 @@ import java.util.List;
 public class RolesResource {
 
         @Inject
+        Keycloak keycloak; <1>
+
+        @GET
+        @Path("/roles")
+        public List<RoleRepresentation> getRoles() {
+            return keycloak.realm("quarkus").roles().list();
+        }
+
+}
+----
+<1> Create  a default Keycloak Admin Client which can perform Keycloak `master` realm administration tasks as an `admin-cli` client, such as adding new realms, clients and users.
+
+The only configuration which is required to create this Keycloak Admin Client is a Keycloak server URL, for example:
+
+[source,properties]
+----
+quarkus.keycloak.admin-client.server-url=http://localhost:8081
+----
+
+[NOTE]
+====
+It is important that `quarkus.keycloak.admin-client.server-url` is configured if you would like to have `Keycloak` injected. The injection will fail if you attempt to inject `Keycloak` without configuring this property.
+====
+
+Injecting Keycloak Admin Client instead of creating it directly in the application code is a simpler and more flexible option but you can create the same admin client manually if necessary:
+
+[source,java]
+----
+package org.acme.keycloak.admin.client;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import javax.annotations.PostConstruct;
+import javax.annotations.PreConstruct;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.List;
+
+@Path("/api/admin")
+public class RolesResource {
+
         Keycloak keycloak;
+
+        @PostConstruct
+        public void initKeycloak() {
+            keycloak = KeycloakBuilder.builder()
+                .serverUrl("http://localhost:8081")
+                .realm("master")
+                .clientId("admin-cli")
+                .username("admin")
+                .password("admin")
+                .build();
+        }
+
+        @PreDestroy
+        public void closeKeycloak() {
+            keycloak.close();
+        }
 
         @GET
         @Path("/roles")
@@ -85,16 +146,12 @@ public class RolesResource {
 }
 ----
 
-Now, you can produce the `Keycloak` bean yourself, or you can instruct Quarkus to produce `Keycloak` bean.
+You can configure Keycloak Admin Client to administer other realms and clients. It can use either a `password` or `client_credentials` grant to acquire an access token to call the Admin REST API which requires authorization.
 
-NOTE: If you produce the bean yourself, please remember that `org.keycloak.admin.client.Keycloak` implements `AutoCloseable` and it's important to avoid resource exhaustion and related exceptions. If you configure your beans as explained below, Quarkus will do it for you.
-
-The Keycloak admin client needs an access token as its Admin REST API requires authorization.
 If you exchange user's credentials for the access token, here is an example configuration for the `password` grant type:
 
 [source,properties]
 ----
-quarkus.keycloak.admin-client=true
 quarkus.keycloak.admin-client.server-url=http://localhost:8081
 quarkus.keycloak.admin-client.realm=quarkus
 quarkus.keycloak.admin-client.client-id=quarkus-client
@@ -121,7 +178,7 @@ quarkus.keycloak.admin-client.grant-type=CLIENT_CREDENTIALS <1>
 
 NOTE: Note that the xref:security-openid-connect-client.adoc[OidcClient] can also be used to acquire tokens.
 
-[[arc-configuration-reference]]
+[[keycloak-admin-client-configuration-reference]]
 == Quarkus Keycloak Admin Client Configuration Reference
 
 include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+1, opts=optional]
@@ -131,6 +188,6 @@ include::{generated-dir}/config/quarkus-keycloak-admin-client.adoc[leveloffset=+
 * https://www.keycloak.org/documentation.html[Keycloak Documentation]
 * xref:security-keycloak-authorization.adoc[Keycloak Authorization extension]
 * xref:security-openid-connect-web-authentication.adoc[Using OpenID Connect to Protect Web Application]
-* xref:security.adoc[Quarkus Security]
 * xref:security-openid-connect.adoc[Using OpenID Connect to Protect Service Applications]
 * xref:security-openid-connect-client.adoc[OpenID Connect Client and Token Propagation Quickstart]
+* xref:security.adoc[Quarkus Security]

--- a/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientBuildTimeConfig.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientBuildTimeConfig.java
@@ -11,9 +11,9 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class KeycloakAdminClientBuildTimeConfig {
 
     /**
-     * Set to true if you want Quarkus to create the client bean for you.
+     * Set to true if Keycloak Admin Client injection is supported.
      */
-    @ConfigItem(name = ConfigItem.PARENT, defaultValue = "false")
-    public boolean enabled = false;
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled = true;
 
 }

--- a/extensions/keycloak-admin-client-common/deployment/src/test/java/io/quarkus/keycloak/admin/client/common/ConfigValidationTest.java
+++ b/extensions/keycloak-admin-client-common/deployment/src/test/java/io/quarkus/keycloak/admin/client/common/ConfigValidationTest.java
@@ -10,13 +10,6 @@ import org.junit.jupiter.api.Test;
 public class ConfigValidationTest {
 
     @Test
-    public void serverUrlIsRequiredTest() {
-        final KeycloakAdminClientConfig config = createConfig();
-        config.serverUrl = Optional.empty();
-        Assertions.assertThrows(KeycloakAdminClientConfigUtil.KeycloakAdminClientException.class, () -> validate(config));
-    }
-
-    @Test
     public void passwordGrantTypeTest() {
         // negative test
         Assertions.assertDoesNotThrow(() -> validate(createConfig()));

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfig.java
@@ -13,16 +13,19 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class KeycloakAdminClientConfig {
 
     /**
+     * Keycloak server URL, for example, `https://host:port`.
+     * If this property is not set then the Keycloak Admin Client injection will fail - use
+     * {@linkplain org.keycloak.admin.client.KeycloakBuilder}
+     * to create it instead.
+     */
+    @ConfigItem
+    public Optional<String> serverUrl;
+
+    /**
      * Realm.
      */
     @ConfigItem(defaultValue = "master")
     public String realm;
-
-    /**
-     * Keycloak server URL, for example, `https://host:port`.
-     */
-    @ConfigItem
-    public Optional<String> serverUrl;
 
     /**
      * Client id.

--- a/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfigUtil.java
+++ b/extensions/keycloak-admin-client-common/runtime/src/main/java/io/quarkus/keycloak/admin/client/common/KeycloakAdminClientConfigUtil.java
@@ -2,7 +2,10 @@ package io.quarkus.keycloak.admin.client.common;
 
 import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig.GrantType.PASSWORD;
 
+import org.jboss.logging.Logger;
+
 public class KeycloakAdminClientConfigUtil {
+    private static final Logger LOG = Logger.getLogger(KeycloakAdminClientConfigUtil.class);
 
     /**
      * Validates configuration properties. KeycloakBuilder also validates inputs (our config properties) when build()
@@ -11,7 +14,10 @@ public class KeycloakAdminClientConfigUtil {
     public static void validate(KeycloakAdminClientConfig config) {
 
         if (config.serverUrl.isEmpty()) {
-            throw new KeycloakAdminClientException("configuration property 'server-url' is required");
+            LOG.debug(
+                    "Configuration property 'server-url' is not set, 'Keycloak' admin client injection will fail, "
+                            + "use org.keycloak.admin.client.KeycloakBuilder to create it instead");
+            return;
         }
 
         // client id is also required in both cases, but since it's not nullable, we can skip its validation

--- a/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client-reactive/runtime/src/main/java/io/quarkus/keycloak/admin/client/reactive/runtime/ResteasyReactiveKeycloakAdminClientRecorder.java
@@ -29,6 +29,14 @@ public class ResteasyReactiveKeycloakAdminClientRecorder {
 
         final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
         validate(config);
+        if (config.serverUrl.isEmpty()) {
+            return new Supplier<Keycloak>() {
+                @Override
+                public Keycloak get() {
+                    return null;
+                }
+            };
+        }
         final KeycloakBuilder keycloakBuilder = KeycloakBuilder
                 .builder()
                 .clientId(config.clientId)
@@ -37,7 +45,7 @@ public class ResteasyReactiveKeycloakAdminClientRecorder {
                 .username(config.username.orElse(null))
                 .password(config.password.orElse(null))
                 .realm(config.realm)
-                .serverUrl(config.serverUrl.orElse(null))
+                .serverUrl(config.serverUrl.get())
                 .scope(config.scope.orElse(null));
         return new Supplier<Keycloak>() {
             @Override

--- a/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
@@ -25,6 +25,14 @@ public class ResteasyKeycloakAdminClientRecorder {
 
         final KeycloakAdminClientConfig config = keycloakAdminClientConfigRuntimeValue.getValue();
         validate(config);
+        if (config.serverUrl.isEmpty()) {
+            return new Supplier<Keycloak>() {
+                @Override
+                public Keycloak get() {
+                    return null;
+                }
+            };
+        }
         final KeycloakBuilder keycloakBuilder = KeycloakBuilder
                 .builder()
                 .clientId(config.clientId)
@@ -33,7 +41,7 @@ public class ResteasyKeycloakAdminClientRecorder {
                 .username(config.username.orElse(null))
                 .password(config.password.orElse(null))
                 .realm(config.realm)
-                .serverUrl(config.serverUrl.orElse(null))
+                .serverUrl(config.serverUrl.get())
                 .scope(config.scope.orElse(null));
         return new Supplier<Keycloak>() {
             @Override

--- a/integration-tests/keycloak-authorization/src/main/resources/application.properties
+++ b/integration-tests/keycloak-authorization/src/main/resources/application.properties
@@ -82,5 +82,4 @@ quarkus.keycloak.webapp-tenant.policy-enforcer.paths.1.claim-information-point.c
 admin-url=${keycloak.url}
 
 # Configure Keycloak Admin Client
-quarkus.keycloak.admin-client=true
 quarkus.keycloak.admin-client.server-url=${admin-url}


### PR DESCRIPTION
I've added a few minor updates to this new `security-keycloak-admin-client.adoc`:
* I thought now that @michalvavrik have added an option to inject the admin client, these admin client extensions are not really just about making sure the client can run in a native mode, that was the original goal, but now it is implicit and is expected to work in native anyway so I updated a description a bit. 
* Added some clarifications to the existing example and shown how to create it manually as right now it is how it is created in the released versions of Quarkus
* Put a link to the parent security.adoc as the last one

@michalvavrik Michal, can you please review as well.