### PR TITLE
Use routing context end handler

### DIFF
--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveOutputStream.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.server.vertx;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -53,9 +54,9 @@ public class ResteasyReactiveOutputStream extends OutputStream {
             }
         });
 
-        request.response().endHandler(new Handler<Void>() {
+        context.getContext().addEndHandler(new Handler<AsyncResult<Void>>() {
             @Override
-            public void handle(Void event) {
+            public void handle(AsyncResult<Void> event) {
                 synchronized (request.connection()) {
                     if (waitingForDrain) {
                         request.connection().notifyAll();


### PR DESCRIPTION
Setting the end handler on the response means the routing contexts end handler is not called.