### PR TITLE
Fix compatibility issue with Redis 6

### DIFF
--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
@@ -18,7 +18,7 @@ public class IncrementResource {
 
     @GET
     public int increment() {
-        return (int) commands.incrby("counter", INCREMENT);
+        return (int) commands.incrby("counter-dev-mode", INCREMENT);
     }
 
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchArgs.java
@@ -212,12 +212,12 @@ public class GeoSearchArgs<V> implements RedisCommandExtraArguments {
         if (radius > 0) {
             list.add("BYRADIUS");
             list.add(Double.toString(radius));
-            list.add(unit.name());
+            list.add(unit.toString());
         } else {
             list.add("BYBOX");
             list.add(Double.toString(width));
             list.add(Double.toString(height));
-            list.add(unit.name());
+            list.add(unit.toString());
         }
 
         if (direction != null) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchStoreArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoSearchStoreArgs.java
@@ -174,12 +174,12 @@ public class GeoSearchStoreArgs<V> implements RedisCommandExtraArguments {
         if (radius > 0) {
             list.add("BYRADIUS");
             list.add(Double.toString(radius));
-            list.add(unit.name());
+            list.add(unit.toString());
         } else {
             list.add("BYBOX");
             list.add(Double.toString(width));
             list.add(Double.toString(height));
-            list.add(unit.name());
+            list.add(unit.toString());
         }
 
         if (direction != null) {

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoUnit.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/geo/GeoUnit.java
@@ -1,5 +1,7 @@
 package io.quarkus.redis.datasource.geo;
 
+import java.util.Locale;
+
 public enum GeoUnit {
 
     /**
@@ -21,4 +23,9 @@ public enum GeoUnit {
      * mile.
      */
     MI;
+
+    public String toString() {
+        // Redis 6 requires lower case, uppercase has only been added in Redis 7.
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractGeoCommands.java
@@ -103,7 +103,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
                 .put(marshaller.encode(key))
                 .put(marshaller.encode(from))
                 .put(marshaller.encode(to))
-                .put(unit.name()));
+                .put(unit.toString()));
     }
 
     Uni<Response> _geohash(K key, V... members) {
@@ -142,7 +142,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
 
         return execute(RedisCommand.of(Command.GEORADIUS)
                 .put(marshaller.encode(key)).put(longitude).put(latitude).put(radius)
-                .put(unit.name()));
+                .put(unit.toString()));
     }
 
     Uni<Response> _georadius(K key, double longitude, double latitude, double radius, GeoUnit unit,
@@ -155,7 +155,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
         nonNull(geoArgs, "geoArgs");
         return execute(RedisCommand.of(Command.GEORADIUS)
                 .put(marshaller.encode(key)).put(longitude).put(latitude).put(radius)
-                .put(unit.name())
+                .put(unit.toString())
                 .putArgs(geoArgs));
     }
 
@@ -169,7 +169,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
         nonNull(geoArgs, "geoArgs");
         return execute(RedisCommand.of(Command.GEORADIUS)
                 .put(marshaller.encode(key)).put(longitude).put(latitude).put(radius)
-                .put(unit.name())
+                .put(unit.toString())
                 .putArgs(geoArgs, keyCodec));
     }
 
@@ -180,7 +180,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
         nonNull(unit, "unit");
         nonNull(geoArgs, "geoArgs");
         return execute(RedisCommand.of(Command.GEORADIUSBYMEMBER).put(marshaller.encode(key)).put(marshaller.encode(member))
-                .put(distance).put(unit.name())
+                .put(distance).put(unit.toString())
                 .putArgs(geoArgs));
     }
 
