### PR TITLE
Fix codestart properties with yaml null key

### DIFF
--- a/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
+++ b/independent-projects/tools/codestarts/src/main/java/io/quarkus/devtools/codestarts/core/strategy/SmartConfigMergeCodestartFileStrategyHandler.java
@@ -64,7 +64,8 @@ final class SmartConfigMergeCodestartFileStrategyHandler implements CodestartFil
         final HashMap<String, String> flat = new HashMap<>();
         flatten("", flat, config);
         for (Map.Entry<String, String> entry : flat.entrySet()) {
-            builder.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
+            final String key = entry.getKey().replaceAll("\\.~$", "");
+            builder.append(key).append("=").append(entry.getValue()).append("\n");
         }
         final Path propertiesTargetPath = targetPath.getParent()
                 .resolve(targetPath.getFileName().toString().replace(".yml", ".properties"));


### PR DESCRIPTION
In codestarts, config is always written in yaml.

When using `~` as documented here https://quarkus.io/guides/config-yaml#configuration-key-conflicts, then generated application.properties is wrong `.~=`:
 e.g.:
```yaml
quarkus:
  quinoa:
    package-manager-install:
      ~: true
      node-version: 16.17.0
    dev-server:
      port: 3000
```

gives:

```properties
quarkus.quinoa.package-manager-install.~=true
quarkus.quinoa.dev-server.port=3000
quarkus.quinoa.package-manager-install.node-version=16.17.0
```

This fix is making sure we generate this instead:
```properties
quarkus.quinoa.package-manager-install=true
quarkus.quinoa.dev-server.port=3000
quarkus.quinoa.package-manager-install.node-version=16.17.0
```
