### PR TITLE
Enforce project's dependency constraints on the classpath used for dev mode bootstrap

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -67,6 +67,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -1096,10 +1097,10 @@ public class DevMojo extends AbstractMojo {
         for (Artifact appDep : project.getArtifacts()) {
             // only add the artifact if it's present in the dev mode context
             // we need this to avoid having jars on the classpath multiple times
-            ArtifactKey key = ArtifactKey.of(appDep.getGroupId(), appDep.getArtifactId(),
+            final ArtifactKey key = ArtifactKey.of(appDep.getGroupId(), appDep.getArtifactId(),
                     appDep.getClassifier(), appDep.getArtifactHandler().getExtension());
             if (!builder.isLocal(key) && configuredParentFirst.contains(key)) {
-                builder.classpathEntry(appDep.getFile());
+                builder.classpathEntry(key, appDep.getFile());
             }
         }
 
@@ -1203,6 +1204,21 @@ public class DevMojo extends AbstractMojo {
             throw new MojoExecutionException("Classpath resource " + pomPropsPath + " is missing version");
         }
 
+        final List<org.eclipse.aether.graph.Dependency> managed = new ArrayList<>(
+                project.getDependencyManagement().getDependencies().size());
+        project.getDependencyManagement().getDependencies().forEach(d -> {
+            final List<Exclusion> exclusions;
+            if (!d.getExclusions().isEmpty()) {
+                exclusions = new ArrayList<>(d.getExclusions().size());
+                d.getExclusions().forEach(e -> exclusions.add(new Exclusion(e.getGroupId(), e.getArtifactId(), null, null)));
+            } else {
+                exclusions = List.of();
+            }
+            managed.add(new org.eclipse.aether.graph.Dependency(
+                    new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()),
+                    d.getScope(), d.isOptional(), exclusions));
+        });
+
         final DefaultArtifact devModeJar = new DefaultArtifact(devModeGroupId, devModeArtifactId, ArtifactCoords.TYPE_JAR,
                 devModeVersion);
         final DependencyResult cpRes = repoSystem.resolveDependencies(repoSession,
@@ -1212,6 +1228,7 @@ public class DevMojo extends AbstractMojo {
                                         // it doesn't matter what the root artifact is, it's an alias
                                         .setRootArtifact(new DefaultArtifact("io.quarkus", "quarkus-devmode-alias",
                                                 ArtifactCoords.TYPE_JAR, "1.0"))
+                                        .setManagedDependencies(managed)
                                         .setDependencies(List.of(
                                                 new org.eclipse.aether.graph.Dependency(devModeJar, JavaScopes.RUNTIME),
                                                 new org.eclipse.aether.graph.Dependency(new DefaultArtifact(
@@ -1222,13 +1239,16 @@ public class DevMojo extends AbstractMojo {
 
         for (ArtifactResult appDep : cpRes.getArtifactResults()) {
             //we only use the launcher for launching from the IDE, we need to exclude it
-            if (!(appDep.getArtifact().getGroupId().equals("io.quarkus")
-                    && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
-                if (appDep.getArtifact().getGroupId().equals("io.quarkus")
-                        && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
-                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+            final org.eclipse.aether.artifact.Artifact a = appDep.getArtifact();
+            if (!(a.getArtifactId().equals("quarkus-ide-launcher")
+                    && a.getGroupId().equals("io.quarkus"))) {
+                if (a.getArtifactId().equals("quarkus-class-change-agent")
+                        && a.getGroupId().equals("io.quarkus")) {
+                    builder.jvmArgs("-javaagent:" + a.getFile().getAbsolutePath());
                 } else {
-                    builder.classpathEntry(appDep.getArtifact().getFile());
+                    builder.classpathEntry(
+                            ArtifactKey.of(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension()),
+                            a.getFile());
                 }
             }
         }


### PR DESCRIPTION
@gsmet this will fix the duplicate slf4j version warning in the jakarta-rewrite branch.