### PR TITLE
DevMojo add only properties from the quarkus namespace

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/configuration/BuildTimeConfigurationReader.java
@@ -878,13 +878,16 @@ public final class BuildTimeConfigurationReader {
          * We collect all properties from eligible ConfigSources, because Config#getPropertyNames exclude the active
          * profiled properties, meaning that the property is written in the default config source without the profile
          * prefix. This may cause issues if we run with a different profile and fallback to defaults.
-         *
+         * <br>
          * We also filter the properties coming from the System with the registered roots, because we don't want to
          * record properties set by the compiling JVM (or other properties that are only related to the build).
+         * <br>
+         * Properties coming from the Environment are ignored.
          */
         private Set<String> getAllProperties(final Set<String> registeredRoots) {
             Set<String> properties = new HashSet<>();
             for (ConfigSource configSource : config.getConfigSources()) {
+                // This is a BuildTimeSysPropConfigSource
                 if (configSource instanceof SysPropConfigSource) {
                     for (String propertyName : configSource.getProperties().keySet()) {
                         NameIterator ni = new NameIterator(propertyName);
@@ -893,6 +896,7 @@ public final class BuildTimeConfigurationReader {
                         }
                     }
                 } else {
+                    // The BuildTimeEnvConfigSource returns an empty Set
                     properties.addAll(configSource.getPropertyNames());
                 }
             }
@@ -906,10 +910,10 @@ public final class BuildTimeConfigurationReader {
          * Use this Config instance to record the runtime default values. We cannot use the main Config
          * instance because it may record values coming from the EnvSource in build time. Environment variable values
          * may be completely different between build and runtime, so it doesn't make sense to record these.
-         *
+         * <br>
          * We do exclude the properties coming from the EnvSource, but a call to getValue may still provide a result
          * coming from the EnvSource, so we need to exclude it from the sources when recording values for runtime.
-         *
+         * <br>
          * We also do not want to completely exclude the EnvSource, because it may provide values for the build. This
          * is only specific when recording the defaults.
          *

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1,5 +1,7 @@
 package io.quarkus.maven;
 
+import static io.smallrye.common.expression.Expression.Flag.LENIENT_SYNTAX;
+import static io.smallrye.common.expression.Expression.Flag.NO_TRIM;
 import static java.util.function.Predicate.not;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
@@ -105,6 +107,7 @@ import io.quarkus.maven.dependency.GACT;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathList;
 import io.quarkus.runtime.LaunchMode;
+import io.smallrye.common.expression.Expression;
 
 /**
  * The dev mojo, that runs a quarkus app in a forked process. A background compilation process is launched and any changes are
@@ -983,7 +986,31 @@ public class DevMojo extends AbstractMojo {
         }
 
         builder.projectDir(project.getFile().getParentFile());
-        builder.buildSystemProperties((Map) project.getProperties());
+
+        Properties projectProperties = project.getProperties();
+        Map<String, String> effectiveProperties = new HashMap<>();
+        for (String name : projectProperties.stringPropertyNames()) {
+            if (name.startsWith("quarkus.")) {
+                effectiveProperties.put(name, projectProperties.getProperty(name));
+            }
+        }
+
+        // Add other properties that may be required for expansion
+        for (String value : effectiveProperties.values()) {
+            for (String reference : Expression.compile(value, LENIENT_SYNTAX, NO_TRIM).getReferencedStrings()) {
+                String referenceValue = session.getUserProperties().getProperty(reference);
+                if (referenceValue != null) {
+                    effectiveProperties.put(reference, referenceValue);
+                    continue;
+                }
+
+                referenceValue = projectProperties.getProperty(reference);
+                if (referenceValue != null) {
+                    effectiveProperties.put(reference, referenceValue);
+                }
+            }
+        }
+        builder.buildSystemProperties(effectiveProperties);
 
         builder.applicationName(project.getArtifactId());
         builder.applicationVersion(project.getVersion());


### PR DESCRIPTION
- Fixes #27884

There is a difference in the recorded properties between the build and dev mode. In dev mode, all properties were being recorded, which cause the issue described in #27884.