### PR TITLE
Remove leftover error messages from CSRF Reactive filter

### DIFF
--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfRequestResponseReactiveFilter.java
@@ -197,8 +197,6 @@ public class CsrfRequestResponseReactiveFilter {
     }
 
     private boolean isCsrfTokenRequired(RoutingContext routing, CsrfReactiveConfig config) {
-        LOG.error("**************Request path: " + routing.request().path());
-        LOG.error("**************Token path: " + config.createTokenPath.get());
         return config.createTokenPath.isPresent() ? config.createTokenPath.get().equals(routing.request().path()) : true;
     }
 


### PR DESCRIPTION
Sorry about it, not sure how I missed it, I recall I had problems debugging in a reactive flow, so added those and forgot to remove, I did not plan to keep them as debug-level messages. Guillaume, I've built it locally, so there should be no formatting errors, may be it can be merged immediately...