### PR TITLE
Update RestEasy Classic mappers and Vert.x HTTP to log messages related to 401

### DIFF
--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationCompletionExceptionMapper.java
@@ -4,13 +4,18 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.security.AuthenticationCompletionException;
 
 @Provider
 public class AuthenticationCompletionExceptionMapper implements ExceptionMapper<AuthenticationCompletionException> {
 
+    private static final Logger log = Logger.getLogger(AuthenticationCompletionExceptionMapper.class.getName());
+
     @Override
     public Response toResponse(AuthenticationCompletionException ex) {
+        log.debug("Authentication has failed, returning HTTP status 401");
         return Response.status(401).build();
     }
 

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/AuthenticationFailedExceptionMapper.java
@@ -7,6 +7,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.security.ChallengeData;
@@ -16,6 +18,7 @@ import io.vertx.ext.web.RoutingContext;
 @Provider
 @Priority(Priorities.USER + 1)
 public class AuthenticationFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
+    private static final Logger log = Logger.getLogger(AuthenticationFailedExceptionMapper.class.getName());
 
     private volatile CurrentVertxRequest currentVertxRequest;
 
@@ -38,8 +41,13 @@ public class AuthenticationFailedExceptionMapper implements ExceptionMapper<Auth
                 if (challengeData.headerName != null) {
                     status.header(challengeData.headerName.toString(), challengeData.headerContent);
                 }
+                log.debugf("Returning an authentication challenge, status code: %d", challengeData.status);
                 return status.build();
+            } else {
+                log.error("HttpAuthenticator is not found, returning HTTP status 401");
             }
+        } else {
+            log.error("RoutingContext is not found, returning HTTP status 401");
         }
         return Response.status(401).entity("Not Authenticated").build();
     }

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/UnauthorizedExceptionMapper.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/UnauthorizedExceptionMapper.java
@@ -48,11 +48,17 @@ public class UnauthorizedExceptionMapper implements ExceptionMapper<Unauthorized
                     if (challengeData.headerName != null) {
                         status.header(challengeData.headerName.toString(), challengeData.headerContent);
                     }
+                    log.debugf("Returning an authentication challenge, status code: %d", challengeData.status);
                     return status.build();
                 } else {
+                    log.debug("ChallengeData is null, returning HTTP status 401");
                     return Response.status(401).build();
                 }
+            } else {
+                log.error("HttpAuthenticator is not found, returning HTTP status 401");
             }
+        } else {
+            log.error("RoutingContext is not found, returning HTTP status 401");
         }
         return Response.status(401).entity("Not authorized").build();
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthenticator.java
@@ -11,6 +11,8 @@ import java.util.function.Function;
 import javax.enterprise.inject.Instance;
 import javax.inject.Singleton;
 
+import org.jboss.logging.Logger;
+
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.IdentityProviderManager;
@@ -25,6 +27,8 @@ import io.vertx.ext.web.RoutingContext;
  */
 @Singleton
 public class HttpAuthenticator {
+    private static final Logger log = Logger.getLogger(HttpAuthenticator.class);
+
     private final IdentityProviderManager identityProviderManager;
     private final Instance<PathMatchingHttpSecurityPolicy> pathMatchingPolicy;
     private final HttpAuthenticationMechanism[] mechanisms;
@@ -164,6 +168,7 @@ public class HttpAuthenticator {
             @Override
             public Uni<? extends Boolean> apply(Boolean authDone) {
                 if (!authDone) {
+                    log.debug("Authentication has not been done, returning HTTP status 401");
                     routingContext.response().setStatusCode(401);
                     routingContext.response().end();
                 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -92,6 +92,7 @@ public class HttpSecurityRecorder {
                                 }
                             });
                         } else if (throwable instanceof AuthenticationCompletionException) {
+                            log.debug("Authentication has failed, returning HTTP status 401");
                             event.response().setStatusCode(401);
                             event.response().end();
                         } else if (throwable instanceof AuthenticationRedirectException) {

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -85,7 +85,7 @@ quarkus.oidc.tenant-refresh.authentication.cookie-path=/tenant-refresh
 quarkus.oidc.tenant-refresh.authentication.session-age-extension=2M
 quarkus.oidc.tenant-refresh.token.refresh-expired=true
 
-quarkus.oidc.tenant-autorefresh.auth-server-url=${keycloak.url}/realms/logout-realm
+quarkus.oidc.tenant-autorefresh.auth-server-url=${keycloak.url}/realms/quarkus
 quarkus.oidc.tenant-autorefresh.client-id=quarkus-app
 quarkus.oidc.tenant-autorefresh.credentials.secret=secret
 quarkus.oidc.tenant-autorefresh.application-type=web-app
@@ -171,5 +171,10 @@ quarkus.http.proxy.allow-forwarded=true
 
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".min-level=TRACE
 quarkus.log.category."io.quarkus.oidc.runtime.CodeAuthenticationMechanism".level=TRACE
+quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationFailedExceptionMapper".level=DEBUG
+quarkus.log.category."io.quarkus.resteasy.runtime.AuthenticationCompletionExceptionMapper".level=DEBUG
+quarkus.log.category."io.quarkus.resteasy.runtime.UnauthorizedExceptionMapper".level=DEBUG
+quarkus.log.category."io.quarkus.vertx.http.runtime.security.HttpAuthenticator".level=DEBUG
+quarkus.log.category."io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder".level=DEBUG
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -502,7 +502,7 @@ public class CodeFlowTest {
     public void testTokenAutoRefresh() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/tenant-autorefresh");
-            assertEquals("Sign in to logout-realm", page.getTitleText());
+            assertEquals("Sign in to quarkus", page.getTitleText());
             HtmlForm loginForm = page.getForms().get(0);
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");


### PR DESCRIPTION
One of the OIDC refresh tests failed again today in #28142 however the [raw logs](https://pipelines.actions.githubusercontent.com/serviceHosts/db7e007d-ef45-446a-a481-86fd29e0a95c/_apis/pipelines/1/runs/168547/signedlogcontent/59?urlExpires=2022-09-22T12%3A49%3A42.6109617Z&urlSigningMethod=HMACV1&urlSignature=17yl602kbVWAVSlKyewHdl%2BDJR%2BaKCKDU7j8toodnK0%3D) show nothing  related to the source of `401` despite me covering all of the `CodeAuthenticationMechanism` code related to producing 401. 
It may suggest that `401` is likely reported from elsewhere, either from Vert.x HTTP or ResteasyClassic exception mappers, so here is one more and very likely the final attempt to trace it before disabling it as I really see no other sources of 401 or any reasons for it in the OIDC code:
- Log in Vert.x HTTP and Resteasy Classic mappers where 401 is reported without any log messages 
- Also update CodeFlowTest#testTokenAutoRefresh to use a realm different from the one used by the previous `testRPInitiatedLogout` test as it might be that logging out the user from a `logout-realm` and then signing in to the same realm and auto-refreshing might be causing some transient side-effects in KC  