### PR TITLE
ArC - verify _registered_ qualifiers

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanDeployment.java
@@ -149,7 +149,7 @@ public class BeanDeployment {
                         nonbindingMembers = Collections.emptySet();
                     }
                     qualifierNonbindingMembers.put(dotName, nonbindingMembers);
-                    this.qualifiers.put(dotName, classInfo);
+                    qualifiers.put(dotName, classInfo);
                 }
             }
         }
@@ -558,7 +558,7 @@ public class BeanDeployment {
     }
 
     boolean isInheritedQualifier(DotName name) {
-        return (getQualifier(name).classAnnotation(DotNames.INHERITED) != null);
+        return (getQualifier(name).declaredAnnotation(DotNames.INHERITED) != null);
     }
 
     /**
@@ -682,7 +682,7 @@ public class BeanDeployment {
     private Map<DotName, ClassInfo> findContainerAnnotations(Map<DotName, ClassInfo> annotations, IndexView index) {
         Map<DotName, ClassInfo> containerAnnotations = new HashMap<>();
         for (ClassInfo annotation : annotations.values()) {
-            AnnotationInstance repeatableMetaAnnotation = annotation.classAnnotation(DotNames.REPEATABLE);
+            AnnotationInstance repeatableMetaAnnotation = annotation.declaredAnnotation(DotNames.REPEATABLE);
             if (repeatableMetaAnnotation != null) {
                 DotName containerAnnotationName = repeatableMetaAnnotation.value().asClass().name();
                 ClassInfo containerClass = getClassByName(index, containerAnnotationName);
@@ -799,7 +799,7 @@ public class BeanDeployment {
                 }
                 boolean isAdditionalStereotype = additionalStereotypes.contains(stereotypeName);
                 final ScopeInfo scope = getValidScope(scopes, stereotypeClass);
-                boolean isInherited = stereotypeClass.classAnnotation(DotNames.INHERITED) != null;
+                boolean isInherited = stereotypeClass.declaredAnnotation(DotNames.INHERITED) != null;
                 stereotypes.put(stereotypeName, new StereotypeInfo(scope, bindings, isAlternative, alternativePriority,
                         isNamed, isAdditionalStereotype, stereotypeClass, isInherited, parentStereotypes));
             }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/ComponentsProviderGenerator.java
@@ -129,6 +129,13 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
                     classOutput);
         }
 
+        // All qualifiers
+        ResultHandle qualifiers = getComponents.newInstance(MethodDescriptor.ofConstructor(HashSet.class));
+        for (ClassInfo qualifier : beanDeployment.getQualifiers()) {
+            getComponents.invokeInterfaceMethod(MethodDescriptors.SET_ADD, qualifiers,
+                    getComponents.load(qualifier.name().toString()));
+        }
+
         // Qualifier non-binding members
         ResultHandle qualifiersNonbindingMembers = getComponents.newInstance(MethodDescriptor.ofConstructor(HashMap.class));
         for (Entry<DotName, Set<String>> entry : beanDeployment.getQualifierNonbindingMembers().entrySet()) {
@@ -143,9 +150,9 @@ public class ComponentsProviderGenerator extends AbstractGenerator {
 
         ResultHandle componentsHandle = getComponents.newInstance(
                 MethodDescriptor.ofConstructor(Components.class, Collection.class, Collection.class, Collection.class,
-                        Map.class, Collection.class, Map.class),
+                        Map.class, Collection.class, Map.class, Set.class),
                 beansHandle, observersHandle, contextsHandle, transitiveBindingsHandle, removedBeansHandle,
-                qualifiersNonbindingMembers);
+                qualifiersNonbindingMembers, qualifiers);
         getComponents.returnValue(componentsHandle);
 
         // Finally write the bytecode

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Components.java
@@ -2,7 +2,6 @@ package io.quarkus.arc;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -14,23 +13,19 @@ public final class Components {
     private final Collection<InjectableContext> contexts;
     private final Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings;
     private final Map<String, Set<String>> qualifierNonbindingMembers;
-
-    public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
-            Collection<InjectableContext> contexts,
-            Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings) {
-        this(beans, observers, contexts, transitiveInterceptorBindings, Collections.emptyList(), Collections.emptyMap());
-    }
+    private final Set<String> qualifiers;
 
     public Components(Collection<InjectableBean<?>> beans, Collection<InjectableObserverMethod<?>> observers,
             Collection<InjectableContext> contexts,
             Map<Class<? extends Annotation>, Set<Annotation>> transitiveInterceptorBindings,
-            Collection<RemovedBean> removedBeans, Map<String, Set<String>> qualifierNonbindingMembers) {
+            Collection<RemovedBean> removedBeans, Map<String, Set<String>> qualifierNonbindingMembers, Set<String> qualifiers) {
         this.beans = beans;
         this.observers = observers;
         this.contexts = contexts;
         this.transitiveInterceptorBindings = transitiveInterceptorBindings;
         this.removedBeans = removedBeans;
         this.qualifierNonbindingMembers = qualifierNonbindingMembers;
+        this.qualifiers = qualifiers;
     }
 
     public Collection<InjectableBean<?>> getBeans() {
@@ -53,8 +48,22 @@ public final class Components {
         return removedBeans;
     }
 
+    /**
+     * Values in the map are never null.
+     *
+     * @return a map of fully-qualified class names of all custom qualifiers to the set of non-binding members
+     * @see javax.enterprise.util.Nonbinding
+     */
     public Map<String, Set<String>> getQualifierNonbindingMembers() {
         return qualifierNonbindingMembers;
+    }
+
+    /**
+     *
+     * @return the set of fully-qualified class names of all registered qualifiers
+     */
+    public Set<String> getQualifiers() {
+        return qualifiers;
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanManagerImpl.java
@@ -163,7 +163,7 @@ public class BeanManagerImpl implements BeanManager {
     @Override
     public boolean isQualifier(Class<? extends Annotation> annotationType) {
         return annotationType.isAnnotationPresent(Qualifier.class)
-                || ArcContainerImpl.instance().getCustomQualifiers().contains(annotationType.getName());
+                || ArcContainerImpl.instance().registeredQualifiers.isRegistered(annotationType);
     }
 
     @Override

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
@@ -120,7 +120,7 @@ class EventImpl<T> implements Event<T> {
 
     @Override
     public Event<T> select(Annotation... qualifiers) {
-        Qualifiers.verify(qualifiers, ArcContainerImpl.instance().getCustomQualifiers());
+        ArcContainerImpl.instance().registeredQualifiers.verify(qualifiers);
         Set<Annotation> mergedQualifiers = new HashSet<>(this.qualifiers);
         Collections.addAll(mergedQualifiers, qualifiers);
         return new EventImpl<T>(eventType, mergedQualifiers);
@@ -128,7 +128,7 @@ class EventImpl<T> implements Event<T> {
 
     @Override
     public <U extends T> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
-        Qualifiers.verify(qualifiers, ArcContainerImpl.instance().getCustomQualifiers());
+        ArcContainerImpl.instance().registeredQualifiers.verify(qualifiers);
         Set<Annotation> mergerdQualifiers = new HashSet<>(this.qualifiers);
         Collections.addAll(mergerdQualifiers, qualifiers);
         return new EventImpl<U>(subtype, mergerdQualifiers);
@@ -136,7 +136,7 @@ class EventImpl<T> implements Event<T> {
 
     @Override
     public <U extends T> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
-        Qualifiers.verify(qualifiers, ArcContainerImpl.instance().getCustomQualifiers());
+        ArcContainerImpl.instance().registeredQualifiers.verify(qualifiers);
         if (Types.containsTypeVariable(subtype.getType())) {
             throw new IllegalArgumentException(
                     "Event#select(TypeLiteral, Annotation...) cannot be used with type variable parameter");

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/Qualifiers.java
@@ -14,46 +14,52 @@ import java.util.function.BiFunction;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
 
 public final class Qualifiers {
 
     public static final Set<Annotation> DEFAULT_QUALIFIERS = Set.of(Default.Literal.INSTANCE, Any.Literal.INSTANCE);
 
-    @SuppressWarnings("unused")
     public static final Set<Annotation> IP_DEFAULT_QUALIFIERS = Collections.singleton(Default.Literal.INSTANCE);
 
-    private Qualifiers() {
+    final Set<String> allQualifiers;
+    // custom qualifier -> non-binding members (can be empty but never null)
+    final Map<String, Set<String>> qualifierNonbindingMembers;
+
+    Qualifiers(Set<String> qualifiers, Map<String, Set<String>> qualifierNonbindingMembers) {
+        this.allQualifiers = qualifiers;
+        this.qualifierNonbindingMembers = qualifierNonbindingMembers;
     }
 
-    static void verify(Collection<Annotation> qualifiers, Set<String> customQualifiers) {
+    boolean isRegistered(Class<? extends Annotation> annotationType) {
+        return allQualifiers.contains(annotationType.getName());
+    }
+
+    void verify(Collection<Annotation> qualifiers) {
         if (qualifiers.isEmpty()) {
             return;
         }
-
         if (qualifiers.size() == 1) {
-            verifyQualifier(qualifiers.iterator().next().annotationType(), customQualifiers);
+            verifyQualifier(qualifiers.iterator().next().annotationType());
         } else {
             Map<Class<? extends Annotation>, Integer> timesQualifierWasSeen = new HashMap<>();
             for (Annotation qualifier : qualifiers) {
-                verifyQualifier(qualifier.annotationType(), customQualifiers);
+                verifyQualifier(qualifier.annotationType());
                 timesQualifierWasSeen.compute(qualifier.annotationType(), TimesSeenBiFunction.INSTANCE);
             }
             checkQualifiersForDuplicates(timesQualifierWasSeen);
         }
     }
 
-    static void verify(Annotation[] qualifiers, Set<String> customQualifiers) {
+    void verify(Annotation[] qualifiers) {
         if (qualifiers.length == 0) {
             return;
         }
-
         if (qualifiers.length == 1) {
-            verifyQualifier(qualifiers[0].annotationType(), customQualifiers);
+            verifyQualifier(qualifiers[0].annotationType());
         } else {
             Map<Class<? extends Annotation>, Integer> timesQualifierWasSeen = new HashMap<>();
             for (Annotation qualifier : qualifiers) {
-                verifyQualifier(qualifier.annotationType(), customQualifiers);
+                verifyQualifier(qualifier.annotationType());
                 timesQualifierWasSeen.compute(qualifier.annotationType(), TimesSeenBiFunction.INSTANCE);
             }
             checkQualifiersForDuplicates(timesQualifierWasSeen);
@@ -72,18 +78,16 @@ public final class Qualifiers {
         }
     }
 
-    static boolean hasQualifiers(Set<Annotation> beanQualifiers, Map<String, Set<String>> qualifierNonbindingMembers,
-            Annotation... requiredQualifiers) {
+    boolean hasQualifiers(Set<Annotation> beanQualifiers, Annotation... requiredQualifiers) {
         for (Annotation qualifier : requiredQualifiers) {
-            if (!hasQualifier(beanQualifiers, qualifier, qualifierNonbindingMembers)) {
+            if (!hasQualifier(beanQualifiers, qualifier)) {
                 return false;
             }
         }
         return true;
     }
 
-    static boolean hasQualifier(Iterable<Annotation> qualifiers, Annotation requiredQualifier,
-            Map<String, Set<String>> qualifierNonbindingMembers) {
+    boolean hasQualifier(Iterable<Annotation> qualifiers, Annotation requiredQualifier) {
 
         Class<? extends Annotation> requiredQualifierClass = requiredQualifier.annotationType();
         Method[] members = requiredQualifierClass.getDeclaredMethods();
@@ -123,10 +127,9 @@ public final class Qualifiers {
         return false;
     }
 
-    static boolean isSubset(Set<Annotation> observedQualifiers, Set<Annotation> eventQualifiers,
-            Map<String, Set<String>> qualifierNonbindingMembers) {
+    boolean isSubset(Set<Annotation> observedQualifiers, Set<Annotation> eventQualifiers) {
         for (Annotation required : observedQualifiers) {
-            if (!hasQualifier(eventQualifiers, required, qualifierNonbindingMembers)) {
+            if (!hasQualifier(eventQualifiers, required)) {
                 return false;
             }
         }
@@ -135,9 +138,7 @@ public final class Qualifiers {
 
     private static Object invoke(Method method, Object instance) {
         try {
-            if (!method.isAccessible()) {
-                method.setAccessible(true);
-            }
+            method.setAccessible(true);
             return method.invoke(instance);
         } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(
@@ -145,13 +146,9 @@ public final class Qualifiers {
         }
     }
 
-    private static void verifyQualifier(Class<? extends Annotation> annotationType, Set<String> customQualifiers) {
-        if (customQualifiers.contains(annotationType.getName())) {
-            return;
-        }
-
-        if (!annotationType.isAnnotationPresent(Qualifier.class)) {
-            throw new IllegalArgumentException("Annotation is not a qualifier: " + annotationType);
+    private void verifyQualifier(Class<? extends Annotation> annotationType) {
+        if (!allQualifiers.contains(annotationType.getName())) {
+            throw new IllegalArgumentException("Annotation is not a registered qualifier: " + annotationType);
         }
     }
 

--- a/independent-projects/arc/runtime/src/test/java/io/quarkus/arc/impl/QualifiersTest.java
+++ b/independent-projects/arc/runtime/src/test/java/io/quarkus/arc/impl/QualifiersTest.java
@@ -14,18 +14,19 @@ public class QualifiersTest {
 
     @Test
     public void testIsSubset() {
+        Qualifiers qualifiers = new Qualifiers(Collections.emptySet(), Collections.emptyMap());
         Set<Annotation> observed = Set.of(Initialized.Literal.REQUEST, Any.Literal.INSTANCE);
         Set<Annotation> event = Set.of(Initialized.Literal.APPLICATION, Any.Literal.INSTANCE);
-        assertFalse(Qualifiers.isSubset(observed, event, Collections.emptyMap()));
+        assertFalse(qualifiers.isSubset(observed, event));
 
         observed = Set.of(Initialized.Literal.APPLICATION, Any.Literal.INSTANCE);
-        assertTrue(Qualifiers.isSubset(observed, event, Collections.emptyMap()));
+        assertTrue(qualifiers.isSubset(observed, event));
 
         observed = Set.of(Any.Literal.INSTANCE);
-        assertTrue(Qualifiers.isSubset(observed, event, Collections.emptyMap()));
+        assertTrue(qualifiers.isSubset(observed, event));
 
         observed = Set.of(Initialized.Literal.APPLICATION);
-        assertTrue(Qualifiers.isSubset(observed, event, Collections.emptyMap()));
+        assertTrue(qualifiers.isSubset(observed, event));
     }
 
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/all/ListAllTest.java
@@ -14,6 +14,7 @@ import javax.annotation.PreDestroy;
 import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ public class ListAllTest {
     @RegisterExtension
     public ArcTestContainer container = new ArcTestContainer(Service.class, ServiceAlpha.class, ServiceBravo.class);
 
+    @SuppressWarnings("serial")
     @Test
     public void testSelectAll() {
         List<InstanceHandle<Service>> services = Arc.container().listAll(Service.class);
@@ -43,6 +45,9 @@ public class ListAllTest {
         assertEquals(true, ServiceBravo.DESTROYED.get());
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> bravoHandle.get());
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Arc.container().listAll(Service.class, new AnnotationLiteral<Test>() {
+                }));
     }
 
     interface Service {

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/ArcContainerSelectTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.test.instance;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,6 +20,7 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -46,6 +48,9 @@ public class ArcContainerSelectTest {
         assertTrue(strings.contains("washcloth"));
         assertTrue(Washcloth.INIT.get());
         assertTrue(Washcloth.DESTROYED.get());
+        assertThatThrownBy(() -> Arc.container().select(Alpha.class, new AnnotationLiteral<Test>() {
+        }))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Singleton

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InvalidQualifierInstanceTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/instance/InvalidQualifierInstanceTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.arc.test.instance;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class InvalidQualifierInstanceTest {
+
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(Alpha.class);
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testIllegalArgumentException() {
+        assertThatThrownBy(() -> Arc.container().instance(Alpha.class).get().instance.select(new AnnotationLiteral<Test>() {
+        }))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Singleton
+    static class Alpha {
+
+        @Inject
+        Instance<Object> instance;
+
+    }
+
+}


### PR DESCRIPTION
- Instance.select(), ArcContainer.select() and ArcContainer.listAll() should verify that a qualifier annotation instance is a _registered_ qualifier
- previously, an annotation that was annotated with the `@Qualifier` meta-annotation was considered valid; we need to check that the qualifier was actually indexed, discovered and registered by the container