### PR TITLE
Ensure that Mongo DNS lookup does not happen on the event loop

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -69,6 +69,7 @@ import io.quarkus.mongodb.runtime.dns.MongoDnsClient;
 import io.quarkus.mongodb.runtime.dns.MongoDnsClientProvider;
 import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
+import io.quarkus.vertx.deployment.VertxBuildItem;
 
 public class MongoClientProcessor {
     private static final String MONGODB_TRACING_COMMANDLISTENER_CLASSNAME = "io.quarkus.mongodb.tracing.MongoTracingCommandListener";
@@ -281,7 +282,8 @@ public class MongoClientProcessor {
             MongoClientBuildTimeConfig mongoClientBuildTimeConfig,
             MongodbConfig mongodbConfig,
             List<MongoUnremovableClientsBuildItem> mongoUnremovableClientsBuildItem,
-            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
+            VertxBuildItem vertxBuildItem) {
 
         boolean makeUnremovable = !mongoUnremovableClientsBuildItem.isEmpty();
 
@@ -328,6 +330,8 @@ public class MongoClientProcessor {
                     .produce(createReactiveSyntheticBean(recorder, mongodbConfig, makeUnremovable, mongoClientName.getName(),
                             mongoClientName.isAddQualifier()));
         }
+
+        recorder.performInitialization(mongodbConfig, vertxBuildItem.getVertx());
     }
 
     private SyntheticBeanBuildItem createBlockingSyntheticBean(MongoClientRecorder recorder, MongodbConfig mongodbConfig,

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/MongoDnsClientProvider.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/runtime/dns/MongoDnsClientProvider.java
@@ -4,11 +4,15 @@ import com.mongodb.spi.dns.DnsClient;
 import com.mongodb.spi.dns.DnsClientProvider;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.vertx.core.Vertx;
 
 @RegisterForReflection
 public class MongoDnsClientProvider implements DnsClientProvider {
+
+    public static volatile Vertx vertx;
+
     @Override
     public DnsClient create() {
-        return new MongoDnsClient();
+        return new MongoDnsClient(vertx);
     }
 }


### PR DESCRIPTION
This is done by performing the DNS lookup at application startup and caching the results

Fixes: #27627