### PR TITLE
Kubernetes Kind: Fix documentation and log warning if not correct

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -782,8 +782,7 @@ experience as frictionless as possible, Quarkus provides the `quarkus-kind` exte
 </dependency>
 ----
 
-The purpose of this extension is to generate Kubernetes manifests (`kind.yaml` and `kind.json`) that are tailored to Kind and also to automate the process of loading images to the cluster
-when performing container image builds. The tailor made manifests will be pretty similar (they share the same rules) with Minikube (see above).
+The purpose of this extension is to automate the process of loading images to the cluster when performing container image builds. This will only work if you set the image pull policy to either `if-not-present` or `never` (for example, using the property `quarkus.kubernetes.image-pull-policy=if-not-present`).
 
 == Tuning the generated resources using application.properties
 

--- a/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
+++ b/extensions/kubernetes/kind/deployment/src/main/java/io/quarkus/kind/deployment/KindProcessor.java
@@ -1,123 +1,37 @@
 package io.quarkus.kind.deployment;
 
-import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT;
-import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_GROUP;
-import static io.quarkus.kubernetes.deployment.Constants.DEPLOYMENT_VERSION;
-import static io.quarkus.kubernetes.deployment.Constants.KIND;
-import static io.quarkus.kubernetes.deployment.Constants.KUBERNETES;
-import static io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem.DEFAULT_PRIORITY;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import io.quarkus.container.spi.BaseImageInfoBuildItem;
+import org.jboss.logging.Logger;
+
+import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.quarkus.container.spi.ContainerImageBuilderBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
-import io.quarkus.container.spi.ContainerImageLabelBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
-import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
-import io.quarkus.deployment.pkg.PackageConfig;
 import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
-import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.deployment.util.ExecUtil;
-import io.quarkus.kubernetes.deployment.AddPortToKubernetesConfig;
-import io.quarkus.kubernetes.deployment.DevClusterHelper;
-import io.quarkus.kubernetes.deployment.KubernetesCommonHelper;
 import io.quarkus.kubernetes.deployment.KubernetesConfig;
