### PR TITLE
Stop index warn by excluding resource removed by extension from indexing

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/index/ApplicationArchiveBuildStep.java
@@ -102,6 +102,9 @@ public class ApplicationArchiveBuildStep {
             removedResources.put(new GACT(entry.getKey().split(":")), entry.getValue());
         }
 
+        // Add resources removed from the classpath by extensions
+        removedResources.putAll(curateOutcomeBuildItem.getApplicationModel().getRemovedResources());
+
         List<ApplicationArchive> applicationArchives = scanForOtherIndexes(buildCloseables,
                 appMarkers, root, additionalApplicationArchiveBuildItem, indexDependencyBuildItems, indexCache,
                 curateOutcomeBuildItem, removedResources);

--- a/extensions/keycloak-admin-client-reactive/runtime/pom.xml
+++ b/extensions/keycloak-admin-client-reactive/runtime/pom.xml
@@ -73,6 +73,14 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <configuration>
+                    <removedResources>
+                        <artifact>
+                            <key>org.keycloak:keycloak-admin-client</key>
+                            <resources>org/keycloak/admin/client/JacksonProvider.class</resources>
+                        </artifact>
+                    </removedResources>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
fixes: #27907

Excludes resources removed by extension from indexing as according to `io.quarkus.maven.ExtensionDescriptorMojo#removedResources` should be equivalent of `quarkus.class-loading.removed-resources`, however later classes are excluded from indexing while former are not. Fix is used  to exclude `org.keycloak.admin.client.JacksonProvider` that extends `org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider` from indexing. The file is never used as we set `io.quarkus.keycloak.admin.client.reactive.runtime.ResteasyReactiveKeycloakAdminClientRecorder#setClientProvider` and it produces incorrect warning (see linked issue).