### PR TITLE
ArC - fix @TransientReference destruction

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/CreationalContextImpl.java
@@ -47,16 +47,17 @@ public class CreationalContextImpl<T> implements CreationalContext<T>, Function<
         return dependentInstances != null && !dependentInstances.isEmpty();
     }
 
-    boolean destroyDependentInstance(Object dependentInstance) {
-        synchronized (this) {
-            if (dependentInstances != null) {
-                for (Iterator<InstanceHandle<?>> iterator = dependentInstances.iterator(); iterator.hasNext();) {
-                    InstanceHandle<?> instanceHandle = iterator.next();
-                    if (instanceHandle.get() == dependentInstance) {
-                        instanceHandle.destroy();
-                        iterator.remove();
-                        return true;
+    public synchronized boolean removeDependentInstance(Object dependentInstance, boolean destroy) {
+        if (dependentInstances != null) {
+            for (Iterator<InstanceHandle<?>> it = dependentInstances.iterator(); it.hasNext();) {
+                InstanceHandle<?> handle = it.next();
+                // The reference equality is used on purpose!
+                if (handle.get() == dependentInstance) {
+                    if (destroy) {
+                        handle.destroy();
                     }
+                    it.remove();
+                    return true;
                 }
             }
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectableReferenceProviders.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InjectableReferenceProviders.java
@@ -11,6 +11,8 @@ public final class InjectableReferenceProviders {
 
     /**
      * Unwraps the provider if necessary and invokes {@link Contextual#destroy(Object, CreationalContext)}.
+     * <p>
+     * If there is a parent context available then attempt to remove the dependent instance.
      *
      * @param <T>
      * @param provider
@@ -18,15 +20,20 @@ public final class InjectableReferenceProviders {
      * @param creationalContext
      * @throws IllegalArgumentException If the specified provider is not a bean
      */
-    @SuppressWarnings("unchecked")
     public static <T> void destroy(InjectableReferenceProvider<T> provider, T instance,
             CreationalContext<T> creationalContext) {
         if (provider instanceof CurrentInjectionPointProvider) {
             provider = ((CurrentInjectionPointProvider<T>) provider).getDelegate();
         }
         if (provider instanceof Contextual) {
+            @SuppressWarnings("unchecked")
             Contextual<T> contextual = (Contextual<T>) provider;
             contextual.destroy(instance, creationalContext);
+            CreationalContextImpl<T> ctx = CreationalContextImpl.unwrap(creationalContext);
+            CreationalContextImpl<?> parent = ctx.getParent();
+            if (parent != null) {
+                parent.removeDependentInstance(instance, false);
+            }
         } else {
             throw new IllegalArgumentException("Injetable reference provider is not a bean: " + provider.getClass());
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InstanceImpl.java
@@ -138,7 +138,7 @@ public class InstanceImpl<T> implements InjectableInstance<T> {
             context.destroy(proxy.arc_bean());
         } else {
             // First try to destroy a dependent instance
-            if (!creationalContext.destroyDependentInstance(instance)) {
+            if (!creationalContext.removeDependentInstance(instance, true)) {
                 // If not successful then try the singleton context
                 SingletonContext singletonContext = (SingletonContext) Arc.container().getActiveContext(Singleton.class);
                 singletonContext.destroyInstance(instance);


### PR DESCRIPTION
- remove the transient dependent instance from the parent creational context when the invocation completes
- fixes #27906