### PR TITLE
Take quarkus.package.output-directory into account when launching native tests

### DIFF
--- a/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/DefaultNativeImageLauncher.java
@@ -34,6 +34,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
     private String testProfile;
     private List<String> argLine;
     private String nativeImagePath;
+    private String configuredOutputDirectory;
     private Class<?> testClass;
 
     private Process quarkusProcess;
@@ -48,6 +49,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         this.waitTimeSeconds = initContext.waitTime().getSeconds();
         this.testProfile = initContext.testProfile();
         this.nativeImagePath = initContext.nativeImagePath();
+        this.configuredOutputDirectory = initContext.getConfiguredOutputDirectory();
         this.argLine = initContext.argLine();
         this.testClass = initContext.testClass();
     }
@@ -173,7 +175,7 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
         }
     }
 
-    private static String guessPath(Class<?> testClass) {
+    private String guessPath(Class<?> testClass) {
         //ok, lets make a guess
         //this is a horrible hack, but it is intended to make this work in IDE's
 
@@ -203,40 +205,46 @@ public class DefaultNativeImageLauncher implements NativeImageLauncher {
                 "Unable to automatically find native image, please set the native.image.path to the native executable you wish to test");
     }
 
-    private static String guessPath(final URL url) {
+    private String guessPath(final URL url) {
         if (url == null) {
             return null;
         }
+        String file = null;
         if (url.getProtocol().equals("file") && url.getPath().endsWith("test-classes/")) {
             //we have the maven test classes dir
             File testClasses = new File(url.getPath());
-            for (File file : testClasses.getParentFile().listFiles()) {
-                if (isNativeExecutable(file)) {
-                    logGuessedPath(file.getAbsolutePath());
-                    return file.getAbsolutePath();
-                }
-            }
+            file = guessPathFromDir(testClasses.getParentFile());
         } else if (url.getProtocol().equals("file") && url.getPath().endsWith("test/")) {
             //we have the gradle test classes dir, build/classes/java/test
             File testClasses = new File(url.getPath());
-            for (File file : testClasses.getParentFile().getParentFile().getParentFile().listFiles()) {
-                if (isNativeExecutable(file)) {
-                    logGuessedPath(file.getAbsolutePath());
-                    return file.getAbsolutePath();
-                }
-            }
+            file = guessPathFromDir(testClasses.getParentFile().getParentFile().getParentFile());
         } else if (url.getProtocol().equals("file") && url.getPath().contains("/target/surefire/")) {
             //this will make mvn failsafe:integration-test work
             String path = url.getPath();
             int index = path.lastIndexOf("/target/");
             File targetDir = new File(path.substring(0, index) + "/target/");
-            for (File file : targetDir.listFiles()) {
-                if (isNativeExecutable(file)) {
-                    logGuessedPath(file.getAbsolutePath());
-                    return file.getAbsolutePath();
-                }
-            }
+            file = guessPathFromDir(targetDir);
 
+        }
+        return file;
+    }
+
+    private String guessPathFromDir(File dir) {
+        if (dir == null) {
+            return null;
+        }
+        if (configuredOutputDirectory != null) {
+            dir = dir.toPath().resolve(configuredOutputDirectory).toFile();
+        }
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return null;
+        }
+        for (File file : files) {
+            if (isNativeExecutable(file)) {
+                logGuessedPath(file.getAbsolutePath());
+                return file.getAbsolutePath();
+            }
         }
         return null;
     }

--- a/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
+++ b/test-framework/common/src/main/java/io/quarkus/test/common/NativeImageLauncher.java
@@ -6,6 +6,8 @@ public interface NativeImageLauncher extends ArtifactLauncher<NativeImageLaunche
 
         String nativeImagePath();
 
+        String getConfiguredOutputDirectory();
+
         Class<?> testClass();
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/NativeTestExtension.java
@@ -217,6 +217,7 @@ public class NativeTestExtension extends AbstractQuarkusTestWithContextExtension
                     }
                 },
                 System.getProperty("native.image.path"),
+                config.getOptionalValue("quarkus.package.output-directory", String.class).orElse(null),
                 requiredTestClass));
         return launcher;
     }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/NativeImageLauncherProvider.java
@@ -45,6 +45,7 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
                     ConfigUtil.argLineValue(config),
                     context.devServicesLaunchResult(),
                     System.getProperty("native.image.path"),
+                    config.getOptionalValue("quarkus.package.output-directory", String.class).orElse(null),
                     context.testClass()));
             return launcher;
         } else {
@@ -57,18 +58,25 @@ public class NativeImageLauncherProvider implements ArtifactLauncherProvider {
 
         private final String nativeImagePath;
         private final Class<?> testClass;
+        private final String configuredOutputDirectory;
 
         public DefaultNativeImageInitContext(int httpPort, int httpsPort, Duration waitTime, String testProfile,
                 List<String> argLine, ArtifactLauncher.InitContext.DevServicesLaunchResult devServicesLaunchResult,
-                String nativeImagePath, Class<?> testClass) {
+                String nativeImagePath, String configuredOutputDirectory, Class<?> testClass) {
             super(httpPort, httpsPort, waitTime, testProfile, argLine, devServicesLaunchResult);
             this.nativeImagePath = nativeImagePath;
+            this.configuredOutputDirectory = configuredOutputDirectory;
             this.testClass = testClass;
         }
 
         @Override
         public String nativeImagePath() {
             return nativeImagePath;
+        }
+
+        @Override
+        public String getConfiguredOutputDirectory() {
+            return configuredOutputDirectory;
         }
 
         @Override


### PR DESCRIPTION
Fixes: #28131