### PR TITLE
Fix handling of HTTP/2 H2 empty frames

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -17,6 +17,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.RoutingContext;
 
@@ -270,6 +271,14 @@ public class VertxInputStream extends InputStream {
         @Override
         public void handle(Buffer event) {
             synchronized (request.connection()) {
+                if (event.length() == 0 && request.version() == HttpVersion.HTTP_2) {
+                    // When using HTTP/2 H2, this indicates that we won't receive anymore data.
+                    eof = true;
+                    if (waiting) {
+                        request.connection().notifyAll();
+                    }
+                    return;
+                }
                 if (input1 == null) {
                     input1 = event;
                 } else {


### PR DESCRIPTION
The frames indicate that the client does not have anything more to send and should not be considered as part of the body.

Fix https://github.com/keycloak/keycloak/issues/13315
