### PR TITLE
Provide details about failing MetaInfJandexReader

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/IndexingUtil.java
@@ -257,13 +257,13 @@ public class IndexingUtil {
             }
             try (InputStream in = Files.newInputStream(visit.getPath())) {
                 IndexReader reader = new IndexReader(in);
-                if (reader.getIndexVersion() < REQUIRED_INDEX_VERSION) {
-                    log.warnf(
-                            "Re-indexing %s - at least Jandex 2.1 must be used to index an application dependency",
-                            visit.getPath());
-                    return null;
-                }
                 try {
+                    if (reader.getIndexVersion() < REQUIRED_INDEX_VERSION) {
+                        log.warnf(
+                                "Re-indexing %s - at least Jandex 2.1 must be used to index an application dependency",
+                                visit.getPath());
+                        return null;
+                    }
                     return reader.read();
                 } catch (UnsupportedVersion e) {
                     throw new UnsupportedVersion(


### PR DESCRIPTION
reader.getIndexVersion() can throw UnsupportedVersion too 

Example: 
```
Build step io.quarkus.deployment.index.ApplicationArchiveBuildStep#build threw an exception: org.jboss.jandex.UnsupportedVersion: Can't read index version 11; this IndexReader only supports index versions 2-3,6-10
        at org.jboss.jandex.IndexReader.initReader(IndexReader.java:87)
        at org.jboss.jandex.IndexReader.readVersion(IndexReader.java:140)
        at org.jboss.jandex.IndexReader.getIndexVersion(IndexReader.java:127)
        at io.quarkus.deployment.index.IndexingUtil$MetaInfJandexReader.apply(IndexingUtil.java:244)
        at io.quarkus.deployment.index.IndexingUtil$MetaInfJandexReader.apply(IndexingUtil.java:230)
        at io.quarkus.paths.PathTreeVisit.process(PathTreeVisit.java:40)
```