### PR TITLE
Add configuration for the Quarkus GitHub Lottery

### DIFF
--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -1,0 +1,15 @@
+notifications:
+  createIssues:
+    repository: "quarkusio/quarkus-github-lottery-reports"
+buckets:
+  triage:
+    needsTriageLabel: "triage/needs-triage"
+    notificationExpiration: P3D
+labels:
+  needsTriage: "triage/needs-triage"
+participants:
+  - username: "yrodiere"
+    timezone: "Europe/Paris"
+    days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+    triage:
+      maxIssues: 3


### PR DESCRIPTION
This is still work in progress, but I would like to check the setup.

The application will not change issues of the quarkus repository in any way: it will just create reports in a separate repository.