### PR TITLE
Accept detached entities in Panache delete() methods

### DIFF
--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/session/TransactionScopedSession.java
@@ -208,6 +208,14 @@ public class TransactionScopedSession implements Session {
     }
 
     @Override
+    public <T> T getReference(T object) {
+        checkBlocking();
+        try (SessionResult emr = acquireSession()) {
+            return emr.session.getReference(object);
+        }
+    }
+
+    @Override
     public void flush() {
         checkBlocking();
         try (SessionResult emr = acquireSession()) {

--- a/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
+++ b/extensions/panache/hibernate-orm-panache-common/runtime/src/main/java/io/quarkus/hibernate/orm/panache/common/runtime/AbstractJpaOperations.java
@@ -15,6 +15,8 @@ import javax.persistence.Query;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
+import org.hibernate.Session;
+
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.agroal.DataSource;
 import io.quarkus.arc.Arc;
@@ -119,7 +121,7 @@ public abstract class AbstractJpaOperations<PanacheQueryType> {
 
     public void delete(Object entity) {
         EntityManager em = getEntityManager(entity.getClass());
-        em.remove(entity);
+        em.remove(em.contains(entity) ? entity : em.unwrap(Session.class).getReference(entity));
     }
 
     public boolean isPersistent(Object entity) {

--- a/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
+++ b/integration-tests/hibernate-orm-panache/src/test/java/io/quarkus/it/panache/PanacheFunctionalityTest.java
@@ -233,4 +233,9 @@ public class PanacheFunctionalityTest {
     Person getBug7102(Long id) {
         return Person.findById(id);
     }
+
+    @Test
+    public void testEnhancement27184DeleteDetached() {
+        RestAssured.when().get("/test/testEnhancement27184DeleteDetached").then().body(is("OK"));
+    }
 }


### PR DESCRIPTION
Fixes #27184
Supersedes #27832

~Creating as draft, as we need https://hibernate.atlassian.net/browse/HHH-15508 to get fixed in Hibernate ORM first. Tests currently pass only if you install Hibernate ORM locally first, then run the Quarkus build.~ => Upgrade done in `main`.

Compared to #27832, we're not longer attempting to merge the detached entity, which could lead to serious problems when Hibernate ORM handles cascades or lifecycle callbacks.

Unfortunately, like in #27832, when attempting to delete a detached entity we still load the entity from the database for no reason (even if there are no cascades or lifecycle callbacks to handle). But that's a limitation in Hibernate ORM: https://hibernate.atlassian.net/browse/HHH-15509. Hopefully it will be lifted one day, and we should benefit from it without any change, as soon as we upgrade.