### PR TITLE
Upgrade to JBoss Threads 3.4.3.Final and silence JBoss Threads version printing via system property

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -32,6 +32,7 @@ import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.deployment.dev.DevModeContext.ModuleInfo;
 import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.runtime.util.JavaVersionUtil;
 import io.quarkus.utilities.JavaBinFinder;
 
@@ -313,6 +314,7 @@ public abstract class QuarkusDevModeLauncher {
      * Attempts to prepare the dev mode runner.
      */
     protected void prepare() throws Exception {
+        JBossVersion.disableVersionLogging();
 
         if (!JavaVersionUtil.isGraalvmJdk()) {
             // prevent C2 compiler for kicking in - makes startup a little faster

--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -7,6 +7,7 @@ import java.util.function.BiConsumer;
 import org.jboss.logging.Logger;
 
 import io.quarkus.launcher.QuarkusLauncher;
+import io.quarkus.runtime.logging.JBossVersion;
 
 /**
  * The entry point for applications that use a main method. Quarkus will shut down when the main method returns.
@@ -56,6 +57,7 @@ public class Quarkus {
     public static void run(Class<? extends QuarkusApplication> quarkusApplication, BiConsumer<Integer, Throwable> exitHandler,
             String... args) {
         try {
+            JBossVersion.disableVersionLogging();
             System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
             System.setProperty("java.util.concurrent.ForkJoinPool.common.threadFactory",
                     "io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory");

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/JBossVersion.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/JBossVersion.java
@@ -1,0 +1,13 @@
+package io.quarkus.runtime.logging;
+
+public final class JBossVersion {
+
+    private static final String JBOSS_LOG_VERSION = "jboss.log-version";
+
+    private JBossVersion() {
+    }
+
+    public static void disableVersionLogging() {
+        System.setProperty(JBOSS_LOG_VERSION, "false");
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusIntegrationTestExtension.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.opentest4j.TestAbortedException;
 
 import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.DevServicesContext;
@@ -134,6 +135,8 @@ public class QuarkusIntegrationTestExtension extends AbstractQuarkusTestWithCont
     private QuarkusTestExtensionState doProcessStart(Properties quarkusArtifactProperties,
             Class<? extends QuarkusTestProfile> profile, ExtensionContext context)
             throws Throwable {
+        JBossVersion.disableVersionLogging();
+
         String artifactType = getArtifactType(quarkusArtifactProperties);
 
         boolean isDockerLaunch = isContainer(artifactType);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainIntegrationTestExtension.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
+import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.test.common.ArtifactLauncher;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.junit.launcher.ArtifactLauncherProvider;
@@ -58,6 +59,8 @@ public class QuarkusMainIntegrationTestExtension extends AbstractQuarkusTestWith
     }
 
     private LaunchResult doLaunch(ExtensionContext context, String[] arguments) throws Exception {
+        JBossVersion.disableVersionLogging();
+
         if (quarkusArtifactProperties == null) {
             prepare(context);
         }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusMainTestExtension.java
@@ -27,6 +27,7 @@ import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.deployment.dev.testing.LogCapturingOutputFilter;
 import io.quarkus.dev.console.QuarkusConsole;
 import io.quarkus.dev.testing.TracingHandler;
+import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.test.common.TestResourceManager;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
@@ -65,6 +66,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
 
     private void ensurePrepared(ExtensionContext extensionContext, Class<? extends QuarkusTestProfile> profile)
             throws Exception {
+        JBossVersion.disableVersionLogging();
+
         ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
         Class<?> testType = store.get(IO_QUARKUS_TESTING_TYPE, Class.class);
         if (testType != null) {
@@ -190,6 +193,8 @@ public class QuarkusMainTestExtension extends AbstractJvmQuarkusTestExtension
 
     private int doJavaStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile, String[] arguments)
             throws Exception {
+        JBossVersion.disableVersionLogging();
+
         TracingHandler.quarkusStarting();
         Closeable testResourceManager = null;
         try {

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -88,6 +88,7 @@ import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.DurationConverter;
 import io.quarkus.runtime.configuration.ProfileManager;
+import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.runtime.test.TestHttpEndpointProvider;
 import io.quarkus.test.TestMethodInvoker;
 import io.quarkus.test.common.GroovyCacheCleaner;
@@ -204,6 +205,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     }
 
     private ExtensionState doJavaStart(ExtensionContext context, Class<? extends QuarkusTestProfile> profile) throws Throwable {
+        JBossVersion.disableVersionLogging();
+
         TracingHandler.quarkusStarting();
         hangDetectionExecutor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
             @Override


### PR DESCRIPTION
In some cases (typically Quarkus main tests), it is extremely hard to avoid printing the JBoss Threads version. Thus why we introduced a system property to disable version printing in JBoss Threads.

From:

```
[INFO] Running io.quarkiverse.githubaction.it.SimpleActionTest
2022-09-08 10:13:54,491 INFO  [org.jbo.threads] (main) JBoss Threads version 3.4.2.Final
2022-09-08 10:13:55,310 INFO  [org.jbo.threads] (main) JBoss Threads version 3.4.2.Final
SimpleAction - Test output
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.929 s - in io.quarkiverse.githubaction.it.SimpleActionTest
```

we now have:

```
[INFO] Running io.quarkiverse.githubaction.it.SimpleActionTest
SimpleAction - Test output
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.856 s - in io.quarkiverse.githubaction.it.SimpleActionTest
```

Fixes #24283