### PR TITLE
Ensure that InitialConfigurator uses the Quarkus configured min log level

### DIFF
--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/logging/InitialConfigurator.java
@@ -13,10 +13,28 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
 public final class InitialConfigurator implements EmbeddedConfigurator {
 
     public static final QuarkusDelayedHandler DELAYED_HANDLER = new QuarkusDelayedHandler();
+    private static final Level MIN_LEVEL;
+
+    private static final String SYS_PROP_NAME = "logging.initial-configurator.min-level";
+
+    static {
+        Level minLevel = Level.ALL;
+        String minLevelSysProp = System.getProperty(SYS_PROP_NAME);
+        if (minLevelSysProp != null) {
+            try {
+                minLevel = Level.parse(minLevelSysProp);
+            } catch (IllegalArgumentException ignored) {
+                throw new IllegalArgumentException(
+                        String.format("Unable to convert %s (obtained from the %s system property) into a known logging level.",
+                                minLevelSysProp, SYS_PROP_NAME));
+            }
+        }
+        MIN_LEVEL = minLevel;
+    }
 
     @Override
     public Level getMinimumLevelOf(final String loggerName) {
-        return Level.ALL;
+        return MIN_LEVEL;
     }
 
     @Override


### PR DESCRIPTION
This essentially prevents issues like https://github.com/quarkusio/quarkus/issues/27735 where a piece of Quarkus code executing very early in the startup sequence, would improperly determine the minimum logging level - i.e. ALL was used instead of the Quarkus build configured minimum level.