### PR TITLE
Quartz: Do not create QuartzScheduler bean, if it is not used.

### DIFF
--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/NoQuartzSchedulerTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/NoQuartzSchedulerTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.quartz.test;
+
+import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoQuartzSchedulerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setExpectedException(UnsatisfiedResolutionException.class);
+
+    @Inject
+    org.quartz.Scheduler quartzScheduler;
+
+    @Test
+    public void test() {
+    }
+}


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus/issues/27929

I removed creation of quarkus scheduler in case that no `quarkus.quartz` property or `@Scheduled` method exists.
Test covering this behavior is added.

@mkouba I tried to investigate a little bit my concept and it is easily applicable, From my PoV it makes sense to not create a scheduler if it is not required. What do you think?