### PR TITLE
Redis value group (replacing the string group)

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -275,7 +275,7 @@ As mentioned above, the API is divided into groups:
 - set - `.set(memberType)`
 - sorted-set - `.sortedSet(memberType)`
 - stream (not available yet)
-- string - `.string(valueType)`
+- string - `.value(valueType)`
 - transactions - `withTransaction`
 
 Each of these methods returns an object that lets you execute the commands related to the group.
@@ -317,9 +317,9 @@ In this case, `quarkus-jackson` is used.
 
 To store binary data, use `byte[]`.
 
-=== The `string` group
+=== The `value` group
 
-The `string` group is used to manipulate https://redis.io/docs/manual/data-types/#strings[Redis Strings].
+The `value` group is used to manipulate https://redis.io/docs/manual/data-types/#strings[Redis Strings].
 Thus, this group is not limited to Java Strings but can be used for integers (like a counter) or binary content (like images).
 
 ==== Caching values
@@ -332,10 +332,10 @@ The following snippet shows how such a command can be used to store `BusinessObj
 @ApplicationScoped
 public static class MyRedisCache {
 
-    private final StringCommands<String, BusinessObject> commands;
+    private final ValueCommands<String, BusinessObject> commands;
 
     public MyRedisCache(RedisDataSource ds) {
-        commands = ds.string(BusinessObject.class);
+        commands = ds.value(BusinessObject.class);
     }
 
     public BusinessObject get(String key) {
@@ -375,10 +375,10 @@ In this case, we will use `byte[]` as value type:
 @ApplicationScoped
 public static class MyBinaryRepository {
 
-    private final StringCommands<String, byte[]> commands;
+    private final ValueCommands<String, byte[]> commands;
 
     public MyBinaryRepository(RedisDataSource ds) {
-        commands = ds.string(byte[].class);
+        commands = ds.value(byte[].class);
     }
 
     public byte[] get(String key) {
@@ -408,10 +408,10 @@ You can store counters in Redis as demonstrated below:
 @ApplicationScoped
 public static class MyRedisCounter {
 
-    private final StringCommands<String, Long> commands;
+    private final ValueCommands<String, Long> commands;
 
     public MyRedisCounter(RedisDataSource ds) {
-        commands = ds.string(Long.class); // <1>
+        commands = ds.value(Long.class); // <1>
     }
 
     public long get(String key) {
@@ -490,11 +490,11 @@ public static class MySubscriber implements Consumer<Notification> {
 @ApplicationScoped
 public static class MyCache {
 
-    private final StringCommands<String, BusinessObject> commands;
+    private final ValueCommands<String, BusinessObject> commands;
     private final PubSubCommands<Notification> pub;
 
     public MyCache(RedisDataSource ds) {
-        commands = ds.string(BusinessObject.class);
+        commands = ds.value(BusinessObject.class);
         pub = ds.pubsub(Notification.class);
     }
 

--- a/docs/src/main/asciidoc/redis.adoc
+++ b/docs/src/main/asciidoc/redis.adoc
@@ -120,10 +120,10 @@ public class IncrementService {
     // Regular applications will pick one of them.
 
     private ReactiveKeyCommands<String> keyCommands; // <1>
-    private StringCommands<String, Long> countCommands; // <2>
+    private ValueCommands<String, Long> countCommands; // <2>
 
     public IncrementService(RedisDataSource ds, ReactiveRedisDataSource reactive) { // <3>
-        countCommands = ds.string(Long.class); // <4>
+        countCommands = ds.value(Long.class); // <4>
         keyCommands = reactive.key();  // <5>
 
     }

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/datasource/DataSourceInjectionTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/datasource/DataSourceInjectionTest.java
@@ -60,24 +60,24 @@ public class DataSourceInjectionTest {
         ReactiveRedisDataSource myRedisReactive;
 
         public void set(String data) {
-            reactive.string(String.class, String.class)
+            reactive.value(String.class, String.class)
                     .set("foo", data)
                     .await().indefinitely();
         }
 
         public String get() {
-            return blocking.string(String.class, String.class)
+            return blocking.value(String.class, String.class)
                     .get("foo");
         }
 
         public void setMyRedis(String data) {
-            myRedisReactive.string(String.class, String.class)
+            myRedisReactive.value(String.class, String.class)
                     .set("foo", data)
                     .await().indefinitely();
         }
 
         public String getMyRedis() {
-            return myRedisBlocking.string(String.class, String.class)
+            return myRedisBlocking.value(String.class, String.class)
                     .get("foo");
         }
 

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/datasource/DataSourceTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/datasource/DataSourceTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.client.deployment.RedisTestResource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
@@ -34,8 +34,8 @@ public class DataSourceTest {
 
     @Test
     public void testThatTheDatasourceUseDifferentDatabases() {
-        StringCommands<String, String> r1s = r1.string(String.class);
-        StringCommands<String, String> r2s = r2.string(String.class);
+        ValueCommands<String, String> r1s = r1.value(String.class);
+        ValueCommands<String, String> r2s = r2.value(String.class);
 
         r1s.set("key", "hello");
         Assertions.assertThat(r2s.get("key")).isNull();

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/devmode/IncrementResource.java
@@ -4,16 +4,16 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 
 @Path("/inc")
 public class IncrementResource {
 
     public static final long INCREMENT = 1;
-    private final StringCommands<String, Integer> commands;
+    private final ValueCommands<String, Integer> commands;
 
     public IncrementResource(RedisDataSource ds) {
-        commands = ds.string(Integer.class);
+        commands = ds.value(Integer.class);
     }
 
     @GET

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/BinaryTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/BinaryTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.redis.client.deployment.RedisTestResource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
@@ -52,10 +52,10 @@ public class BinaryTest {
     @ApplicationScoped
     public static class MyBinaryRepository {
 
-        private final StringCommands<String, byte[]> commands;
+        private final ValueCommands<String, byte[]> commands;
 
         public MyBinaryRepository(RedisDataSource ds) {
-            commands = ds.string(byte[].class);
+            commands = ds.value(byte[].class);
         }
 
         public byte[] get(String key) {

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/CacheTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/CacheTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.redis.client.deployment.RedisTestResource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
@@ -68,10 +68,10 @@ public class CacheTest {
     @ApplicationScoped
     public static class MyRedisCache {
 
-        private final StringCommands<String, BusinessObject> commands;
+        private final ValueCommands<String, BusinessObject> commands;
 
         public MyRedisCache(RedisDataSource ds) {
-            commands = ds.string(BusinessObject.class);
+            commands = ds.value(BusinessObject.class);
         }
 
         public BusinessObject get(String key) {

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/CounterTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/CounterTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.redis.client.deployment.RedisTestResource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 
@@ -47,10 +47,10 @@ public class CounterTest {
     @ApplicationScoped
     public static class MyRedisCounter {
 
-        private final StringCommands<String, Long> commands;
+        private final ValueCommands<String, Long> commands;
 
         public MyRedisCounter(RedisDataSource ds) {
-            commands = ds.string(Long.class);
+            commands = ds.value(Long.class);
         }
 
         public long get(String key) {

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/PubSubOnStartupTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/PubSubOnStartupTest.java
@@ -21,7 +21,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.pubsub.PubSubCommands;
 import io.quarkus.redis.datasource.pubsub.ReactivePubSubCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.runtime.Startup;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -115,11 +115,11 @@ public class PubSubOnStartupTest {
     @ApplicationScoped
     public static class MyCache {
 
-        private final StringCommands<String, BusinessObject> commands;
+        private final ValueCommands<String, BusinessObject> commands;
         private final PubSubCommands<Notification> pub;
 
         public MyCache(RedisDataSource ds) {
-            commands = ds.string(BusinessObject.class);
+            commands = ds.value(BusinessObject.class);
             pub = ds.pubsub(Notification.class);
         }
 

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/PubSubTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/patterns/PubSubTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.redis.client.deployment.RedisTestResource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.pubsub.PubSubCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.runtime.Startup;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -109,11 +109,11 @@ public class PubSubTest {
     @ApplicationScoped
     public static class MyCache {
 
-        private final StringCommands<String, BusinessObject> commands;
+        private final ValueCommands<String, BusinessObject> commands;
         private final PubSubCommands<Notification> pub;
 
         public MyCache(RedisDataSource ds) {
-            commands = ds.string(BusinessObject.class);
+            commands = ds.value(BusinessObject.class);
             pub = ds.pubsub(Notification.class);
         }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResu
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
@@ -234,6 +235,9 @@ public interface ReactiveRedisDataSource {
 
     /**
      * Gets the object to execute commands manipulating stored strings.
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
      *
      * @param redisKeyType the type of the keys
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
@@ -241,6 +245,33 @@ public interface ReactiveRedisDataSource {
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
      */
+    <K, V> ReactiveValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    default <V> ReactiveValueCommands<String, V> value(Class<V> valueType) {
+        return value(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class, Class)} instead
+     */
+    @Deprecated
     <K, V> ReactiveStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType);
 
     /**
@@ -249,7 +280,9 @@ public interface ReactiveRedisDataSource {
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class)} instead
      */
+    @Deprecated
     default <V> ReactiveStringCommands<String, V> string(Class<V> valueType) {
         return string(String.class, valueType);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.datasource.string.StringCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Response;
 
@@ -231,12 +232,44 @@ public interface RedisDataSource {
     /**
      * Gets the object to execute commands manipulating stored strings.
      *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
      * @param redisKeyType the type of the keys
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <K> the type of the key
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
      */
+    <K, V> ValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    default <V> ValueCommands<String, V> value(Class<V> valueType) {
+        return value(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class, Class)} instead
+     */
+    @Deprecated
     <K, V> StringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType);
 
     /**
@@ -245,7 +278,9 @@ public interface RedisDataSource {
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class)} instead
      */
+    @Deprecated
     default <V> StringCommands<String, V> string(Class<V> valueType) {
         return string(String.class, valueType);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/GetExArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/GetExArgs.java
@@ -9,8 +9,11 @@ import io.quarkus.redis.datasource.RedisCommandExtraArguments;
 
 /**
  * Argument list for the Redis <a href="https://redis.io/commands/getex">GETEX</a> command.
+ *
+ * @deprecated use {@link io.quarkus.redis.datasource.value.GetExArgs} instead
  */
-public class GetExArgs implements RedisCommandExtraArguments {
+@Deprecated
+public class GetExArgs extends io.quarkus.redis.datasource.value.GetExArgs implements RedisCommandExtraArguments {
 
     private long ex = -1;
     private long exAt = -1;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
@@ -15,7 +15,9 @@ import io.smallrye.mutiny.Uni;
  *
  * @param <K> the type of the key
  * @param <V> the type of the value
+ * @deprecated Use {@link io.quarkus.redis.datasource.value.ReactiveValueCommands} instead.
  */
+@Deprecated
 public interface ReactiveStringCommands<K, V> extends ReactiveRedisCommands {
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveTransactionalStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveTransactionalStringCommands.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.smallrye.mutiny.Uni;
 
+@Deprecated
 public interface ReactiveTransactionalStringCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
@@ -14,7 +14,9 @@ import io.quarkus.redis.datasource.RedisCommands;
  *
  * @param <K> the type of the key
  * @param <V> the type of the value
+ * @deprecated Use {@link io.quarkus.redis.datasource.value.ValueCommands} instead.
  */
+@Deprecated
 public interface StringCommands<K, V> extends RedisCommands {
 
     /**

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -9,6 +9,7 @@ import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
+import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 
@@ -131,12 +132,44 @@ public interface ReactiveTransactionalRedisDataSource {
     /**
      * Gets the object to execute commands manipulating stored strings.
      *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
      * @param redisKeyType the type of the keys
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <K> the type of the key
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
      */
+    <K, V> ReactiveTransactionalValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    default <V> ReactiveTransactionalValueCommands<String, V> value(Class<V> valueType) {
+        return value(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class, Class)} instead
+     */
+    @Deprecated
     <K, V> ReactiveTransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType);
 
     /**
@@ -145,7 +178,9 @@ public interface ReactiveTransactionalRedisDataSource {
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class)} instead
      */
+    @Deprecated
     default <V> ReactiveTransactionalStringCommands<String, V> string(Class<V> valueType) {
         return string(String.class, valueType);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -9,6 +9,7 @@ import io.quarkus.redis.datasource.list.TransactionalListCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.vertx.mutiny.redis.client.Command;
 
 /**
@@ -129,12 +130,44 @@ public interface TransactionalRedisDataSource {
     /**
      * Gets the object to execute commands manipulating stored strings.
      *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
      * @param redisKeyType the type of the keys
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <K> the type of the key
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
      */
+    <K, V> TransactionalValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * <p>
+     * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+     * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+     *
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     */
+    default <V> TransactionalValueCommands<String, V> value(Class<V> valueType) {
+        return value(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to execute commands manipulating stored strings.
+     *
+     * @param redisKeyType the type of the keys
+     * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class, Class)} instead.
+     */
+    @Deprecated
     <K, V> TransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType);
 
     /**
@@ -143,7 +176,9 @@ public interface TransactionalRedisDataSource {
      * @param valueType the type of the value, often String, or the value are encoded/decoded using codecs.
      * @param <V> the type of the value
      * @return the object to manipulate stored strings.
+     * @deprecated Use {@link #value(Class)} instead
      */
+    @Deprecated
     default <V> TransactionalStringCommands<String, V> string(Class<V> valueType) {
         return string(String.class, valueType);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/GetExArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/GetExArgs.java
@@ -1,4 +1,4 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -8,21 +8,15 @@ import java.util.List;
 import io.quarkus.redis.datasource.RedisCommandExtraArguments;
 
 /**
- * Argument list for the Redis <a href="https://redis.io/commands/SET">SET</a> command.
- *
- * @deprecated Use {@link io.quarkus.redis.datasource.value.SetArgs} instead.
+ * Argument list for the Redis <a href="https://redis.io/commands/getex">GETEX</a> command.
  */
-@Deprecated
-public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implements RedisCommandExtraArguments {
+public class GetExArgs implements RedisCommandExtraArguments {
 
     private long ex = -1;
     private long exAt = -1;
     private long px = -1;
     private long pxAt = -1;
-    private boolean nx;
-    private boolean keepttl;
-    private boolean xx;
-    private boolean get;
+    private boolean persist;
 
     /**
      * Set the specified expire time, in seconds.
@@ -30,10 +24,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timeout expire time in seconds.
      * @return the current {@code GetExArgs}
      */
-    public SetArgs ex(long timeout) {
-        if (timeout <= 0) {
-            throw new IllegalArgumentException("`timeout` must be positive");
-        }
+    public GetExArgs ex(long timeout) {
         this.ex = timeout;
         return this;
     }
@@ -44,7 +35,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timeout expire time in seconds.
      * @return the current {@code GetExArgs}
      */
-    public SetArgs ex(Duration timeout) {
+    public GetExArgs ex(Duration timeout) {
         if (timeout == null) {
             throw new IllegalArgumentException("`timeout` must not be `null`");
         }
@@ -57,7 +48,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timestamp the timestamp
      * @return the current {@code GetExArgs}
      */
-    public SetArgs exAt(long timestamp) {
+    public GetExArgs exAt(long timestamp) {
         this.exAt = timestamp;
         return this;
     }
@@ -68,7 +59,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timestamp the timestamp type: posix time in seconds.
      * @return the current {@code GetExArgs}
      */
-    public SetArgs exAt(Instant timestamp) {
+    public GetExArgs exAt(Instant timestamp) {
         if (timestamp == null) {
             throw new IllegalArgumentException("`timestamp` must not be `null`");
         }
@@ -82,10 +73,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timeout expire time in milliseconds.
      * @return the current {@code GetExArgs}
      */
-    public SetArgs px(long timeout) {
-        if (timeout < 0) {
-            throw new IllegalArgumentException("`timeout` must be positive");
-        }
+    public GetExArgs px(long timeout) {
         this.px = timeout;
         return this;
     }
@@ -96,7 +84,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timeout expire time in milliseconds.
      * @return the current {@code GetExArgs}
      */
-    public SetArgs px(Duration timeout) {
+    public GetExArgs px(Duration timeout) {
         if (timeout == null) {
             throw new IllegalArgumentException("`timeout` must not be `null`");
         }
@@ -109,7 +97,7 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * @param timestamp the timestamp
      * @return the current {@code GetExArgs}
      */
-    public SetArgs pxAt(long timestamp) {
+    public GetExArgs pxAt(long timestamp) {
         this.pxAt = timestamp;
         return this;
     }
@@ -118,9 +106,9 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
      * Set the specified Unix time at which the key will expire, in milliseconds.
      *
      * @param timestamp the timestamp
-     * @return the current {@code SetArgs}
+     * @return the current {@code GetExArgs}
      */
-    public SetArgs pxAt(Instant timestamp) {
+    public GetExArgs pxAt(Instant timestamp) {
         if (timestamp == null) {
             throw new IllegalArgumentException("`timestamp` must not be `null`");
         }
@@ -128,43 +116,12 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
     }
 
     /**
-     * Only set the key if it does not already exist.
+     * Sets {@code PERSIST}
      *
-     * @return the current {@code SetArgs}
+     * @return the current {@code GetExArgs}
      */
-    public SetArgs nx() {
-        this.nx = true;
-        return this;
-    }
-
-    /**
-     * Set the value and retain the existing TTL.
-     *
-     * @return the current {@code SetArgs}
-     */
-    public SetArgs keepttl() {
-        this.keepttl = true;
-        return this;
-    }
-
-    /**
-     * Only set the key if it already exists.
-     *
-     * @return the current {@code SetArgs}
-     */
-    public SetArgs xx() {
-        this.xx = true;
-        return this;
-    }
-
-    /**
-     * Return the old string stored at key, or nil if key did not exist. An error is returned and SET aborted if the
-     * value stored at key is not a string.
-     *
-     * @return the current {@code SetArgs}
-     */
-    public SetArgs get() {
-        this.get = true;
+    public GetExArgs persist() {
+        this.persist = true;
         return this;
     }
 
@@ -190,20 +147,8 @@ public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implement
             args.add(Long.toString(pxAt));
         }
 
-        if (nx) {
-            args.add("NX");
-        }
-
-        if (xx) {
-            args.add("XX");
-        }
-
-        if (keepttl) {
-            args.add("KEEPTTL");
-        }
-
-        if (get) {
-            args.add("GET");
+        if (persist) {
+            args.add("PERSIST");
         }
         return args;
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveTransactionalValueCommands.java
@@ -1,11 +1,11 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.util.Map;
 
-import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
 
-@Deprecated
-public interface TransactionalStringCommands<K, V> extends TransactionalRedisCommands {
+public interface ReactiveTransactionalValueCommands<K, V> extends ReactiveTransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.
@@ -15,8 +15,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void append(K key, V value);
+    Uni<Void> append(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decr">DECR</a>.
@@ -25,8 +27,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void decr(K key);
+    Uni<Void> decr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decrby">DECRBY</a>.
@@ -36,8 +40,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void decrby(K key, long amount);
+    Uni<Void> decrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/get">GET</a>.
@@ -46,8 +52,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void get(K key);
+    Uni<Void> get(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getdel">GETDEL</a>.
@@ -56,8 +64,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 6.2.0
      *
      * @param key the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void getdel(K key);
+    Uni<Void> getdel(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getex">GETEX</a>.
@@ -67,8 +77,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param args the getex command extra-arguments
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void getex(K key, GetExArgs args);
+    Uni<Void> getex(K key, GetExArgs args);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getrange">GETRANGE</a>.
@@ -79,8 +91,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param start the start offset
      * @param end the end offset
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void getrange(K key, long start, long end);
+    Uni<Void> getrange(K key, long start, long end);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getset">GETSET</a>.
@@ -90,9 +104,11 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      * @deprecated See https://redis.io/commands/getset
      */
-    void getset(K key, V value);
+    Uni<Void> getset(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incr">INCR</a>.
@@ -101,8 +117,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void incr(K key);
+    Uni<Void> incr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrby">INCRBY</a>.
@@ -112,8 +130,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void incrby(K key, long amount);
+    Uni<Void> incrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrbyfloat">INCRBYFLOAT</a>.
@@ -123,8 +143,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void incrbyfloat(K key, double amount);
+    Uni<Void> incrbyfloat(K key, double amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -134,8 +156,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void lcs(K key1, K key2);
+    Uni<Void> lcs(K key1, K key2);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -145,8 +169,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void lcsLength(K key1, K key2);
+    Uni<Void> lcsLength(K key1, K key2);
 
     /**
      * Execute the command <a href="https://redis.io/commands/mget">MGET</a>.
@@ -155,8 +181,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param keys the keys
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void mget(K... keys);
+    Uni<Void> mget(K... keys);
 
     /**
      * Execute the command <a href="https://redis.io/commands/mset">MSET</a>.
@@ -165,8 +193,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void mset(Map<K, V> map);
+    Uni<Void> mset(Map<K, V> map);
 
     /**
      * Execute the command <a href="https://redis.io/commands/msetnx">MSETNX</a>.
@@ -175,8 +205,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void msetnx(Map<K, V> map);
+    Uni<Void> msetnx(Map<K, V> map);
 
     /**
      * Execute the command <a href="https://redis.io/commands/psetex">PSETEX</a>.
@@ -187,8 +219,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param milliseconds the duration in ms
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void psetex(K key, long milliseconds, V value);
+    Uni<Void> psetex(K key, long milliseconds, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -198,8 +232,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void set(K key, V value);
+    Uni<Void> set(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -210,8 +246,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void set(K key, V value, SetArgs setArgs);
+    Uni<Void> set(K key, V value, SetArgs setArgs);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -221,8 +259,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void setGet(K key, V value);
+    Uni<Void> setGet(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -233,8 +273,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void setGet(K key, V value, SetArgs setArgs);
+    Uni<Void> setGet(K key, V value, SetArgs setArgs);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setex">SETEX</a>.
@@ -245,7 +287,7 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      */
-    void setex(K key, long seconds, V value);
+    Uni<Void> setex(K key, long seconds, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setnx">SETNX</a>.
@@ -255,8 +297,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void setnx(K key, V value);
+    Uni<Void> setnx(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setrange">SETRANGE</a>.
@@ -266,8 +310,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void setrange(K key, long offset, V value);
+    Uni<Void> setrange(K key, long offset, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/strlen">STRLEN</a>.
@@ -276,6 +322,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 2.2.0
      *
      * @param key the key
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
      */
-    void strlen(K key);
+    Uni<Void> strlen(K key);
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
@@ -1,11 +1,25 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.util.Map;
 
-import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.mutiny.Uni;
 
-@Deprecated
-public interface TransactionalStringCommands<K, V> extends TransactionalRedisCommands {
+/**
+ * Allows executing commands from the {@code string} group.
+ * See <a href="https://redis.io/commands/?group=string">the string command list</a> for further information
+ * about these commands.
+ * <p>
+ * This group can be used with value of type {@code String}, or a type which will be automatically
+ * serialized/deserialized with a codec.
+ * <p>
+ * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+ * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ */
+public interface ReactiveValueCommands<K, V> extends ReactiveRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.
@@ -15,8 +29,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void append(K key, V value);
+     * @return the length of the string after the append operation.
+     **/
+    Uni<Long> append(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decr">DECR</a>.
@@ -25,8 +40,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void decr(K key);
+     * @return the value of key after the decrement
+     **/
+    Uni<Long> decr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decrby">DECRBY</a>.
@@ -36,8 +52,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void decrby(K key, long amount);
+     * @return the value of key after the decrement
+     **/
+    Uni<Long> decrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/get">GET</a>.
@@ -46,8 +63,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void get(K key);
+     * @return the value of key, or {@code null} when key does not exist.
+     **/
+    Uni<V> get(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getdel">GETDEL</a>.
@@ -56,8 +74,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 6.2.0
      *
      * @param key the key
-     */
-    void getdel(K key);
+     * @return the value of key, {@code null} when key does not exist, or an error if the key's value type isn't a string.
+     **/
+    Uni<V> getdel(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getex">GETEX</a>.
@@ -67,8 +86,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param args the getex command extra-arguments
-     */
-    void getex(K key, GetExArgs args);
+     * @return the value of key, or {@code null} when key does not exist.
+     **/
+    Uni<V> getex(K key, GetExArgs args);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getrange">GETRANGE</a>.
@@ -79,8 +99,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param start the start offset
      * @param end the end offset
-     */
-    void getrange(K key, long start, long end);
+     * @return the sub-string
+     **/
+    Uni<String> getrange(K key, long start, long end);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getset">GETSET</a>.
@@ -90,9 +111,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return the old value stored at key, or {@code null} when key did not exist.
      * @deprecated See https://redis.io/commands/getset
-     */
-    void getset(K key, V value);
+     **/
+    Uni<V> getset(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incr">INCR</a>.
@@ -101,8 +123,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void incr(K key);
+     * @return the value of key after the increment
+     **/
+    Uni<Long> incr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrby">INCRBY</a>.
@@ -112,8 +135,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void incrby(K key, long amount);
+     * @return the value of key after the increment
+     **/
+    Uni<Long> incrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrbyfloat">INCRBYFLOAT</a>.
@@ -123,8 +147,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void incrbyfloat(K key, double amount);
+     * @return the value of key after the increment.
+     **/
+    Uni<Double> incrbyfloat(K key, double amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -134,8 +159,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
-     */
-    void lcs(K key1, K key2);
+     * @return the string representing the longest common substring is returned.
+     **/
+    Uni<String> lcs(K key1, K key2);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -145,8 +171,11 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
-     */
-    void lcsLength(K key1, K key2);
+     * @return the length of the longest common substring.
+     **/
+    Uni<Long> lcsLength(K key1, K key2);
+
+    // TODO Add LCS with IDX support
 
     /**
      * Execute the command <a href="https://redis.io/commands/mget">MGET</a>.
@@ -155,8 +184,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param keys the keys
-     */
-    void mget(K... keys);
+     * @return list of values at the specified keys.
+     **/
+    Uni<Map<K, V>> mget(K... keys);
 
     /**
      * Execute the command <a href="https://redis.io/commands/mset">MSET</a>.
@@ -165,8 +195,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
-     */
-    void mset(Map<K, V> map);
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
+    Uni<Void> mset(Map<K, V> map);
 
     /**
      * Execute the command <a href="https://redis.io/commands/msetnx">MSETNX</a>.
@@ -175,8 +206,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
-     */
-    void msetnx(Map<K, V> map);
+     * @return {@code true} the all the keys were set. {@code false} no key was set (at least one key already existed).
+     **/
+    Uni<Boolean> msetnx(Map<K, V> map);
 
     /**
      * Execute the command <a href="https://redis.io/commands/psetex">PSETEX</a>.
@@ -187,8 +219,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param milliseconds the duration in ms
      * @param value the value
-     */
-    void psetex(K key, long milliseconds, V value);
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
+    Uni<Void> psetex(K key, long milliseconds, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -198,8 +231,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void set(K key, V value);
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
+    Uni<Void> set(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -210,8 +244,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     */
-    void set(K key, V value, SetArgs setArgs);
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
+    Uni<Void> set(K key, V value, SetArgs setArgs);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -221,8 +256,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setGet(K key, V value);
+     * @return the old value, {@code null} if not present
+     **/
+    Uni<V> setGet(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -233,8 +269,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     */
-    void setGet(K key, V value, SetArgs setArgs);
+     * @return the old value, {@code null} if not present
+     **/
+    Uni<V> setGet(K key, V value, SetArgs setArgs);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setex">SETEX</a>.
@@ -244,8 +281,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setex(K key, long seconds, V value);
+     **/
+    Uni<Void> setex(K key, long seconds, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setnx">SETNX</a>.
@@ -255,8 +292,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setnx(K key, V value);
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    Uni<Boolean> setnx(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setrange">SETRANGE</a>.
@@ -266,8 +304,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setrange(K key, long offset, V value);
+     * @return the length of the string after it was modified by the command.
+     **/
+    Uni<Long> setrange(K key, long offset, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/strlen">STRLEN</a>.
@@ -276,6 +315,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 2.2.0
      *
      * @param key the key
-     */
-    void strlen(K key);
+     * @return the length of the string at key, or 0 when key does not exist.
+     **/
+    Uni<Long> strlen(K key);
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/SetArgs.java
@@ -1,4 +1,4 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -9,11 +9,8 @@ import io.quarkus.redis.datasource.RedisCommandExtraArguments;
 
 /**
  * Argument list for the Redis <a href="https://redis.io/commands/SET">SET</a> command.
- *
- * @deprecated Use {@link io.quarkus.redis.datasource.value.SetArgs} instead.
  */
-@Deprecated
-public class SetArgs extends io.quarkus.redis.datasource.value.SetArgs implements RedisCommandExtraArguments {
+public class SetArgs implements RedisCommandExtraArguments {
 
     private long ex = -1;
     private long exAt = -1;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/TransactionalValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/TransactionalValueCommands.java
@@ -1,11 +1,10 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.util.Map;
 
 import io.quarkus.redis.datasource.TransactionalRedisCommands;
 
-@Deprecated
-public interface TransactionalStringCommands<K, V> extends TransactionalRedisCommands {
+public interface TransactionalValueCommands<K, V> extends TransactionalRedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
@@ -1,11 +1,24 @@
-package io.quarkus.redis.datasource.string;
+package io.quarkus.redis.datasource.value;
 
 import java.util.Map;
 
-import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.RedisCommands;
 
-@Deprecated
-public interface TransactionalStringCommands<K, V> extends TransactionalRedisCommands {
+/**
+ * Allows executing commands from the {@code string} group.
+ * See <a href="https://redis.io/commands/?group=string">the string command list</a> for further information
+ * about these commands.
+ * <p>
+ * This group can be used with value of type {@code String}, or a type which will be automatically
+ * serialized/deserialized with a codec.
+ * <p>
+ * <strong>NOTE:</strong> Instead of {@code string}, this group is named {@code value} to avoid the confusion with the
+ * Java String type. Indeed, Redis strings can be strings, numbers, byte arrays...
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ */
+public interface ValueCommands<K, V> extends RedisCommands {
 
     /**
      * Execute the command <a href="https://redis.io/commands/append">APPEND</a>.
@@ -15,8 +28,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void append(K key, V value);
+     * @return the length of the string after the append operation.
+     **/
+    long append(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decr">DECR</a>.
@@ -25,8 +39,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void decr(K key);
+     * @return the value of key after the decrement
+     **/
+    long decr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/decrby">DECRBY</a>.
@@ -36,8 +51,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void decrby(K key, long amount);
+     * @return the value of key after the decrement
+     **/
+    long decrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/get">GET</a>.
@@ -46,8 +62,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void get(K key);
+     * @return the value of key, or {@code null} when key does not exist.
+     **/
+    V get(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getdel">GETDEL</a>.
@@ -56,8 +73,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 6.2.0
      *
      * @param key the key
-     */
-    void getdel(K key);
+     * @return the value of key, {@code null} when key does not exist, or an error if the key's value type isn't a string.
+     **/
+    V getdel(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getex">GETEX</a>.
@@ -67,8 +85,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param args the getex command extra-arguments
-     */
-    void getex(K key, GetExArgs args);
+     * @return the value of key, or {@code null} when key does not exist.
+     **/
+    V getex(K key, GetExArgs args);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getrange">GETRANGE</a>.
@@ -79,8 +98,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param start the start offset
      * @param end the end offset
-     */
-    void getrange(K key, long start, long end);
+     * @return the sub-string
+     **/
+    String getrange(K key, long start, long end);
 
     /**
      * Execute the command <a href="https://redis.io/commands/getset">GETSET</a>.
@@ -90,9 +110,10 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
+     * @return the old value stored at key, or {@code null} when key did not exist.
      * @deprecated See https://redis.io/commands/getset
-     */
-    void getset(K key, V value);
+     **/
+    V getset(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incr">INCR</a>.
@@ -101,8 +122,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param key the key
-     */
-    void incr(K key);
+     * @return the value of key after the increment
+     **/
+    long incr(K key);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrby">INCRBY</a>.
@@ -112,8 +134,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void incrby(K key, long amount);
+     * @return the value of key after the increment
+     **/
+    long incrby(K key, long amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/incrbyfloat">INCRBYFLOAT</a>.
@@ -123,8 +146,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param amount the amount, can be negative
-     */
-    void incrbyfloat(K key, double amount);
+     * @return the value of key after the increment.
+     **/
+    double incrbyfloat(K key, double amount);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -134,8 +158,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
-     */
-    void lcs(K key1, K key2);
+     * @return the string representing the longest common substring is returned.
+     **/
+    String lcs(K key1, K key2);
 
     /**
      * Execute the command <a href="https://redis.io/commands/lcs">LCS</a>.
@@ -145,8 +170,11 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key1 the key
      * @param key2 the key
-     */
-    void lcsLength(K key1, K key2);
+     * @return the length of the longest common substring.
+     **/
+    long lcsLength(K key1, K key2);
+
+    // TODO Add LCS with IDX support
 
     /**
      * Execute the command <a href="https://redis.io/commands/mget">MGET</a>.
@@ -155,8 +183,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.0
      *
      * @param keys the keys
-     */
-    void mget(K... keys);
+     * @return list of values at the specified keys.
+     **/
+    Map<K, V> mget(K... keys);
 
     /**
      * Execute the command <a href="https://redis.io/commands/mset">MSET</a>.
@@ -165,7 +194,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
-     */
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
     void mset(Map<K, V> map);
 
     /**
@@ -175,8 +205,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 1.0.1
      *
      * @param map the key/value map containing the items to store
-     */
-    void msetnx(Map<K, V> map);
+     * @return {@code true} the all the keys were set. {@code false} no key was set (at least one key already existed).
+     **/
+    boolean msetnx(Map<K, V> map);
 
     /**
      * Execute the command <a href="https://redis.io/commands/psetex">PSETEX</a>.
@@ -187,7 +218,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param milliseconds the duration in ms
      * @param value the value
-     */
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
     void psetex(K key, long milliseconds, V value);
 
     /**
@@ -198,7 +230,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
     void set(K key, V value);
 
     /**
@@ -210,7 +243,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     */
+     * @return a Uni producing a {@code null} item on success, a failure otherwise
+     **/
     void set(K key, V value, SetArgs setArgs);
 
     /**
@@ -221,8 +255,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setGet(K key, V value);
+     * @return the old value, {@code null} if not present
+     **/
+    V setGet(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/set">SET</a>.
@@ -233,8 +268,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * @param key the key
      * @param value the value
      * @param setArgs the set command extra-arguments
-     */
-    void setGet(K key, V value, SetArgs setArgs);
+     * @return the old value, {@code null} if not present
+     **/
+    V setGet(K key, V value, SetArgs setArgs);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setex">SETEX</a>.
@@ -244,7 +280,7 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
+     **/
     void setex(K key, long seconds, V value);
 
     /**
@@ -255,8 +291,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setnx(K key, V value);
+     * @return {@code true} the key was set {@code false} the key was not set
+     **/
+    boolean setnx(K key, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/setrange">SETRANGE</a>.
@@ -266,8 +303,9 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      *
      * @param key the key
      * @param value the value
-     */
-    void setrange(K key, long offset, V value);
+     * @return the length of the string after it was modified by the command.
+     **/
+    long setrange(K key, long offset, V value);
 
     /**
      * Execute the command <a href="https://redis.io/commands/strlen">STRLEN</a>.
@@ -276,6 +314,8 @@ public interface TransactionalStringCommands<K, V> extends TransactionalRedisCom
      * Requires Redis 2.2.0
      *
      * @param key the key
-     */
-    void strlen(K key);
+     * @return the length of the string at key, or 0 when key does not exist.
+     **/
+    long strlen(K key);
+
 }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractStringCommands.java
@@ -45,6 +45,17 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
         return execute(cmd);
     }
 
+    Uni<Response> _set(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        nonNull(key, "key");
+        nonNull(value, "value");
+        nonNull(setArgs, "setArgs");
+        RedisCommand cmd = RedisCommand.of(Command.SET);
+        cmd.put(marshaller.encode(key));
+        cmd.put(marshaller.encode(value));
+        cmd.putArgs(setArgs);
+        return execute(cmd);
+    }
+
     Uni<Response> _setGet(K key, V value) {
         nonNull(key, "key");
         nonNull(value, "value");
@@ -60,6 +71,17 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
     }
 
     Uni<Response> _setGet(K key, V value, SetArgs setArgs) {
+        nonNull(key, "key");
+        nonNull(value, "value");
+        nonNull(setArgs, "setArgs");
+        RedisCommand cmd = RedisCommand.of(Command.SET);
+        cmd.put(marshaller.encode(key));
+        cmd.put(marshaller.encode(value));
+        cmd.putArgs(setArgs.get());
+        return execute(cmd);
+    }
+
+    Uni<Response> _setGet(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
         nonNull(key, "key");
         nonNull(value, "value");
         nonNull(setArgs, "setArgs");
@@ -140,6 +162,15 @@ class AbstractStringCommands<K, V> extends AbstractRedisCommands {
     }
 
     Uni<Response> _getex(K key, GetExArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+        RedisCommand cmd = RedisCommand.of(Command.GETEX);
+        cmd.put(marshaller.encode(key));
+        cmd.putArgs(args);
+        return execute(cmd);
+    }
+
+    Uni<Response> _getex(K key, io.quarkus.redis.datasource.value.GetExArgs args) {
         nonNull(key, "key");
         nonNull(args, "args");
         RedisCommand cmd = RedisCommand.of(Command.GETEX);

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -22,6 +22,7 @@ import io.quarkus.redis.datasource.string.StringCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
@@ -192,7 +193,12 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
 
     @Override
     public <K1, V1> StringCommands<K1, V1> string(Class<K1> redisKeyType, Class<V1> valueType) {
-        return new BlockingStringCommandsImpl<>(this, reactive.string(redisKeyType, valueType), timeout);
+        return new BlockingStringCommandsImpl<>(this, reactive.value(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> ValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingStringCommandsImpl<>(this, reactive.value(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingStringCommandsImpl.java
@@ -5,15 +5,17 @@ import java.util.Map;
 
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.string.GetExArgs;
-import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 
-public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup implements StringCommands<K, V> {
+public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup
+        implements StringCommands<K, V>, ValueCommands<K, V> {
 
-    private final ReactiveStringCommands<K, V> reactive;
+    private final ReactiveValueCommands<K, V> reactive;
 
-    public BlockingStringCommandsImpl(RedisDataSource ds, ReactiveStringCommands<K, V> reactive, Duration timeout) {
+    public BlockingStringCommandsImpl(RedisDataSource ds, ReactiveValueCommands<K, V> reactive, Duration timeout) {
         super(ds, timeout);
         this.reactive = reactive;
     }
@@ -46,6 +48,12 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup 
 
     @Override
     public V getex(K key, GetExArgs args) {
+        return reactive.getex(key, args)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public V getex(K key, io.quarkus.redis.datasource.value.GetExArgs args) {
         return reactive.getex(key, args)
                 .await().atMost(timeout);
     }
@@ -120,6 +128,12 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup 
     }
 
     @Override
+    public void set(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        reactive.set(key, value, setArgs)
+                .await().atMost(timeout);
+    }
+
+    @Override
     public V setGet(K key, V value) {
         return reactive.setGet(key, value)
                 .await().atMost(timeout);
@@ -127,6 +141,12 @@ public class BlockingStringCommandsImpl<K, V> extends AbstractRedisCommandGroup 
 
     @Override
     public V setGet(K key, V value, SetArgs setArgs) {
+        return reactive.setGet(key, value, setArgs)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public V setGet(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
         return reactive.setGet(key, value, setArgs)
                 .await().atMost(timeout);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -13,6 +13,7 @@ import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.vertx.mutiny.redis.client.Command;
 
 public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRedisDataSource {
@@ -64,7 +65,12 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
 
     @Override
     public <K, V> TransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType) {
-        return new BlockingTransactionalStringCommandsImpl<>(this, reactive.string(redisKeyType, valueType), timeout);
+        return new BlockingTransactionalStringCommandsImpl<>(this, reactive.value(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TransactionalValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTransactionalStringCommandsImpl<>(this, reactive.value(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalStringCommandsImpl.java
@@ -4,18 +4,19 @@ import java.time.Duration;
 import java.util.Map;
 
 import io.quarkus.redis.datasource.string.GetExArgs;
-import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
+import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 
 public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
-        implements TransactionalStringCommands<K, V> {
+        implements TransactionalStringCommands<K, V>, TransactionalValueCommands<K, V> {
 
-    private final ReactiveTransactionalStringCommands<K, V> reactive;
+    private final ReactiveTransactionalValueCommands<K, V> reactive;
 
     public BlockingTransactionalStringCommandsImpl(TransactionalRedisDataSource ds,
-            ReactiveTransactionalStringCommands<K, V> reactive, Duration timeout) {
+            ReactiveTransactionalValueCommands<K, V> reactive, Duration timeout) {
         super(ds, timeout);
         this.reactive = reactive;
     }
@@ -47,6 +48,11 @@ public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTrans
 
     @Override
     public void getex(K key, GetExArgs args) {
+        this.reactive.getex(key, args).await().atMost(this.timeout);
+    }
+
+    @Override
+    public void getex(K key, io.quarkus.redis.datasource.value.GetExArgs args) {
         this.reactive.getex(key, args).await().atMost(this.timeout);
     }
 
@@ -116,12 +122,22 @@ public class BlockingTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
+    public void set(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        this.reactive.set(key, value, setArgs).await().atMost(this.timeout);
+    }
+
+    @Override
     public void setGet(K key, V value) {
         this.reactive.setGet(key, value).await().atMost(this.timeout);
     }
 
     @Override
     public void setGet(K key, V value, SetArgs setArgs) {
+        this.reactive.setGet(key, value, setArgs).await().atMost(this.timeout);
+    }
+
+    @Override
+    public void setGet(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
         this.reactive.setGet(key, value, setArgs).await().atMost(this.timeout);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -23,6 +23,7 @@ import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Command;
@@ -248,6 +249,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
 
     @Override
     public <K, V> ReactiveStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveStringCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveStringCommandsImpl<>(this, redisKeyType, valueType);
     }
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveStringCommandsImpl.java
@@ -6,10 +6,12 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
-public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, V> implements ReactiveStringCommands<K, V> {
+public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, V>
+        implements ReactiveStringCommands<K, V>, ReactiveValueCommands<K, V> {
 
     private final ReactiveRedisDataSource reactive;
 
@@ -36,6 +38,12 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
     }
 
     @Override
+    public Uni<Void> set(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        return super._set(key, value, setArgs)
+                .replaceWithVoid();
+    }
+
+    @Override
     public Uni<V> setGet(K key, V value) {
         return super._setGet(key, value)
                 .map(this::decodeV);
@@ -43,6 +51,12 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
 
     @Override
     public Uni<V> setGet(K key, V value, SetArgs setArgs) {
+        return super._setGet(key, value, setArgs)
+                .map(this::decodeV);
+    }
+
+    @Override
+    public Uni<V> setGet(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
         return super._setGet(key, value, setArgs)
                 .map(this::decodeV);
     }
@@ -103,6 +117,12 @@ public class ReactiveStringCommandsImpl<K, V> extends AbstractStringCommands<K, 
 
     @Override
     public Uni<V> getex(K key, GetExArgs args) {
+        return super._getex(key, args)
+                .map(this::decodeV);
+    }
+
+    @Override
+    public Uni<V> getex(K key, io.quarkus.redis.datasource.value.GetExArgs args) {
         return super._getex(key, args)
                 .map(this::decodeV);
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -15,6 +15,7 @@ import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 
@@ -61,9 +62,15 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     }
 
     @Override
+    public <K, V> ReactiveTransactionalValueCommands<K, V> value(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTransactionalStringCommandsImpl<>(this,
+                (ReactiveStringCommandsImpl<K, V>) this.reactive.value(redisKeyType, valueType), tx);
+    }
+
+    @Override
     public <K, V> ReactiveTransactionalStringCommands<K, V> string(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveTransactionalStringCommandsImpl<>(this,
-                (ReactiveStringCommandsImpl<K, V>) this.reactive.string(redisKeyType, valueType), tx);
+                (ReactiveStringCommandsImpl<K, V>) this.reactive.value(redisKeyType, valueType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalStringCommandsImpl.java
@@ -6,11 +6,12 @@ import io.quarkus.redis.datasource.string.GetExArgs;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
 import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Response;
 
 public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTransactionalCommands
-        implements ReactiveTransactionalStringCommands<K, V> {
+        implements ReactiveTransactionalStringCommands<K, V>, ReactiveTransactionalValueCommands<K, V> {
 
     private final ReactiveStringCommandsImpl<K, V> reactive;
 
@@ -52,6 +53,12 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
 
     @Override
     public Uni<Void> getex(K key, GetExArgs args) {
+        this.tx.enqueue(this.reactive::decodeV);
+        return this.reactive._getex(key, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> getex(K key, io.quarkus.redis.datasource.value.GetExArgs args) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._getex(key, args).invoke(this::queuedOrDiscard).replaceWithVoid();
     }
@@ -135,6 +142,12 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
     }
 
     @Override
+    public Uni<Void> set(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
+        this.tx.enqueue(resp -> null);
+        return this.reactive._set(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
     public Uni<Void> setGet(K key, V value) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._setGet(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
@@ -142,6 +155,12 @@ public class ReactiveTransactionalStringCommandsImpl<K, V> extends AbstractTrans
 
     @Override
     public Uni<Void> setGet(K key, V value, SetArgs setArgs) {
+        this.tx.enqueue(this.reactive::decodeV);
+        return this.reactive._setGet(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> setGet(K key, V value, io.quarkus.redis.datasource.value.SetArgs setArgs) {
         this.tx.enqueue(this.reactive::decodeV);
         return this.reactive._setGet(key, value, setArgs).invoke(this::queuedOrDiscard).replaceWithVoid();
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ConnectionRecyclingTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ConnectionRecyclingTest.java
@@ -25,20 +25,20 @@ public class ConnectionRecyclingTest extends DatasourceTestBase {
     void verifyThatConnectionsAreClosed() {
         String k = "increment";
         for (int i = 0; i < 1000; i++) {
-            ds.withConnection(x -> x.string(String.class, Integer.class).incr(k));
+            ds.withConnection(x -> x.value(String.class, Integer.class).incr(k));
         }
 
-        assertThat(ds.string(String.class, Integer.class).get(k)).isEqualTo(1000);
+        assertThat(ds.value(String.class, Integer.class).get(k)).isEqualTo(1000);
     }
 
     @Test
     void verifyThatConnectionsAreClosedWithTheReactiveDataSource() {
         String k = "increment";
         for (int i = 0; i < 1000; i++) {
-            rds.withConnection(x -> x.string(String.class, Integer.class).incr(k)
+            rds.withConnection(x -> x.value(String.class, Integer.class).incr(k)
                     .replaceWithVoid()).await().indefinitely();
         }
 
-        assertThat(rds.string(String.class, Integer.class).get(k).await().indefinitely()).isEqualTo(1000);
+        assertThat(rds.value(String.class, Integer.class).get(k).await().indefinitely()).isEqualTo(1000);
     }
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -26,7 +26,7 @@ import io.quarkus.redis.datasource.keys.RedisKeyNotFoundException;
 import io.quarkus.redis.datasource.keys.RedisValueType;
 import io.quarkus.redis.datasource.list.ListCommands;
 import io.quarkus.redis.datasource.sortedset.SortedSetCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
 public class KeyCommandsTest extends DatasourceTestBase {
@@ -35,13 +35,13 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     static String key = "key-generic";
     private KeyCommands<String> keys;
-    private StringCommands<String, Person> strings;
+    private ValueCommands<String, Person> values;
 
     @BeforeEach
     void initialize() {
         ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
 
-        strings = ds.string(Person.class);
+        values = ds.value(Person.class);
         keys = ds.key();
     }
 
@@ -57,75 +57,75 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     @Test
     void del() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat((long) keys.del(key)).isEqualTo(1);
-        strings.set(key + "1", Person.person7);
-        strings.set(key + "2", Person.person7);
+        values.set(key + "1", Person.person7);
+        values.set(key + "2", Person.person7);
 
         assertThat(keys.del(key + "1", key + "2")).isEqualTo(2);
     }
 
     @Test
     void unlink() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat((long) keys.unlink(key)).isEqualTo(1);
-        strings.set(key + "1", Person.person7);
-        strings.set(key + "2", Person.person7);
+        values.set(key + "1", Person.person7);
+        values.set(key + "2", Person.person7);
         assertThat(keys.unlink(key + "1", key + "2")).isEqualTo(2);
     }
 
     @Test
     void copy() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.copy(key, key + "2")).isTrue();
         assertThat(keys.copy("unknown", key + "2")).isFalse();
-        assertThat(strings.get(key + "2")).isEqualTo(Person.person7);
+        assertThat(values.get(key + "2")).isEqualTo(Person.person7);
     }
 
     @Test
     void copyWithReplace() {
-        strings.set(key, Person.person7);
-        strings.set(key + 2, Person.person1);
+        values.set(key, Person.person7);
+        values.set(key + 2, Person.person1);
         assertThat(keys.copy(key, key + "2", new CopyArgs().replace(true))).isTrue();
-        assertThat(strings.get(key + "2")).isEqualTo(Person.person7);
+        assertThat(values.get(key + "2")).isEqualTo(Person.person7);
     }
 
     @Test
     void copyWithDestinationDb() {
         ds.withConnection(connection -> {
-            connection.string(String.class, Person.class).set(key, Person.person7);
+            connection.value(String.class, Person.class).set(key, Person.person7);
             connection.key(String.class).copy(key, key, new CopyArgs().destinationDb(2));
             connection.select(2);
-            assertThat(connection.string(String.class, Person.class).get(key)).isEqualTo(Person.person7);
+            assertThat(connection.value(String.class, Person.class).get(key)).isEqualTo(Person.person7);
         });
     }
 
     @Test
     void dump() {
         assertThat(keys.dump("invalid")).isNull();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.dump(key).length() > 0).isTrue();
     }
 
     @Test
     void exists() {
         assertThat(keys.exists(key)).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.exists(key)).isTrue();
     }
 
     @Test
     void existsVariadic() {
         assertThat(keys.exists(key, "key2", "key3")).isEqualTo(0);
-        strings.set(key, Person.person7);
-        strings.set("key2", Person.person7);
+        values.set(key, Person.person7);
+        values.set("key2", Person.person7);
         assertThat(keys.exists(key, "key2", "key3")).isEqualTo(2);
     }
 
     @Test
     void expire() {
         assertThat(keys.expire(key, 10)).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.expire(key, 10)).isTrue();
         assertThat(keys.ttl(key)).isBetween(5L, 10L);
 
@@ -137,7 +137,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @RequiresRedis7OrHigher
     void expireWithArgs() {
         assertThat(keys.expire(key, 10, new ExpireArgs().xx())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.expire(key, 10, new ExpireArgs().nx())).isTrue();
         assertThat(keys.ttl(key)).isBetween(5L, 10L);
 
@@ -149,7 +149,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void expireat() {
         Date expiration = new Date(System.currentTimeMillis() + 10000);
         assertThat(keys.expireat(key, expiration.toInstant().toEpochMilli())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.expireat(key, expiration.toInstant())).isTrue();
 
         assertThat(keys.ttl(key)).isGreaterThanOrEqualTo(8);
@@ -163,7 +163,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void expireatWithArgs() {
         Date expiration = new Date(System.currentTimeMillis() + 10000);
         assertThat(keys.expireat(key, expiration.toInstant().getEpochSecond(), new ExpireArgs().xx())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.expireat(key, expiration.toInstant(), new ExpireArgs().nx())).isTrue();
 
         assertThat(keys.ttl(key)).isGreaterThanOrEqualTo(8);
@@ -182,7 +182,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
         map.put("one", Person.person1);
         map.put("two", Person.person2);
         map.put("three", Person.person3);
-        strings.mset(map);
+        values.mset(map);
         List<String> k = keys.keys("???");
         assertThat(k).hasSize(2);
         assertThat(k.contains("one")).isTrue();
@@ -192,7 +192,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     public void move() {
         ds.withConnection(connection -> {
-            StringCommands<String, Person> commands = connection.string(String.class, Person.class);
+            ValueCommands<String, Person> commands = connection.value(String.class, Person.class);
             commands.set("foo", Person.person3);
             commands.set(key, Person.person7);
             assertThat(connection.key(String.class).move(key, 1)).isTrue();
@@ -206,7 +206,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     void persist() {
         assertThat(keys.persist(key)).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.persist(key)).isFalse();
         keys.expire(key, 10);
         assertThat(keys.persist(key)).isTrue();
@@ -215,7 +215,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     void pexpire() {
         assertThat(keys.pexpire(key, 5000)).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pexpire(key, 5000)).isTrue();
         assertThat(keys.pttl(key)).isGreaterThan(0).isLessThanOrEqualTo(5000);
 
@@ -227,7 +227,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @RequiresRedis7OrHigher
     void pexpireWithArgs() {
         assertThat(keys.pexpire(key, 5000, new ExpireArgs().xx())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pexpire(key, 5000, new ExpireArgs().nx())).isTrue();
         assertThat(keys.pttl(key)).isGreaterThan(0).isLessThanOrEqualTo(5000);
 
@@ -241,7 +241,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @RequiresRedis7OrHigher
     void pexpireWithDuration() {
         assertThat(keys.pexpire(key, Duration.ofSeconds(5))).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pexpire(key, Duration.ofSeconds(1))).isTrue();
         assertThat(keys.pttl(key)).isGreaterThan(0).isLessThanOrEqualTo(1000);
 
@@ -253,7 +253,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void pexpireat() {
         Instant expiration = new Date(System.currentTimeMillis() + 5000).toInstant();
         assertThat(keys.pexpireat(key, expiration.getEpochSecond())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pexpireat(key, expiration)).isTrue();
         assertThat(keys.pttl(key)).isGreaterThan(0);
 
@@ -266,7 +266,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void pexpireatWithArgs() {
         Instant expiration = new Date(System.currentTimeMillis() + 5000).toInstant();
         assertThat(keys.pexpireat(key, expiration.getEpochSecond(), new ExpireArgs().xx())).isFalse();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pexpireat(key, expiration, new ExpireArgs().nx())).isTrue();
         assertThat(keys.pttl(key)).isGreaterThan(0);
 
@@ -277,7 +277,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     void pttl() {
         assertThatThrownBy(() -> keys.pttl(key)).isInstanceOf(RedisKeyNotFoundException.class);
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.pttl(key)).isEqualTo(-1);
         keys.pexpire(key, 5000);
         assertThat(keys.pttl(key)).isGreaterThan(0).isLessThanOrEqualTo(5000);
@@ -286,20 +286,20 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     void randomkey() {
         assertThat(keys.randomkey()).isNull();
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.randomkey()).isEqualTo(key);
     }
 
     @Test
     void rename() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
 
         keys.rename(key, key + "X");
-        assertThat(strings.get(key)).isNull();
-        assertThat(strings.get(key + "X")).isEqualTo(Person.person7);
-        strings.set(key, Person.person4);
+        assertThat(values.get(key)).isNull();
+        assertThat(values.get(key + "X")).isEqualTo(Person.person7);
+        values.set(key, Person.person4);
         keys.rename(key + "X", key);
-        assertThat(strings.get(key)).isEqualTo(Person.person7);
+        assertThat(values.get(key)).isEqualTo(Person.person7);
     }
 
     @Test
@@ -309,10 +309,10 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     @Test
     void renamenx() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.renamenx(key, key + "X")).isTrue();
-        assertThat(strings.get(key + "X")).isEqualTo(Person.person7);
-        strings.set(key, Person.person7);
+        assertThat(values.get(key + "X")).isEqualTo(Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.renamenx(key + "X", key)).isFalse();
     }
 
@@ -324,14 +324,14 @@ public class KeyCommandsTest extends DatasourceTestBase {
     @Test
     void touch() {
         assertThat((long) keys.touch(key)).isEqualTo(0);
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat((long) keys.touch(key, "key2")).isEqualTo(1);
     }
 
     @Test
     void ttl() {
         assertThatThrownBy(() -> keys.pttl(key)).isInstanceOf(RedisKeyNotFoundException.class);
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.ttl(key)).isEqualTo(-1);
         keys.expire(key, 10);
         assertThat(keys.ttl(key)).isEqualTo(10);
@@ -341,7 +341,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     void type() {
         assertThat(keys.type(key)).isEqualTo(RedisValueType.NONE);
 
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         assertThat(keys.type(key)).isEqualTo(RedisValueType.STRING);
 
         ds.hash(String.class, String.class, Person.class).hset(key + "H", "p3", Person.person3);
@@ -361,7 +361,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     @Test
     void scan() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         KeyScanCursor<String> cursor = keys.scan();
         assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.next()).containsExactly(key);
@@ -389,7 +389,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     @Test
     void scanWithArgs() {
-        strings.set(key, Person.person7);
+        values.set(key, Person.person7);
         KeyScanCursor<String> cursor = keys.scan(new KeyScanArgs().count(10));
         assertThat(cursor.cursorId()).isEqualTo(Cursor.INITIAL_CURSOR_ID);
         assertThat(cursor.next()).containsExactly(key);
@@ -399,7 +399,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     @Test
     void scanWithType() {
-        strings.set("key1", Person.person7);
+        values.set("key1", Person.person7);
         ds.list(Person.class).lpush("key2", Person.person7);
 
         KeyScanCursor<String> cursor = keys.scan(new KeyScanArgs().type(RedisValueType.STRING));
@@ -459,7 +459,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
 
     void populateMany(Set<String> expect) {
         for (int i = 0; i < 100; i++) {
-            strings.set(key + i, new Person("a", "b" + i));
+            values.set(key + i, new Person("a", "b" + i));
             expect.add(key + i);
         }
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/NumericCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/NumericCommandsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
 public class NumericCommandsTest extends DatasourceTestBase {
@@ -17,12 +17,12 @@ public class NumericCommandsTest extends DatasourceTestBase {
     private RedisDataSource ds;
 
     static String key = "key-sort";
-    private StringCommands<String, Long> num;
+    private ValueCommands<String, Long> num;
 
     @BeforeEach
     void initialize() {
         ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(5));
-        num = ds.string(Long.class);
+        num = ds.value(Long.class);
     }
 
     @AfterEach

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/PubSubTest.java
@@ -48,7 +48,7 @@ public class PubSubTest extends DatasourceTestBase {
         ps.publish("people", person1).await().indefinitely();
         ps.publish("people", person2).await().indefinitely();
 
-        ds.string(String.class, String.class)
+        ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
 
         ps.publish("people", person2).await().indefinitely();
@@ -68,7 +68,7 @@ public class PubSubTest extends DatasourceTestBase {
         ps.publish("people", person1).await().indefinitely();
         ps.publish("people", person2).await().indefinitely();
 
-        ds.string(String.class, String.class)
+        ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
 
         ps.publish("people", person2).await().indefinitely();
@@ -87,7 +87,7 @@ public class PubSubTest extends DatasourceTestBase {
         ps.publish("people1", person1).await().indefinitely();
         ps.publish("people2", person2).await().indefinitely();
 
-        ds.string(String.class, String.class)
+        ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
 
         ps.publish("people1", person2).await().indefinitely();
@@ -109,7 +109,7 @@ public class PubSubTest extends DatasourceTestBase {
         ps.publish("people1", person1).await().indefinitely();
         ps.publish("people2", person2).await().indefinitely();
 
-        ds.string(String.class, String.class)
+        ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
 
         ps.publish("people1", person2).await().indefinitely();
@@ -132,7 +132,7 @@ public class PubSubTest extends DatasourceTestBase {
             ps.publish("people", new Person("p" + i, "")).await().indefinitely();
         }
 
-        ds.string(String.class, String.class)
+        ds.value(String.class, String.class)
                 .set("hello", "foo").await().indefinitely();
 
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortCommandsTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.redis.datasource.list.ListCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
 public class SortCommandsTest extends DatasourceTestBase {
@@ -19,14 +19,14 @@ public class SortCommandsTest extends DatasourceTestBase {
 
     static String key = "key-sort";
     private ListCommands<String, String> lists;
-    private StringCommands<String, String> strings;
+    private ValueCommands<String, String> strings;
 
     @BeforeEach
     void initialize() {
         ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(5));
 
         lists = ds.list(String.class);
-        strings = ds.string(String.class);
+        strings = ds.value(String.class);
     }
 
     @AfterEach

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
@@ -21,6 +21,7 @@ import io.quarkus.redis.datasource.string.SetArgs;
 import io.quarkus.redis.datasource.string.StringCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
+@SuppressWarnings("deprecation")
 public class StringCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
@@ -9,14 +9,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
-import io.quarkus.redis.datasource.string.TransactionalStringCommands;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
+import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
-@SuppressWarnings("deprecation")
-public class TransactionalStringCommandsTest extends DatasourceTestBase {
+public class TransactionalValueCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;
     private ReactiveRedisDataSource reactive;
@@ -35,7 +34,7 @@ public class TransactionalStringCommandsTest extends DatasourceTestBase {
     @Test
     public void setBlocking() {
         TransactionResult result = blocking.withTransaction(tx -> {
-            TransactionalStringCommands<String, String> string = tx.string(String.class);
+            TransactionalValueCommands<String, String> string = tx.value(String.class);
             assertThat(string.getDataSource()).isEqualTo(tx);
             string.set(key, "hello");
             string.setnx("k2", "bonjour");
@@ -55,7 +54,7 @@ public class TransactionalStringCommandsTest extends DatasourceTestBase {
     @Test
     public void setReactive() {
         TransactionResult result = reactive.withTransaction(tx -> {
-            ReactiveTransactionalStringCommands<String, String> string = tx.string(String.class);
+            ReactiveTransactionalValueCommands<String, String> string = tx.value(String.class);
             return string.set(key, "hello")
                     .chain(() -> string.setnx("k2", "bonjour"))
                     .chain(() -> string.append(key, "-1"))

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
@@ -1,0 +1,278 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.keys.KeyCommands;
+import io.quarkus.redis.datasource.value.GetExArgs;
+import io.quarkus.redis.datasource.value.SetArgs;
+import io.quarkus.redis.datasource.value.ValueCommands;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+public class ValueCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    String value = UUID.randomUUID().toString();
+    private ValueCommands<String, String> values;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+
+        values = ds.value(String.class);
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(values.getDataSource());
+    }
+
+    @Test
+    void append() {
+        assertThat(values.append(key, value)).isEqualTo(value.length());
+        assertThat(values.append(key, "X")).isEqualTo(value.length() + 1);
+    }
+
+    @Test
+    void get() {
+        assertThat(values.get(key)).isNull();
+        values.set(key, value);
+        assertThat(values.get(key)).isEqualTo(value);
+    }
+
+    @Test
+    void getbit() {
+        assertThat(ds.bitmap(String.class).getbit(key, 0)).isEqualTo(0);
+        ds.bitmap(String.class).setbit(key, 0, 1);
+        assertThat(ds.bitmap(String.class).getbit(key, 0)).isEqualTo(1);
+    }
+
+    @Test
+    void getdel() {
+        values.set(key, value);
+        assertThat(values.getdel(key)).isEqualTo(value);
+        assertThat(values.get(key)).isNull();
+    }
+
+    @Test
+    void getex() {
+        values.set(key, value);
+        assertThat(values.getex(key, new GetExArgs().ex(Duration.ofSeconds(100)))).isEqualTo(value);
+        assertThat(ds.key(String.class).ttl(key)).isGreaterThan(1);
+        assertThat(values.getex(key, new GetExArgs().persist())).isEqualTo(value);
+        assertThat(ds.key(String.class).ttl(key)).isEqualTo(-1);
+    }
+
+    @Test
+    void getrange() {
+        assertThat(values.getrange(key, 0, -1)).isEqualTo("");
+        values.set(key, "foobar");
+        assertThat(values.getrange(key, 2, 4)).isEqualTo("oba");
+        assertThat(values.getrange(key, 3, -1)).isEqualTo("bar");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void getset() {
+        assertThat(values.getset(key, value)).isNull();
+        assertThat(values.getset(key, "two")).isEqualTo(value);
+        assertThat(values.get(key)).isEqualTo("two");
+    }
+
+    @Test
+    void mget() {
+        assertThat(values.mget(key)).isEmpty();
+        values.set("one", "1");
+        values.set("two", "2");
+        assertThat(values.mget("one", "two")).containsExactly(entry("one", "1"), entry("two", "2"));
+    }
+
+    @Test
+    void mset() {
+        assertThat(values.mget("one", "two")).isEmpty();
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("one", "1");
+        map.put("two", "2");
+        values.mset(map);
+        assertThat(values.mget("one", "two")).containsExactly(entry("one", "1"), entry("two", "2"));
+    }
+
+    @Test
+    void msetnx() {
+        values.set("one", "1");
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("one", "1");
+        map.put("two", "2");
+        assertThat(values.msetnx(map)).isFalse();
+        ds.key(String.class).del("one");
+        assertThat(values.msetnx(map)).isTrue();
+        assertThat(values.get("two")).isEqualTo("2");
+    }
+
+    @Test
+    void set() {
+        KeyCommands<String> keys = ds.key(String.class);
+        assertThat(values.get(key)).isNull();
+        values.set(key, value);
+        assertThat(values.get(key)).isEqualTo(value);
+
+        values.set(key, value, new SetArgs().px(20000));
+        values.set(key, value, new SetArgs().ex(10));
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.ttl(key)).isGreaterThanOrEqualTo(9);
+
+        values.set(key, value, new SetArgs().ex(Duration.ofSeconds(10)));
+        assertThat(keys.ttl(key)).isBetween(5L, 10L);
+
+        values.set(key, value, new SetArgs().px(Duration.ofSeconds(10)));
+        assertThat(keys.ttl(key)).isBetween(5L, 10L);
+
+        values.set(key, value, new SetArgs().px(10000));
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.ttl(key)).isGreaterThanOrEqualTo(9);
+
+        values.set(key, value, new SetArgs().nx());
+        values.set(key, value, new SetArgs().xx());
+        assertThat(values.get(key)).isEqualTo(value);
+
+        keys.del(key);
+        values.set(key, value, new SetArgs().nx());
+        assertThat(values.get(key)).isEqualTo(value);
+
+        keys.del(key);
+
+        values.set(key, value, new SetArgs().px(20000).nx());
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.ttl(key) >= 19).isTrue();
+    }
+
+    @Test
+    void setExAt() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        values.set(key, value, new SetArgs().exAt(Instant.now().plusSeconds(60)));
+        assertThat(keys.ttl(key)).isBetween(50L, 61L);
+
+        values.set(key, value, new SetArgs().pxAt(Instant.now().plusSeconds(60)));
+        assertThat(keys.ttl(key)).isBetween(50L, 61L);
+    }
+
+    @Test
+    void setKeepTTL() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        values.set(key, value, new SetArgs().ex(10));
+        values.set(key, "value2", new SetArgs().keepttl());
+        assertThat(values.get(key)).isEqualTo("value2");
+        assertThat(keys.ttl(key) >= 1).isTrue();
+    }
+
+    @Test
+    void setNegativeEX() {
+        assertThatThrownBy(() -> values.set(key, value, new SetArgs().ex(-10))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setNegativePX() {
+        assertThatThrownBy(() -> values.set(key, value, new SetArgs().px(-1000))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void setGet() {
+        assertThat(values.setGet(key, value)).isNull();
+        assertThat(values.setGet(key, "value2")).isEqualTo(value);
+        assertThat(values.get(key)).isEqualTo("value2");
+    }
+
+    @Test
+    void setGetWithArgs() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        assertThat(values.setGet(key, value)).isNull();
+        assertThat(values.setGet(key, "value2", new SetArgs().ex(100))).isEqualTo(value);
+        assertThat(values.get(key)).isEqualTo("value2");
+        assertThat(keys.ttl(key)).isGreaterThanOrEqualTo(10);
+    }
+
+    @Test
+    void setbit() {
+        assertThat(ds.bitmap(String.class).setbit(key, 0, 1)).isEqualTo(0);
+        assertThat(ds.bitmap(String.class).setbit(key, 0, 0)).isEqualTo(1);
+    }
+
+    @Test
+    void setex() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        values.setex(key, 10, value);
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.ttl(key) >= 9).isTrue();
+    }
+
+    @Test
+    void psetex() {
+        KeyCommands<String> keys = ds.key(String.class);
+
+        values.psetex(key, 20000, value);
+        assertThat(values.get(key)).isEqualTo(value);
+        assertThat(keys.pttl(key) >= 19000).isTrue();
+    }
+
+    @Test
+    void setnx() {
+        assertThat(values.setnx(key, value)).isTrue();
+        assertThat(values.setnx(key, value)).isFalse();
+    }
+
+    @Test
+    void setrange() {
+        assertThat(values.setrange(key, 0, "foo")).isEqualTo("foo".length());
+        assertThat(values.setrange(key, 3, "bar")).isEqualTo(6);
+        assertThat(values.get(key)).isEqualTo("foobar");
+    }
+
+    @Test
+    void strlen() {
+        assertThat(values.strlen(key)).isEqualTo(0);
+        values.set(key, value);
+        assertThat(values.strlen(key)).isEqualTo(value.length());
+    }
+
+    @Test
+    @RequiresRedis7OrHigher
+    void lcs() {
+        values.mset(Map.of("key1", "ohmytext", "key2", "mynewtext"));
+        assertThat(values.lcs("key1", "key2")).isEqualTo("mytext");
+
+        // LEN parameter
+        assertThat(values.lcsLength("key1", "key2")).isEqualTo(6);
+    }
+
+    @Test
+    void binary() {
+        byte[] content = new byte[2048];
+        new Random().nextBytes(content);
+        ValueCommands<String, byte[]> commands = ds.value(byte[].class);
+        commands.set(key, content);
+        byte[] bytes = commands.get(key);
+        assertThat(bytes).isEqualTo(content);
+    }
+}

--- a/integration-tests/container-image/maven-invoker-way/src/it/container-image-jib-with-redis/src/main/java/org/acme/redis/IncrementService.java
+++ b/integration-tests/container-image/maven-invoker-way/src/it/container-image-jib-with-redis/src/main/java/org/acme/redis/IncrementService.java
@@ -2,7 +2,7 @@ package org.acme.redis;
 
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.keys.KeyCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 
 import javax.inject.Singleton;
 import java.util.List;
@@ -12,12 +12,12 @@ class IncrementService {
 
 
     private final KeyCommands<String> keyCommands;
-    private final StringCommands<String, Integer> stringCommands;
+    private final ValueCommands<String, Integer> valueCommands;
 
     public IncrementService(RedisDataSource ds) {
 
         keyCommands = ds.key();
-        stringCommands = ds.string(Integer.class);
+        valueCommands = ds.value(Integer.class);
 
     }
 
@@ -26,16 +26,15 @@ class IncrementService {
     }
 
     Integer get(String key) {
-        return stringCommands.get(key);
+        return valueCommands.get(key);
     }
 
     void set(String key, Integer value) {
-        stringCommands.set(key, value);
-        ;
+        valueCommands.set(key, value);
     }
 
     void increment(String key, Integer incrementBy) {
-        stringCommands.incrby(key, incrementBy);
+        valueCommands.incrby(key, incrementBy);
     }
 
     List<String> keys() {

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResource.java
@@ -8,21 +8,21 @@ import javax.ws.rs.PathParam;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.ReactiveStringCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.smallrye.mutiny.Uni;
 
 @Path("/quarkus-redis")
 @ApplicationScoped
 public class RedisResource {
 
-    private final StringCommands<String, String> blocking;
-    private final ReactiveStringCommands<String, String> reactive;
+    private final ValueCommands<String, String> blocking;
+    private final ReactiveValueCommands<String, String> reactive;
 
     public RedisResource(RedisDataSource ds,
             ReactiveRedisDataSource reactiveDs) {
-        blocking = ds.string(String.class);
-        reactive = reactiveDs.string(String.class);
+        blocking = ds.value(String.class);
+        reactive = reactiveDs.value(String.class);
     }
 
     // synchronous

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResourceWithNamedClient.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisResourceWithNamedClient.java
@@ -9,22 +9,22 @@ import javax.ws.rs.PathParam;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.ReactiveStringCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.smallrye.mutiny.Uni;
 
 @Path("/quarkus-redis-with-name")
 @ApplicationScoped
 public class RedisResourceWithNamedClient {
 
-    private final StringCommands<String, String> blocking;
-    private final ReactiveStringCommands<String, String> reactive;
+    private final ValueCommands<String, String> blocking;
+    private final ReactiveValueCommands<String, String> reactive;
 
     public RedisResourceWithNamedClient(
             @RedisClientName("named-client") RedisDataSource ds,
             @RedisClientName("named-reactive-client") ReactiveRedisDataSource reactiveDs) {
-        blocking = ds.string(String.class);
-        reactive = reactiveDs.string(String.class);
+        blocking = ds.value(String.class);
+        reactive = reactiveDs.value(String.class);
     }
 
     // synchronous

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithProvidedHostsResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithProvidedHostsResource.java
@@ -10,22 +10,22 @@ import javax.ws.rs.PathParam;
 import io.quarkus.redis.client.RedisClientName;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.string.ReactiveStringCommands;
-import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
 import io.smallrye.mutiny.Uni;
 
 @Path("/quarkus-redis-provided-hosts")
 @ApplicationScoped
 public class RedisWithProvidedHostsResource {
 
-    private final StringCommands<String, String> blocking;
-    private final ReactiveStringCommands<String, String> reactive;
+    private final ValueCommands<String, String> blocking;
+    private final ReactiveValueCommands<String, String> reactive;
 
     @Inject
     public RedisWithProvidedHostsResource(@RedisClientName("provided-hosts") RedisDataSource ds,
             @RedisClientName("provided-hosts") ReactiveRedisDataSource reactiveDs) {
-        blocking = ds.string(String.class);
-        reactive = reactiveDs.string(String.class);
+        blocking = ds.value(String.class);
+        reactive = reactiveDs.value(String.class);
     }
 
     @GET


### PR DESCRIPTION
Deprecate the Redis string group (because it's misleading, as it refers to Redis strings, not Java strings) and rename it to "value."
This change is backward compatible; it adds the new groups and deprecates the previous one.

This change is based on user feedback.
