### PR TITLE
With disabled proactive sec., only create sec. identity when required

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledProactiveSecIdentityProviderTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/DisabledProactiveSecIdentityProviderTest.java
@@ -1,0 +1,116 @@
+package io.quarkus.vertx.http.security;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class DisabledProactiveSecIdentityProviderTest {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.proactive=false\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=admin\n" +
+            "quarkus.http.auth.permission.roles1.paths=/admin\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(PathHandler.class, FailingAuthenticationMechanism.class, BasicIdentityProvider.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @Test
+    public void testAuthenticationIsAttempted() {
+        // path requires authentication
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .get("/admin")
+                .then()
+                .assertThat()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testAuthenticationIsNotAttempted() {
+        // path does not require authentication
+        RestAssured
+                .given()
+                .auth().preemptive().basic("admin", "admin")
+                .redirects().follow(false)
+                .when()
+                .get("/anonymous")
+                .then()
+                .assertThat()
+                .statusCode(200);
+    }
+
+    @ApplicationScoped
+    public static class FailingAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                final RoutingContext context, final IdentityProviderManager identityProviderManager) {
+            throw new AuthenticationFailedException();
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(final RoutingContext context) {
+            return Uni.createFrom().nullItem();
+        }
+
+        @Override
+        public Uni<Boolean> sendChallenge(final RoutingContext context) {
+            return Uni.createFrom().item(false);
+        }
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -107,8 +107,8 @@ public class HttpSecurityRecorder {
                     }
                 });
 
-                Uni<SecurityIdentity> potentialUser = authenticator.attemptAuthentication(event).memoize().indefinitely();
                 if (proactiveAuthentication) {
+                    Uni<SecurityIdentity> potentialUser = authenticator.attemptAuthentication(event).memoize().indefinitely();
                     potentialUser
                             .subscribe().withSubscriber(new UniSubscriber<SecurityIdentity>() {
                                 @Override
@@ -166,7 +166,13 @@ public class HttpSecurityRecorder {
                             });
                 } else {
 
-                    Uni<SecurityIdentity> lazyUser = potentialUser
+                    Uni<SecurityIdentity> lazyUser = Uni
+                            .createFrom()
+                            .nullItem()
+                            // Only attempt to authenticate if required
+                            .flatMap(n -> authenticator.attemptAuthentication(event))
+                            .memoize()
+                            .indefinitely()
                             .flatMap(new Function<SecurityIdentity, Uni<? extends SecurityIdentity>>() {
                                 @Override
                                 public Uni<? extends SecurityIdentity> apply(SecurityIdentity securityIdentity) {


### PR DESCRIPTION
fixes: #27316

When proactive security is disabled (`quarkus.http.auth.proactive=false`), security identity is only created (or more specifically, `io.quarkus.vertx.http.runtime.security.HttpAuthenticator#attemptAuthentication` is only called) when required. This behavior is expected by user (see linked issue) and was described here https://github.com/quarkusio/quarkus/issues/27316#issuecomment-1250861996 by @sberyozkin.

Added test `io.quarkus.vertx.http.security.DisabledProactiveSecIdentityProviderTest#testAuthenticationIsNotAttempted` would fail prior to this PR (tested).