### PR TITLE
Ensure that @QuarkusIntegrationTest does not leave dangling processes

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultJarLauncher.java
@@ -165,6 +165,6 @@ public class DefaultJarLauncher implements JarArtifactLauncher {
 
     @Override
     public void close() {
-        quarkusProcess.destroy();
+        LauncherUtil.destroyProcess(quarkusProcess);
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -267,6 +267,6 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
 
     @Override
     public void close() {
-        quarkusProcess.destroy();
+        LauncherUtil.destroyProcess(quarkusProcess);
     }
 }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/LauncherUtil.java
@@ -110,7 +110,7 @@ public final class LauncherUtil {
      * Try to destroy the process normally a few times
      * and resort to forceful destruction if necessary
      */
-    private static void destroyProcess(Process quarkusProcess) {
+    static void destroyProcess(Process quarkusProcess) {
         quarkusProcess.destroy();
         int i = 0;
         while (i++ < 10) {


### PR DESCRIPTION
Fixes: #28114