### PR TITLE
Increase token lifespans in the default realm created by DevServices for Keycloak

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -644,6 +644,8 @@ public class KeycloakDevServicesProcessor {
         realm.setEnabled(true);
         realm.setUsers(new ArrayList<>());
         realm.setClients(new ArrayList<>());
+        realm.setAccessTokenLifespan(600);
+        realm.setSsoSessionMaxLifespan(600);
 
         RolesRepresentation roles = new RolesRepresentation();
         List<RoleRepresentation> realmRoles = new ArrayList<>();


### PR DESCRIPTION
`Dev Services for Keycloak` will create a default realm if no custom realm has been provided, and after a login to this realm, Keycloak will issue short-lived access and id tokens, which is inconvenient when using them from Dev UI - for example, I tried Dev UI, then started looking at the tests (another time I was examining the tokens and was using them slowly enough in UI), and then retrying the token from Dev Ui fails with `401`.

So I've increased it `600` to secs (10 mins), users can then change it further if needed via a `Keycloak Admin` link, 10 mins seems to be just enough, but we can tune further