### PR TITLE
Fix Knative/OpenShift client environment check

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KnativeDeployer.java
@@ -5,7 +5,6 @@ import static io.quarkus.kubernetes.deployment.Constants.KNATIVE;
 import java.util.List;
 import java.util.Optional;
 
-import io.fabric8.knative.client.KnativeClient;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
@@ -23,7 +22,8 @@ public class KnativeDeployer {
                 return;
             }
             if (target.getEntry().getName().equals(KNATIVE)) {
-                if (client.getClient().isAdaptable(KnativeClient.class)) {
+                // use 'isSupported' once https://github.com/fabric8io/kubernetes-client/issues/4447 is resolved
+                if (client.getClient().hasApiGroup("knative.dev", false)) {
                     deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(KNATIVE));
                 } else {
                     throw new IllegalStateException(

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftDeployer.java
@@ -24,11 +24,16 @@ public class OpenshiftDeployer {
                 return;
             }
             if (target.getEntry().getName().equals(OPENSHIFT)) {
-                if (client.getClient().isAdaptable(OpenShiftClient.class)) {
-                    deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(OPENSHIFT));
-                } else {
-                    throw new IllegalStateException(
-                            "Openshift was requested as a deployment, but the target cluster is not an Openshift cluster!");
+                try (var openShiftClient = client.getClient().adapt(OpenShiftClient.class)) {
+                    if (openShiftClient.isSupported()) {
+                        deploymentCluster.produce(new KubernetesDeploymentClusterBuildItem(OPENSHIFT));
+                    } else {
+                        throw new IllegalStateException(
+                                "Openshift was requested as a deployment, but the target cluster is not an Openshift cluster!");
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            "Failed to configure OpenShift. Make sure you have the Quarkus OpenShift extension.", e);
                 }
             }
         });


### PR DESCRIPTION
fixes: #28171

According to https://github.com/fabric8io/kubernetes-client/blob/master/doc/MIGRATION-v6.md#adapt-changes, `isAdaptable` method semantic has changed (and the method is deprecated) and it's causing failures in Quarkus QE Test Suite. AFAIK originally `isAdaptable` check wasn't strict (`contains`, `endsWith`), so you could have ApiGroups like (see below) and check would succeed https://github.com/fabric8io/kubernetes-client/commit/bb6115a75a6d42df19d1f99953791c4dd26eb472#diff-a23a9372cb2d1a1c4121272460b2c8e2f8dd79bf5722b8b2a36ba5d4578cef75 . Now, check fails if there is no group that strictly matches `APIGroup` `knative.dev`. That's however not necessary for our app to work, f.e. our APIGroups are:
- serving.knative.dev
- serving.knative.dev/v1
- serving.knative.dev/v1
- serving.knative.dev/v1beta1
- serving.knative.dev/v1alpha1
- autoscaling.internal.knative.dev
- autoscaling.internal.knative.dev/v1alpha1
- autoscaling.internal.knative.dev/v1alpha1
- caching.internal.knative.dev
- caching.internal.knative.dev/v1alpha1
- caching.internal.knative.dev/v1alpha1
- networking.internal.knative.dev
- networking.internal.knative.dev/v1alpha1
- networking.internal.knative.dev/v1alpha1
- operator.knative.dev
- operator.knative.dev/v1alpha1
- operator.knative.dev/v1alpha1

When Quarkus is not performing strict tests for `knative.dev`, our app is working and check performed is same as before.