### PR TITLE
De-duplicate mention of `quarkus.debug.transformed-classes-dir` in docs

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2274,7 +2274,7 @@ The property is also honored when running tests:
 ./mvnw clean test -Dquarkus.debug.generated-classes-dir=target/dump-generated-classes
 ----
 
-Analogously, you can use the `quarkus.debug.transformed-classes-dir` and `quarkus.debug.transformed-classes-dir` properties to dump the relevant output.
+Analogously, you can use the `quarkus.debug.transformed-classes-dir` and `quarkus.debug.generated-sources-dir` properties to dump the relevant output.
 
 ==== Multi-module Maven Projects and the Development Mode
 


### PR DESCRIPTION
I noticed that in one line in the extensions guide `quarkus.debug.transformed-classes-dir` appears in the text twice, separated by 'or'. I think the second property must be intended to be generated sources.