### PR TITLE
Return proper response code when an HTTP request contains an invalid Q value

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/util/MediaTypeHelper.java
@@ -33,7 +33,9 @@ public class MediaTypeHelper {
                     return rtn;
                 }
             } catch (NumberFormatException e) {
-                throw new RuntimeException(String.format("Media type %s value must be a float: %s", parameterName, type), e);
+                throw new WebApplicationException(
+                        String.format("Media type %s value must be a float: %s", parameterName, type),
+                        Response.Status.BAD_REQUEST);
             }
         }
         return 2.0f;

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MatchedResourceTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/resource/basic/MatchedResourceTest.java
@@ -91,6 +91,17 @@ public class MatchedResourceTest {
         response.close();
     }
 
+    @Test
+    @DisplayName("Test Invalid Q Value")
+    public void testInvalidQValue() throws Exception {
+        WebTarget base = client.target(generateURL("/match"));
+        Response response = base.request()
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=malformed")
+                .get();
+        Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        response.close();
+    }
+
     public void generalPostTest(String uri, String value) {
         WebTarget base = client.target(uri);
         Response response = base.request().get();


### PR DESCRIPTION
JAX-RS does not specify what should happen in this case, but I don't think `500` is a reasonable response code - nor in my mind is `200` as the original issue proposes.

Closes: #27852