### PR TITLE
Bump smallrye-open-api from 2.2.0 to 2.2.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-config.version>2.12.0</smallrye-config.version>
         <smallrye-health.version>3.2.1</smallrye-health.version>
         <smallrye-metrics.version>3.0.5</smallrye-metrics.version>
-        <smallrye-open-api.version>2.2.0</smallrye-open-api.version>
+        <smallrye-open-api.version>2.2.1</smallrye-open-api.version>
         <smallrye-graphql.version>1.7.1</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.5.0</smallrye-fault-tolerance.version>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -557,7 +557,7 @@ recipeList:
       newValue: 4.0.0-RC1
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-open-api.version
-      newValue: 3.0.0-RC3
+      newValue: 3.0.0-RC4
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-opentracing-api.version
       newValue: 3.0


### PR DESCRIPTION
Includes Jakarta rewrite smallrye-open-api bump from 3.0.0-RC3 to 3.0.0-RC4

Fixes #27022
Fixes #27375
