### PR TITLE
Flyway callbacks can now access the Flyway instance

### DIFF
--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionCDICallback.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionCDICallback.java
@@ -1,0 +1,48 @@
+package io.quarkus.flyway.test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.callback.Context;
+import org.flywaydb.core.api.callback.Event;
+
+public class FlywayExtensionCDICallback implements Callback {
+
+    public static List<Event> DEFAULT_EVENTS = Arrays.asList(
+            Event.BEFORE_BASELINE,
+            Event.AFTER_BASELINE,
+            Event.BEFORE_MIGRATE,
+            Event.BEFORE_EACH_MIGRATE,
+            Event.AFTER_EACH_MIGRATE,
+            Event.AFTER_VERSIONED,
+            Event.AFTER_MIGRATE,
+            Event.AFTER_MIGRATE_OPERATION_FINISH);
+
+    @Override
+    public boolean supports(Event event, Context context) {
+        return DEFAULT_EVENTS.contains(event);
+    }
+
+    @Override
+    public boolean canHandleInTransaction(Event event, Context context) {
+        return true;
+    }
+
+    @Override
+    public void handle(Event event, Context context) {
+        try {
+            CDI.current().select(Flyway.class).get();
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    @Override
+    public String getCallbackName() {
+        return "Quarked Flyway Callback with CDI";
+    }
+}

--- a/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionCallbackTest.java
+++ b/extensions/flyway/deployment/src/test/java/io/quarkus/flyway/test/FlywayExtensionCallbackTest.java
@@ -40,7 +40,7 @@ public class FlywayExtensionCallbackTest {
             .setAfterAllCustomizer(customizer::stopH2)
             .withApplicationRoot((jar) -> jar
                     .addClasses(FlywayH2TestCustomizer.class,
-                            FlywayExtensionCallback.class, FlywayExtensionCallback2.class)
+                            FlywayExtensionCallback.class, FlywayExtensionCallback2.class, FlywayExtensionCDICallback.class)
                     .addAsResource("db/migration/V1.0.3__Quarkus_Callback.sql")
                     .addAsResource("callback-config.properties", "application.properties"));
 

--- a/extensions/flyway/deployment/src/test/resources/callback-config.properties
+++ b/extensions/flyway/deployment/src/test/resources/callback-config.properties
@@ -7,4 +7,4 @@ quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost:11303/mem:quarkus-flyway-cal
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.baseline-on-migrate=true
 quarkus.flyway.baseline-version=0.0.1
-quarkus.flyway.callbacks=io.quarkus.flyway.test.FlywayExtensionCallback,io.quarkus.flyway.test.FlywayExtensionCallback2
+quarkus.flyway.callbacks=io.quarkus.flyway.test.FlywayExtensionCallback,io.quarkus.flyway.test.FlywayExtensionCallback2,io.quarkus.flyway.test.FlywayExtensionCDICallback


### PR DESCRIPTION
This prevents the following exception from happening when a Flyway Callback implementation attempts to access the Flyway object in Arc (using `CDI.current().select(Flyway.class).get()`)

```
javax.enterprise.inject.CreationException: Synthetic bean instance for org.flywaydb.core.Flyway not initialized yet:
org_flywaydb_core_Flyway_3cb728d15a0a04006cc75d03f784feb2bba9a5fb
        - a synthetic bean initialized during RUNTIME_INIT must not be accessed during STATIC_INIT
        - RUNTIME_INIT build steps that require access to synthetic beans initialized during RUNTIME_INIT should consume the
SyntheticBeansRuntimeInitBuildItem
```

- Reproducer here: https://github.com/quarkusio/quarkus/issues/27734#issuecomment-1238490067