### PR TITLE
Drop "deployment" dependency on org.graalvm.nativeimage.impl package

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -19,7 +19,6 @@ import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
-import org.graalvm.nativeimage.impl.ConfigurationCondition;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -76,14 +75,15 @@ public class NativeImageFeatureStep {
             "org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport",
             "rerunInitialization", void.class, Class.class, String.class);
 
+    public static final String CONFIGURATION_CONDITION = "org.graalvm.nativeimage.impl.ConfigurationCondition";
     private static final MethodDescriptor CONFIGURATION_ALWAYS_TRUE = ofMethod(
-            "org.graalvm.nativeimage.impl.ConfigurationCondition",
-            "alwaysTrue", "org.graalvm.nativeimage.impl.ConfigurationCondition");
+            CONFIGURATION_CONDITION,
+            "alwaysTrue", CONFIGURATION_CONDITION);
 
     private static final MethodDescriptor REGISTER_LAMBDA_CAPTURING_CLASS = ofMethod(
             "org.graalvm.nativeimage.impl.RuntimeSerializationSupport",
             "registerLambdaCapturingClass", void.class,
-            "org.graalvm.nativeimage.impl.ConfigurationCondition",
+            CONFIGURATION_CONDITION,
             String.class);
 
     private static final MethodDescriptor LOOKUP_METHOD = ofMethod(
@@ -311,7 +311,7 @@ public class NativeImageFeatureStep {
 
             TryBlock tc = overallCatch.tryBlock();
 
-            ResultHandle resourcesArgTypes = tc.marshalAsArray(Class.class, tc.loadClassFromTCCL(ConfigurationCondition.class),
+            ResultHandle resourcesArgTypes = tc.marshalAsArray(Class.class, tc.loadClassFromTCCL(CONFIGURATION_CONDITION),
                     tc.loadClassFromTCCL(String.class));
             AssignableResultHandle resourcesArgs = tc.createVariable(Object[].class);
             tc.assign(resourcesArgs,
@@ -387,7 +387,7 @@ public class NativeImageFeatureStep {
 
                 ResultHandle runtimeResourceSupportClass = greaterThan22_2.loadClassFromTCCL(RUNTIME_RESOURCE_SUPPORT);
                 ResultHandle addResourceBundlesParams = greaterThan22_2.marshalAsArray(Class.class,
-                        greaterThan22_2.loadClassFromTCCL(ConfigurationCondition.class),
+                        greaterThan22_2.loadClassFromTCCL(CONFIGURATION_CONDITION),
                         greaterThan22_2.loadClassFromTCCL(String.class));
                 ResultHandle addResourceBundlesMethod = greaterThan22_2.invokeStaticMethod(
                         LOOKUP_METHOD,


### PR DESCRIPTION
Resolves errors (appearing after https://github.com/quarkusio/quarkus/pull/27728) like:

```
[error]: Build step io.quarkus.deployment.steps.NativeImageFeatureStep#generateFeature threw an exception: java.lang.IllegalAccessError: class io.quarkus.deployment.steps.NativeImageFeatureStep (in unnamed module @0x53fa18a5) cannot access class org.graalvm.nativeimage.impl.ConfigurationCondition (in module org.graalvm.sdk) because module org.graalvm.sdk does not export org.graalvm.nativeimage.impl to unnamed module @0x53fa18a5
```

Note that this is a temporary work-around until the reliance on `org.graalvm.nativeimage.impl` is completely dropped in favor of using public APIs only as discussed in https://github.com/quarkusio/quarkus/pull/27728#discussion_r971970749.

Fixes https://github.com/graalvm/mandrel/issues/417