### PR TITLE
Disable flaky CodeFlowTest.testTokenAutoRefresh

### DIFF
--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -499,6 +500,8 @@ public class CodeFlowTest {
     }
 
     @Test
+    // See https://github.com/quarkusio/quarkus/issues/27900
+    @Disabled("flaky")
     public void testTokenAutoRefresh() throws IOException {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/tenant-autorefresh");


### PR DESCRIPTION
Failed today in #28199, but with 0 indication of the source of `401`, so I'll investigate further as part of #27900