### PR TITLE
Reduce `native-image` `-H:` options

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -49,7 +49,10 @@ public class NativeConfig {
 
     /**
      * If {@code -H:+InlineBeforeAnalysis} flag will be added to the native-image run
+     *
+     * @deprecated inlineBeforeAnalysis is always enabled starting from GraalVM 21.3.
      */
+    @Deprecated
     @ConfigItem(defaultValue = "true")
     public boolean inlineBeforeAnalysis;
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -741,11 +741,11 @@ public class NativeImageBuildStep {
                 }
 
                 if (nativeConfig.enableFallbackImages) {
-                    nativeImageArgs.add("-H:FallbackThreshold=5");
+                    nativeImageArgs.add("--auto-fallback");
                 } else {
                     //Default: be strict as those fallback images aren't very useful
                     //and tend to cover up real problems.
-                    nativeImageArgs.add("-H:FallbackThreshold=0");
+                    nativeImageArgs.add("--no-fallback");
                 }
 
                 // 22.1 removes --allow-incomplete-classpath and makes it the default. --link-at-build-time is now
@@ -757,7 +757,7 @@ public class NativeImageBuildStep {
                 }
 
                 if (nativeConfig.reportErrorsAtRuntime) {
-                    nativeImageArgs.add("-H:+ReportUnsupportedElementsAtRuntime");
+                    nativeImageArgs.add("--report-unsupported-elements-at-runtime");
                 }
                 if (nativeConfig.reportExceptionStackTraces) {
                     nativeImageArgs.add("-H:+ReportExceptionStackTraces");
@@ -796,7 +796,7 @@ public class NativeImageBuildStep {
                     nativeImageArgs.add("-H:-AddAllCharsets");
                 }
                 if (!protocols.isEmpty()) {
-                    nativeImageArgs.add("-H:EnableURLProtocols=" + String.join(",", protocols));
+                    nativeImageArgs.add("--enable-url-protocols=" + String.join(",", protocols));
                 }
                 if (!inlineBeforeAnalysis) {
                     nativeImageArgs.add("-H:-InlineBeforeAnalysis");

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -798,12 +798,7 @@ public class NativeImageBuildStep {
                 if (!protocols.isEmpty()) {
                     nativeImageArgs.add("-H:EnableURLProtocols=" + String.join(",", protocols));
                 }
-                if (inlineBeforeAnalysis) {
-                    if (graalVMVersion.isOlderThan(GraalVM.Version.VERSION_21_3)) {
-                        // Enabled by default in GraalVM >= 21.3
-                        nativeImageArgs.add("-H:+InlineBeforeAnalysis");
-                    }
-                } else {
+                if (!inlineBeforeAnalysis) {
                     nativeImageArgs.add("-H:-InlineBeforeAnalysis");
                 }
                 if (!noPIE.isEmpty()) {


### PR DESCRIPTION
`-H:` options are considered non-public and should thus be avoided as they can change without notice.

Part of https://github.com/quarkusio/quarkus/issues/27784
Relates to #25943 