### PR TITLE
Docs - do not collapse description on copy button click

### DIFF
--- a/docs/src/main/asciidoc/javascript/config.js
+++ b/docs/src/main/asciidoc/javascript/config.js
@@ -296,6 +296,11 @@ function makeCollapsibleHandler(descDiv, td, row,
             return;
         }
 
+        // don't collapse if the target is button with attribute "do-not-collapse"
+        if( (target.localName == 'button' && target.hasAttribute("do-not-collapse"))) {
+            return;
+        }
+
         var isCollapsed = descDiv.classList.contains('description-collapsed');
         if( isCollapsed ) {
             collapsibleSpan.childNodes.item(0).nodeValue = 'Show less';


### PR DESCRIPTION
When you want to copy environment variable in configuration table description, description collapse on click. There is an attribute https://github.com/quarkusio/quarkusio.github.io/blob/develop/_plugins/asciidoctor-extension.rb#L48 called `do-not-collapse` that I added specifically to avoid such behavior, but I accidentally didn't add it here. This PR prevents config property description from collapsing when clicking on the button.