### PR TITLE
Add skeleton tests for extension descriptor

### DIFF
--- a/independent-projects/bootstrap/bom-test/pom.xml
+++ b/independent-projects/bootstrap/bom-test/pom.xml
@@ -39,6 +39,30 @@
                 <scope>test</scope>
                 <version>${shrinkwrap-depchain.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-testing</groupId>
+                <artifactId>maven-plugin-testing-harness</artifactId>
+                <version>3.3.0</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!-- let's prefer the plexus-utils pulled by maven-resolver-provider -->
+                    <exclusion>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-utils</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <!-- maven compat is needed because the maven testing harness still uses maven 2 APIs -->
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${maven.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -201,7 +201,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     @Parameter(required = false, defaultValue = "${skipExtensionValidation}")
     private boolean skipExtensionValidation;
 
-    @Parameter(required = false, defaultValue = "${ignoreNotDetectedQuarkusCoreVersion")
+    @Parameter(required = false, defaultValue = "${ignoreNotDetectedQuarkusCoreVersion}")
     boolean ignoreNotDetectedQuarkusCoreVersion;
 
     @Parameter

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -39,6 +39,12 @@
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
     </properties>
     <build>
+        <testResources>
+                <testResource>
+                    <directory>src/test/resources</directory>
+                    <filtering>true</filtering>
+                </testResource>
+        </testResources>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -46,6 +52,20 @@
                     <configuration>
                         <quiet>true</quiet>
                         <doclint>none</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <!-- The tests cause generated files to appear in the test-data projects, so clean them up when we clean -->
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <configuration>
+                        <filesets>
+                            <fileset>
+                                <directory>src/test/resources</directory>
+                                <includes>
+                                    <include>**/target/**</include>
+                                </includes>
+                            </fileset>
+                        </filesets>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -188,6 +208,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-bom-test</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Jackson dependencies, imported as a BOM -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -196,6 +223,7 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -237,6 +265,29 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
+       <!-- maven compat is needed because the maven testing harness still uses maven 2 APIs -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -103,7 +103,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
      * @component
      */
     @Component
-    private RepositorySystem repoSystem;
+    RepositorySystem repoSystem;
 
     @Component
     RemoteRepositoryManager remoteRepoManager;
@@ -121,7 +121,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
      * @readonly
      */
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
-    private RepositorySystemSession repoSession;
+    RepositorySystemSession repoSession;
 
     /**
      * The project's remote repositories to use for the resolution of artifacts and
@@ -213,7 +213,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
      * Whether to ignore failure detecting the Quarkus core version used to build the extension,
      * which would be recorded in the extension's metadata.
      */
-    @Parameter(required = false, defaultValue = "${ignoreNotDetectedQuarkusCoreVersion")
+    @Parameter(required = false, defaultValue = "${ignoreNotDetectedQuarkusCoreVersion}")
     boolean ignoreNotDetectedQuarkusCoreVersion;
 
     /**

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
@@ -1,14 +1,181 @@
 package io.quarkus.maven;
 
 import static io.quarkus.maven.ExtensionDescriptorMojo.getCodestartArtifact;
-import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ExtensionDescriptorMojoTest {
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+
+class ExtensionDescriptorMojoTest extends AbstractMojoTestCase {
+
+    private static final boolean RESOLVE_OFFLINE = true;
+    // Test resources end up in target/test-classes after filtering
+    public static final String TEST_RESOURCES = "target/test-classes/";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // Assume that all our test data has a common org, for ease of cleanup
+        File repoPath = new File(getLocalRepoPath(), "io/quackiverse");
+        deleteDirectory(repoPath);
+    }
 
     @Test
-    void testGetCodestartArtifact() {
+    public void shouldExecuteSimplePomCleanly()
+            throws Exception {
+        ExtensionDescriptorMojo mojo = makeMojo("simple-pom-with-checks-disabled");
+        mojo.execute();
+    }
+
+    @Test
+    public void shouldCreateExtensionProperties()
+            throws Exception {
+        ExtensionDescriptorMojo mojo = makeMojo("simple-pom-with-checks-disabled");
+        File propertiesFile = getGeneratedExtensionMetadataFile(mojo.project.getBasedir(),
+                "target/classes/META-INF/quarkus-extension.properties");
+
+        // Tidy up any artifacts from previous runs
+        if (propertiesFile.exists()) {
+            Files.delete(propertiesFile.toPath());
+        }
+        mojo.execute();
+        assertTrue(propertiesFile.exists());
+    }
+
+    @Test
+    public void shouldCreateMetadata()
+            throws Exception {
+        ExtensionDescriptorMojo mojo = makeMojo("simple-pom-with-checks-disabled");
+        File yamlFile = getGeneratedExtensionMetadataFile(mojo.project.getBasedir(),
+                "target/classes/META-INF/quarkus-extension.yaml");
+
+        // Tidy up any artifacts from previous runs
+        if (yamlFile.exists()) {
+            Files.delete(yamlFile.toPath());
+        }
+        mojo.execute();
+        assertTrue(yamlFile.exists());
+
+        String fileContents = readFileAsString(yamlFile);
+        assertYamlContains(fileContents, "name", "an arbitrary name");
+        assertYamlContains(fileContents, "artifact", "io.quackiverse:test-artifact::jar:1.4.2-SNAPSHOT");
+
+    }
+
+    @Test
+    public void shouldProcessRealisticExtensionCleanly()
+            throws Exception {
+
+        // We need to get these poms into our local repository before executing the plugin
+        mavenExecPom("fake-extension-runtime");
+        mavenExecPom("fake-extension-deployment");
+
+        ExtensionDescriptorMojo mojo = makeMojo("fake-extension-runtime");
+        mojo.execute();
+
+    }
+
+    @Test
+    public void shouldFlagMissingDependenciesInARealisticExtension()
+            throws Exception {
+
+        // Build both halves of the extension first so the install phase is done
+        mavenExecPom("fake-extension-runtime-with-missing-dependencies");
+        mavenExecPom("fake-extension-deployment");
+
+        Exception thrown = Assertions.assertThrows(MojoExecutionException.class, () -> {
+            ExtensionDescriptorMojo mojo = makeMojo("fake-extension-runtime-with-missing-dependencies");
+            mojo.execute();
+        });
+        assertTrue("Message format does not match expectations: \n" + thrown.getMessage(),
+                thrown.getMessage().contains(" corresponding runtime artifacts were not found"));
+        assertTrue("Missing artifact 'io.quarkus:quarkus-arc-deployment::jar' is not flagged: \n" + thrown.getMessage(),
+                thrown.getMessage().contains("io.quarkus:quarkus-arc-deployment::jar"));
+        assertTrue(
+                "Missing artifact 'io.quarkus:quarkus-smallrye-context-propagation-deployment::jar' is not flagged: \n"
+                        + thrown.getMessage(),
+                thrown.getMessage().contains("io.quarkus:quarkus-smallrye-context-propagation-deployment::jar"));
+    }
+
+    @Test
+    public void shouldFlagIncorrectRuntimeDependencyOnDeployment()
+            throws Exception {
+
+        // Build both halves of the extension first so the install phase is done
+        mavenExecPom("fake-extension-runtime-with-deployment-dependency");
+        mavenExecPom("fake-extension-deployment");
+
+        Exception thrown = Assertions.assertThrows(MojoExecutionException.class, () -> {
+            ExtensionDescriptorMojo mojo = makeMojo("fake-extension-runtime-with-missing-dependencies");
+            mojo.execute();
+        });
+        String message = thrown.getMessage();
+        assertTrue("Message format does not match expectations: \n" + message,
+                message.contains("depends on the following Quarkus extension deployment artifacts")
+                        || message.contains("The following deployment artifact(s) appear on the runtime classpath"));
+    }
+
+    // TODO we could also add some more tests about the dependency resolution and other extension descriptor functions here; see ExtensionDescriptorTaskTest for some ideas
+
+    private File getGeneratedExtensionMetadataFile(File project, String child) {
+        return new File(project, child);
+    }
+
+    private void assertYamlContains(File file, String key, String value) throws IOException {
+        assertYamlContains(readFileAsString(file), key, value);
+    }
+
+    // Naive yaml processing; we do it this way for readability, and simplicity, and because it's how a human would check it by eye.
+    private void assertYamlContains(String fileContents, String key, String value) {
+        // ... we should probably cache the file read
+        assertTrue("Missing key '" + key + "' in \n" + fileContents, fileContents.contains(key));
+        assertTrue("Missing value '" + value + "' in \n" + fileContents, fileContents.contains(key + ": \"" + value + "\""));
+
+    }
+
+    private static String readFileAsString(File file) throws IOException {
+        return new String(Files.readAllBytes(file.toPath()));
+    }
+
+    @Test
+    public void testGetCodestartArtifact() {
         assertEquals("io.quarkus:my-ext:999-SN",
                 getCodestartArtifact("io.quarkus:my-ext", "999-SN"));
         assertEquals("io.quarkus:my-ext:codestarts:jar:999-SN",
@@ -18,4 +185,96 @@ class ExtensionDescriptorMojoTest {
         assertEquals("io.quarkus:my-ext:999-SN",
                 getCodestartArtifact("io.quarkus:my-ext:${project.version}", "999-SN"));
     }
+
+    private ExtensionDescriptorMojo makeMojo(String dirName) throws Exception {
+        File basedir = getTestFile(TEST_RESOURCES + dirName);
+        File pom = new File(basedir, "pom.xml");
+
+        MavenProject project = readMavenProject(basedir);
+        MavenSession session = newMavenSession(project);
+
+        // add localRepo - framework doesn't do this on its own
+        ArtifactRepository localRepo = createLocalArtifactRepository();
+        session.getRequest().setLocalRepository(localRepo);
+
+        final MavenArtifactResolver mvn = new MavenArtifactResolver(
+                new BootstrapMavenContext(BootstrapMavenContext.config()
+                        .setCurrentProject(pom.getAbsolutePath())
+                        .setOffline(RESOLVE_OFFLINE)));
+
+        ExtensionDescriptorMojo mojo = (ExtensionDescriptorMojo) lookupConfiguredMojo(session,
+                newMojoExecution("extension-descriptor"));
+        mojo.repoSystem = mvn.getSystem();
+        mojo.repoSession = mvn.getSession();
+        return mojo;
+    }
+
+    protected MavenProject readMavenProject(File basedir)
+            throws ProjectBuildingException, ComponentLookupException {
+        File pom = getGeneratedExtensionMetadataFile(basedir, "pom.xml");
+        assertTrue(pom.exists());
+
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setBaseDirectory(basedir);
+        ProjectBuildingRequest configuration = request.getProjectBuildingRequest();
+        configuration.setRepositorySession(new DefaultRepositorySystemSession());
+        configuration.setLocalRepository(createLocalArtifactRepository());
+        MavenProject project = lookup(ProjectBuilder.class).build(pom, configuration).getProject();
+        assertNotNull(project);
+        return project;
+    }
+
+    private ArtifactRepository createLocalArtifactRepository() {
+        String repo = getLocalRepoPath();
+        File localRepoDir = new File(repo);
+        return new MavenArtifactRepository("local",
+                localRepoDir.toURI().toString(),
+                new DefaultRepositoryLayout(),
+                new ArtifactRepositoryPolicy(true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                        ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE),
+                new ArtifactRepositoryPolicy(true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                        ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE)
+
+        );
+    }
+
+    private String getLocalRepoPath() {
+        String repo = System.getProperty("maven.repo.local");
+        if (repo == null) {
+            repo = new File(System.getProperty("user.home"), ".m2/repository").getAbsolutePath();
+        }
+        return repo;
+    }
+
+    private void mavenExecPom(String dir) throws MavenInvocationException {
+        InvocationRequest request = new DefaultInvocationRequest();
+        File projectPath = getTestFile(TEST_RESOURCES, dir + "/pom.xml");
+
+        request.setPomFile(projectPath);
+
+        request.setGoals(Collections.singletonList("install"));
+        Invoker invoker = new DefaultInvoker();
+
+        // This is a bit ugly, but bake in knowledge about where we are in the hierarchy to find maven
+        invoker.setMavenHome(new File("../../").getAbsoluteFile());
+        invoker.setMavenExecutable(new File("../../mvnw").getAbsoluteFile());
+
+        invoker.execute(request);
+    }
+
+    private void deleteDirectory(File fileToDelete) throws IOException {
+
+        if (fileToDelete.exists()) {
+            Path pathToBeDeleted = fileToDelete.toPath();
+
+            Files.walk(pathToBeDeleted)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+
+            assertFalse("Directory still exists",
+                    Files.exists(pathToBeDeleted));
+        }
+    }
+
 }

--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-deployment/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-deployment/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- This is a cut down version of a real extension pom.
+  Including a quarkus-parent or quarkus-extensions-parent makes maven test harness unhappy, and causes
+  a ' NullPointer repository system session's local repository manager cannot be null' error
+  Sadly, that means we need to hardcode version numbers.-->
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.quackiverse</groupId>
+  <artifactId>quarkus-fake-extension-deployment</artifactId>
+  <version>${project.version}</version>
+  <name>Quarkus - Fake extension - Deployment</name>
+  <description>A support pom to provide test data to use against the runtime pom</description>
+  <properties>
+    <agroal.version>1.16</agroal.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quackiverse</groupId>
+      <artifactId>quarkus-fake-extension</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-datasource-deployment</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-narayana-jta-deployment</artifactId>
+          <version>2.12.0.Final</version>
+        </dependency>
+
+    <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+      <optional>true</optional>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-api</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-narayana</artifactId>
+      <version>${agroal.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-credentials</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <capabilities>
+            <provides>io.quarkus.agroal</provides>
+          </capabilities>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+</project>

--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-deployment-dependency/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-deployment-dependency/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- This is a cut down version of a real extension pom.
+  Including a quarkus-parent or quarkus-extensions-parent makes maven test harness unhappy, and causes
+  a ' NullPointer repository system session's local repository manager cannot be null' error
+  Sadly, that means we need to hardcode version numbers.-->
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.quackiverse</groupId>
+  <artifactId>quarkus-fake-extension</artifactId>
+  <version>${project.version}</version>
+  <name>Quarkus - Fake extension - Runtime</name>
+  <description>An artifact which depends on the deployment artifact</description>
+  <properties>
+    <agroal.version>1.16</agroal.version>
+  </properties>
+
+  <!-- The versions in these dependencies are arbitrary, but need to match
+  in the runtime and deployment poms. -->
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-datasource</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-narayana-jta</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+    <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+      <optional>true</optional>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-api</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-narayana</artifactId>
+      <version>${agroal.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-credentials</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <capabilities>
+            <provides>io.quarkus.agroal</provides>
+          </capabilities>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+</project>

--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-missing-dependencies/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime-with-missing-dependencies/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- This is a cut down version of a real extension pom.
+  Including a quarkus-extensions-parent makes maven test harness unhappy, and causes
+  a ' NullPointer repository system session's local repository manager cannot be null' error -->
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.quackiverse</groupId>
+  <artifactId>quarkus-fake-extension</artifactId>
+  <version>${project.version}</version>
+  <name>Quarkus - Fake extension - Deployment</name>
+  <description>A version of the fake extension whose pom is missing dependencies</description>
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Mirror of the deployment artifact's dependencies would be here, but is deliberately missing -->
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <capabilities>
+            <provides>io.quarkus.agroal</provides>
+          </capabilities>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+</project>

--- a/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/fake-extension-runtime/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- This is a cut down version of a real extension pom.
+  Including a quarkus-parent or quarkus-extensions-parent makes maven test harness unhappy, and causes
+  a ' NullPointer repository system session's local repository manager cannot be null' error
+  Sadly, that means we need to hardcode version numbers.-->
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.quackiverse</groupId>
+  <artifactId>quarkus-fake-extension</artifactId>
+  <version>${project.version}</version>
+  <name>Quarkus - Fake extension - Runtime</name>
+  <description>Pool JDBC database connections (included in Hibernate ORM)</description>
+  <properties>
+    <agroal.version>1.16</agroal.version>
+  </properties>
+
+  <!-- The versions in these dependencies are arbitrary, but need to match
+  in the runtime and deployment poms. -->
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-datasource</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-narayana-jta</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+    <!-- Add the health extension as optional as we will produce the health check only if it's included -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+      <optional>true</optional>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-api</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-narayana</artifactId>
+      <version>${agroal.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <version>${agroal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-credentials</artifactId>
+      <version>2.12.0.Final</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <capabilities>
+            <provides>io.quarkus.agroal</provides>
+          </capabilities>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+</project>

--- a/independent-projects/extension-maven-plugin/src/test/resources/simple-pom-with-checks-disabled/pom.xml
+++ b/independent-projects/extension-maven-plugin/src/test/resources/simple-pom-with-checks-disabled/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.quackiverse</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.4.2-SNAPSHOT</version>
+  <name>an arbitrary name</name>
+
+  <properties>
+    <skipExtensionValidation>true</skipExtensionValidation>
+    <ignoreNotDetectedQuarkusCoreVersion>true</ignoreNotDetectedQuarkusCoreVersion>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>quarkus.io</groupId>
+        <artifactId>extension-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
I've also corrected (because the tests caught it!) a missing brace on one of the "please don't complain" properties.

I haven't tested the bootstrap extension descriptor since it is deprecated, but we could copy things across fairly easily if we think it's worthwhile.

I also haven't tested everything the descriptor does, but now that we have a skeleton which drives the mojo, we can add new tests more easily.

The maven test harness is a bit delicate. I had to play around with the dependencies a lot to get things working, and we may find some things we want to test can't easily be driven. I found, for example, adding the quarkus parent poms made the harness unhappy, and under normal circumstances we might want those in our test data. But I was able to drive things usefully even without the parents. 