### PR TITLE
Ensure that classes declaring @ServerRequestFilter can contain non-static fields

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ResponseFilter.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/ResponseFilter.java
@@ -5,12 +5,16 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
+@SuppressWarnings("FieldCanBeLocal") // we use the local fields to test the code path where the generated class is @ApplicationScoped
 public class ResponseFilter {
+
+    private final String headerName = "response-input";
+    private final String abortValue = "abort";
 
     @ServerRequestFilter
     public Response aborting(HttpHeaders httpHeaders) {
-        String abortInputHeader = httpHeaders.getHeaderString("response-input");
-        if ("abort".equals(abortInputHeader)) {
+        String abortInputHeader = httpHeaders.getHeaderString(headerName);
+        if (abortValue.equals(abortInputHeader)) {
             return Response.accepted().entity(abortInputHeader).build();
         }
         return null;

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
@@ -29,8 +29,8 @@ public class FilterGeneration {
             }
             MethodInfo methodInfo = instance.target().asMethod();
             GeneratedClassOutput output = new GeneratedClassOutput();
-            String generatedClassName = CustomFilterGenerator.generateContainerRequestFilter(methodInfo, output,
-                    unwrappableTypes, additionalBeanAnnotations);
+            String generatedClassName = new CustomFilterGenerator(index, unwrappableTypes, additionalBeanAnnotations).generateContainerRequestFilter(methodInfo, output
+            );
             Integer priority = null;
             boolean preMatching = false;
             boolean nonBlockingRequired = false;
@@ -87,8 +87,8 @@ public class FilterGeneration {
             Integer priority = null;
             Set<String> nameBindingNames = new HashSet<>();
             GeneratedClassOutput output = new GeneratedClassOutput();
-            String generatedClassName = CustomFilterGenerator.generateContainerResponseFilter(methodInfo, output,
-                    unwrappableTypes, additionalBeanAnnotations);
+            String generatedClassName = new CustomFilterGenerator(index, unwrappableTypes, additionalBeanAnnotations).generateContainerResponseFilter(methodInfo, output
+            );
 
             AnnotationValue priorityValue = instance.value("priority");
             if (priorityValue != null) {

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
@@ -29,8 +29,8 @@ public class FilterGeneration {
             }
             MethodInfo methodInfo = instance.target().asMethod();
             GeneratedClassOutput output = new GeneratedClassOutput();
-            String generatedClassName = new CustomFilterGenerator(index, unwrappableTypes, additionalBeanAnnotations).generateContainerRequestFilter(methodInfo, output
-            );
+            String generatedClassName = new CustomFilterGenerator(unwrappableTypes, additionalBeanAnnotations)
+                    .generateContainerRequestFilter(methodInfo, output);
             Integer priority = null;
             boolean preMatching = false;
             boolean nonBlockingRequired = false;
@@ -87,8 +87,8 @@ public class FilterGeneration {
             Integer priority = null;
             Set<String> nameBindingNames = new HashSet<>();
             GeneratedClassOutput output = new GeneratedClassOutput();
-            String generatedClassName = new CustomFilterGenerator(index, unwrappableTypes, additionalBeanAnnotations).generateContainerResponseFilter(methodInfo, output
-            );
+            String generatedClassName = new CustomFilterGenerator(unwrappableTypes, additionalBeanAnnotations)
+                    .generateContainerResponseFilter(methodInfo, output);
 
             AnnotationValue priorityValue = instance.value("priority");
             if (priorityValue != null) {

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/Filters.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/Filters.kt
@@ -4,12 +4,15 @@ import kotlinx.coroutines.delay
 import org.jboss.resteasy.reactive.server.ServerRequestFilter
 import org.jboss.resteasy.reactive.server.ServerResponseFilter
 import org.jboss.resteasy.reactive.server.SimpleResourceInfo
+import java.security.SecureRandom
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerResponseContext
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriInfo
 
 class Filters {
+
+    private val secureRandom = SecureRandom()
 
     @ServerRequestFilter
     suspend fun addHeader(uriInfo: UriInfo, context: ContainerRequestContext) {
@@ -22,7 +25,7 @@ class Filters {
     suspend fun addHeaderOrAbort(context: ContainerRequestContext): Response? {
         delay(100)
         if (context.headers.containsKey("abort")) {
-            return Response.noContent().build()
+            return Response.noContent().header("random", "" + secureRandom.nextInt()).build()
         }
         context.headers.add("lastName", "bar")
         delay(100)

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
@@ -31,6 +31,7 @@ class GreetingResourceTest {
             get("/greeting")
         } Then {
             statusCode(204)
+            header("random", CoreMatchers.notNullValue())
         }
     }
 


### PR DESCRIPTION
Same goes for `@ServerResponseFilter`.

This is done by making the generated classes `@ApplicationScoped`, thus ensuring
that their instantiation is done lazily instead of eagerly.

Resolves: #27752