### PR TITLE
Add RESTEasy Reactive StatusType equals and hashCode methods

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/StatusTypeImpl.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/StatusTypeImpl.java
@@ -1,5 +1,6 @@
 package org.jboss.resteasy.reactive.common.jaxrs;
 
+import java.util.Objects;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.Response.StatusType;
@@ -13,7 +14,16 @@ public class StatusTypeImpl implements StatusType {
 
     public StatusTypeImpl(int status, String reasonPhrase) {
         this.status = status;
-        this.reasonPhrase = reasonPhrase != null ? reasonPhrase : DEFAULT_REASON_PHRASE;
+        this.reasonPhrase = reasonPhrase != null ? reasonPhrase : getDefaultReasonPhrase(status);
+    }
+
+    private static String getDefaultReasonPhrase(int providedStatus) {
+        for (Response.Status defaultStatus : Response.Status.values()) {
+            if (providedStatus == defaultStatus.getStatusCode()) {
+                return defaultStatus.getReasonPhrase() != null ? defaultStatus.getReasonPhrase() : DEFAULT_REASON_PHRASE;
+            }
+        }
+        return DEFAULT_REASON_PHRASE;
     }
 
     @Override
@@ -29,6 +39,20 @@ public class StatusTypeImpl implements StatusType {
     @Override
     public String getReasonPhrase() {
         return reasonPhrase;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof StatusType)) {
+            return false;
+        }
+        return this.status == ((StatusType) other).getStatusCode()
+                && this.reasonPhrase.equals(((StatusType) other).getReasonPhrase());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(status) + 37 * reasonPhrase.hashCode();
     }
 
     public static StatusTypeImpl valueOf(StatusType statusType) {

--- a/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/jaxrs/StatusTypeImplTest.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/test/java/org/jboss/resteasy/reactive/common/jaxrs/StatusTypeImplTest.java
@@ -1,0 +1,21 @@
+package org.jboss.resteasy.reactive.common.jaxrs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+public class StatusTypeImplTest {
+    @Test
+    public void testEquals() {
+        Response.StatusType statusType = new StatusTypeImpl(200, null);
+        assertEquals(statusType, Response.Status.OK);
+    }
+
+    @Test
+    public void testNotEquals() {
+        Response.StatusType statusType = new StatusTypeImpl(200, "All works OK");
+        assertNotEquals(statusType, Response.Status.OK);
+    }
+}


### PR DESCRIPTION
Hey @geoand It should address the status type equals issue reported in the Zulip thread - note I've tried to get the same reason phrase for well-known status types if the provided reason phrase is null and only use the default one if none is found (doing it with `Response.Status.fromStatusCode(int)` is simpler but I was concerned about introducing a loop as it may go recurse to `StatusTypeImpl` - so checking a few well-known types manually should be fine).

The reason I'm not 100% sure it should be sufficient is that I don't know, if, in the reported case, the status code is created with the null phrase or if RestEasy Reactive tries to deduce something from the response, so we'll see and can tune more if needed I guess.

Fixes #27749