### PR TITLE
Improve OIDC code flow tests

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/CodeAuthenticationMechanism.java
@@ -250,7 +250,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                                             }
                                             if (!configContext.oidcConfig.token.refreshExpired) {
                                                 LOG.debug("Token has expired, token refresh is not allowed");
-                                                throw new AuthenticationCompletionException(t.getCause());
+                                                throw new AuthenticationFailedException(t.getCause());
                                             }
                                             LOG.debug("Token has expired, trying to refresh it");
                                             return refreshSecurityIdentity(configContext,
@@ -833,7 +833,7 @@ public class CodeAuthenticationMechanism extends AbstractOidcAuthenticationMecha
                     @Override
                     public Uni<SecurityIdentity> apply(final AuthorizationCodeTokens tokens, final Throwable t) {
                         if (t != null) {
-                            LOG.debugf("ID token refresh has failed: %s", t.getMessage());
+                            LOG.errorf("ID token refresh has failed: %s", t.getMessage());
                             if (autoRefresh) {
                                 LOG.debug("Using the current SecurityIdentity since the ID token is still valid");
                                 return Uni.createFrom().item(((TokenAutoRefreshException) t).getSecurityIdentity());

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/ProtectedResource.java
@@ -175,12 +175,6 @@ public class ProtectedResource {
     }
 
     @GET
-    @Path("tenant-logout")
-    public String getTenantLogout() {
-        return "Tenant Logout";
-    }
-
-    @GET
     @Path("access")
     public String getAccessToken() {
         if (accessToken.getRawToken() != null &&

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAutoRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantAutoRefresh.java
@@ -1,15 +1,20 @@
 package io.quarkus.it.keycloak;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
 
 @Path("/tenant-autorefresh")
 public class TenantAutoRefresh {
+    @Inject
+    RoutingContext context;
+
     @Authenticated
     @GET
     public String getTenantLogout() {
-        return "Tenant AutoRefresh";
+        return "Tenant AutoRefresh, refreshed: " + (context.get("refresh_token_grant_response") != null);
     }
 }

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantLogout.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -9,6 +10,7 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 
 import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
 
 @Path("/tenant-logout")
 public class TenantLogout {
@@ -16,10 +18,13 @@ public class TenantLogout {
     @Context
     HttpHeaders headers;
 
+    @Inject
+    RoutingContext context;
+
     @Authenticated
     @GET
     public String getTenantLogout() {
-        return "Tenant Logout";
+        return "Tenant Logout, refreshed: " + (context.get("refresh_token_grant_response") != null);
     }
 
     // It is needed for the proactive-auth=false to work: /tenant-logout/logout should match a user initiated logout request

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -86,6 +86,7 @@ quarkus.oidc.tenant-autorefresh.application-type=web-app
 quarkus.oidc.tenant-autorefresh.authentication.cookie-path=/tenant-autorefresh
 quarkus.oidc.tenant-autorefresh.token.refresh-expired=true
 quarkus.oidc.tenant-autorefresh.token.refresh-token-time-skew=30S
+quarkus.oidc.tenant-autorefresh.authentication.remove-redirect-parameters=false
 
 # Tenant which is used to test that the redirect_uri https scheme is enforced.
 quarkus.oidc.tenant-https.auth-server-url=${keycloak.url}/realms/quarkus


### PR DESCRIPTION
I've tried to improve a bit and also simplify the two `CodeFlowTest` tests which are randomly failing :
- Updated test endpoints used in these tests to return a flag indicating if the token refresh has succeeded
- `testTokenAutoRefresh`: updated its configuration not to do a 2nd redirect dropping the code flow query parameters as it causes an immediate auto-refresh and updated the test code to check that no auto-refresh has happened during the 1st request, then auto-refresh has happened during the 2nd request (ID token is still valid but the configured refresh skew requires auto-refresh) - and I removed the code from this test checking the token refresh when ID token expires because it is also tested in another test
- `testRPInitiatedLogout` - this test is too complex, I've split in 2 tests, `testRPInitiatedLogout` where only the RP logout is tested, and `testRefreshToken` where it is tested that the token has been refreshed after the ID token has expired
- Removed unused code from `ProtectedResource`
- Also, minor update to `CodeAuthenticationMechanism` - currently, on `main` if the token auto-refresh is requested but it is not allowed via the configuration then 401 will be reported - which is wrong - the user should be reauthenticated instead, so changed the type of the exception thrown in this case

CC @pedroigor 