### PR TITLE
Revert "Upgrade to jreleaser 1.2.0"

### DIFF
--- a/devtools/cli/distribution/release-cli.sh
+++ b/devtools/cli/distribution/release-cli.sh
@@ -45,7 +45,7 @@ export JRELEASER_PROJECT_VERSION=${VERSION}
 export JRELEASER_BRANCH=${BRANCH}
 export JRELEASER_CHOCOLATEY_GITHUB_BRANCH=${BRANCH}
 
-jbang org.jreleaser:jreleaser:1.2.0 full-release \
+jbang org.jreleaser:jreleaser:1.1.0 full-release \
   --git-root-search \
   -od target
 


### PR DESCRIPTION
Reverts quarkusio/quarkus#27555

Because of: https://github.com/jreleaser/jreleaser/issues/930