### PR TITLE
Enable the registration of @LoggingFilter classes via CDI

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/logging/LoggingFilter.java
+++ b/core/runtime/src/main/java/io/quarkus/logging/LoggingFilter.java
@@ -8,8 +8,6 @@ import java.lang.annotation.Target;
 /**
  * Makes the filter class known to Quarkus by the specified name.
  * The filter can then be configured for a handler (like the logging handler using {@code quarkus.log.console.filter}).
- *
- * This class must ONLY be placed on implementations of {@link java.util.logging.Filter} that are marked as {@code final}.
  */
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LogFilterFactory.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LogFilterFactory.java
@@ -1,0 +1,57 @@
+package io.quarkus.runtime.logging;
+
+import java.util.ServiceLoader;
+import java.util.logging.Filter;
+
+/**
+ * Factory that allows for the creation of {@link Filter} classes annotated with {@link io.quarkus.logging.LoggingFilter}.
+ * Implementations of this class are loaded via the {@link ServiceLoader} and the implementation selected is the one
+ * with the lowest value returned from the {@code priority} method.
+ */
+public interface LogFilterFactory {
+
+    int MIN_PRIORITY = Integer.MAX_VALUE;
+    int DEFAULT_PRIORITY = 0;
+
+    Filter create(String className) throws Exception;
+
+    default int priority() {
+        return DEFAULT_PRIORITY;
+    }
+
+    static LogFilterFactory load() {
+        LogFilterFactory result = null;
+        ServiceLoader<LogFilterFactory> load = ServiceLoader.load(LogFilterFactory.class);
+        for (LogFilterFactory next : load) {
+            if (result == null) {
+                result = next;
+            } else {
+                if (next.priority() < result.priority()) {
+                    result = next;
+                }
+            }
+        }
+        if (result == null) {
+            result = new ReflectionLogFilterFactory();
+        }
+        return result;
+    }
+
+    /**
+     * The default implementation used when no other implementation is found.
+     * This simply calls the class' no-arg constructor (and fails if one does not exist).
+     */
+    class ReflectionLogFilterFactory implements LogFilterFactory {
+
+        @Override
+        public Filter create(String className) throws Exception {
+            return (Filter) Class.forName(className, true, Thread.currentThread().getContextClassLoader())
+                    .getConstructor().newInstance();
+        }
+
+        @Override
+        public int priority() {
+            return LogFilterFactory.MIN_PRIORITY;
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/logging/LoggingSetupRecorder.java
@@ -254,13 +254,12 @@ public class LoggingSetupRecorder {
         }
 
         Map<String, Filter> nameToFilter = new HashMap<>();
+        LogFilterFactory logFilterFactory = LogFilterFactory.load();
         discoveredLogComponents.getNameToFilterClass().forEach(new BiConsumer<>() {
             @Override
             public void accept(String name, String className) {
                 try {
-                    nameToFilter.put(name,
-                            (Filter) Class.forName(className, true, Thread.currentThread().getContextClassLoader())
-                                    .getConstructor().newInstance());
+                    nameToFilter.put(name, logFilterFactory.create(className));
                 } catch (Exception e) {
                     throw new RuntimeException("Unable to create instance of Logging Filter '" + className + "'");
                 }

--- a/docs/src/main/asciidoc/logging.adoc
+++ b/docs/src/main/asciidoc/logging.adoc
@@ -325,7 +325,8 @@ These filters are registered by placing the `@io.quarkus.logging.LoggingFilter` 
 
 Finally, the filter is attached using the `filter` configuration property of the appropriate handler.
 
-Let's say for example that we wanted to filter out logging records that contained the word `test` from the console logs.
+Let's say for example that we wanted to filter out logging records that contained a part of text from the console logs.
+The text itself is part of the application configuration and is not hardcoded.
 We could write a filter like so:
 
 [source,java]
@@ -336,12 +337,27 @@ import java.util.logging.LogRecord;
 
 @LoggingFilter(name = "my-filter")
 public final class TestFilter implements Filter {
+
+    private final String part;
+
+    public TestFilter(@ConfigProperty(name = "my-filter.part") String part) {
+        this.part = part;
+    }
+
     @Override
     public boolean isLoggable(LogRecord record) {
-        return !record.getMessage().contains("test");
+        return !record.getMessage().contains(part);
     }
 }
 ----
+
+and configure it in the usual Quarkus way (for example using `application.properties`) like so:
+
+[source,properties]
+----
+my-filter.part=TEST
+----
+
 
 And we would register this filter to the console handler like so:
 

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LoggingBeanSupportProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LoggingBeanSupportProcessor.java
@@ -1,0 +1,16 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.processor.BuiltinScope;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.logging.LoggingResourceProcessor;
+
+public class LoggingBeanSupportProcessor {
+
+    @BuildStep
+    public void discoveredComponents(BuildProducer<BeanDefiningAnnotationBuildItem> beanDefiningAnnotationProducer) {
+        beanDefiningAnnotationProducer.produce(new BeanDefiningAnnotationBuildItem(
+                LoggingResourceProcessor.LOGGING_FILTER, BuiltinScope.SINGLETON.getName(), false));
+    }
+
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/logging/ArcLogFilterFactory.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/logging/ArcLogFilterFactory.java
@@ -1,0 +1,29 @@
+package io.quarkus.arc.runtime.logging;
+
+import java.util.logging.Filter;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.runtime.logging.LogFilterFactory;
+
+/**
+ * Creates the implementation of the class by getting a bean from Arc.
+ * This class is loaded automatically by the {@link java.util.ServiceLoader}.
+ */
+public class ArcLogFilterFactory implements LogFilterFactory {
+
+    @Override
+    public Filter create(String className) throws Exception {
+        InstanceHandle<?> instance = Arc.container().instance(Class.forName(className, true, Thread.currentThread()
+                .getContextClassLoader()));
+        if (!instance.isAvailable()) {
+            throw new IllegalStateException("Improper integration of '" + LogFilterFactory.class.getName() + "' detected");
+        }
+        return (Filter) instance.get();
+    }
+
+    @Override
+    public int priority() {
+        return LogFilterFactory.DEFAULT_PRIORITY - 100;
+    }
+}

--- a/extensions/arc/runtime/src/main/resources/META-INF/services/io.quarkus.runtime.logging.LogFilterFactory
+++ b/extensions/arc/runtime/src/main/resources/META-INF/services/io.quarkus.runtime.logging.LogFilterFactory
@@ -1,0 +1,1 @@
+io.quarkus.arc.runtime.logging.ArcLogFilterFactory

--- a/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/filter/TestFilter.java
+++ b/integration-tests/logging-min-level-set/src/main/java/io/quarkus/it/logging/minlevel/set/filter/TestFilter.java
@@ -3,13 +3,21 @@ package io.quarkus.it.logging.minlevel.set.filter;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import io.quarkus.logging.LoggingFilter;
 
 @LoggingFilter(name = "my-filter")
-public final class TestFilter implements Filter {
+public class TestFilter implements Filter {
+
+    private final String part;
+
+    public TestFilter(@ConfigProperty(name = "my-filter.part") String part) {
+        this.part = part;
+    }
 
     @Override
     public boolean isLoggable(LogRecord record) {
-        return !record.getMessage().contains("TEST");
+        return !record.getMessage().contains(part);
     }
 }

--- a/integration-tests/logging-min-level-set/src/main/resources/application.properties
+++ b/integration-tests/logging-min-level-set/src/main/resources/application.properties
@@ -4,3 +4,4 @@ quarkus.log.category."io.quarkus.it.logging.minlevel.set.below".min-level=TRACE
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.below.child".min-level=inherit
 quarkus.log.category."io.quarkus.it.logging.minlevel.set.promote".min-level=ERROR
 quarkus.log.console.filter=my-filter
+my-filter.part=TEST


### PR DESCRIPTION
This allows for users to configure their filters
via the usual Quarkus configuration approach.

Follows up on: #27864

~~_P.S. This is in draft because I need to add Javadoc to the new interface and also update the logging docs with a working example._~~