### PR TITLE
Propagate values within the JsonProperty annotation

### DIFF
--- a/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheConstants.java
+++ b/extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheConstants.java
@@ -18,8 +18,16 @@ public final class PanacheConstants {
 
     private static final String JSON_PROPERTY_BINARY_NAME = "com/fasterxml/jackson/annotation/JsonProperty";
     public static final String JSON_PROPERTY_SIGNATURE = "L" + JSON_PROPERTY_BINARY_NAME + ";";
+    public static final String JSON_PROPERTY_ACCESS_SIGNATURE = "L" + JSON_PROPERTY_BINARY_NAME + "$Access;";
 
     public static final DotName JSON_IGNORE_DOT_NAME = DotName.createSimple("com.fasterxml.jackson.annotation.JsonIgnore");
     public static final DotName JSON_PROPERTY_DOT_NAME = DotName.createSimple("com.fasterxml.jackson.annotation.JsonProperty");
+
+    public static final String JSON_PROPERTY_VALUE = "value";
+    public static final String JSON_PROPERTY_NAMESPACE = "namespace";
+    public static final String JSON_PROPERTY_REQUIRED = "required";
+    public static final String JSON_PROPERTY_INDEX = "index";
+    public static final String JSON_PROPERTY_DEFAULT_VALUE = "defaultValue";
+    public static final String JSON_PROPERTY_ACCESS = "access";
 
 }


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/28016

_I didn't add any test because the existing coverage should be suffice to ensure these changes do not add breaking changes. Moreover, this is part of the jakarta transition where if we checkout the branch `jakarta-rewrite`, we will see that the panache tests are broken, so if we try these changes in this branch, the panache tests should be fixed_