### PR TITLE
Remove javax generated classes from mapstruct gradle tests

### DIFF
--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/application/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -12,16 +12,10 @@ import org.acme.common.domain.CarDTO;
 @Path("/hello")
 public class HelloResource {
 
-    private final CarMapper carMapper;
-
-    public HelloResource(CarMapper carMapper) {
-        this.carMapper = carMapper;
-    }
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public CarDTO hello() {
         Car car = new Car("foo", 4);
-        return carMapper.carToCarDTO(car);
+        return CarMapper.INSTANCE.carToCarDTO(car);
     }
 }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/common/src/main/java/org/acme/common/CarMapper.java
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/common/src/main/java/org/acme/common/CarMapper.java
@@ -2,12 +2,14 @@ package org.acme.common;
 
 import org.acme.common.domain.Car;
 import org.acme.common.domain.CarDTO;
-import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "cdi", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper
 public interface CarMapper {
+
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
 
     @Mapping(source = "numberOfSeats", target = "seatNumber")
     CarDTO carToCarDTO(Car car);

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/src/main/java/org/acme/quarkus/CarMapper.java
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/src/main/java/org/acme/quarkus/CarMapper.java
@@ -5,9 +5,12 @@ import org.acme.quarkus.domain.CarDTO;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "cdi", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper
 public interface CarMapper {
+
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
 
     @Mapping(source = "numberOfSeats", target = "seatNumber")
     CarDTO carToCarDTO(Car car);

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/src/main/java/org/acme/quarkus/sample/HelloResource.java
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/src/main/java/org/acme/quarkus/sample/HelloResource.java
@@ -12,16 +12,10 @@ import org.acme.quarkus.domain.CarDTO;
 @Path("/hello")
 public class HelloResource {
 
-    private final CarMapper carMapper;
-
-    public HelloResource(CarMapper carMapper) {
-        this.carMapper = carMapper;
-    }
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public CarDTO hello() {
         Car car = new Car("foo", 4);
-        return carMapper.carToCarDTO(car);
+        return CarMapper.INSTANCE.carToCarDTO(car);
     }
 }


### PR DESCRIPTION
This disables CDI capabilities from mapstruct to make sure no jakarta classes are used in the generated code.

close #28005 