### PR TITLE
Add "scm" property with github coordinates to extension metadata

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/build.gradle
+++ b/devtools/gradle/gradle-extension-plugin/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation "io.quarkus:quarkus-bootstrap-gradle-resolver"
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+    testImplementation "org.assertj:assertj-core"
 }
 
 group = "io.quarkus.extension"
@@ -29,4 +30,8 @@ pluginBundle {
     website = 'https://quarkus.io/'
     vcsUrl = 'https://github.com/quarkusio/quarkus'
     tags = ['quarkus', 'quarkusio', 'graalvm']
+}
+
+tasks.withType(Test) {
+    environment 'GITHUB_REPOSITORY','some/repo'
 }

--- a/independent-projects/bootstrap/maven-plugin/pom.xml
+++ b/independent-projects/bootstrap/maven-plugin/pom.xml
@@ -47,6 +47,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
+                <configuration>
+                    <environmentVariables>
+                        <GITHUB_REPOSITORY>some/repo</GITHUB_REPOSITORY>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
+++ b/independent-projects/bootstrap/maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
@@ -1,7 +1,13 @@
 package io.quarkus.maven;
 
 import static io.quarkus.maven.ExtensionDescriptorMojo.getCodestartArtifact;
-import static org.junit.jupiter.api.Assertions.*;
+import static io.quarkus.maven.ExtensionDescriptorMojo.getSourceRepo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,5 +23,17 @@ class ExtensionDescriptorMojoTest {
                 getCodestartArtifact("io.quarkus:my-ext:codestarts:jar:1.0", "999-SN"));
         assertEquals("io.quarkus:my-ext:999-SN",
                 getCodestartArtifact("io.quarkus:my-ext:${project.version}", "999-SN"));
+    }
+
+    @Test
+    void testGetSourceControlCoordinates() {
+        // From maven this property should be set, running in an IDE it won't be unless specially configured
+        if (System.getenv("GITHUB_REPOSITORY") != null) {
+            Map repo = getSourceRepo();
+            assertNotNull(repo);
+            assertTrue(repo.get("url").toString().matches("https://github.com/some/repo"));
+        } else {
+            assertNull(getSourceRepo());
+        }
     }
 }

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -124,6 +124,9 @@
                         <!-- set tmpdir as early as possible because failsafe sets it too late for JDK16 -->
                         <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
                         <excludedEnvironmentVariables>MAVEN_OPTS</excludedEnvironmentVariables>
+                        <environmentVariables>
+                            <GITHUB_REPOSITORY>some/repo</GITHUB_REPOSITORY>
+                        </environmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This is useful for enriching the information we show on any potential extension pages. 

@aloubyansky, would welcome your thoughts. I've used the key "source" but maybe "source-control" would be less ambiguous?

Can we add label:area/marketplace please?