### PR TITLE
Update mvn commands in docs to match the ones ran by quarkus-cli

### DIFF
--- a/docs/src/main/asciidoc/includes/devtools/build-native-container-parameters.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native-container-parameters.adoc
@@ -8,7 +8,7 @@ ifdef::devtools-wrapped[+]
 [source, bash, subs=attributes+, role="secondary asciidoc-tabs-sync-maven"]
 .Maven
 ----
-./mvnw package -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
+./mvnw install -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
 ----
 endif::[]
 ifndef::devtools-no-gradle[]

--- a/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native-container.adoc
@@ -15,10 +15,10 @@ ifdef::devtools-wrapped[+]
 .Maven
 ----
 ifdef::build-additional-parameters[]
-./mvnw package -Dnative -Dquarkus.native.container-build=true {build-additional-parameters}
+./mvnw install -Dnative -DskipTests -Dquarkus.native.container-build=true {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-./mvnw package -Dnative -Dquarkus.native.container-build=true
+./mvnw install -Dnative -DskipTests -Dquarkus.native.container-build=true
 endif::[]
 ----
 endif::[]

--- a/docs/src/main/asciidoc/includes/devtools/build-native.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build-native.adoc
@@ -14,10 +14,10 @@ ifdef::devtools-wrapped[+]
 .Maven
 ----
 ifdef::build-additional-parameters[]
-./mvnw package -Dnative {build-additional-parameters}
+./mvnw install -Dnative {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-./mvnw package -Dnative
+./mvnw install -Dnative
 endif::[]
 ----
 endif::[]

--- a/docs/src/main/asciidoc/includes/devtools/build.adoc
+++ b/docs/src/main/asciidoc/includes/devtools/build.adoc
@@ -14,10 +14,10 @@ ifdef::devtools-wrapped[+]
 .Maven
 ----
 ifdef::build-additional-parameters[]
-./mvnw clean package {build-additional-parameters}
+./mvnw install {build-additional-parameters}
 endif::[]
 ifndef::build-additional-parameters[]
-./mvnw clean package
+./mvnw install
 endif::[]
 ----
 endif::[]


### PR DESCRIPTION
`quarkus build` runs `mvn install` not `mvn package`

The main noticeable difference when it come to the guides is that
`mvn install` also runs tests while `mvn package` doesn't, though
some guides imply that the tests are being run even with `mvn package`.