### PR TITLE
Remove unnecessary field from ResteasyReactiveRequestContext

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContext.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.SecurityContext;
 
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
@@ -66,11 +65,11 @@ public class ServletRequestContext extends ResteasyReactiveRequestContext
     Consumer<Throwable> asyncWriteHandler;
     protected Consumer<ResteasyReactiveRequestContext> preCommitTask;
 
-    public ServletRequestContext(Deployment deployment, ProvidersImpl providers,
+    public ServletRequestContext(Deployment deployment,
             HttpServletRequest request, HttpServletResponse response,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain,
             RoutingContext context, HttpServerExchange exchange) {
-        super(deployment, providers, requestContext, handlerChain, abortHandlerChain);
+        super(deployment, requestContext, handlerChain, abortHandlerChain);
         this.request = request;
         this.response = response;
         this.context = context;

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContextFactory.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-servlet/runtime/src/main/java/io/quarkus/resteasy/reactive/server/servlet/runtime/ServletRequestContextFactory.java
@@ -6,7 +6,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.RequestContextFactory;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
@@ -18,11 +17,11 @@ public class ServletRequestContextFactory implements RequestContextFactory {
     public static final ServletRequestContextFactory INSTANCE = new ServletRequestContextFactory();
 
     @Override
-    public ResteasyReactiveRequestContext createContext(Deployment deployment, ProvidersImpl providers,
+    public ResteasyReactiveRequestContext createContext(Deployment deployment,
             Object context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
             ServerRestHandler[] abortHandlerChain) {
         io.undertow.servlet.handlers.ServletRequestContext src = (io.undertow.servlet.handlers.ServletRequestContext) context;
-        return new ServletRequestContext(deployment, providers, (HttpServletRequest) src.getServletRequest(),
+        return new ServletRequestContext(deployment, (HttpServletRequest) src.getServletRequest(),
                 (HttpServletResponse) src.getServletResponse(), requestContext, handlerChain, abortHandlerChain,
                 (RoutingContext) ((VertxHttpExchange) src.getExchange().getDelegate()).getContext(), src.getExchange());
     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/QuarkusResteasyReactiveRequestContext.java
@@ -3,7 +3,6 @@ package io.quarkus.resteasy.reactive.server.runtime;
 import javax.ws.rs.core.SecurityContext;
 
 import org.jboss.resteasy.reactive.server.core.Deployment;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -20,11 +19,11 @@ public class QuarkusResteasyReactiveRequestContext extends VertxResteasyReactive
     final CurrentIdentityAssociation association;
     boolean userSetup = false;
 
-    public QuarkusResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
+    public QuarkusResteasyReactiveRequestContext(Deployment deployment,
             RoutingContext context, ThreadSetupAction requestContext, ServerRestHandler[] handlerChain,
             ServerRestHandler[] abortHandlerChain, ClassLoader devModeTccl,
             CurrentIdentityAssociation currentIdentityAssociation) {
-        super(deployment, providers, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
+        super(deployment, context, requestContext, handlerChain, abortHandlerChain, devModeTccl);
         this.association = currentIdentityAssociation;
         if (VertxContext.isOnDuplicatedContext()) {
             VertxContextSafetyToggle.setCurrentContextSafe(true);

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -28,7 +28,6 @@ import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
 import org.jboss.resteasy.reactive.server.core.startup.RuntimeDeploymentManager;
 import org.jboss.resteasy.reactive.server.handlers.RestInitialHandler;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.model.ContextResolvers;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvoker;
 import org.jboss.resteasy.reactive.server.spi.EndpointInvokerFactory;
@@ -156,9 +155,9 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
             contextFactory = new RequestContextFactory() {
                 @Override
                 public ResteasyReactiveRequestContext createContext(Deployment deployment,
-                        ProvidersImpl providers, Object context, ThreadSetupAction requestContext,
+                        Object context, ThreadSetupAction requestContext,
                         ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
-                    return new QuarkusResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
+                    return new QuarkusResteasyReactiveRequestContext(deployment, (RoutingContext) context,
                             requestContext,
                             handlerChain,
                             abortHandlerChain, launchMode == LaunchMode.DEVELOPMENT ? tccl : null, currentIdentityAssociation);

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/RequestContextFactory.java
@@ -1,12 +1,11 @@
 package org.jboss.resteasy.reactive.server.core;
 
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
 public interface RequestContextFactory {
 
-    ResteasyReactiveRequestContext createContext(Deployment deployment, ProvidersImpl providers,
+    ResteasyReactiveRequestContext createContext(Deployment deployment,
             Object context,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain);
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -57,7 +57,6 @@ public abstract class ResteasyReactiveRequestContext
 
     public static final Object[] EMPTY_ARRAY = new Object[0];
     protected final Deployment deployment;
-    protected final ProvidersImpl providers;
     /**
      * The parameters array, populated by handlers
      */
@@ -145,11 +144,10 @@ public abstract class ResteasyReactiveRequestContext
     private OutputStream underlyingOutputStream;
     private FormData formData;
 
-    public ResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
+    public ResteasyReactiveRequestContext(Deployment deployment,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
         super(handlerChain, abortHandlerChain, requestContext);
         this.deployment = deployment;
-        this.providers = providers;
         this.parameters = EMPTY_ARRAY;
     }
 
@@ -162,7 +160,9 @@ public abstract class ResteasyReactiveRequestContext
     }
 
     public ProvidersImpl getProviders() {
-        return providers;
+        // this is rarely called (basically only of '@Context Providers' is used),
+        // so let's avoid creating an extra field
+        return new ProvidersImpl(deployment);
     }
 
     /**

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
@@ -7,7 +7,6 @@ import javax.ws.rs.NotFoundException;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.RequestContextFactory;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.mapping.RequestMapper;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
@@ -16,7 +15,6 @@ public class RestInitialHandler implements ServerRestHandler {
 
     final RequestMapper<InitialMatch> mappers;
     final Deployment deployment;
-    final ProvidersImpl providers;
     final List<ServerRestHandler> preMappingHandlers;
     final ServerRestHandler[] initialChain;
 
@@ -27,7 +25,6 @@ public class RestInitialHandler implements ServerRestHandler {
     public RestInitialHandler(Deployment deployment) {
         this.mappers = new RequestMapper<>(deployment.getClassMappers());
         this.deployment = deployment;
-        this.providers = new ProvidersImpl(deployment);
         this.preMappingHandlers = deployment.getPreMatchHandlers();
         this.resumeOn404 = deployment.isResumeOn404();
         if (preMappingHandlers.isEmpty()) {
@@ -45,7 +42,7 @@ public class RestInitialHandler implements ServerRestHandler {
     }
 
     public void beginProcessing(Object extenalHttpContext) {
-        ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, providers, extenalHttpContext,
+        ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, extenalHttpContext,
                 requestContext,
                 initialChain, deployment.getAbortHandlerChain());
         rq.run();

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxRequestContextFactory.java
@@ -3,7 +3,6 @@ package org.jboss.resteasy.reactive.server.vertx;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.RequestContextFactory;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 import org.jboss.resteasy.reactive.spi.ThreadSetupAction;
 
@@ -12,9 +11,9 @@ import io.vertx.ext.web.RoutingContext;
 public class VertxRequestContextFactory implements RequestContextFactory {
     @Override
     public ResteasyReactiveRequestContext createContext(Deployment deployment,
-            ProvidersImpl providers, Object context, ThreadSetupAction requestContext,
+            Object context, ThreadSetupAction requestContext,
             ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain) {
-        return new VertxResteasyReactiveRequestContext(deployment, providers, (RoutingContext) context,
+        return new VertxResteasyReactiveRequestContext(deployment, (RoutingContext) context,
                 requestContext, handlerChain, abortHandlerChain, null);
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxResteasyReactiveRequestContext.java
@@ -20,7 +20,6 @@ import org.jboss.resteasy.reactive.common.util.CaseInsensitiveMap;
 import org.jboss.resteasy.reactive.server.core.Deployment;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.multipart.FormData;
-import org.jboss.resteasy.reactive.server.jaxrs.ProvidersImpl;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpRequest;
 import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
@@ -53,11 +52,11 @@ public class VertxResteasyReactiveRequestContext extends ResteasyReactiveRequest
     protected Consumer<ResteasyReactiveRequestContext> preCommitTask;
     ContinueState continueState = ContinueState.NONE;
 
-    public VertxResteasyReactiveRequestContext(Deployment deployment, ProvidersImpl providers,
+    public VertxResteasyReactiveRequestContext(Deployment deployment,
             RoutingContext context,
             ThreadSetupAction requestContext, ServerRestHandler[] handlerChain, ServerRestHandler[] abortHandlerChain,
             ClassLoader devModeTccl) {
-        super(deployment, providers, requestContext, handlerChain, abortHandlerChain);
+        super(deployment, requestContext, handlerChain, abortHandlerChain);
         this.context = context;
         this.request = context.request();
         this.response = context.response();


### PR DESCRIPTION
The providers field is almost never used, so let's remove it and simply create the value on demand.

This is part of an ongoing effort to reduce the size of the RR context object in order to make it fit better in caches