### PR TITLE
Auto-approve workflow runs from established contributors or low-risk files

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -2,6 +2,17 @@
 # The format of this file is documented here:
 # https://github.com/quarkusio/quarkus-bot#triage-issues
 features: [ALL]
+workflows:
+  rules:
+    - allow:
+        users:
+          minContributions: 10
+        files:
+          - "**/*.md"
+          - "**/*.adoc"
+      unless:
+        files:
+          - ".github/**"
 workflowRunAnalysis:
   workflows: ["Quarkus CI"]
 projectsClassic:


### PR DESCRIPTION
I've added an extra set of rules which leverage https://github.com/quarkusio/quarkus-github-bot/issues/256 to control what PRs are allowed to run on the runners. This helps secure both the new M1 runner and the existing hosted runners.