### PR TITLE
Rest client classic: revert to package private visibility for configuration methods

### DIFF
--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientBuilderFactory.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientBuilderFactory.java
@@ -1,0 +1,34 @@
+package io.quarkus.restclient.config;
+
+import java.util.ServiceLoader;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+/**
+ * Factory which creates MicroProfile RestClientBuilder instance configured according to current Quarkus application
+ * configuration.
+ *
+ * The builder instance can be further tweaked, if needed, before building the rest client proxy.
+ */
+public interface RestClientBuilderFactory {
+
+    default RestClientBuilder newBuilder(Class<?> proxyType) {
+        return newBuilder(proxyType, RestClientsConfig.getInstance());
+    }
+
+    RestClientBuilder newBuilder(Class<?> proxyType, RestClientsConfig restClientsConfigRoot);
+
+    static RestClientBuilderFactory getInstance() {
+        ServiceLoader<RestClientBuilderFactory> sl = ServiceLoader.load(RestClientBuilderFactory.class);
+        RestClientBuilderFactory instance = null;
+        for (RestClientBuilderFactory spi : sl) {
+            if (instance != null) {
+                throw new IllegalStateException("Multiple RestClientBuilderFactory implementations found: "
+                        + spi.getClass().getName() + " and "
+                        + instance.getClass().getName());
+            }
+            instance = spi;
+        }
+        return instance;
+    }
+}

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -65,8 +65,6 @@ public class RestClientsConfig {
      * (or IP address) and port for requests of clients to use.
      *
      * Can be overwritten by client-specific settings.
-     *
-     * This property is applicable to reactive REST clients only.
      */
     @ConfigItem
     public Optional<String> proxyAddress;

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClassicRestClientBuilderFactoryTest.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/ClassicRestClientBuilderFactoryTest.java
@@ -1,0 +1,36 @@
+package io.quarkus.restclient.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.restclient.config.RestClientBuilderFactory;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ClassicRestClientBuilderFactoryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(EchoClientWithoutAnnotation.class, EchoClientWithConfigKey.class,
+                    EchoResource.class))
+            .withConfigurationResource("factory-test-application.properties");
+
+    @Test
+    public void testAnnotatedClientClass() {
+        RestClientBuilder restClientBuilder = RestClientBuilderFactory.getInstance().newBuilder(EchoClientWithConfigKey.class);
+        EchoClientWithConfigKey restClient = restClientBuilder.build(EchoClientWithConfigKey.class);
+
+        assertThat(restClient.echo("Hello")).contains("Hello");
+    }
+
+    @Test
+    public void testNotAnnotatedClientClass() {
+        RestClientBuilder restClientBuilder = RestClientBuilderFactory.getInstance()
+                .newBuilder(EchoClientWithoutAnnotation.class);
+        EchoClientWithoutAnnotation restClient = restClientBuilder.build(EchoClientWithoutAnnotation.class);
+
+        assertThat(restClient.echo("Hello")).contains("Hello");
+    }
+}

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/EchoClientWithoutAnnotation.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/java/io/quarkus/restclient/configuration/EchoClientWithoutAnnotation.java
@@ -1,0 +1,18 @@
+package io.quarkus.restclient.configuration;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/echo")
+public interface EchoClientWithoutAnnotation {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.TEXT_PLAIN)
+    String echo(@QueryParam("message") String message);
+
+}

--- a/extensions/resteasy-classic/rest-client/deployment/src/test/resources/factory-test-application.properties
+++ b/extensions/resteasy-classic/rest-client/deployment/src/test/resources/factory-test-application.properties
@@ -1,0 +1,3 @@
+quarkus.rest-client.echo-client.url=http://localhost:8081
+quarkus.rest-client.EchoClientWithoutAnnotation.url=http://localhost:8081
+quarkus.rest-client.read-timeout=3456

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/ClassicRestClientBuilderFactory.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/ClassicRestClientBuilderFactory.java
@@ -1,0 +1,27 @@
+package io.quarkus.restclient.runtime;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.restclient.config.RestClientBuilderFactory;
+import io.quarkus.restclient.config.RestClientsConfig;
+
+public class ClassicRestClientBuilderFactory implements RestClientBuilderFactory {
+
+    public RestClientBuilder newBuilder(Class<?> proxyType, RestClientsConfig restClientsConfigRoot) {
+        RegisterRestClient annotation = proxyType.getAnnotation(RegisterRestClient.class);
+        String configKey = null;
+        String baseUri = null;
+        if (annotation != null) {
+            configKey = annotation.configKey();
+            baseUri = annotation.baseUri();
+        }
+
+        RestClientBuilder restClientBuilder = RestClientBuilder.newBuilder();
+        RestClientBase restClientBase = new RestClientBase(proxyType, baseUri, configKey, new Class[0], restClientsConfigRoot);
+        restClientBase.configureBuilder(restClientBuilder);
+
+        return restClientBuilder;
+    }
+
+}

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -66,7 +66,7 @@ public class RestClientBase {
         return builder.build(proxyType);
     }
 
