### PR TITLE
Make it easier to configure that OIDC JWT introspection only is required

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect.adoc
@@ -404,6 +404,18 @@ quarkus.oidc.discovery-enabled=false
 quarkus.oidc.introspection-path=/protocol/openid-connect/tokens/introspect
 ----
 
+An advantage of this indirect enforcement of JWT tokens being only introspected remotely is that two remote call are avoided: a remote OIDC metadata discovery call followed by another remote call fetching the verification keys which will not be used, while its disavantage is that the users need to know the introspection endpoint address and configure it manually.
+
+The alternative approach is to allow discovering the OIDC metadata (which is a default option) but require that only the remote JWT introspection is performed:
+
+[source, properties]
+----
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
+quarkus.oidc.token.require-jwt-introspection-only=true
+----
+
+An advantage of this approach is that the configuration is simple and easy to understand, while its disavantage is that a remote OIDC metadata discovery call is required to discover an introspection endpoint address (though the verification keys will also not be fetched).
+
 Note that `io.quarkus.oidc.TokenIntrospection` (a simple `javax.json.JsonObject` wrapper) object will be created and can be either injected or accessed as a SecurityIdentity `introspection` attribute if either JWT or opaque token has been successfully introspected.
 
 [[token-introspection-userinfo-cache]]

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -1125,6 +1125,13 @@ public class OidcTenantConfig extends OidcCommonConfig {
         public boolean allowJwtIntrospection = true;
 
         /**
+         * Require that JWT tokens are only introspected remotely.
+         *
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean requireJwtIntrospectionOnly = false;
+
+        /**
          * Allow the remote introspection of the opaque tokens.
          *
          * Set this property to 'false' if only JWT tokens are expected.
@@ -1242,6 +1249,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setRequiredClaims(Map<String, String> requiredClaims) {
             this.requiredClaims = requiredClaims;
+        }
+
+        public boolean isRequireJwtIntrospectionOnly() {
+            return requireJwtIntrospectionOnly;
+        }
+
+        public void setRequireJwtIntrospectionOnly(boolean requireJwtIntrospectionOnly) {
+            this.requireJwtIntrospectionOnly = requireJwtIntrospectionOnly;
         }
     }
 

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcIdentityProvider.java
@@ -283,7 +283,8 @@ public class OidcIdentityProvider implements IdentityProvider<TokenAuthenticatio
                 throw new AuthenticationFailedException();
             }
             return introspectTokenUni(resolvedContext, token);
-        } else if (resolvedContext.provider.getMetadata().getJsonWebKeySetUri() == null) {
+        } else if (resolvedContext.provider.getMetadata().getJsonWebKeySetUri() == null
+                || resolvedContext.oidcConfig.token.requireJwtIntrospectionOnly) {
             // Verify JWT token with the remote introspection
             return introspectTokenUni(resolvedContext, token);
         } else {

--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/OidcRecorder.java
@@ -249,7 +249,8 @@ public class OidcRecorder {
                 .transformToUni(new Function<OidcProviderClient, Uni<? extends OidcProvider>>() {
                     @Override
                     public Uni<OidcProvider> apply(OidcProviderClient client) {
-                        if (client.getMetadata().getJsonWebKeySetUri() != null) {
+                        if (client.getMetadata().getJsonWebKeySetUri() != null
+                                && !oidcConfig.token.requireJwtIntrospectionOnly) {
                             return getJsonWebSetUni(client, oidcConfig).onItem()
                                     .transform(new Function<JsonWebKeySet, OidcProvider>() {
 

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -78,8 +78,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.token.setAllowJwtIntrospection(false);
                     config.setClientId("client");
                     return config;
-                } else if ("tenant-oidc-introspection-only".equals(tenantId)
-                        || "tenant-oidc-introspection-only-cache".equals(tenantId)) {
+                } else if ("tenant-oidc-introspection-only".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();
                     config.setTenantId(tenantId);
                     String uri = context.request().absoluteURI();
@@ -89,19 +88,26 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.authentication.setUserInfoRequired(true);
                     config.setIntrospectionPath("introspect");
                     config.setUserInfoPath("userinfo");
-                    if ("tenant-oidc-introspection-only".equals(tenantId)) {
-                        config.setClientId("client-introspection-only");
-                        config.setAllowTokenIntrospectionCache(false);
-                        config.setAllowUserInfoCache(false);
-                        Credentials creds = config.getCredentials();
-                        creds.clientSecret.setMethod(Credentials.Secret.Method.POST_JWT);
-                        creds.getJwt().setKeyFile("ecPrivateKey.pem");
-                        creds.getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
-                    } else {
-                        config.setClientId("client-introspection-only-cache");
-                        config.getIntrospectionCredentials().setName("bob");
-                        config.getIntrospectionCredentials().setSecret("bob_secret");
-                    }
+                    config.setClientId("client-introspection-only");
+                    config.setAllowTokenIntrospectionCache(false);
+                    config.setAllowUserInfoCache(false);
+                    Credentials creds = config.getCredentials();
+                    creds.clientSecret.setMethod(Credentials.Secret.Method.POST_JWT);
+                    creds.getJwt().setKeyFile("ecPrivateKey.pem");
+                    creds.getJwt().setSignatureAlgorithm(SignatureAlgorithm.ES256.getAlgorithm());
+                    return config;
+                } else if ("tenant-oidc-introspection-only-cache".equals(tenantId)) {
+                    OidcTenantConfig config = new OidcTenantConfig();
+                    config.setTenantId(tenantId);
+                    String uri = context.request().absoluteURI();
+                    String authServerUri = uri.replace("/tenant/" + tenantId + "/api/user", "/oidc");
+                    config.setAuthServerUrl(authServerUri);
+                    config.authentication.setUserInfoRequired(true);
+                    config.setUserInfoPath("userinfo");
+                    config.setClientId("client-introspection-only-cache");
+                    config.getIntrospectionCredentials().setName("bob");
+                    config.getIntrospectionCredentials().setSecret("bob_secret");
+                    config.getToken().setRequireJwtIntrospectionOnly(true);
                     return config;
                 } else if ("tenant-oidc-no-opaque-token".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();


### PR DESCRIPTION
Fixes #27637 

Right now one can enforce indirectly that OIDC JWT tokens are only introspected remotely:
```
quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
quarkus.oidc.introspection-path=/protocol/openid-connect/tokens/introspect
```
which is causing confusion and is more difficult to configure, so as agreed in #27637, a new property is introduced to provide a simpler and easier to understand way to to setup it up:

```
quarkus.oidc.auth-server-url=http://localhost:8180/realms/quarkus
quarkus.oidc.token.require-jwt-introspection-only=true
```

I've updated the tests, one of the tenants continues testing the indirect way of enforcing it, the other one is now checking a new property