### PR TITLE
Cross-link to quarkiverse wiki

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2997,15 +2997,27 @@ Then, at the end of your documentation, include the extensive documentation:
 
 Finally, generate the documentation and check it out.
 
+[[ecosystem]]
+== Ecosystem integration
+
+Some extensions may be private, and some may wish to be part of the
+broader Quarkus ecosystem, and available for community re-use.
+Inclusion in the Quarkiverse Hub is a convenient mechanism for handling
+continuous testing and publication.
+The link:https://github.com/quarkiverse/quarkiverse/wiki#getting-an-extension-onboarded[Quarkiverse Hub wiki] has instructions
+for on-boarding your extension.
+
+Alternatively, continuous testing and publication can be handled manually.
+
 [[ecosystem-ci]]
-== Continuous testing of your extension
+=== Continuous testing of your extension
 
 In order to make it easy for extension authors to test their extensions daily against the latest snapshot of Quarkus, Quarkus has introduced
 the notion of Ecosystem CI. The Ecosystem CI link:https://github.com/quarkusio/quarkus-ecosystem-ci/blob/main/README.adoc[README]
 has all the details on how to set up a GitHub Actions job to take advantage of this capability, while this link:https://www.youtube.com/watch?v=VpbRA1n0hHQ[video] provides an overview
 of what the process looks like.
 
-== Publish your extension in registry.quarkus.io
+=== Publish your extension in registry.quarkus.io
 
 Before publishing your extension to the xref:tooling.adoc[Quarkus tooling], make sure that the following requirements are met:
 


### PR DESCRIPTION
I had some difficulty figuring out the link between writing an extension and the Quarkiverse hub, so I have cross-linked from the guide to the wiki. 