### PR TITLE
Add a specific codec for byte arrays

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/codecs/Codecs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/codecs/Codecs.java
@@ -22,6 +22,9 @@ public class Codecs {
         if (clazz.equals(String.class)) {
             return (Codec<T>) StringCodec.INSTANCE;
         }
+        if (clazz.equals(byte[].class)) {
+            return (Codec<T>) ByteArrayCodec.INSTANCE;
+        }
         // JSON by default
         return new JsonCodec<>(clazz);
     }
@@ -111,6 +114,25 @@ public class Codecs {
                 return 0;
             }
             return Integer.parseInt(new String(item, StandardCharsets.UTF_8));
+        }
+    }
+
+    public static class ByteArrayCodec implements Codec<byte[]> {
+
+        public static ByteArrayCodec INSTANCE = new ByteArrayCodec();
+
+        private ByteArrayCodec() {
+            // Avoid direct instantiation;
+        }
+
+        @Override
+        public byte[] encode(byte[] item) {
+            return item;
+        }
+
+        @Override
+        public byte[] decode(byte[] item) {
+            return item;
         }
     }
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
@@ -20,6 +20,8 @@ import io.quarkus.redis.datasource.value.GetExArgs;
 import io.quarkus.redis.datasource.value.SetArgs;
 import io.quarkus.redis.datasource.value.ValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
 
 public class ValueCommandsTest extends DatasourceTestBase {
 
@@ -274,5 +276,10 @@ public class ValueCommandsTest extends DatasourceTestBase {
         commands.set(key, content);
         byte[] bytes = commands.get(key);
         assertThat(bytes).isEqualTo(content);
+
+        // Verify that we do not get through the JSON codec (which would base64 encode the byte[])
+        ValueCommands<String, String> cmd = ds.value(String.class);
+        String str = cmd.get(key);
+        assertThatThrownBy(() -> Json.decodeValue(str, byte[].class)).isInstanceOf(DecodeException.class);
     }
 }


### PR DESCRIPTION
Initially, it relied on the JSON codec (encoding the byte arrays using base 64). This was breaking the compatibility with other libraries.

Fix https://github.com/quarkusio/quarkus/issues/28029.