-import io.quarkus.kubernetes.deployment.ResourceNameUtil;
-import io.quarkus.kubernetes.spi.ConfiguratorBuildItem;
-import io.quarkus.kubernetes.spi.CustomProjectRootBuildItem;
-import io.quarkus.kubernetes.spi.DecoratorBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesAnnotationBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesCommandBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesDeploymentTargetBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesEnvBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesHealthLivenessPathBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesHealthReadinessPathBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesLabelBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesPortBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesResourceMetadataBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesRoleBindingBuildItem;
-import io.quarkus.kubernetes.spi.KubernetesRoleBuildItem;
 
 public class KindProcessor {
 
-    private static final int KIND_PRIORITY = DEFAULT_PRIORITY + 30;
+    private static final Logger LOGGER = Logger.getLogger(KindProcessor.class);
 
     @BuildStep
-    public void checkKind(ApplicationInfoBuildItem applicationInfo, KubernetesConfig config,
-            BuildProducer<KubernetesDeploymentTargetBuildItem> deploymentTargets,
-            BuildProducer<KubernetesResourceMetadataBuildItem> resourceMeta) {
-        deploymentTargets.produce(
-                new KubernetesDeploymentTargetBuildItem(KIND, DEPLOYMENT, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION,
-                        KIND_PRIORITY, true));
-
-        String name = ResourceNameUtil.getResourceName(config, applicationInfo);
-        resourceMeta.produce(
-                new KubernetesResourceMetadataBuildItem(KUBERNETES, DEPLOYMENT_GROUP, DEPLOYMENT_VERSION, DEPLOYMENT, name));
-    }
-
-    @BuildStep
-    public void createAnnotations(KubernetesConfig config, BuildProducer<KubernetesAnnotationBuildItem> annotations) {
-        config.getAnnotations().forEach((k, v) -> {
-            annotations.produce(new KubernetesAnnotationBuildItem(k, v, KIND));
-        });
-    }
-
-    @BuildStep
-    public void createLabels(KubernetesConfig config, BuildProducer<KubernetesLabelBuildItem> labels,
-            BuildProducer<ContainerImageLabelBuildItem> imageLabels) {
-        config.getLabels().forEach((k, v) -> {
-            labels.produce(new KubernetesLabelBuildItem(k, v, KIND));
-            imageLabels.produce(new ContainerImageLabelBuildItem(k, v));
-        });
-    }
-
-    @BuildStep
-    public List<ConfiguratorBuildItem> createConfigurators(KubernetesConfig config,
-            List<KubernetesPortBuildItem> ports) {
-        List<ConfiguratorBuildItem> result = new ArrayList<>();
-        KubernetesCommonHelper.combinePorts(ports, config).entrySet().forEach(e -> {
-            result.add(new ConfiguratorBuildItem(new AddPortToKubernetesConfig(e.getValue())));
-        });
-        return result;
-    }
-
-    @BuildStep
-    public List<DecoratorBuildItem> createDecorators(ApplicationInfoBuildItem applicationInfo,
-            OutputTargetBuildItem outputTarget,
-            KubernetesConfig config,
-            PackageConfig packageConfig,
-            Optional<MetricsCapabilityBuildItem> metricsConfiguration,
-            List<KubernetesAnnotationBuildItem> annotations,
-            List<KubernetesLabelBuildItem> labels,
-            List<KubernetesEnvBuildItem> envs,
-            Optional<BaseImageInfoBuildItem> baseImage,
-            Optional<ContainerImageInfoBuildItem> image,
-            Optional<KubernetesCommandBuildItem> command,
-            List<KubernetesPortBuildItem> ports,
-            Optional<KubernetesHealthLivenessPathBuildItem> livenessPath,
-            Optional<KubernetesHealthReadinessPathBuildItem> readinessPath,
-            List<KubernetesRoleBuildItem> roles,
-            List<KubernetesRoleBindingBuildItem> roleBindings,
-            Optional<CustomProjectRootBuildItem> customProjectRoot) {
-
-        return DevClusterHelper.createDecorators(KIND, applicationInfo, outputTarget, config, packageConfig,
-                metricsConfiguration, annotations, labels, envs, baseImage, image, command, ports, livenessPath, readinessPath,
-                roles, roleBindings, customProjectRoot);
-    }
-
-    @BuildStep
-    public void postBuild(ContainerImageInfoBuildItem image, List<ContainerImageBuilderBuildItem> builders,
+    public void postBuild(ContainerImageInfoBuildItem image, KubernetesConfig kubernetesConfig,
+            List<ContainerImageBuilderBuildItem> builders,
             @SuppressWarnings("unused") BuildProducer<ArtifactResultBuildItem> artifactResults) {
         boolean isLoadSupported = builders.stream().anyMatch(b -> b.getBuilder().equals("docker")
                 || b.getBuilder().equals("jib")
                 || b.getBuilder().equals("buildpack"));
         if (isLoadSupported) {
-            ExecUtil.exec("kind", "load", "docker-image", image.getImage());
+            if (kubernetesConfig.getImagePullPolicy() == ImagePullPolicy.Always) {
+                LOGGER.warn("The image pull policy is `always` (this is the default value), so Kubernetes will always pull the "
+                        + "image from the registry, not from the Kind images. If this was not intentional, set the property "
+                        + "`quarkus.kubernetes.image-pull-policy` to either `if-not-present` or `never`.");
+            } else {
+                ExecUtil.exec("kind", "load", "docker-image", image.getImage());
+            }
         }
     }
 }


### PR DESCRIPTION
From my point of view, the KInd extension was not configured to generate the `kind.yaml` manifests, but only to load the image. I've fixed the documentation, plus I've also added a warning if users don't use the correct image pull policy to pull the images loaded in Kind. 

Fix https://github.com/quarkusio/quarkus/issues/28078