### PR TITLE
Fix bot notifications for extension proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/extension_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/extension_proposal.yml
@@ -1,6 +1,7 @@
 name: Extension Proposal
 description: Propose a new extension in Quarkiverse
 labels: [area/quarkiverse,kind/extension-proposal]
+title: "[Extension Proposal] "
 body:
   - type: textarea
     validations:
@@ -41,7 +42,7 @@ body:
   - type: textarea
     attributes:
       label: Repository Topics
-      description: "To help other people find and contribute to your project, you can add topics to your repository related to your project's intended purpose, subject area, affinity groups, or other important qualities."
+      description: "To help other people find and contribute to your project, you can add topics to your repository related to your project's intended purpose, subject area, affinity groups, or other important qualities. They must include only lowercase alphanumeric characters or hyphens and cannot start with a hyphen and consist of 35 characters or less"
       value: |
         - quarkus-extension
         - 

--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -1,6 +1,6 @@
 ---
 # The format of this file is documented here:
-# https://github.com/quarkusio/quarkus-bot#triage-issues
+# https://github.com/quarkusio/quarkus-github-bot#triage-issues
 features: [ALL]
 workflows:
   rules:
@@ -531,8 +531,8 @@ triage:
     - labels: [area/optaplanner]
       title: "optaplanner"
       notify: [ge0ffrey, rsynek, Christopher-Chianelli]
-    - labels: [kind/extension-proposal]
-      title: quarkiverse
+    - labels: [kind/extension-proposal,area/quarkiverse]
+      title: "Extension Proposal"
       notify: [gastaldi, gsmet, aloubyansky, maxandersen]
     - labels: [area/mailer]
       title: "\\bmail\\b"


### PR DESCRIPTION
- Issues with `[Extension Proposal]` in the title are properly labeled
- Add repository topics format explanation
