### PR TITLE
OIDC: Preserve the refresh token if no new refresh token is returned

### DIFF
--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -1,9 +1,11 @@
 package io.quarkus.it.keycloak;
 
 import java.security.PublicKey;
+import java.time.Duration;
 import java.util.Base64;
 
 import javax.annotation.PostConstruct;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -39,6 +41,7 @@ public class OidcResource {
     private volatile int revokeEndpointCallCount;
     private volatile int userInfoEndpointCallCount;
     private volatile boolean enableDiscovery = true;
+    private volatile int refreshEndpointCallCount;
 
     @PostConstruct
     public void init() throws Exception {
@@ -193,7 +196,38 @@ public class OidcResource {
     @POST
     @Path("token")
     @Produces("application/json")
-    public String token(@QueryParam("kid") String kid) {
+    public String token(@FormParam("grant_type") String grantType) {
+        if ("authorization_code".equals(grantType)) {
+            return "{\"id_token\": \"" + jwt("1") + "\"," +
+                    "\"access_token\": \"" + jwt("1") + "\"," +
+                    "   \"token_type\": \"Bearer\"," +
+                    "   \"refresh_token\": \"123456789\"," +
+                    "   \"expires_in\": 300 }";
+        } else if ("refresh_token".equals(grantType)) {
+            // Emulate the case where the provider returns the refresh token only once
+            // and does not recycle refresh tokens during  the refresh token grant request.
+
+            if (refreshEndpointCallCount++ == 0) {
+                // first refresh token request
+                return "{\"id_token\": \"" + jwt("1") + "\"," +
+                        "\"access_token\": \"" + jwt("1") + "\"," +
+                        "   \"token_type\": \"Bearer\"," +
+                        "   \"expires_in\": 300 }";
+            } else {
+                // force an error to test the case where the refresh token eventually becomes invalid
+                // quarkus-oidc should redirect the user to authenticate again if refreshing the token fails
+                throw new BadRequestException();
+            }
+        } else {
+            // unexpected grant request
+            throw new BadRequestException();
+        }
+    }
+
+    @POST
+    @Path("accesstoken")
+    @Produces("application/json")
+    public String testAccessToken(@QueryParam("kid") String kid) {
         return "{\"access_token\": \"" + jwt(kid) + "\"," +
                 "   \"token_type\": \"Bearer\"," +
                 "   \"refresh_token\": \"123456789\"," +
@@ -203,7 +237,7 @@ public class OidcResource {
     @POST
     @Path("opaque-token")
     @Produces("application/json")
-    public String opaqueToken(@QueryParam("kid") String kid) {
+    public String testOpaqueToken(@QueryParam("kid") String kid) {
         return "{\"access_token\": \"987654321\"," +
                 "   \"token_type\": \"Bearer\"," +
                 "   \"refresh_token\": \"123456789\"," +
@@ -258,6 +292,7 @@ public class OidcResource {
                 .upn("alice")
                 .preferredUserName("alice")
                 .groups("user")
+                .expiresIn(Duration.ofSeconds(4))
                 .jws().keyId(kid)
                 .sign(key.getPrivateKey());
     }

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/TenantRefreshTokenResource.java
@@ -1,0 +1,36 @@
+package io.quarkus.it.keycloak;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+import io.quarkus.oidc.IdToken;
+import io.quarkus.oidc.RefreshToken;
+
+@Path("/tenant-refresh")
+public class TenantRefreshTokenResource {
+
+    @Inject
+    @IdToken
+    JsonWebToken idToken;
+
+    @Inject
+    JsonWebToken accessToken;
+
+    @Inject
+    RefreshToken refreshToken;
+
+    @GET
+    @Path("/tenant-web-app-refresh/api/user")
+    @RolesAllowed("user")
+    public String checkTokens() {
+        return "userName: " + idToken.getName()
+                + ", idToken: " + (idToken.getRawToken() != null)
+                + ", accessToken: " + (accessToken.getRawToken() != null)
+                + ", refreshToken: " + (refreshToken.getToken() != null);
+    }
+
+}

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -113,3 +113,6 @@ quarkus.http.auth.proactive=false
 
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.pem
 
+
+quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE

--- a/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
+++ b/integration-tests/oidc-tenancy/src/test/java/io/quarkus/it/keycloak/BearerTokenAuthorizationTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.it.keycloak;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -8,6 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessTokenResponse;
@@ -95,6 +99,67 @@ public class BearerTokenAuthorizationTest {
             loginForm.getInputByName("password").setValueAttribute("alice");
             page = loginForm.getInputByName("login").click();
             assertEquals("tenant-web-app2:alice", page.getBody().asText());
+            webClient.getCookieManager().clearCookies();
+        }
+    }
+
+    @Test
+    public void testCodeFlowRefreshTokens() throws IOException, InterruptedException {
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8081/tenant-refresh/tenant-web-app-refresh/api/user");
+            assertEquals("Sign in to quarkus-webapp", page.getTitleText());
+            HtmlForm loginForm = page.getForms().get(0);
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+            page = loginForm.getInputByName("login").click();
+
+            assertEquals("userName: alice, idToken: true, accessToken: true, refreshToken: true",
+                    page.getBody().asText());
+
+            assertNotNull(getSessionCookie(page.getWebClient(), "tenant-web-app-refresh"));
+            assertNotNull(getSessionAtCookie(page.getWebClient(), "tenant-web-app-refresh"));
+            Cookie rtCookie = getSessionRtCookie(page.getWebClient(), "tenant-web-app-refresh");
+            assertNotNull(rtCookie);
+
+            // Wait till the session expires - which should cause the first and also last token refresh request,
+            // id and access tokens should have new values, refresh token value should remain the same.
+            // No new sign-in process is required.
+            await().atLeast(6, TimeUnit.SECONDS);
+
+            page = webClient.getPage("http://localhost:8081/tenant-refresh/tenant-web-app-refresh/api/user");
+            assertEquals("userName: alice, idToken: true, accessToken: true, refreshToken: true",
+                    page.getBody().asText());
+
+            assertNotNull(getSessionCookie(page.getWebClient(), "tenant-web-app-refresh"));
+            assertNotNull(getSessionAtCookie(page.getWebClient(), "tenant-web-app-refresh"));
+            Cookie rtCookie2 = getSessionRtCookie(page.getWebClient(), "tenant-web-app-refresh");
+            assertNotNull(rtCookie2);
+            assertEquals(rtCookie2.getValue(), rtCookie.getValue());
+
+            //Verify all the cookies are cleared after the session timeout
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.getCache().clear();
+
+            await().atMost(10, TimeUnit.SECONDS)
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(new Callable<Boolean>() {
+                        @Override
+                        public Boolean call() throws Exception {
+                            webClient.getOptions().setRedirectEnabled(false);
+                            WebResponse webResponse = webClient
+                                    .loadWebResponse(new WebRequest(
+                                            URI.create("http://localhost:8081/tenant-refresh/tenant-web-app-refresh/api/user")
+                                                    .toURL()));
+                            // Should redirect to login page given that session is now expired and
+                            // the 2nd refresh token is expected to fail in the test OidcResource
+                            return 302 == webResponse.getStatusCode();
+                        }
+                    });
+
+            assertNull(getSessionCookie(webClient, "tenant-web-app-refresh"));
+            assertNull(getSessionAtCookie(webClient, "tenant-web-app-refresh"));
+            assertNull(getSessionRtCookie(webClient, "tenant-web-app-refresh"));
+
             webClient.getCookieManager().clearCookies();
         }
     }
@@ -540,8 +605,9 @@ public class BearerTokenAuthorizationTest {
         String json = RestAssured
                 .given()
                 .queryParam("kid", kid)
+                .formParam("grant_type", "authorization_code")
                 .when()
-                .post("/oidc/token")
+                .post("/oidc/accesstoken")
                 .body().asString();
         JsonObject object = new JsonObject(json);
         return object.getString("access_token");
@@ -573,5 +639,13 @@ public class BearerTokenAuthorizationTest {
     private String getStateCookieSavedPath(WebClient webClient, String tenantId) {
         String[] parts = getStateCookie(webClient, tenantId).getValue().split("\\|");
         return parts.length == 2 ? parts[1] : null;
+    }
+
+    private Cookie getSessionAtCookie(WebClient webClient, String tenantId) {
+        return webClient.getCookieManager().getCookie("q_session_at" + (tenantId == null ? "_Default_test" : "_" + tenantId));
+    }
+
+    private Cookie getSessionRtCookie(WebClient webClient, String tenantId) {
+        return webClient.getCookieManager().getCookie("q_session_rt" + (tenantId == null ? "_Default_test" : "_" + tenantId));
     }
 }

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -119,6 +119,10 @@ quarkus.oidc.bearer-wrong-role-path.roles.role-claim-path=path
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".min-level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProvider".level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".min-level=TRACE
+quarkus.log.category."io.quarkus.oidc.runtime.OidcProviderClient".level=TRACE
 
 quarkus.http.auth.permission.logout.paths=/code-flow/logout
 quarkus.http.auth.permission.logout.policy=authenticated


### PR DESCRIPTION
Fixes #27753.

As described in #27753, some providers do not recycle the tokens after the refresh grant completes, and in such cases, refreshing the sessions is not no longer possible because `quarkus-oidc` does not keep the original refresh token which was used to complete the first (and currently last in such cases) refresh grant request.
The right approach is to keep the original refresh token if no new refresh token has been returned in the refresh grant response. If this RT becomes expired then the provider will reject it anyway - but in this case the refresh token is cleared.

The actual fix is straightforward - just keep the current RT if the successful RT grant response has no new RT.

But I've spent nearly 2 days on creating a test - first in `integration-tests/oidc-wiremock` where it worked but not always due to some wiremock state issues and eventually I did it in  `integration-tests/oidc-tenancy` where we have a test `OidcResource` provider endpoint.
The test emulates this flow as precisely as possible: 1) tokens are obtained using the code flow first, then, 2) after an id token expiration, the first refresh grant request is performed but it returns no new RT so the original one is kept, and finally, 3) when a new id token also expires, another RT grant it performed with OIDC server failing it and it causes a redirect for the user to reauthenticate