### PR TITLE
More progress on Jakarta

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4401,6 +4401,10 @@
                         <groupId>javax.activation</groupId>
                         <artifactId>activation</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jandex</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/extensions/infinispan-client/runtime/pom.xml
+++ b/extensions/infinispan-client/runtime/pom.xml
@@ -163,7 +163,6 @@
                         <configuration>
                             <activeRecipes>
                                 <recipe>io.quarkus.infinispan</recipe>
-                                <recipe>io.quarkus.fix-infinispan-commons</recipe>
                             </activeRecipes>
                         </configuration>
                     </plugin>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -851,7 +851,7 @@ displayName: Adjust Infinispan version and dependencies
 recipeList:
   - org.openrewrite.maven.ChangePropertyValue:
       key: infinispan.version
-      newValue: 14.0.0.Dev04
+      newValue: 14.0.0.CR2
   - org.openrewrite.maven.ChangePropertyValue:
       key: infinispan.protostream.version
       newValue: 14.0.0.CR2
@@ -865,41 +865,24 @@ recipeList:
       oldGroupId: org.infinispan
       oldArtifactId: infinispan-client-hotrod
       newGroupId: org.infinispan
-      newArtifactId: infinispan-client-hotrod
-      newClassifier: jakarta
+      newArtifactId: infinispan-client-hotrod-jakarta
   - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
       oldGroupId: org.infinispan
       oldArtifactId: infinispan-commons
       newGroupId: org.infinispan
-      newArtifactId: infinispan-commons
-      newClassifier: jakarta
+      newArtifactId: infinispan-commons-jakarta
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.infinispan
       oldArtifactId: infinispan-core
       newGroupId: org.infinispan
-      newArtifactId: infinispan-core
-      newClassifier: jakarta
+      newArtifactId: infinispan-core-jakarta
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.infinispan
       oldArtifactId: infinispan-client-hotrod
       newGroupId: org.infinispan
-      newArtifactId: infinispan-client-hotrod
-      newClassifier: jakarta
+      newArtifactId: infinispan-client-hotrod-jakarta
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.infinispan
       oldArtifactId: infinispan-commons
       newGroupId: org.infinispan
-      newArtifactId: infinispan-commons
-      newClassifier: jakarta
----
-type: specs.openrewrite.org/v1beta/recipe
-name: io.quarkus.fix-infinispan-commons
-displayName: Adjust Infinispan version and dependencies
-recipeList:
-  - org.openrewrite.maven.ExcludeDependency:
-      groupId: org.infinispan
-      artifactId: infinispan-commons
-  - org.openrewrite.maven.AddDependencyNoQuestionsAsked:
-      groupId: org.infinispan
-      artifactId: infinispan-commons
-      classifier: jakarta
+      newArtifactId: infinispan-commons-jakarta

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -361,7 +361,7 @@ git cherry-pick -x ${JAKARTA_10_CDI_HASH}
 
 ## JAX-RS/RESTEasy Reactive
 git fetch origin jakarta-10-jaxrs
-git rev-list e466a63792db2e5d87eb0b662384618f16aaa419..origin/jakarta-10-jaxrs | tac | xargs git cherry-pick -x
+git rev-list 1ac748346b91512957121e9b2f68c3b960c41565..origin/jakarta-10-jaxrs | tac | xargs git cherry-pick -x
 
 # Build phase
 


### PR DESCRIPTION
- Upgrade to Infinispan 14.0.0.CR2 and new Jakarta artifacts
- Adjust JAX-RS 3.1 hash - fixes #28052
- Exclude old Jandex from resteasy-core