### PR TITLE
Add link to Mutiny guide

### DIFF
--- a/extensions/mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/mutiny/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,6 +8,7 @@ metadata:
   - "reactive"
   - "RXJava"
   - "Reactor"
+  guide: "https://quarkus.io/guides/mutiny-primer"
   categories:
   - "reactive"
   status: "stable"


### PR DESCRIPTION
This will add a link in the Dev UI to the Mutiny Guide