### PR TITLE
RESTEasy Reactive - Prefer application-supplied provider over a pre-packaged one

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -707,7 +707,7 @@ public class ResteasyReactiveProcessor {
                             continue;
                         }
                         MessageBodyReaderBuildItem.Builder builder = new MessageBodyReaderBuildItem.Builder(
-                                providerClassName, handledClassName);
+                                providerClassName, handledClassName).setBuiltin(true);
                         Consumes consumes = providerClass.getAnnotation(Consumes.class);
                         if (consumes != null) {
                             builder.setMediaTypeStrings(Arrays.asList(consumes.value()));
@@ -725,7 +725,7 @@ public class ResteasyReactiveProcessor {
                             continue;
                         }
                         MessageBodyWriterBuildItem.Builder builder = new MessageBodyWriterBuildItem.Builder(
-                                providerClassName, handledClassName);
+                                providerClassName, handledClassName).setBuiltin(true);
                         Produces produces = providerClass.getAnnotation(Produces.class);
                         if (produces != null) {
                             builder.setMediaTypeStrings(Arrays.asList(produces.value()));

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/AppSuppliedProvider.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/AppSuppliedProvider.kt
@@ -1,0 +1,53 @@
+package io.quarkus.it.resteasy.reactive.kotlin
+
+import io.quarkus.it.shared.Shared
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.Type
+import java.nio.charset.StandardCharsets
+import javax.ws.rs.Consumes
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.MultivaluedMap
+import javax.ws.rs.ext.MessageBodyReader
+import javax.ws.rs.ext.MessageBodyWriter
+import javax.ws.rs.ext.Provider
+
+@Provider
+@Produces("text/plain")
+@Consumes("text/plain")
+class AppSuppliedProvider : MessageBodyReader<Shared>, MessageBodyWriter<Shared> {
+
+    override fun isReadable(p0: Class<*>?, type: Type?, p2: Array<out Annotation>?, p3: MediaType?): Boolean {
+        return Shared::class.java == type
+    }
+
+    override fun readFrom(
+        p0: Class<Shared>?,
+        p1: Type?,
+        p2: Array<out Annotation>?,
+        p3: MediaType?,
+        p4: MultivaluedMap<String, String>?,
+        p5: InputStream?
+    ): Shared {
+        return Shared("app")
+    }
+
+    override fun isWriteable(p0: Class<*>?, type: Type?, p2: Array<out Annotation>?, p3: MediaType?): Boolean {
+        return Shared::class.java == type
+    }
+
+    override fun writeTo(
+        shared: Shared?,
+        p1: Class<*>?,
+        p2: Type?,
+        p3: Array<out Annotation>?,
+        p4: MediaType?,
+        p5: MultivaluedMap<String, Any>?,
+        entityStream: OutputStream?
+    ) {
+        entityStream?.write(
+            String.format("{\"message\": \"app+%s\"}", shared!!.message).toByteArray(StandardCharsets.UTF_8)
+        )
+    }
+}

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SharedResource.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SharedResource.kt
@@ -9,8 +9,8 @@ import javax.ws.rs.Produces
 @Path("/shared")
 class SharedResource {
 
-    @Consumes("application/json")
-    @Produces("application/json")
+    @Consumes(value = ["application/json", "text/plain"])
+    @Produces(value = ["application/json", "text/plain"])
     @POST
     fun returnAsIs(shared: Shared) = shared
 }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SharedResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/SharedResourceTest.kt
@@ -23,4 +23,18 @@ class SharedResourceTest {
             body(CoreMatchers.`is`("""{"message": "canned+canned"}"""))
         }
     }
+
+    @Test
+    fun testApplicationSuppliedProviderIsPreferred() {
+        Given {
+            body("""{ "message": "will not be used" }""")
+            contentType(ContentType.TEXT)
+            accept(ContentType.TEXT)
+        } When {
+            post("/shared")
+        } Then {
+            statusCode(200)
+            body(CoreMatchers.`is`("""{"message": "app+app"}"""))
+        }
+    }
 }

--- a/integration-tests/shared-library/src/main/java/io/quarkus/it/shared/SharedProvider.java
+++ b/integration-tests/shared-library/src/main/java/io/quarkus/it/shared/SharedProvider.java
@@ -15,8 +15,8 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 
-@Produces("application/json")
-@Consumes("application/json")
+@Produces({ "application/json", "text/plain" })
+@Consumes({ "application/json", "text/plain" })
 public class SharedProvider implements MessageBodyReader<Shared>, MessageBodyWriter<Shared> {
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {


### PR DESCRIPTION
fixes: #28040

Message body readers/writers defined with `@Provider` are preferred over providers from class path (`META-INF/services/`).