-    void configureBuilder(RestClientBuilder builder) {
+    protected void configureBuilder(RestClientBuilder builder) {
         configureBaseUrl(builder);
         configureTimeouts(builder);
         configureProviders(builder);
@@ -77,7 +77,7 @@ public class RestClientBase {
         configureCustomProperties(builder);
     }
 
-    private void configureCustomProperties(RestClientBuilder builder) {
+    protected void configureCustomProperties(RestClientBuilder builder) {
         Optional<Integer> connectionPoolSize = oneOf(clientConfigByClassName().connectionPoolSize,
                 clientConfigByConfigKey().connectionPoolSize, configRoot.connectionPoolSize);
         if (connectionPoolSize.isPresent()) {
@@ -92,7 +92,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureProxy(RestClientBuilder builder) {
+    protected void configureProxy(RestClientBuilder builder) {
         Optional<String> proxyAddress = oneOf(clientConfigByClassName().proxyAddress, clientConfigByConfigKey().proxyAddress,
                 configRoot.proxyAddress);
         if (proxyAddress.isPresent() && !NONE.equals(proxyAddress.get())) {
@@ -116,7 +116,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureRedirects(RestClientBuilder builder) {
+    protected void configureRedirects(RestClientBuilder builder) {
         Optional<Boolean> followRedirects = oneOf(clientConfigByClassName().followRedirects,
                 clientConfigByConfigKey().followRedirects, configRoot.followRedirects);
         if (followRedirects.isPresent()) {
@@ -124,7 +124,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureQueryParamStyle(RestClientBuilder builder) {
+    protected void configureQueryParamStyle(RestClientBuilder builder) {
         Optional<QueryParamStyle> queryParamStyle = oneOf(clientConfigByClassName().queryParamStyle,
                 clientConfigByConfigKey().queryParamStyle, configRoot.queryParamStyle);
         if (queryParamStyle.isPresent()) {
@@ -132,7 +132,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureSsl(RestClientBuilder builder) {
+    protected void configureSsl(RestClientBuilder builder) {
         Optional<String> trustStore = oneOf(clientConfigByClassName().trustStore, clientConfigByConfigKey().trustStore,
                 configRoot.trustStore);
         if (trustStore.isPresent() && !trustStore.get().isBlank() && !NONE.equals(trustStore.get())) {
@@ -249,7 +249,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureProviders(RestClientBuilder builder) {
+    protected void configureProviders(RestClientBuilder builder) {
         Optional<String> providers = oneOf(clientConfigByClassName().providers, clientConfigByConfigKey().providers,
                 configRoot.providers);
 
@@ -277,7 +277,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureTimeouts(RestClientBuilder builder) {
+    protected void configureTimeouts(RestClientBuilder builder) {
         Long connectTimeout = oneOf(clientConfigByClassName().connectTimeout,
                 clientConfigByConfigKey().connectTimeout).orElse(this.configRoot.connectTimeout);
         if (connectTimeout != null) {
@@ -291,7 +291,7 @@ public class RestClientBase {
         }
     }
 
-    private void configureBaseUrl(RestClientBuilder builder) {
+    protected void configureBaseUrl(RestClientBuilder builder) {
         Optional<String> baseUrlOptional = oneOf(clientConfigByClassName().uri, clientConfigByConfigKey().uri);
         if (baseUrlOptional.isEmpty()) {
             baseUrlOptional = oneOf(clientConfigByClassName().url, clientConfigByConfigKey().url);
@@ -333,7 +333,7 @@ public class RestClientBase {
     @SafeVarargs
     private static <T> Optional<T> oneOf(Optional<T>... optionals) {
         for (Optional<T> o : optionals) {
-            if (o.isPresent()) {
+            if (o != null && o.isPresent()) {
                 return o;
             }
         }

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/services/io.quarkus.restclient.config.RestClientBuilderFactory
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/resources/META-INF/services/io.quarkus.restclient.config.RestClientBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkus.restclient.runtime.ClassicRestClientBuilderFactory

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ReactiveRestClientBuilderFactoryTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/ReactiveRestClientBuilderFactoryTest.java
@@ -1,0 +1,29 @@
+package io.quarkus.rest.client.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.rest.client.reactive.configuration.EchoResource;
+import io.quarkus.restclient.config.RestClientBuilderFactory;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ReactiveRestClientBuilderFactoryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(HelloClient2.class, EchoResource.class))
+            .withConfigurationResource("factory-test-application.properties");
+
+    @Test
+    public void test() throws Exception {
+        RestClientBuilder restClientBuilder = RestClientBuilderFactory.getInstance().newBuilder(HelloClient2.class);
+        HelloClient2 restClient = restClientBuilder.build(HelloClient2.class);
+
+        assertThat(restClientBuilder.getConfiguration().getProperties().get("io.quarkus.rest.client.read-timeout"))
+                .isEqualTo(3456L);
+        assertThat(restClient.echo("Hello")).contains("Hello");
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/factory-test-application.properties
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/factory-test-application.properties
@@ -1,0 +1,2 @@
+quarkus.rest-client.hello2.url=http://localhost:8081/hello
+quarkus.rest-client.read-timeout=3456

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ReactiveRestClientBuilderFactory.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/ReactiveRestClientBuilderFactory.java
@@ -1,0 +1,28 @@
+package io.quarkus.rest.client.reactive.runtime;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.quarkus.restclient.config.RestClientBuilderFactory;
+import io.quarkus.restclient.config.RestClientsConfig;
+
+public class ReactiveRestClientBuilderFactory implements RestClientBuilderFactory {
+
+    public RestClientBuilder newBuilder(Class<?> proxyType, RestClientsConfig restClientsConfigRoot) {
+        RegisterRestClient annotation = proxyType.getAnnotation(RegisterRestClient.class);
+        String configKey = null;
+        String baseUri = null;
+        if (annotation != null) {
+            configKey = annotation.configKey();
+            baseUri = annotation.baseUri();
+        }
+
+        RestClientBuilderImpl restClientBuilder = new RestClientBuilderImpl();
+        RestClientCDIDelegateBuilder<?> restClientBase = new RestClientCDIDelegateBuilder<>(proxyType, baseUri, configKey,
+                restClientsConfigRoot);
+        restClientBase.configureBuilder(restClientBuilder);
+
+        return restClientBuilder;
+    }
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -60,10 +60,11 @@ public class RestClientCDIDelegateBuilder<T> {
             throw new IllegalStateException("Expected RestClientBuilder to be an instance of "
                     + RestClientBuilderImpl.class.getName() + ", got " + builder.getClass().getName());
         }
-        return build((RestClientBuilderImpl) builder);
+        configureBuilder((RestClientBuilderImpl) builder);
+        return builder.build(jaxrsInterface);
     }
 
-    T build(RestClientBuilderImpl builder) {
+    void configureBuilder(RestClientBuilderImpl builder) {
         configureBaseUrl(builder);
         configureTimeouts(builder);
         configureProviders(builder);
@@ -73,12 +74,11 @@ public class RestClientCDIDelegateBuilder<T> {
         configureProxy(builder);
         configureShared(builder);
         configureCustomProperties(builder);
-        return builder.build(jaxrsInterface);
     }
 
     private void configureCustomProperties(RestClientBuilder builder) {
         Optional<String> encoder = configRoot.multipartPostEncoderMode;
-        if (encoder.isPresent()) {
+        if (encoder != null && encoder.isPresent()) {
             HttpPostRequestEncoder.EncoderMode mode = HttpPostRequestEncoder.EncoderMode
                     .valueOf(encoder.get().toUpperCase(Locale.ROOT));
             builder.property(QuarkusRestClientProperties.MULTIPART_ENCODER_MODE, mode);

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/io.quarkus.restclient.config.RestClientBuilderFactory
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/resources/META-INF/services/io.quarkus.restclient.config.RestClientBuilderFactory
@@ -1,0 +1,1 @@
+io.quarkus.rest.client.reactive.runtime.ReactiveRestClientBuilderFactory

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/test/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilderTest.java
@@ -82,7 +82,7 @@ public class RestClientCDIDelegateBuilderTest {
         new RestClientCDIDelegateBuilder<>(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
-                configRoot).build(restClientBuilderMock);
+                configRoot).configureBuilder(restClientBuilderMock);
 
         // then
 
@@ -125,7 +125,7 @@ public class RestClientCDIDelegateBuilderTest {
         new RestClientCDIDelegateBuilder<>(TestClient.class,
                 "http://localhost:8080",
                 "test-client",
-                configRoot).build(restClientBuilderMock);
+                configRoot).configureBuilder(restClientBuilderMock);
 
         // then
 


### PR DESCRIPTION
1. Use "protected" visibility for `RestClientBase.configure*` methods, to accommodate kogito extension that accesses these. Originally the visibility of these methods was package private, but was changed to private, which broke kogito extension.
2. Introduce `RestClientBuilder` factories, that allow developers to produce `RestClientBuilder` instances that are already configured according to application.properties (reusing the configuration code from classic/reactive rest-client extensions). The builders can then be further tweaked and finally used to programmatically produce rest client proxies.

Related to https://github.com/quarkusio/quarkus/issues/12486