### PR TITLE
Use notifyAll instead of notify

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxInputStream.java
@@ -190,7 +190,7 @@ public class VertxInputStream extends InputStream {
                             synchronized (connection) {
                                 eof = true;
                                 if (waiting) {
-                                    connection.notify();
+                                    connection.notifyAll();
                                 }
                             }
                         }
@@ -212,7 +212,7 @@ public class VertxInputStream extends InputStream {
                                     }
                                 }
                                 if (waiting) {
-                                    connection.notify();
+                                    connection.notifyAll();
                                 }
                             }
                         }

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/VertxInputStream.java
@@ -190,7 +190,7 @@ public class VertxInputStream extends InputStream {
                             synchronized (connection) {
                                 eof = true;
                                 if (waiting) {
-                                    connection.notify();
+                                    connection.notifyAll();
                                 }
                             }
                         }
@@ -212,7 +212,7 @@ public class VertxInputStream extends InputStream {
                                     }
                                 }
                                 if (waiting) {
-                                    connection.notify();
+                                    connection.notifyAll();
                                 }
                             }
                         }


### PR DESCRIPTION
HTTP/2 could have multiple threads waiting on the connection, so we need to wake up all of them.

In future we could move to a park/unpark based approach but it would need some performance testing.

Fixes #28116