### PR TITLE
Bump Reactive Messaging version to 3.20.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,7 +52,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.26.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.19.1</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>3.20.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.2.0</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>


### PR DESCRIPTION
Includes fix for #12486, #26809