### PR TITLE
Ensure that @ClientHeaderParam works when the rest client contains a method with a primitive return type

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/main/java/io/quarkus/rest/client/reactive/deployment/MicroProfileRestClientEnricher.java
@@ -445,7 +445,7 @@ class MicroProfileRestClientEnricher implements JaxrsClientReactiveEnricher {
                 for (MethodInfo method : methods) {
                     if (Modifier.isAbstract(method.flags())) {
                         MethodCreator methodCreator = classCreator.getMethodCreator(MethodDescriptor.of(method));
-                        methodCreator.returnValue(methodCreator.loadNull());
+                        methodCreator.throwException(IllegalStateException.class, "This should never be called");
                     }
                 }
             }

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/subresource/SubResourceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -106,6 +107,12 @@ public class SubResourceTest {
         @ClientHeaderParam(name = "fromRootMethod", value = "{fillingMethod}")
         @ClientHeaderParam(name = "overridable", value = "RootClient#sub")
         SubClient sub(@PathParam("rootParam") String rootParam, @PathParam("methodParam") String methodParam);
+
+        // we only add this to make sure that the inclusion of @ClientHeaderParam does not break
+        // when the rest client interface contains a method returning a primitive type
+        @Path("/dummy")
+        @DELETE
+        boolean dummy();
 
         default String fillingMethod() {
             return "RootClientComputed";


### PR DESCRIPTION
Resolves: #27959