### PR TITLE
Fix link in redis.adoc

### DIFF
--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -526,4 +526,4 @@ Once the build is finished, you can run the executable with:
 
 == Going further
 
-To learn more about the Quarkus Redis extension, check link:../redis-reference.adoc[the redis extension reference guide].
+To learn more about the Quarkus Redis extension, check link:redis-reference.adoc[the Redis extension reference guide].


### PR DESCRIPTION
Maybe here is mistake at Link in reference at bottom. How about this one ?

before:
 link:../redis-reference.adoc[the redis extension reference guide].
after:
 link:../guides/redis-reference.adoc[the redis extension reference guide].