### PR TITLE
Avoid mixing the RESTEasy Classic and RESTEasy Reactive REST layers

### DIFF
--- a/integration-tests/smallrye-opentracing/pom.xml
+++ b/integration-tests/smallrye-opentracing/pom.xml
@@ -47,7 +47,7 @@
         <!-- Client dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-mutiny</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
 
         <!-- In-memory tracer -->
@@ -130,7 +130,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
+            <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>


### PR DESCRIPTION
@Sgitario I'm surprised this didn't trigger a build error? I thought we had guards to avoid this kind of mixup.