### PR TITLE
Add more OIDC debug messages and update the refresh token test

### DIFF
--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/CustomTenantResolver.java
@@ -52,6 +52,10 @@ public class CustomTenantResolver implements TenantResolver {
             return "tenant-autorefresh";
         }
 
+        if (path.contains("tenant-refresh")) {
+            return "tenant-refresh";
+        }
+
         if (path.contains("tenant-https")) {
             if (context.getCookie("q_session_tenant-https_test") != null) {
                 context.put("reauthenticated", "true");

--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantRefresh.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.keycloak;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import io.quarkus.security.Authenticated;
+import io.vertx.ext.web.RoutingContext;
+
+@Path("/tenant-refresh")
+public class TenantRefresh {
+    @Inject
+    RoutingContext context;
+
+    @Authenticated
+    @GET
+    public String getTenantRefresh() {
+        return "Tenant Refresh, refreshed: " + (context.get("refresh_token_grant_response") != null);
+    }
+}

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -74,10 +74,16 @@ quarkus.oidc.tenant-logout.client-id=quarkus-app
 quarkus.oidc.tenant-logout.credentials.secret=secret
 quarkus.oidc.tenant-logout.application-type=web-app
 quarkus.oidc.tenant-logout.authentication.cookie-path=/tenant-logout
-quarkus.oidc.tenant-logout.authentication.session-age-extension=2M
 quarkus.oidc.tenant-logout.logout.path=/tenant-logout/logout
 quarkus.oidc.tenant-logout.logout.post-logout-path=/tenant-logout/post-logout
-quarkus.oidc.tenant-logout.token.refresh-expired=true
+
+quarkus.oidc.tenant-refresh.auth-server-url=${keycloak.url}/realms/logout-realm
+quarkus.oidc.tenant-refresh.client-id=quarkus-app
+quarkus.oidc.tenant-refresh.credentials.secret=secret
+quarkus.oidc.tenant-refresh.application-type=web-app
+quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
+quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
+quarkus.oidc.tenant-refresh.token.refresh-expired=true
 
 quarkus.oidc.tenant-autorefresh.auth-server-url=${keycloak.url}/realms/logout-realm
 quarkus.oidc.tenant-autorefresh.client-id=quarkus-app


### PR DESCRIPTION
Here is another try at chasing the refresh token test failure but also it tries to improve the way the OIDC errors are logged, here is a summary of changes:
- the test fails with `401` instead of `200`, at least as far as OIDC `CodeAuthenticationMechanism` is concerned it can be caused only by `AuthenticationCompletionException` (as opposed to `AuthenticationFailedException` which is a signal to challenge via a redirect, to authenticate in KC/etc) so I've updated the code to produce an `error` log messages in all such cases and updated/added error message 
- Use `Uni.createFrom().failure` instead of `throw` where possible
- Reverted an earlier change I did to the way the refresh token failure is logged - since it is not a real error as far as the working application is concerned, it just means the user will have to re-authenticate instead of the ID token/session being refreshed seamlessly, so now it is again a `debug` log message
- `CodeFlowTest#testTokenRefresh` - 3 tests in CodeFlowTest use the `tenant-logout` configuration and the request URI ending with `tenant-logout`, so it is hard to see in the build log which of these tests has produced which log messages, so I've updated this test to use a dedicated `tenant-refresh` tenant and URI space, and also decreased the frequency of the polling