### PR TITLE
Ignore RESTEasy Classic providers found on classpath

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -691,10 +691,15 @@ public class ResteasyReactiveProcessor {
     public void providersFromClasspath(BuildProducer<MessageBodyReaderBuildItem> messageBodyReaderProducer,
             BuildProducer<MessageBodyWriterBuildItem> messageBodyWriterProducer) {
         String fileName = "META-INF/services/" + Providers.class.getName();
+        // we never want to include the Classic RESTEasy providers - these can end up on the classpath by using the Keycloak client for example
+        Predicate<String> ignoredProviders = s -> s.startsWith("org.jboss.resteasy.plugins.providers");
         try {
             Set<String> detectedProviders = new HashSet<>(ServiceUtil.classNamesNamedIn(getClass().getClassLoader(),
                     fileName));
             for (String providerClassName : detectedProviders) {
+                if (ignoredProviders.test(providerClassName)) {
+                    continue;
+                }
                 try {
                     Class<?> providerClass = Class.forName(providerClassName, false,
                             Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
These can end up on the classpath by using the Keycloak client for example and can mess up the handling of request (for example for multipart)

Follows up on: https://github.com/quarkusio/quarkus/pull/27981