### PR TITLE
Include `null` value in the mget and hmget command responses

### DIFF
--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/HashCommands.java
@@ -125,6 +125,7 @@ public interface HashCommands<K, F, V> extends RedisCommands {
      * @param key the key
      * @param fields the fields
      * @return list of values associated with the given fields, in the same order as they are requested.
+     *         If a requested field does not exist, the returned map contains a {@code null} value for that field.
      **/
     Map<F, V> hmget(K key, F... fields);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hash/ReactiveHashCommands.java
@@ -126,6 +126,7 @@ public interface ReactiveHashCommands<K, F, V> extends ReactiveRedisCommands {
      * @param key the key
      * @param fields the fields
      * @return list of values associated with the given fields, in the same order as they are requested.
+     *         If a requested field does not exist, the returned map contains a {@code null} value for that field.
      **/
     Uni<Map<F, V>> hmget(K key, F... fields);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/ReactiveStringCommands.java
@@ -183,7 +183,8 @@ public interface ReactiveStringCommands<K, V> extends ReactiveRedisCommands {
      * Requires Redis 1.0.0
      *
      * @param keys the keys
-     * @return list of values at the specified keys.
+     * @return the value of key, or {@code null} when key does not exist. If one of the passed key does not exist, the
+     *         returned map contains a {@code null} value associated with the missing key.
      **/
     Uni<Map<K, V>> mget(K... keys);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/string/StringCommands.java
@@ -182,7 +182,8 @@ public interface StringCommands<K, V> extends RedisCommands {
      * Requires Redis 1.0.0
      *
      * @param keys the keys
-     * @return list of values at the specified keys.
+     * @return list of values at the specified keys. If one of the passed key does not exist, the returned map contains
+     *         a {@code null} value associated with the missing key.
      **/
     Map<K, V> mget(K... keys);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ReactiveValueCommands.java
@@ -63,7 +63,8 @@ public interface ReactiveValueCommands<K, V> extends ReactiveRedisCommands {
      * Requires Redis 1.0.0
      *
      * @param key the key
-     * @return the value of key, or {@code null} when key does not exist.
+     * @return the value of key, or {@code null} when key does not exist. If one of the passed key does not exist, the
+     *         returned map contains a {@code null} value associated with the missing key.
      **/
     Uni<V> get(K key);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/value/ValueCommands.java
@@ -183,7 +183,8 @@ public interface ValueCommands<K, V> extends RedisCommands {
      * Requires Redis 1.0.0
      *
      * @param keys the keys
-     * @return list of values at the specified keys.
+     * @return list of values at the specified keys. If one of the passed key does not exist, the returned map contains
+     *         a {@code null} value associated with the missing key.
      **/
     Map<K, V> mget(K... keys);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
@@ -149,9 +149,7 @@ public class Marshaller {
         Map<F, V> map = new LinkedHashMap<>();
         for (F field : fields) {
             Response v = iterator.next();
-            if (v != null) { // Skip null entries
-                map.put(field, decode(typeOfValue, v));
-            }
+            map.put(field, decode(typeOfValue, v));
         }
         return map;
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
@@ -142,12 +142,12 @@ public class HashCommandsTest extends DatasourceTestBase {
     void hmget() {
         populateForHmget();
         Map<String, Person> values = hash.hmget(key, "one", "missing", "two");
-        assertThat(values).hasSize(2);
-        assertThat(values).containsExactly(entry("one", Person.person1), entry("two", Person.person2));
+        assertThat(values).hasSize(3);
+        assertThat(values).containsExactly(entry("one", Person.person1), entry("missing", null), entry("two", Person.person2));
     }
 
     private void populateForHmget() {
-        assertThat(hash.hmget(key, "one", "two").values()).isEmpty();
+        assertThat(hash.hmget(key, "one", "two")).allSatisfy((s, p) -> assertThat(p).isNull());
         hash.hset(key, "one", Person.person1);
         hash.hset(key, "two", Person.person2);
     }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
@@ -99,15 +99,24 @@ public class StringCommandsTest extends DatasourceTestBase {
 
     @Test
     void mget() {
-        assertThat(strings.mget(key)).isEmpty();
+        assertThat(strings.mget(key)).containsExactly(entry(key, null));
         strings.set("one", "1");
         strings.set("two", "2");
         assertThat(strings.mget("one", "two")).containsExactly(entry("one", "1"), entry("two", "2"));
     }
 
     @Test
+    void mgetWithMissingKey() {
+        assertThat(strings.mget(key)).containsExactly(entry(key, null));
+        strings.set("one", "1");
+        strings.set("two", "2");
+        assertThat(strings.mget("one", "missing", "two")).containsExactly(entry("one", "1"),
+                entry("missing", null), entry("two", "2"));
+    }
+
+    @Test
     void mset() {
-        assertThat(strings.mget("one", "two")).isEmpty();
+        assertThat(strings.mget(key)).containsExactly(entry(key, null));
         Map<String, String> map = new LinkedHashMap<>();
         map.put("one", "1");
         map.put("two", "2");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
@@ -99,15 +99,24 @@ public class ValueCommandsTest extends DatasourceTestBase {
 
     @Test
     void mget() {
-        assertThat(values.mget(key)).isEmpty();
+        assertThat(values.mget(key)).containsExactly(entry(key, null));
         values.set("one", "1");
         values.set("two", "2");
         assertThat(values.mget("one", "two")).containsExactly(entry("one", "1"), entry("two", "2"));
     }
 
     @Test
+    void mgetWithMissingKey() {
+        assertThat(values.mget(key)).containsExactly(entry(key, null));
+        values.set("one", "1");
+        values.set("two", "2");
+        assertThat(values.mget("one", "missing", "two")).containsExactly(entry("one", "1"),
+                entry("missing", null), entry("two", "2"));
+    }
+
+    @Test
     void mset() {
-        assertThat(values.mget("one", "two")).isEmpty();
+        assertThat(values.mget("one", "two")).containsExactly(entry("one", null), entry("two", null));
         Map<String, String> map = new LinkedHashMap<>();
         map.put("one", "1");
         map.put("two", "2");


### PR DESCRIPTION
Do not filter out missing keys from the `mget` and `hmget` commands to be closer to the Redis semantic.

Fix https://github.com/quarkusio/quarkus/issues/28049.
