### PR TITLE
Rest Client: Add property to skip hostname verification

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -283,6 +283,19 @@ quarkus.rest-client.extensions-api.url=https://stage.code.quarkus.io/api
 quarkus.rest-client.extensions-api.scope=javax.inject.Singleton
 ----
 
+=== Disabling Hostname Verification
+
+To disable the SSL hostname verification for a specific REST client, add the following property to your configuration:
+
+[source,properties]
+----
+quarkus.rest-client.extensions-api.verify-host=false
+----
+[WARNING]
+====
+This setting should not be used in production as it will disable the SSL hostname verification.
+====
+
 == Create the JAX-RS resource
 
 Create the `src/main/java/org/acme/rest/client/ExtensionsResource.java` file with the following content:

--- a/docs/src/main/asciidoc/rest-client.adoc
+++ b/docs/src/main/asciidoc/rest-client.adoc
@@ -232,8 +232,24 @@ To disable the SSL hostname verification for a specific REST client, add the fol
 
 [source,properties]
 ----
-quarkus.rest-client.extensions-api.hostname-verifier=io.quarkus.restclient.NoopHostnameVerifier
+quarkus.rest-client.extensions-api.verify-host=false
 ----
+[WARNING]
+====
+This setting should not be used in production as it will disable the SSL hostname verification.
+====
+
+Moreover, you can configure a REST client to use your custom hostname verify strategy. All you need to do is to provide a class that implements the interface `javax.net.ssl.HostnameVerifier` and add the following property to your configuration:
+
+[source,properties]
+----
+quarkus.rest-client.extensions-api.hostname-verifier=<full qualified custom hostname verifier class name>
+----
+
+[NOTE]
+====
+Quarkus REST client provides an embedded hostname verifier strategy to disable the hostname verification called `io.quarkus.restclient.NoopHostnameVerifier`.
+====
 
 === Disabling SSL verifications
 

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientConfig.java
@@ -31,6 +31,7 @@ public class RestClientConfig {
         EMPTY.proxyPassword = Optional.empty();
         EMPTY.nonProxyHosts = Optional.empty();
         EMPTY.queryParamStyle = Optional.empty();
+        EMPTY.verifyHost = Optional.empty();
         EMPTY.trustStore = Optional.empty();
         EMPTY.trustStorePassword = Optional.empty();
         EMPTY.trustStoreType = Optional.empty();
@@ -133,6 +134,12 @@ public class RestClientConfig {
      */
     @ConfigItem
     public Optional<QueryParamStyle> queryParamStyle;
+
+    /**
+     * Set whether hostname verification is enabled.
+     */
+    @ConfigItem
+    public Optional<Boolean> verifyHost;
 
     /**
      * The trust store location. Can point to either a classpath resource or a file.
@@ -246,6 +253,7 @@ public class RestClientConfig {
         instance.proxyPassword = getConfigValue(configKey, "proxy-password", String.class);
         instance.nonProxyHosts = getConfigValue(configKey, "non-proxy-hosts", String.class);
         instance.queryParamStyle = getConfigValue(configKey, "query-param-style", QueryParamStyle.class);
+        instance.verifyHost = getConfigValue(configKey, "verify-host", Boolean.class);
         instance.trustStore = getConfigValue(configKey, "trust-store", String.class);
         instance.trustStorePassword = getConfigValue(configKey, "trust-store-password", String.class);
         instance.trustStoreType = getConfigValue(configKey, "trust-store-type", String.class);
@@ -279,6 +287,7 @@ public class RestClientConfig {
         instance.proxyPassword = getConfigValue(interfaceClass, "proxy-password", String.class);
         instance.nonProxyHosts = getConfigValue(interfaceClass, "non-proxy-hosts", String.class);
         instance.queryParamStyle = getConfigValue(interfaceClass, "query-param-style", QueryParamStyle.class);
+        instance.verifyHost = getConfigValue(interfaceClass, "verify-host", Boolean.class);
         instance.trustStore = getConfigValue(interfaceClass, "trust-store", String.class);
         instance.trustStorePassword = getConfigValue(interfaceClass, "trust-store-password", String.class);
         instance.trustStoreType = getConfigValue(interfaceClass, "trust-store-type", String.class);

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptor.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientFallbackConfigSourceInterceptor.java
@@ -31,6 +31,7 @@ public class RestClientFallbackConfigSourceInterceptor extends FallbackConfigSou
         CLIENT_PROPERTIES.put("connect-timeout", "connectTimeout");
         CLIENT_PROPERTIES.put("read-timeout", "readTimeout");
         CLIENT_PROPERTIES.put("hostname-verifier", "hostnameVerifier");
+        CLIENT_PROPERTIES.put("verify-host", "verifyHost");
         CLIENT_PROPERTIES.put("trust-store", "trustStore");
         CLIENT_PROPERTIES.put("trust-store-password", "trustStorePassword");
         CLIENT_PROPERTIES.put("trust-store-type", "trustStoreType");

--- a/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
+++ b/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java
@@ -218,6 +218,14 @@ public class RestClientsConfig {
     public Optional<QueryParamStyle> queryParamStyle;
 
     /**
+     * Set whether hostname verification is enabled.
+     *
+     * Can be overwritten by client-specific settings.
+     */
+    @ConfigItem
+    public Optional<Boolean> verifyHost;
+
+    /**
      * The trust store location. Can point to either a classpath resource or a file.
      *
      * Can be overwritten by client-specific settings.

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientBase.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.restclient.NoopHostnameVerifier;
 import io.quarkus.restclient.config.RestClientConfig;
 import io.quarkus.restclient.config.RestClientsConfig;
 
@@ -149,6 +150,13 @@ public class RestClientBase {
                 clientConfigByConfigKey().hostnameVerifier, configRoot.hostnameVerifier);
         if (hostnameVerifier.isPresent()) {
             registerHostnameVerifier(hostnameVerifier.get(), builder);
+        } else {
+            // If `verify-host` is disabled, we configure the client using the `NoopHostnameVerifier` verifier.
+            Optional<Boolean> verifyHost = oneOf(clientConfigByClassName().verifyHost, clientConfigByConfigKey().verifyHost,
+                    configRoot.verifyHost);
+            if (verifyHost.isPresent() && !verifyHost.get()) {
+                registerHostnameVerifier(NoopHostnameVerifier.class.getName(), builder);
+            }
         }
     }
 

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientBuilderImpl.java
@@ -89,6 +89,11 @@ public class RestClientBuilderImpl implements RestClientBuilder {
         return this;
     }
 
+    public RestClientBuilderImpl verifyHost(boolean verifyHost) {
+        clientBuilder.verifyHost(verifyHost);
+        return this;
+    }
+
     @Override
     public RestClientBuilderImpl trustStore(KeyStore trustStore) {
         clientBuilder.trustStore(trustStore);
@@ -319,6 +324,7 @@ public class RestClientBuilderImpl implements RestClientBuilder {
                 .orElse(false);
 
         clientBuilder.trustAll(trustAll);
+        restClientsConfig.verifyHost.ifPresent(clientBuilder::verifyHost);
 
         String userAgent = (String) getConfiguration().getProperty(QuarkusRestClientProperties.USER_AGENT);
         if (userAgent != null) {

--- a/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java
@@ -201,6 +201,9 @@ public class RestClientCDIDelegateBuilder<T> {
         if (maybeHostnameVerifier.isPresent()) {
             registerHostnameVerifier(maybeHostnameVerifier.get(), builder);
         }
+
+        oneOf(clientConfigByClassName().verifyHost, clientConfigByConfigKey().verifyHost, configRoot.verifyHost)
+                .ifPresent(builder::verifyHost);
     }
 
     private void registerHostnameVerifier(String verifier, RestClientBuilder builder) {

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientBuilderImpl.java
@@ -59,6 +59,7 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     private boolean followRedirects;
     private boolean trustAll;
+    private boolean verifyHost;
 
     private LoggingScope loggingScope;
     private Integer loggingBodySize = 100;
@@ -178,6 +179,7 @@ public class ClientBuilderImpl extends ClientBuilder {
         HttpClientOptions options = Optional.ofNullable(configuration.getFromContext(HttpClientOptions.class))
                 .orElseGet(HttpClientOptions::new);
 
+        options.setVerifyHost(verifyHost);
         if (trustAll) {
             options.setTrustAll(true);
             options.setVerifyHost(false);
@@ -344,6 +346,11 @@ public class ClientBuilderImpl extends ClientBuilder {
 
     public ClientBuilderImpl trustAll(boolean trustAll) {
         this.trustAll = trustAll;
+        return this;
+    }
+
+    public ClientBuilderImpl verifyHost(boolean verifyHost) {
+        this.verifyHost = verifyHost;
         return this;
     }
 

--- a/integration-tests/rest-client-reactive/pom.xml
+++ b/integration-tests/rest-client-reactive/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <self-signed.trust-store>${project.build.directory}/self-signed.p12</self-signed.trust-store>
         <self-signed.trust-store-password>changeit</self-signed.trust-store-password>
+        <wrong-host.trust-store>${project.build.directory}/wrong-host.p12</wrong-host.trust-store>
+        <wrong-host.trust-store-password>changeit</wrong-host.trust-store-password>
     </properties>
 
     <!--todo add ssl tests-->
@@ -170,6 +172,23 @@
                             <truststorePassword>${self-signed.trust-store-password}</truststorePassword>
                             <servers>
                                 <server>self-signed.badssl.com:443</server>
+                            </servers>
+                            <trustAllCertificates>true</trustAllCertificates>
+                            <includeCertificates>LEAF</includeCertificates>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>wrong-host-truststore</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>generate-truststore</goal>
+                        </goals>
+                        <configuration>
+                            <truststoreFormat>PKCS12</truststoreFormat>
+                            <truststoreFile>${wrong-host.trust-store}</truststoreFile>
+                            <truststorePassword>${wrong-host.trust-store-password}</truststorePassword>
+                            <servers>
+                                <server>wrong.host.badssl.com:443</server>
                             </servers>
                             <trustAllCertificates>true</trustAllCertificates>
                             <includeCertificates>LEAF</includeCertificates>

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/ClientCallingResource.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.quarkus.it.rest.client.main.MyResponseExceptionMapper.MyException;
 import io.quarkus.it.rest.client.main.selfsigned.ExternalSelfSignedClient;
+import io.quarkus.it.rest.client.main.wronghost.WrongHostClient;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Future;
 import io.vertx.core.json.Json;
@@ -47,6 +48,9 @@ public class ClientCallingResource {
 
     @RestClient
     ExternalSelfSignedClient externalSelfSignedClient;
+
+    @RestClient
+    WrongHostClient wrongHostClient;
 
     @Inject
     InMemorySpanExporter inMemorySpanExporter;
@@ -172,6 +176,9 @@ public class ClientCallingResource {
 
         router.get("/self-signed").blockingHandler(
                 rc -> rc.response().setStatusCode(200).end(String.valueOf(externalSelfSignedClient.invoke().getStatus())));
+
+        router.get("/wrong-host").blockingHandler(
+                rc -> rc.response().setStatusCode(200).end(String.valueOf(wrongHostClient.invoke().getStatus())));
     }
 
     private Future<Void> success(RoutingContext rc, String body) {

--- a/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/wronghost/WrongHostClient.java
+++ b/integration-tests/rest-client-reactive/src/main/java/io/quarkus/it/rest/client/main/wronghost/WrongHostClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.rest.client.main.wronghost;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(baseUri = "https://wrong.host.badssl.com/", configKey = "wrong-host")
+public interface WrongHostClient {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @Retry(delay = 1000)
+    Response invoke();
+}

--- a/integration-tests/rest-client-reactive/src/main/resources/application.properties
+++ b/integration-tests/rest-client-reactive/src/main/resources/application.properties
@@ -2,6 +2,10 @@ w-exception-mapper/mp-rest/url=${test.url}
 w-fault-tolerance/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.main.ParamClient/mp-rest/url=${test.url}
 io.quarkus.it.rest.client.multipart.MultipartClient/mp-rest/url=${test.url}
-# HTTPS
+# Self-Signed client
 quarkus.rest-client.self-signed.trust-store=${self-signed.trust-store}
 quarkus.rest-client.self-signed.trust-store-password=${self-signed.trust-store-password}
+# Wrong Host client
+quarkus.rest-client.wrong-host.trust-store=${wrong-host.trust-store}
+quarkus.rest-client.wrong-host.trust-store-password=${wrong-host.trust-store-password}
+quarkus.rest-client.wrong-host.verify-host=false

--- a/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client-reactive/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestCase.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.rest.client.wronghost;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ExternalWrongHostTestCase {
+    @Test
+    public void restClient() {
+        when()
+                .get("/wrong-host")
+                .then()
+                .statusCode(200)
+                .body(is("200"));
+    }
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/trustall/ExternalTlsTrustAllTestCase.java
@@ -5,11 +5,13 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.it.rest.client.wronghost.ExternalWrongHostTestResourceUsingHostnameVerifier;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(ExternalTlsTrustAllTestResource.class)
+@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingHostnameVerifier.class, restrictToAnnotatedClass = true)
 public class ExternalTlsTrustAllTestCase {
 
     @Test

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/BaseExternalWrongHostTestCase.java
@@ -7,12 +7,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
-
-@QuarkusTest
-@QuarkusTestResource(ExternalWrongHostTestResource.class)
-public class ExternalWrongHostTestCase {
+public abstract class BaseExternalWrongHostTestCase {
 
     @Test
     public void restClient() {

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingHostnameVerifier.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingHostnameVerifier.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.rest.client.wronghost;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.restclient.NoopHostnameVerifier;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * The only point of this class is to propagate the properties when running the native tests
+ */
+public class ExternalWrongHostTestResourceUsingHostnameVerifier implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> result = new HashMap<>();
+        result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
+        result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
+        result.put("wrong-host/mp-rest/hostnameVerifier", NoopHostnameVerifier.class.getName());
+        return result;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingVerifyHost.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostTestResourceUsingVerifyHost.java
@@ -3,20 +3,19 @@ package io.quarkus.it.rest.client.wronghost;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.quarkus.restclient.NoopHostnameVerifier;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 /**
  * The only point of this class is to propagate the properties when running the native tests
  */
-public class ExternalWrongHostTestResource implements QuarkusTestResourceLifecycleManager {
+public class ExternalWrongHostTestResourceUsingVerifyHost implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
         Map<String, String> result = new HashMap<>();
         result.put("wrong-host/mp-rest/trustStore", System.getProperty("rest-client.trustStore"));
         result.put("wrong-host/mp-rest/trustStorePassword", System.getProperty("rest-client.trustStorePassword"));
-        result.put("wrong-host/mp-rest/hostnameVerifier", NoopHostnameVerifier.class.getName());
+        result.put("wrong-host/mp-rest/verifyHost", Boolean.FALSE.toString());
         return result;
     }
 

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierIT.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierIT.java
@@ -3,5 +3,5 @@ package io.quarkus.it.rest.client.wronghost;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-public class ExternalWrongHostIT extends ExternalWrongHostTestCase {
+public class ExternalWrongHostUsingHostnameVerifierIT extends ExternalWrongHostUsingHostnameVerifierTestCase {
 }

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingHostnameVerifierTestCase.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.rest.client.wronghost;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingHostnameVerifier.class, restrictToAnnotatedClass = true)
+public class ExternalWrongHostUsingHostnameVerifierTestCase extends BaseExternalWrongHostTestCase {
+}

--- a/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
+++ b/integration-tests/rest-client/src/test/java/io/quarkus/it/rest/client/wronghost/ExternalWrongHostUsingVerifyHostTestCase.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.rest.client.wronghost;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(value = ExternalWrongHostTestResourceUsingVerifyHost.class, restrictToAnnotatedClass = true)
+public class ExternalWrongHostUsingVerifyHostTestCase extends BaseExternalWrongHostTestCase {
+}


### PR DESCRIPTION
Before these changes, we only can disable the hostname verification in Rest Client classic by providing the following property:

```
quarkus.rest-client.extensions-api.hostname-verifier=io.quarkus.restclient.NoopHostnameVerifier
```

However, this is not working in Rest Client reactive because setting a hostname verifier strategy is not supported by the Vert-x HTTP Client. 

With these changes, we have added a new property in both Rest Client classic and reactive `quarkus.rest-client.extensions-api.verify-host=true or false`. In Rest Client classic, when disabling the verify host, internally it will add the `NoopHostnameVerifier` strategy. In Rest Client reactive, it will properly configure the Vert.x HTTP client to disable the hostname verification. Therefore, in both Rest Client implementations (classic and reactive), the behaviour is the same. 

Fix https://github.com/quarkusio/quarkus/issues/27901