### PR TITLE
Use a timer when awaiting Quartz shutdown

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -51,6 +51,14 @@ public class QuartzRuntimeConfig {
     public QuartzStartMode startMode;
 
     /**
+     * The maximum amount of time Quarkus will wait for currently running jobs to finish.
+     * If the value is {@code 0}, then Quarkus will not wait at all for these jobs to finish
+     * - it will call {@code org.quartz.Scheduler.shutdown(false)} in this case.
+     */
+    @ConfigItem(defaultValue = "10")
+    public Duration shutdownWaitTime;
+
+    /**
      * Misfire policy per job configuration.
      */
     @ConfigDocSection


### PR DESCRIPTION
Use a timer when awaiting Quartz shutdown

The Quartz scheduler shutdown seems like it
can block indefinitely if there is an exception
in a yet to be completed job.
To guard against this, we ensure that we only
wait a configurable amount of time for the scheduler
to shut down.

This is a breaking change because previously we waited
indefinitely.

Relates to #28114