### PR TITLE
Loosen rule for what can build without approval

### DIFF
--- a/.github/quarkus-github-bot.yml
+++ b/.github/quarkus-github-bot.yml
@@ -10,9 +10,6 @@ workflows:
         files:
           - "**/*.md"
           - "**/*.adoc"
-      unless:
-        files:
-          - ".github/**"
 workflowRunAnalysis:
   workflows: ["Quarkus CI"]
 projectsClassic:


### PR DESCRIPTION
The M1 build work is slow because of restrictions on workflow changes. 