### PR TITLE
REST Data with Panache: support of entity event listeners

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -354,6 +354,27 @@ It applies to the paged resources only and is a number starting with 1. Default 
 Fields are sorted in the ascending order unless they're prefixed with a `-`.
 E.g. `?sort=name,-age` will sort the result by the name ascending by the age descending.
 
+== Resource Method Before/After Listeners
+
+REST Data with Panache supports the subscription to the following resource method hooks: 
+
+* Before/After add resource
+* Before/After update resource
+* Before/After delete resource
+
+To register your resource method listener, you need to provide a bean that implements the interface `RestDataResourceMethodListener`, for example:
+
+[source,java]
+----
+@ApplicationScoped
+public class PeopleRestDataResourceMethodListener implements RestDataResourceMethodListener<Person> {
+    @Override
+    public void onBeforeAdd(Person person) {
+        System.out.println("Before Save Person: " + person.name);
+    }
+}
+----
+
 == Response body examples
 
 As mentioned above REST Data with Panache supports the `application/json` and `application/hal+json` response content types.

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment;
 
 import static io.quarkus.deployment.Feature.HIBERNATE_ORM_REST_DATA_PANACHE;
+import static io.quarkus.rest.data.panache.deployment.utils.ResourceMethodListenerUtils.getListenersByEntityType;
 
 import java.lang.reflect.Modifier;
 import java.util.List;
@@ -23,10 +24,12 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.hibernate.orm.rest.data.panache.RestDataResourceMethodListener;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.hibernate.orm.rest.data.panache.runtime.jta.TransactionalUpdateExecutor;
 import io.quarkus.rest.data.panache.RestDataPanacheException;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
+import io.quarkus.rest.data.panache.deployment.ResourceMethodListenerBuildItem;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.ExceptionMapperBuildItem;
@@ -39,9 +42,22 @@ class HibernateOrmPanacheRestProcessor {
     private static final DotName PANACHE_REPOSITORY_RESOURCE_INTERFACE = DotName
             .createSimple(PanacheRepositoryResource.class.getName());
 
+    private static final DotName REST_DATA_RESOURCE_METHOD_LISTENER_INTERFACE = DotName
+            .createSimple(RestDataResourceMethodListener.class.getName());
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(HIBERNATE_ORM_REST_DATA_PANACHE);
+    }
+
+    @BuildStep
+    void findResourceMethodListeners(CombinedIndexBuildItem index,
+            BuildProducer<ResourceMethodListenerBuildItem> resourceMethodListeners) {
+        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(REST_DATA_RESOURCE_METHOD_LISTENER_INTERFACE)) {
+            List<Type> generics = getGenericTypes(classInfo);
+            Type entityType = generics.get(0);
+            resourceMethodListeners.produce(new ResourceMethodListenerBuildItem(classInfo, entityType));
+        }
     }
 
     @BuildStep
@@ -65,6 +81,7 @@ class HibernateOrmPanacheRestProcessor {
      */
     @BuildStep
     void findEntityResources(CombinedIndexBuildItem index,
+            List<ResourceMethodListenerBuildItem> resourceMethodListeners,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer) {
         ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getComputingIndex()));
@@ -78,9 +95,11 @@ class HibernateOrmPanacheRestProcessor {
             String entityType = generics.get(0).name().toString();
             String idType = generics.get(1).name().toString();
 
+            List<ClassInfo> listenersForEntityType = getListenersByEntityType(index.getIndex(), resourceMethodListeners,
+                    entityType);
             DataAccessImplementor dataAccessImplementor = new EntityDataAccessImplementor(entityType);
             String resourceClass = resourceImplementor.implement(
-                    classOutput, dataAccessImplementor, resourceInterface, entityType);
+                    classOutput, dataAccessImplementor, resourceInterface, entityType, listenersForEntityType);
 
             restDataResourceProducer.produce(new RestDataResourceBuildItem(
                     new ResourceMetadata(resourceClass, resourceInterface, entityType, idType)));
