### PR TITLE
Bump mockito-bom from 4.7.0 to 4.8.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -173,7 +173,7 @@
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>
         <quarkus-spring-security-api.version>5.3.Final</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
-        <mockito.version>4.7.0</mockito.version>
+        <mockito.version>4.8.0</mockito.version>
         <jna.version>5.8.0</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.9.2</antlr.version>
         <quarkus-security.version>1.1.4.Final</quarkus-security.version>

--- a/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/PanacheMock.java
+++ b/extensions/panache/panache-mock/src/main/java/io/quarkus/panache/mock/PanacheMock.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.mockito.Mockito;
-import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.internal.debugging.LocationFactory;
 import org.mockito.internal.invocation.DefaultInvocationFactory;
 import org.mockito.internal.invocation.InterceptedInvocation;
 import org.mockito.internal.invocation.RealMethod;
@@ -58,7 +58,7 @@ public class PanacheMock {
             MockCreationSettings<?> settings = MockUtil.getMockSettings(mock);
             MyRealMethod myRealMethod = new MyRealMethod();
             InterceptedInvocation invocation = DefaultInvocationFactory.createInvocation(mock, invokedMethod, args,
-                    myRealMethod, settings, new LocationImpl(new Throwable(), true));
+                    myRealMethod, settings, LocationFactory.create(true));
             MockHandler<?> handler = MockUtil.getMockHandler(mock);
             return handler.handle(invocation);
         } catch (InvokeRealMethodException e) {

--- a/independent-projects/tools/pom.xml
+++ b/independent-projects/tools/pom.xml
@@ -55,7 +55,7 @@
         <commons-compress.version>1.21</commons-compress.version>
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <maven-core.version>3.8.6</maven-core.version>
-        <mockito.version>4.7.0</mockito.version>
+        <mockito.version>4.8.0</mockito.version>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <quarkus.version>999-SNAPSHOT</quarkus.version>


### PR DESCRIPTION
Supersedes #27819

The bad news is that, clearly, `PanacheMock#mockMethod` was (and still is) a disaster waiting to happen: it relies on  Mockito's internals... The only solution I had to make it work exactly the same way as before was to break backwards compatibility. People wanting to stay on Mockito 4.7 will no longer be able to use `PanacheMock#mockMethod`. And it's still relying on internals, so we could have the same problem again anytime.

The good news is that `PanacheMock#mockMethod` is not documented as far as I can tell. It's not even tested. So I think we should be able to remove it... Maybe I should open a dedicated PR for that?

/cc @gsmet 