@@ -190,7 +190,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
         positive(distance, "distance");
         nonNull(unit, "unit");
         return execute(RedisCommand.of(Command.GEORADIUSBYMEMBER).put(marshaller.encode(key))
-                .put(marshaller.encode(member)).put(distance).put(unit.name()));
+                .put(marshaller.encode(member)).put(distance).put(unit.toString()));
     }
 
     Uni<Response> _georadiusbymember(K key, V member, double distance, GeoUnit unit, GeoRadiusStoreArgs<K> geoArgs) {
@@ -201,7 +201,7 @@ class AbstractGeoCommands<K, V> extends AbstractRedisCommands {
         nonNull(geoArgs, "geoArgs");
         return execute(RedisCommand.of(Command.GEORADIUSBYMEMBER).put(marshaller.encode(key))
                 .put(marshaller.encode(member))
-                .put(distance).put(unit.name())
+                .put(distance).put(unit.toString())
                 .putArgs(geoArgs, keyCodec));
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -134,6 +134,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void expireWithArgs() {
         assertThat(keys.expire(key, 10, new ExpireArgs().xx())).isFalse();
         strings.set(key, Person.person7);
@@ -158,6 +159,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void expireatWithArgs() {
         Date expiration = new Date(System.currentTimeMillis() + 10000);
         assertThat(keys.expireat(key, expiration.toInstant().getEpochSecond(), new ExpireArgs().xx())).isFalse();
@@ -222,6 +224,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void pexpireWithArgs() {
         assertThat(keys.pexpire(key, 5000, new ExpireArgs().xx())).isFalse();
         strings.set(key, Person.person7);
@@ -235,6 +238,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void pexpireWithDuration() {
         assertThat(keys.pexpire(key, Duration.ofSeconds(5))).isFalse();
         strings.set(key, Person.person7);
@@ -258,6 +262,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void pexpireatWithArgs() {
         Instant expiration = new Date(System.currentTimeMillis() + 5000).toInstant();
         assertThat(keys.pexpireat(key, expiration.getEpochSecond(), new ExpireArgs().xx())).isFalse();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
@@ -47,6 +47,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void blmpop() {
         lists.rpush("two", Person.person1, Person.person2, Person.person3);
         assertThat(lists.blmpop(Duration.ofSeconds(1), Position.RIGHT, "one", "two"))
@@ -59,6 +60,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void blmpopMany() {
         lists.rpush("two", Person.person1, Person.person2, Person.person3);
         assertThat(lists.blmpop(Duration.ofSeconds(1), Position.RIGHT, 2, "one", "two"))
@@ -135,6 +137,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void lmpop() {
         assertThat(lists.lmpop(Position.RIGHT, key)).isNull();
         lists.rpush(key, Person.person1, Person.person2);
@@ -143,6 +146,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void lmpopMany() {
         assertThat(lists.lmpop(Position.RIGHT, 2, key)).isEmpty();
         lists.rpush(key, Person.person1, Person.person2);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis7OrHigherCondition.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis7OrHigherCondition.java
@@ -1,0 +1,35 @@
+package io.quarkus.redis.datasource;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+class Redis7OrHigherCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@RequiresRedis7OrHigher is not present");
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<RequiresRedis7OrHigher> optional = AnnotationUtils.findAnnotation(context.getElement(),
+                RequiresRedis7OrHigher.class);
+
+        if (optional.isPresent()) {
+            String version = DatasourceTestBase.getRedisVersion();
+
+            return isRedis7orHigher(version) ? enabled("Redis " + version + " >= 7")
+                    : disabled("Disabled, Redis " + version + " < 7");
+        }
+
+        return ENABLED_BY_DEFAULT;
+    }
+
+    public static boolean isRedis7orHigher(String version) {
+        return Integer.parseInt(version.split("\\.")[0]) >= 7;
+    }
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis7OrHigher.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis7OrHigher.java
@@ -1,0 +1,18 @@
+package io.quarkus.redis.datasource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@ExtendWith(Redis7OrHigherCondition.class)
+@interface RequiresRedis7OrHigher {
+
+    // Important the class must extend DatasourceTestBase.
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -76,6 +76,7 @@ public class SetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher // because of sintercard
     void sinter() {
         populate();
         assertThat(sets.sinter("key1", "key2", "key3")).isEqualTo(Set.of(person3));

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
@@ -236,6 +236,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void zintercard() {
         setOfPlaces.zadd("zset1", Map.of(Place.crussol, 1.0, Place.grignan, 2.0));
         setOfPlaces.zadd("zset2", Map.of(Place.crussol, 2.0, Place.grignan, 1.0));
@@ -734,6 +735,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     public void zmpopMin() {
         assertThat(setOfPlaces.zmpopMin("zset1")).isEqualTo(null);
 
@@ -754,6 +756,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     public void zmpopMax() {
         assertThat(setOfPlaces.zmpopMax("zset1")).isEqualTo(null);
 
@@ -774,6 +777,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     public void bzmpopMin() {
         assertThat(setOfPlaces.bzmpopMin(Duration.ofSeconds(1), "zset1")).isEqualTo(null);
 
@@ -796,6 +800,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     public void bzmpopMax() {
         assertThat(setOfPlaces.bzmpopMax(Duration.ofSeconds(1), "zset1")).isEqualTo(null);
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
@@ -256,6 +256,7 @@ public class StringCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void lcs() {
         strings.mset(Map.of("key1", "ohmytext", "key2", "mynewtext"));
         assertThat(strings.lcs("key1", "key2")).isEqualTo("mytext");


### PR DESCRIPTION
- Fix #27831 - the GeoUnit must be in lowercase with Redis 6 (uppercase is only valid on 7+)
- Allows testing with Redis 6 and skips tests that require Redis 7.

Note: some commands have been added in Redis 7.  These won't be supported with Redis 6. 