@@ -92,6 +111,7 @@ class HibernateOrmPanacheRestProcessor {
      */
     @BuildStep
     void findRepositoryResources(CombinedIndexBuildItem index,
+            List<ResourceMethodListenerBuildItem> resourceMethodListeners,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer) {
@@ -108,9 +128,11 @@ class HibernateOrmPanacheRestProcessor {
             String entityType = generics.get(1).name().toString();
             String idType = generics.get(2).name().toString();
 
+            List<ClassInfo> listenersForEntityType = getListenersByEntityType(index.getIndex(), resourceMethodListeners,
+                    entityType);
             DataAccessImplementor dataAccessImplementor = new RepositoryDataAccessImplementor(repositoryClassName);
             String resourceClass = resourceImplementor.implement(
-                    classOutput, dataAccessImplementor, resourceInterface, entityType);
+                    classOutput, dataAccessImplementor, resourceInterface, entityType, listenersForEntityType);
             // Make sure that repository bean is not removed and will be injected to the generated resource
             unremovableBeansProducer.produce(new UnremovableBeanBuildItem(
                     new UnremovableBeanBuildItem.BeanClassNameExclusion(repositoryClassName)));

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/ItemRestDataResourceMethodListener.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/ItemRestDataResourceMethodListener.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
+
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_DELETE_COUNTER;
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_SAVE_COUNTER;
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_UPDATE_COUNTER;
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_DELETE_COUNTER;
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_SAVE_COUNTER;
+import static io.quarkus.hibernate.orm.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_UPDATE_COUNTER;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.rest.data.panache.RestDataResourceMethodListener;
+
+@ApplicationScoped
+public class ItemRestDataResourceMethodListener implements RestDataResourceMethodListener<AbstractItem> {
+
+    @Override
+    public void onBeforeAdd(AbstractItem item) {
+        ON_BEFORE_SAVE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterAdd(AbstractItem item) {
+        ON_AFTER_SAVE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onBeforeUpdate(AbstractItem item) {
+        ON_BEFORE_UPDATE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterUpdate(AbstractItem item) {
+        ON_AFTER_UPDATE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onBeforeDelete(Object id) {
+        ON_BEFORE_DELETE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterDelete(Object id) {
+        ON_AFTER_DELETE_COUNTER.incrementAndGet();
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceMethodListenerTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceMethodListenerTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.Response;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PanacheEntityResourceMethodListenerTest {
+
+    public static final AtomicInteger ON_BEFORE_SAVE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_SAVE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_BEFORE_UPDATE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_UPDATE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_BEFORE_DELETE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_DELETE_COUNTER = new AtomicInteger(0);
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Collection.class, CollectionsResource.class, AbstractEntity.class, AbstractItem.class,
+                            Item.class, ItemsResource.class, ItemRestDataResourceMethodListener.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql"));
+
+    @Order(1)
+    @Test
+    void shouldListenersBeCalledWhenCreatingEntities() {
+        whenCreateEntity();
+        assertEquals(1, ON_BEFORE_SAVE_COUNTER.get());
+        assertEquals(1, ON_AFTER_SAVE_COUNTER.get());
+    }
+
+    @Order(2)
+    @Test
+    void shouldListenersBeCalledWhenUpdatingEntities() {
+        whenUpdateEntity();
+        assertEquals(1, ON_BEFORE_UPDATE_COUNTER.get());
+        assertEquals(1, ON_AFTER_UPDATE_COUNTER.get());
+    }
+
+    @Order(3)
+    @Test
+    void shouldListenersBeCalledWhenDeletingEntities() {
+        whenDeleteEntity();
+        assertEquals(1, ON_BEFORE_DELETE_COUNTER.get());
+        assertEquals(1, ON_AFTER_DELETE_COUNTER.get());
+    }
+
+    private void whenCreateEntity() {
+        Response response = given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"name\": \"test-simple\", \"collection\": {\"id\": \"full\"}}")
+                .when().post("/items")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(201);
+    }
+
+    private void whenUpdateEntity() {
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"1\", \"name\": \"first-test\", \"collection\": {\"id\": \"full\"}}")
+                .when().put("/items/1")
+                .then().statusCode(204);
+    }
+
+    private void whenDeleteEntity() {
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"1\", \"name\": \"first-test\", \"collection\": {\"id\": \"full\"}}")
+                .when().delete("/items/1")
+                .then().statusCode(204);
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/AbstractEntity.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/AbstractEntity.java
@@ -4,8 +4,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
 @MappedSuperclass
-public abstract class AbstractEntity<IdType extends Number> {
+public abstract class AbstractEntity<IdType extends Number> extends PanacheEntityBase {
 
     @Id
     @GeneratedValue
@@ -13,5 +15,9 @@ public abstract class AbstractEntity<IdType extends Number> {
 
     public IdType getId() {
         return id;
+    }
+
+    public void setId(IdType id) {
+        this.id = id;
     }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/AbstractItem.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/AbstractItem.java
@@ -9,17 +9,9 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 @MappedSuperclass
 public abstract class AbstractItem<IdType extends Number> extends AbstractEntity<IdType> {
 
-    private String name;
+    public String name;
 
     @ManyToOne(optional = false)
     @JsonProperty(access = Access.WRITE_ONLY)
-    private Collection collection;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
+    public Collection collection;
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/Collection.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/Collection.java
@@ -8,38 +8,16 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
 @Entity
-public class Collection {
+public class Collection extends PanacheEntityBase {
 
     @Id
-    private String id;
+    public String id;
 
-    private String name;
+    public String name;
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "collection")
-    private List<Item> items = new LinkedList<>();
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public List<Item> getItems() {
-        return items;
-    }
-
-    public void setItems(List<Item> items) {
-        this.items = items;
-    }
+    public List<Item> items = new LinkedList<>();
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/EmptyListItem.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/EmptyListItem.java
@@ -1,8 +1,25 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.repository;
 
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
-public class EmptyListItem extends AbstractItem<Long> {
+public class EmptyListItem extends PanacheEntityBase {
 
+    @Id
+    @GeneratedValue
+    private Long cid;
+
+    public String name;
+
+    @ManyToOne(optional = false)
+    @JsonProperty(access = Access.WRITE_ONLY)
+    public Collection collection;
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/RestDataResourceMethodListener.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/RestDataResourceMethodListener.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.orm.rest.data.panache;
+
+/**
+ * REST Data Resource method listener interface to subscribe to the pre-post events for each resource in REST Data with Panache.
+ *
+ * @param <ENTITY> the entity to subscribe.
+ */
+public interface RestDataResourceMethodListener<ENTITY> {
+    /**
+     * This method is triggered before saving an entity.
+     *
+     * @param entity the entity to save.
+     */
+    default void onBeforeAdd(ENTITY entity) {
+    }
+
+    /**
+     * Fired after saving an entity.
+     *
+     * @param entity the saved entity.
+     */
+    default void onAfterAdd(ENTITY entity) {
+    }
+
+    /**
+     * Fired before updating an entity.
+     *
+     * @param entity the entity to update.
+     */
+    default void onBeforeUpdate(ENTITY entity) {
+    }
+
+    /**
+     * Fired after updating an entity.
+     *
+     * @param entity the updated entity.
+     */
+    default void onAfterUpdate(ENTITY entity) {
+    }
+
+    /**
+     * Fired before deleting an entity.
+     *
+     * @param id the entity id to delete.
+     */
+    default void onBeforeDelete(Object id) {
+    }
+
+    /**
+     * Fired after deleting an entity.
+     *
+     * @param id of the deleted entity.
+     */
+    default void onAfterDelete(Object id) {
+    }
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/HibernateReactivePanacheRestProcessor.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/HibernateReactivePanacheRestProcessor.java
@@ -1,6 +1,7 @@
 package io.quarkus.hibernate.reactive.rest.data.panache.deployment;
 
 import static io.quarkus.deployment.Feature.HIBERNATE_REACTIVE_REST_DATA_PANACHE;
+import static io.quarkus.rest.data.panache.deployment.utils.ResourceMethodListenerUtils.getListenersByEntityType;
 
 import java.lang.reflect.Modifier;
 import java.util.List;
@@ -20,8 +21,10 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.gizmo.ClassOutput;
 import io.quarkus.hibernate.reactive.rest.data.panache.PanacheEntityResource;
 import io.quarkus.hibernate.reactive.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.hibernate.reactive.rest.data.panache.RestDataResourceMethodListener;
 import io.quarkus.hibernate.reactive.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
 import io.quarkus.rest.data.panache.deployment.ResourceMetadata;
+import io.quarkus.rest.data.panache.deployment.ResourceMethodListenerBuildItem;
 import io.quarkus.rest.data.panache.deployment.RestDataResourceBuildItem;
 import io.quarkus.resteasy.reactive.spi.CustomExceptionMapperBuildItem;
 
@@ -32,6 +35,9 @@ class HibernateReactivePanacheRestProcessor {
 
     private static final DotName PANACHE_REPOSITORY_RESOURCE_INTERFACE = DotName
             .createSimple(PanacheRepositoryResource.class.getName());
+
+    private static final DotName REST_DATA_RESOURCE_METHOD_LISTENER_INTERFACE = DotName
+            .createSimple(RestDataResourceMethodListener.class.getName());
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -44,27 +50,40 @@ class HibernateReactivePanacheRestProcessor {
                 .produce(new CustomExceptionMapperBuildItem(RestDataPanacheExceptionMapper.class.getName()));
     }
 
+    @BuildStep
+    void findResourceMethodListeners(CombinedIndexBuildItem index,
+            BuildProducer<ResourceMethodListenerBuildItem> resourceMethodListeners) {
+        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(REST_DATA_RESOURCE_METHOD_LISTENER_INTERFACE)) {
+            List<Type> generics = getGenericTypes(classInfo);
+            Type entityType = generics.get(0);
+            resourceMethodListeners.produce(new ResourceMethodListenerBuildItem(classInfo, entityType));
+        }
+    }
+
     /**
      * Find Panache entity resources and generate their implementations.
      */
     @BuildStep
-    void findEntityResources(CombinedIndexBuildItem index,
+    void findEntityResources(CombinedIndexBuildItem indexBuildItem,
+            List<ResourceMethodListenerBuildItem> resourceMethodListeners,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer) {
-        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getIndex()));
+        IndexView index = indexBuildItem.getIndex();
+        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index));
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(PANACHE_ENTITY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+        for (ClassInfo classInfo : index.getKnownDirectImplementors(PANACHE_ENTITY_RESOURCE_INTERFACE)) {
+            validateResource(index, classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();
             String entityType = generics.get(0).name().toString();
             String idType = generics.get(1).name().toString();
 
+            List<ClassInfo> listenersForEntityType = getListenersByEntityType(index, resourceMethodListeners, entityType);
             DataAccessImplementor dataAccessImplementor = new EntityDataAccessImplementor(entityType);
             String resourceClass = resourceImplementor.implement(
-                    classOutput, dataAccessImplementor, resourceInterface, entityType);
+                    classOutput, dataAccessImplementor, resourceInterface, entityType, listenersForEntityType);
 
             restDataResourceProducer.produce(new RestDataResourceBuildItem(
                     new ResourceMetadata(resourceClass, resourceInterface, entityType, idType)));
@@ -75,15 +94,17 @@ class HibernateReactivePanacheRestProcessor {
      * Find Panache repository resources and generate their implementations.
      */
     @BuildStep
-    void findRepositoryResources(CombinedIndexBuildItem index,
+    void findRepositoryResources(CombinedIndexBuildItem indexBuildItem,
+            List<ResourceMethodListenerBuildItem> resourceMethodListeners,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer) {
-        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getIndex()));
+        IndexView index = indexBuildItem.getIndex();
+        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index));
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(PANACHE_REPOSITORY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+        for (ClassInfo classInfo : index.getKnownDirectImplementors(PANACHE_REPOSITORY_RESOURCE_INTERFACE)) {
+            validateResource(index, classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();
@@ -91,9 +112,10 @@ class HibernateReactivePanacheRestProcessor {
             String entityType = generics.get(1).name().toString();
             String idType = generics.get(2).name().toString();
 
+            List<ClassInfo> listenersForEntityType = getListenersByEntityType(index, resourceMethodListeners, entityType);
             DataAccessImplementor dataAccessImplementor = new RepositoryDataAccessImplementor(repositoryClassName);
             String resourceClass = resourceImplementor.implement(
-                    classOutput, dataAccessImplementor, resourceInterface, entityType);
+                    classOutput, dataAccessImplementor, resourceInterface, entityType, listenersForEntityType);
             // Make sure that repository bean is not removed and will be injected to the generated resource
             unremovableBeansProducer.produce(new UnremovableBeanBuildItem(
                     new UnremovableBeanBuildItem.BeanClassNameExclusion(repositoryClassName)));

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/ResourceImplementor.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/ResourceImplementor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.logging.Logger;
 
@@ -20,6 +21,7 @@ import io.quarkus.hibernate.reactive.panache.common.runtime.ReactiveTransactiona
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.rest.data.panache.deployment.Constants;
+import io.quarkus.rest.data.panache.deployment.ResourceMethodListenerImplementor;
 import io.quarkus.runtime.util.HashUtil;
 import io.smallrye.mutiny.Uni;
 
@@ -43,7 +45,7 @@ class ResourceImplementor {
      * Instances of this class are registered as beans and are later used in the generated JAX-RS controllers.
      */
     String implement(ClassOutput classOutput, DataAccessImplementor dataAccessImplementor, String resourceType,
-            String entityType) {
+            String entityType, List<ClassInfo> resourceMethodListeners) {
         String className = resourceType + "Impl_" + HashUtil.sha1(resourceType);
         LOGGER.tracef("Starting generation of '%s'", className);
         ClassCreator classCreator = ClassCreator.builder()
@@ -53,13 +55,17 @@ class ResourceImplementor {
                 .build();
 
         classCreator.addAnnotation(ApplicationScoped.class);
+
+        ResourceMethodListenerImplementor resourceMethodListenerImplementor = new ResourceMethodListenerImplementor(
+                classCreator, resourceMethodListeners, true);
+
         implementList(classCreator, dataAccessImplementor);
         implementCount(classCreator, dataAccessImplementor);
         implementListPageCount(classCreator, dataAccessImplementor);
         implementGet(classCreator, dataAccessImplementor);
-        implementAdd(classCreator, dataAccessImplementor);
-        implementUpdate(classCreator, dataAccessImplementor, entityType);
-        implementDelete(classCreator, dataAccessImplementor);
+        implementAdd(classCreator, dataAccessImplementor, resourceMethodListenerImplementor);
+        implementUpdate(classCreator, dataAccessImplementor, entityType, resourceMethodListenerImplementor);
+        implementDelete(classCreator, dataAccessImplementor, resourceMethodListenerImplementor);
 
         classCreator.close();
         LOGGER.tracef("Completed generation of '%s'", className);
@@ -108,31 +114,42 @@ class ResourceImplementor {
         methodCreator.close();
     }
 
-    private void implementAdd(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
+    private void implementAdd(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor,
+            ResourceMethodListenerImplementor resourceMethodListenerImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("add", Uni.class, Object.class);
         methodCreator.addAnnotation(ReactiveTransactional.class);
         ResultHandle entity = methodCreator.getMethodParam(0);
-        methodCreator.returnValue(dataAccessImplementor.persist(methodCreator, entity));
+        resourceMethodListenerImplementor.onBeforeAdd(methodCreator, entity);
+        ResultHandle uni = dataAccessImplementor.persist(methodCreator, entity);
+        resourceMethodListenerImplementor.onAfterAdd(methodCreator, uni);
+        methodCreator.returnValue(uni);
         methodCreator.close();
     }
 
-    private void implementUpdate(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor,
-            String entityType) {
+    private void implementUpdate(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor, String entityType,
+            ResourceMethodListenerImplementor resourceMethodListenerImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("update", Uni.class, Object.class, Object.class);
         methodCreator.addAnnotation(ReactiveTransactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
         ResultHandle entity = methodCreator.getMethodParam(1);
         // Set entity ID before executing an update to make sure that a requested object ID matches a given entity ID.
         setId(methodCreator, entityType, entity, id);
-        methodCreator.returnValue(dataAccessImplementor.update(methodCreator, entity));
+        resourceMethodListenerImplementor.onBeforeUpdate(methodCreator, entity);
+        ResultHandle uni = dataAccessImplementor.update(methodCreator, entity);
+        resourceMethodListenerImplementor.onAfterUpdate(methodCreator, uni);
+        methodCreator.returnValue(uni);
         methodCreator.close();
     }
 
-    private void implementDelete(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor) {
+    private void implementDelete(ClassCreator classCreator, DataAccessImplementor dataAccessImplementor,
+            ResourceMethodListenerImplementor resourceMethodListenerImplementor) {
         MethodCreator methodCreator = classCreator.getMethodCreator("delete", Uni.class, Object.class);
         methodCreator.addAnnotation(ReactiveTransactional.class);
         ResultHandle id = methodCreator.getMethodParam(0);
-        methodCreator.returnValue(dataAccessImplementor.deleteById(methodCreator, id));
+        resourceMethodListenerImplementor.onBeforeDelete(methodCreator, id);
+        ResultHandle uni = dataAccessImplementor.deleteById(methodCreator, id);
+        resourceMethodListenerImplementor.onAfterDelete(methodCreator, id);
+        methodCreator.returnValue(uni);
         methodCreator.close();
     }
 

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/ItemRestDataResourceMethodListener.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/ItemRestDataResourceMethodListener.java
@@ -1,0 +1,46 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
+
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_DELETE_COUNTER;
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_SAVE_COUNTER;
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_AFTER_UPDATE_COUNTER;
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_DELETE_COUNTER;
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_SAVE_COUNTER;
+import static io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity.PanacheEntityResourceMethodListenerTest.ON_BEFORE_UPDATE_COUNTER;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.reactive.rest.data.panache.RestDataResourceMethodListener;
+
+@ApplicationScoped
+public class ItemRestDataResourceMethodListener implements RestDataResourceMethodListener<Item> {
+
+    @Override
+    public void onBeforeAdd(Item item) {
+        ON_BEFORE_SAVE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterAdd(Item item) {
+        ON_AFTER_SAVE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onBeforeUpdate(Item item) {
+        ON_BEFORE_UPDATE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterUpdate(Item item) {
+        ON_AFTER_UPDATE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onBeforeDelete(Object id) {
+        ON_BEFORE_DELETE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public void onAfterDelete(Object id) {
+        ON_AFTER_DELETE_COUNTER.incrementAndGet();
+    }
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceMethodListenerTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/entity/PanacheEntityResourceMethodListenerTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.hibernate.reactive.rest.data.panache.deployment.entity;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.response.Response;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PanacheEntityResourceMethodListenerTest {
+
+    public static final AtomicInteger ON_BEFORE_SAVE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_SAVE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_BEFORE_UPDATE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_UPDATE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_BEFORE_DELETE_COUNTER = new AtomicInteger(0);
+    public static final AtomicInteger ON_AFTER_DELETE_COUNTER = new AtomicInteger(0);
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Collection.class, CollectionsResource.class, AbstractEntity.class, AbstractItem.class,
+                            Item.class, ItemsResource.class, ItemRestDataResourceMethodListener.class)
+                    .addAsResource("application.properties")
+                    .addAsResource("import.sql"));
+
+    @Order(1)
+    @Test
+    void shouldListenersBeCalledWhenCreatingEntities() {
+        whenCreateEntity();
+        assertEquals(1, ON_BEFORE_SAVE_COUNTER.get());
+        assertEquals(1, ON_AFTER_SAVE_COUNTER.get());
+    }
+
+    @Order(2)
+    @Test
+    void shouldListenersBeCalledWhenUpdatingEntities() {
+        whenUpdateEntity();
+        assertEquals(1, ON_BEFORE_UPDATE_COUNTER.get());
+        assertEquals(1, ON_AFTER_UPDATE_COUNTER.get());
+    }
+
+    @Order(3)
+    @Test
+    void shouldListenersBeCalledWhenDeletingEntities() {
+        whenDeleteEntity();
+        assertEquals(1, ON_BEFORE_DELETE_COUNTER.get());
+        assertEquals(1, ON_AFTER_DELETE_COUNTER.get());
+    }
+
+    private void whenCreateEntity() {
+        Response response = given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"name\": \"test-simple\", \"collection\": {\"id\": \"full\"}}")
+                .when().post("/items")
+                .thenReturn();
+        assertThat(response.statusCode()).isEqualTo(201);
+    }
+
+    private void whenUpdateEntity() {
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"1\", \"name\": \"first-test\", \"collection\": {\"id\": \"full\"}}")
+                .when().put("/items/1")
+                .then().statusCode(204);
+    }
+
+    private void whenDeleteEntity() {
+        given().accept("application/json")
+                .and().contentType("application/json")
+                .and().body("{\"id\": \"1\", \"name\": \"first-test\", \"collection\": {\"id\": \"full\"}}")
+                .when().delete("/items/1")
+                .then().statusCode(204);
+    }
+}

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/AbstractEntity.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/AbstractEntity.java
@@ -4,8 +4,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+
 @MappedSuperclass
-public abstract class AbstractEntity<IdType extends Number> {
+public abstract class AbstractEntity<IdType extends Number> extends PanacheEntityBase {
 
     @Id
     @GeneratedValue
@@ -13,5 +15,9 @@ public abstract class AbstractEntity<IdType extends Number> {
 
     public IdType getId() {
         return id;
+    }
+
+    public void setId(IdType id) {
+        this.id = id;
     }
 }

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/AbstractItem.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/AbstractItem.java
@@ -7,25 +7,13 @@ import javax.persistence.MappedSuperclass;
 @MappedSuperclass
 public abstract class AbstractItem<IdType extends Number> extends AbstractEntity<IdType> {
 
-    private String name;
+    public String name;
 
     @ManyToOne
-    private Collection collection;
+    public Collection collection;
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @JsonbTransient // Avoid infinite loop when serialising
+    @JsonbTransient // Avoid infinite loop when serializing
     public Collection getCollection() {
         return collection;
-    }
-
-    public void setCollection(Collection collection) {
-        this.collection = collection;
     }
 }

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/Collection.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/Collection.java
@@ -8,38 +8,16 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase;
+
 @Entity
-public class Collection {
+public class Collection extends PanacheEntityBase {
 
     @Id
-    private String id;
+    public String id;
 
-    private String name;
+    public String name;
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "collection")
-    private List<Item> items = new LinkedList<>();
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public List<Item> getItems() {
-        return items;
-    }
-
-    public void setItems(List<Item> items) {
-        this.items = items;
-    }
+    public List<Item> items = new LinkedList<>();
 }

--- a/extensions/panache/hibernate-reactive-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/RestDataResourceMethodListener.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/runtime/src/main/java/io/quarkus/hibernate/reactive/rest/data/panache/RestDataResourceMethodListener.java
@@ -1,0 +1,56 @@
+package io.quarkus.hibernate.reactive.rest.data.panache;
+
+/**
+ * REST Data Resource method listener interface to subscribe to the entity events in REST Data with Panache.
+ *
+ * @param <ENTITY> the entity to subscribe.
+ */
+public interface RestDataResourceMethodListener<ENTITY> {
+    /**
+     * This method is triggered before saving an entity.
+     *
+     * @param entity the entity to save.
+     */
+    default void onBeforeAdd(ENTITY entity) {
+    }
+
+    /**
+     * Fired after saving an entity.
+     *
+     * @param entity the saved entity.
+     */
+    default void onAfterAdd(ENTITY entity) {
+    }
+
+    /**
+     * Fired before updating an entity.
+     *
+     * @param entity the entity to update.
+     */
+    default void onBeforeUpdate(ENTITY entity) {
+    }
+
+    /**
+     * Fired after updating an entity.
+     *
+     * @param entity the updated entity.
+     */
+    default void onAfterUpdate(ENTITY entity) {
+    }
+
+    /**
+     * Fired before deleting an entity.
+     *
+     * @param id the entity id to delete.
+     */
+    default void onBeforeDelete(Object id) {
+    }
+
+    /**
+     * Fired after deleting an entity.
+     *
+     * @param id of the deleted entity.
+     */
+    default void onAfterDelete(Object id) {
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/ResourceMethodListenerBuildItem.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/ResourceMethodListenerBuildItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.rest.data.panache.deployment;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Type;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class ResourceMethodListenerBuildItem extends MultiBuildItem {
+
+    private final ClassInfo classInfo;
+    private final Type entityType;
+
+    public ResourceMethodListenerBuildItem(ClassInfo classInfo, Type entityType) {
+        this.classInfo = classInfo;
+        this.entityType = entityType;
+    }
+
+    public ClassInfo getClassInfo() {
+        return classInfo;
+    }
+
+    public Type getEntityType() {
+        return entityType;
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/ResourceMethodListenerImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/ResourceMethodListenerImplementor.java
@@ -1,0 +1,118 @@
+package io.quarkus.rest.data.panache.deployment;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import javax.inject.Inject;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+import io.quarkus.rest.data.panache.deployment.utils.UniImplementor;
+
+public class ResourceMethodListenerImplementor {
+    private static final String ON_AFTER = "onAfter";
+    private static final String ON_BEFORE_ADD_METHOD_NAME = "onBeforeAdd";
+    private static final String ON_AFTER_ADD_METHOD_NAME = ON_AFTER + "Add";
+    private static final String ON_BEFORE_UPDATE_METHOD_NAME = "onBeforeUpdate";
+    private static final String ON_AFTER_UPDATE_METHOD_NAME = ON_AFTER + "Update";
+    private static final String ON_BEFORE_DELETE_METHOD_NAME = "onBeforeDelete";
+    private static final String ON_AFTER_DELETE_METHOD_NAME = ON_AFTER + "Delete";
+
+    private final Map<FieldDescriptor, ClassInfo> listenerFields = new HashMap<>();
+    private final boolean isHibernateReactive;
+
+    public ResourceMethodListenerImplementor(ClassCreator cc, List<ClassInfo> resourceMethodListeners,
+            boolean isHibernateReactive) {
+        this.isHibernateReactive = isHibernateReactive;
+        for (int index = 0; index < resourceMethodListeners.size(); index++) {
+            ClassInfo eventListenerClass = resourceMethodListeners.get(index);
+            FieldCreator delegateField = cc.getFieldCreator("listener" + index, eventListenerClass.name().toString())
+                    .setModifiers(Modifier.PROTECTED);
+            delegateField.addAnnotation(Inject.class);
+
+            listenerFields.put(delegateField.getFieldDescriptor(), eventListenerClass);
+        }
+    }
+
+    public void onBeforeAdd(BytecodeCreator methodCreator, ResultHandle entity) {
+        invokeMethodUsingEntity(ON_BEFORE_ADD_METHOD_NAME, methodCreator, entity);
+    }
+
+    public void onAfterAdd(BytecodeCreator methodCreator, ResultHandle entity) {
+        invokeMethodUsingEntity(ON_AFTER_ADD_METHOD_NAME, methodCreator, entity);
+    }
+
+    public void onBeforeUpdate(BytecodeCreator methodCreator, ResultHandle entity) {
+        invokeMethodUsingEntity(ON_BEFORE_UPDATE_METHOD_NAME, methodCreator, entity);
+    }
+
+    public void onAfterUpdate(BytecodeCreator methodCreator, ResultHandle entity) {
+        invokeMethodUsingEntity(ON_AFTER_UPDATE_METHOD_NAME, methodCreator, entity);
+    }
+
+    public void onBeforeDelete(BytecodeCreator methodCreator, ResultHandle id) {
+        invokeMethodUsingId(ON_BEFORE_DELETE_METHOD_NAME, methodCreator, id);
+    }
+
+    public void onAfterDelete(BytecodeCreator methodCreator, ResultHandle id) {
+        invokeMethodUsingId(ON_AFTER_DELETE_METHOD_NAME, methodCreator, id);
+    }
+
+    private void invokeMethodUsingEntity(String methodName, BytecodeCreator methodCreator, ResultHandle entity) {
+        processEventListener(methodName, methodCreator, (eventListener, method) -> {
+            if (isUsingHibernateReactiveAndOnAfterMethod(methodName)) {
+                UniImplementor.subscribeWith(methodCreator, entity,
+                        (lambda, item) -> {
+                            lambda.invokeVirtualMethod(method, eventListener, item);
+                            lambda.returnNull();
+                        });
+            } else {
+                methodCreator.invokeVirtualMethod(method, eventListener, entity);
+            }
+        });
+    }
+
+    private void invokeMethodUsingId(String methodName, BytecodeCreator methodCreator, ResultHandle id) {
+        processEventListener(methodName, methodCreator, (eventListener, method) -> {
+            methodCreator.invokeVirtualMethod(method, eventListener, id);
+        });
+    }
+
+    private boolean isUsingHibernateReactiveAndOnAfterMethod(String methodName) {
+        return isHibernateReactive && methodName.startsWith(ON_AFTER);
+    }
+
+    private void processEventListener(String methodName, BytecodeCreator methodCreator,
+            BiConsumer<ResultHandle, MethodInfo> apply) {
+        for (Map.Entry<FieldDescriptor, ClassInfo> eventListenerEntry : listenerFields.entrySet()) {
+            MethodInfo method = findMethodByName(eventListenerEntry.getValue(), methodName);
+            if (method != null) {
+                // If method is implemented
+                ResultHandle eventListener = methodCreator.readInstanceField(eventListenerEntry.getKey(),
+                        methodCreator.getThis());
+                apply.accept(eventListener, method);
+            }
+        }
+    }
+
+    private MethodInfo findMethodByName(ClassInfo classInfo, String methodName) {
+        List<MethodInfo> methods = classInfo.methods();
+        for (int index = 0; index < methods.size(); index++) {
+            MethodInfo method = methods.get(index);
+            if (methodName.equals(method.name())) {
+                return method;
+            }
+        }
+
+        return null;
+    }
+}

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResourceMethodListenerUtils.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/utils/ResourceMethodListenerUtils.java
@@ -1,0 +1,49 @@
+package io.quarkus.rest.data.panache.deployment.utils;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+
+import io.quarkus.rest.data.panache.deployment.ResourceMethodListenerBuildItem;
+
+public final class ResourceMethodListenerUtils {
+
+    private ResourceMethodListenerUtils() {
+
+    }
+
+    public static List<ClassInfo> getListenersByEntityType(IndexView index,
+            List<ResourceMethodListenerBuildItem> resourceMethodListeners,
+            String entityTypeName) {
+        ClassInfo entityClass = index.getClassByName(entityTypeName);
+        return resourceMethodListeners.stream()
+                .filter(isCompatibleWithEntityType(index, entityClass))
+                .map(e -> e.getClassInfo())
+                .collect(Collectors.toList());
+    }
+
+    private static Predicate<ResourceMethodListenerBuildItem> isCompatibleWithEntityType(IndexView index,
+            ClassInfo entityClass) {
+        return e -> {
+            DotName entityTypeOfListener = e.getEntityType().asClassType().name();
+            ClassInfo currentEntityClass = entityClass;
+            while (currentEntityClass != null) {
+                if (entityTypeOfListener.equals(currentEntityClass.name())) {
+                    return true;
+                }
+
+                if (currentEntityClass.superName() != null) {
+                    currentEntityClass = index.getClassByName(currentEntityClass.superName());
+                } else {
+                    currentEntityClass = null;
+                }
+            }
+
+            return false;
+        };
+    }
+}


### PR DESCRIPTION
REST Data with Panache supports the subscription to the following entity events: 

* Before/After save events
* Before/After update events
* Before/After delete events

To suscribe to an entity event, you need to provide a bean that implements the interface `EntityEventListener`, for example:

```java
@ApplicationScoped
public class PeopleRestDataResourceMethodListener implements RestDataResourceMethodListener<Person> {
    @Override
    public void onBeforeAdd(Person person) {
        System.out.println("Before Save Person: " + person.name);
    }
}
```

When using the REST Data Reactive with Panache extension, you will receive the Uni instance of the entity in the after methods:

```java
@ApplicationScoped
public class PeopleRestDataResourceMethodListener implements RestDataResourceMethodListener<Person> {
    @Override
    public void onAfterAdd(Uni<Person> uni) {
        uni.subscribe().with(person -> {
            System.out.println("After Save Person: " + person.name);
        });
    }
}
```

Fix https://github.com/quarkusio/quarkus/issues/29095