### PR TITLE
Reenable smallrye config test which was broken on M1 and is now fixed

### DIFF
--- a/integration-tests/smallrye-config/pom.xml
+++ b/integration-tests/smallrye-config/pom.xml
@@ -190,31 +190,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <!-- Disabled pending fix of #28057 -->
-    <profile>
-      <id>mac-m1</id>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-        <property>
-          <name>env.GITHUB_ACTIONS</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/issues/28057 and https://github.com/quarkusio/quarkus/pull/28060/ and https://github.com/quarkusio/quarkus/pull/27156 for discussion.

(... but let's confirm this works on M1 before merging :) )