### PR TITLE
Merge detached entity when deleting with panache CRUD repository

### DIFF
--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -119,7 +119,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public void delete(Object entity) {
         EntityManager em = getEntityManager(entity.getClass());
-        em.remove(entity);
+        em.remove(em.contains(entity) ? entity : em.merge(entity));
     }
 
     public boolean isPersistent(Object entity) {


### PR DESCRIPTION
This PR regards the issue #27184 to allow merging detached entities when calling `delete` with panache CRUD repository and non-transactional control.
In my current project, we don't control database transactions as all our endpoints always run a single SQL statement. I found that the remove method from panache could be improved to be in line with the implementation from Spring. I think it makes sense as it facilitates the migration from Spring to Quarkus.

So I'm proposing to handle unattached objects when calling the `remove(entity)`.