### PR TITLE
Fix Smallrye OpenApi CORS when http path is not attached to main router

### DIFF
--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiDefaultPathTestCase.java
@@ -34,4 +34,20 @@ public class OpenApiDefaultPathTestCase {
                 .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/resource"));
     }
+
+    @Test
+    public void testDefaultOpenApiCorsProperties() {
+        // make sure default CORS properties are present
+        RestAssured
+                .given()
+                .header("Origin", "https://quarkus.io")
+                .get(OPEN_API_PATH)
+                .then()
+                .statusCode(200)
+                .header("access-control-allow-methods", "GET, HEAD, OPTIONS")
+                .header("access-control-allow-headers", "Content-Type, Authorization")
+                .header("access-control-max-age", "86400")
+                .header("access-control-allow-origin", "*")
+                .header("access-control-allow-credentials", "true");
+    }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootDefaultPathTestCase.java
@@ -15,7 +15,8 @@ public class OpenApiHttpRootDefaultPathTestCase {
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(OpenApiRoute.class)
-                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo"), "application.properties"));
+                    .addAsResource(new StringAsset("quarkus.http.root-path=/foo\n" +
+                            "quarkus.http.cors=true"), "application.properties"));
 
     @Test
     public void testOpenApiPathAccessResource() {
@@ -35,5 +36,18 @@ public class OpenApiHttpRootDefaultPathTestCase {
                 .body("openapi", Matchers.startsWith("3.0"))
                 .body("info.title", Matchers.equalTo("quarkus-smallrye-openapi-deployment API"))
                 .body("paths", Matchers.hasKey("/foo/resource"));
+    }
+
+    @Test
+    public void testCorsFilterProperties() {
+        // make sure CORS are present when path is not attached to main router and CORS are enabled
+        RestAssured
+                .given()
+                .header("Origin", "https://quarkus.io")
+                .get(OPEN_API_PATH)
+                .then()
+                .statusCode(200)
+                .header("access-control-allow-origin", "https://quarkus.io")
+                .header("access-control-allow-credentials", "false");
     }
 }

--- a/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootPathCorsTestCase.java
+++ b/extensions/smallrye-openapi/deployment/src/test/java/io/quarkus/smallrye/openapi/test/vertx/OpenApiHttpRootPathCorsTestCase.java
@@ -1,0 +1,34 @@
+package io.quarkus.smallrye.openapi.test.vertx;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.log.ResponseLoggingFilter;
+
+public class OpenApiHttpRootPathCorsTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(OpenApiRoute.class)
+                    .addAsResource(new StringAsset("quarkus.http.cors=true\n" +
+                            "quarkus.http.non-application-root-path=/api/q\n" +
+                            "quarkus.http.root-path=/api"), "application.properties"));
+
+    @Test
+    public void testCorsFilterProperties() {
+        // make sure CORS are present when path is attached to main router and CORS are enabled
+        RestAssured
+                .given()
+                .header("Origin", "https://quarkus.io")
+                .log().all().filter(new ResponseLoggingFilter())
+                .get("/q/openapi")
+                .then()
+                .statusCode(200)
+                .header("access-control-allow-origin", "https://quarkus.io")
+                .header("access-control-allow-credentials", "false");
+    }
+}

--- a/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
+++ b/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiRecorder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -15,7 +16,9 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
+import io.quarkus.vertx.http.runtime.filters.Filter;
 import io.vertx.core.Handler;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
 @Recorder
@@ -25,6 +28,18 @@ public class OpenApiRecorder {
 
     public OpenApiRecorder(RuntimeValue<HttpConfiguration> configuration) {
         this.configuration = configuration;
+    }
+
+    public Consumer<Route> corsFilter(Filter filter) {
+        if (configuration.getValue().corsEnabled && filter.getHandler() != null) {
+            return new Consumer<Route>() {
+                @Override
+                public void accept(Route route) {
+                    route.order(-1 * filter.getPriority()).handler(filter.getHandler());
+                }
+            };
+        }
+        return null;
     }
 
     public Handler<RoutingContext> handler(OpenApiRuntimeConfig runtimeConfig) {


### PR DESCRIPTION
fixes: #26296

When non-application root path is not underneath the HTTP root path, filters (such as authorization, authentication, cors) are not applied. That lead to situation when user had to expose his OpenApi endpoints on application root in order to have (non-default) CORS headers. However current implementation expected CORS filter to be applied when CORS are enabled (please see comment https://github.com/quarkusio/quarkus/blob/main/extensions/smallrye-openapi/runtime/src/main/java/io/quarkus/smallrye/openapi/runtime/OpenApiHandler.java#L78). I don't want to attach SmallRye OpenApi routes to http route router by default is that would defy documented behavior https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus.http.non-application-root-path.

This PR adds CORS filter to (and only to) SmallRye OpenApi routes when CORS are enabled and path is not attached to main router. `autoSecurityFilter` is registered as bean in a separate build step in order to avoid cycle.