### PR TITLE
Re-enable tests which were failing on mac M1 in some timezones

### DIFF
--- a/integration-tests/hibernate-orm-graphql-panache/pom.xml
+++ b/integration-tests/hibernate-orm-graphql-panache/pom.xml
@@ -119,31 +119,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Disabled pending fix of #28035 -->
-        <profile>
-            <id>mac-m1</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-                <property>
-                    <name>env.GITHUB_ACTIONS</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>

--- a/integration-tests/hibernate-orm-rest-data-panache/pom.xml
+++ b/integration-tests/hibernate-orm-rest-data-panache/pom.xml
@@ -139,30 +139,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Disabled pending fix of #28035 -->
-        <profile>
-            <id>mac-m1</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-                <property>
-                    <name>env.GITHUB_ACTIONS</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/integration-tests/jackson/pom.xml
+++ b/integration-tests/jackson/pom.xml
@@ -85,30 +85,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Disabled pending fix of #28035 -->
-        <profile>
-            <id>mac-m1</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-                <property>
-                    <name>env.GITHUB_ACTIONS</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/integration-tests/spring-data-rest/pom.xml
+++ b/integration-tests/spring-data-rest/pom.xml
@@ -139,30 +139,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <!-- Disabled pending fix of #28035 -->
-        <profile>
-            <id>mac-m1</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                    <arch>aarch64</arch>
-                </os>
-                <property>
-                    <name>env.GITHUB_ACTIONS</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
See discussion in https://github.com/quarkusio/quarkus/pull/28044/ and https://github.com/quarkusio/quarkus/issues/28035 and https://github.com/quarkusio/quarkus/pull/27156. The tests were failing, but should now be passing because of @geoand's quick fix.  

(... but let's wait and see what the build does before merging.)