### PR TITLE
ArC - fix behavior of List injection with io.quarkus.arc.All qualifier

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInjectionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/lookup/ListInjectionTest.java
@@ -143,6 +143,7 @@ public class ListInjectionTest {
 
     }
 
+    @MyQualifier
     @Singleton
     static class ServiceAlpha implements Service {
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Instances.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 public final class Instances {
@@ -46,11 +47,19 @@ public final class Instances {
         return List.copyOf(nonSuppressed);
     }
 
+    private static List<InjectableBean<?>> resolveAllBeans(Type requiredType, Set<Annotation> requiredQualifiers) {
+        if (requiredQualifiers == null || requiredQualifiers.isEmpty()) {
+            // If no qualifier is specified then @Any is used
+            return resolveBeans(requiredType, new Annotation[] { Any.Literal.INSTANCE });
+        }
+        return resolveBeans(requiredType, requiredQualifiers.toArray(EMPTY_ANNOTATION_ARRAY));
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> List<T> listOf(InjectableBean<?> targetBean, Type injectionPointType, Type requiredType,
             Set<Annotation> requiredQualifiers,
             CreationalContextImpl<?> creationalContext, Set<Annotation> annotations, Member javaMember, int position) {
-        List<InjectableBean<?>> beans = resolveBeans(requiredType, requiredQualifiers);
+        List<InjectableBean<?>> beans = resolveAllBeans(requiredType, requiredQualifiers);
         if (beans.isEmpty()) {
             return Collections.emptyList();
         }
@@ -87,7 +96,7 @@ public final class Instances {
     public static <T> List<InstanceHandle<T>> listOfHandles(Supplier<InjectionPoint> injectionPoint, Type requiredType,
             Set<Annotation> requiredQualifiers,
             CreationalContextImpl<?> creationalContext) {
-        List<InjectableBean<?>> beans = resolveBeans(requiredType, requiredQualifiers);
+        List<InjectableBean<?>> beans = resolveAllBeans(requiredType, requiredQualifiers);
         if (beans.isEmpty()) {
             return Collections.emptyList();
         }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.test.ArcTestContainer;
+import io.quarkus.arc.test.MyQualifier;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,6 +27,7 @@ public class ListAllTest {
 
     @Test
     public void testSelectAll() {
+        // the behavior should be equivalent to @Inject @Any Instance<Service>
         List<InstanceHandle<Service>> services = Arc.container().listAll(Service.class);
         assertEquals(2, services.size());
         assertThatExceptionOfType(UnsupportedOperationException.class)
@@ -63,6 +65,7 @@ public class ListAllTest {
         }
     }
 
+    @MyQualifier
     @Priority(5) // this impl should go first
     @Dependent
     static class ServiceBravo implements Service {


### PR DESCRIPTION
- if no other qualifier is declared then @Any is used, i.e. the behavior should be equivalent to `@Inject @Any Instance<>`