### PR TITLE
In remote dev delete files after the app has been closed and before it is restarted

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/RuntimeUpdatesProcessor.java
@@ -53,6 +53,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
 
+import io.quarkus.bootstrap.runner.DevModeMediator;
 import io.quarkus.bootstrap.runner.Timing;
 import io.quarkus.changeagent.ClassChangeAgent;
 import io.quarkus.deployment.dev.DevModeContext.ModuleInfo;
@@ -602,6 +603,7 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     ret.add(i.getKey());
                 }
             }
+            List<Path> removedFiles = List.of();
             for (Map.Entry<String, String> remaining : ourHashes.entrySet()) {
                 String file = remaining.getKey();
                 if (file.endsWith("META-INF/MANIFEST.MF") || file.contains("META-INF/maven")
@@ -609,8 +611,14 @@ public class RuntimeUpdatesProcessor implements HotReplacementContext, Closeable
                     //we have some filters, for files that we don't want to delete
                     continue;
                 }
-                log.info("Deleting removed file " + file);
-                Files.deleteIfExists(applicationRoot.resolve(file));
+                log.info("Scheduled for removal " + file);
+                if (removedFiles.isEmpty()) {
+                    removedFiles = new ArrayList<>();
+                }
+                removedFiles.add(applicationRoot.resolve(file));
+            }
+            if (!removedFiles.isEmpty()) {
+                DevModeMediator.removedFiles.addLast(removedFiles);
             }
             return ret;
         } catch (IOException e) {

--- a/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/DevModeMediator.java
+++ b/independent-projects/bootstrap/runner/src/main/java/io/quarkus/bootstrap/runner/DevModeMediator.java
@@ -9,9 +9,11 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Deque;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.LinkedBlockingDeque;
 
 import org.jboss.logging.Logger;
 
@@ -23,6 +25,8 @@ import org.jboss.logging.Logger;
 public class DevModeMediator {
 
     protected static final Logger LOGGER = Logger.getLogger(DevModeMediator.class);
+
+    public static final Deque<List<Path>> removedFiles = new LinkedBlockingDeque<>();
 
     static void doDevMode(Path appRoot) throws IOException, ClassNotFoundException, IllegalAccessException,
             InvocationTargetException, NoSuchMethodException {
@@ -88,6 +92,13 @@ public class DevModeMediator {
                         closeable.close();
                     }
                     closeable = null;
+                    final List<Path> pathsToDelete = removedFiles.pollFirst();
+                    if (pathsToDelete != null) {
+                        for (Path p : pathsToDelete) {
+                            LOGGER.info("Deleting " + p);
+                            Files.deleteIfExists(p);
+                        }
+                    }
                     try {
                         closeable = doStart(appRoot, deploymentClassPath);
                     } catch (Exception e) {


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/28098

This change is reducing the chance of JARs being deleted while the app is still running.

@stuartwdouglas do you have a better idea or suggestion than this?
