### PR TITLE
Move some rarely used async related fields out of QuarkusResteasyReactiveRequestContext

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/AbstractResteasyReactiveContext.java
@@ -37,7 +37,6 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
     private final ThreadSetupAction requestContext;
     private ThreadSetupAction.ThreadState currentRequestScope;
     private List<CompletionCallback> completionCallbacks;
-    private List<ConnectionCallback> connectionCallbacks;
     private boolean abortHandlerChainStarted;
 
     private boolean closed = false;
@@ -399,10 +398,15 @@ public abstract class AbstractResteasyReactiveContext<T extends AbstractResteasy
         completionCallbacks.add(callback);
     }
 
+    private static final String CONNECTION_CALLBACK_PROPERTY_KEY = CUSTOM_RR_PROPERTIES_PREFIX + "CONNECTION_CALLBACK";
+
     @Override
     public synchronized void registerConnectionCallback(ConnectionCallback callback) {
-        if (connectionCallbacks == null)
+        List<ConnectionCallback> connectionCallbacks = (List<ConnectionCallback>) getProperty(CONNECTION_CALLBACK_PROPERTY_KEY);
+        if (connectionCallbacks == null) {
             connectionCallbacks = new ArrayList<>();
+            setProperty(CONNECTION_CALLBACK_PROPERTY_KEY, connectionCallbacks);
+        }
         connectionCallbacks.add(callback);
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -128,7 +128,6 @@ public abstract class ResteasyReactiveRequestContext
      */
     private List<UriMatch> matchedURIs;
 
-    private AsyncResponseImpl asyncResponse;
     private SseEventSinkImpl sseEventSink;
     private List<PathSegment> pathSegments;
     private ReaderInterceptor[] readerInterceptors;
@@ -593,15 +592,18 @@ public abstract class ResteasyReactiveRequestContext
         return this;
     }
 
+    private static final String ASYNC_RESPONSE_PROPERTY_KEY = AbstractResteasyReactiveContext.CUSTOM_RR_PROPERTIES_PREFIX
+            + "AsyncResponse";
+
     public AsyncResponseImpl getAsyncResponse() {
-        return asyncResponse;
+        return (AsyncResponseImpl) getProperty(ASYNC_RESPONSE_PROPERTY_KEY);
     }
 
     public ResteasyReactiveRequestContext setAsyncResponse(AsyncResponseImpl asyncResponse) {
-        if (this.asyncResponse != null) {
+        if (getAsyncResponse() != null) {
             throw new RuntimeException("Async can only be started once");
         }
-        this.asyncResponse = asyncResponse;
+        setProperty(ASYNC_RESPONSE_PROPERTY_KEY, asyncResponse);
         return this;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ResteasyReactiveRequestContext.java
@@ -128,7 +128,6 @@ public abstract class ResteasyReactiveRequestContext
      */
     private List<UriMatch> matchedURIs;
 
-    private SseEventSinkImpl sseEventSink;
     private List<PathSegment> pathSegments;
     private ReaderInterceptor[] readerInterceptors;
     private WriterInterceptor[] writerInterceptors;
@@ -722,12 +721,15 @@ public abstract class ResteasyReactiveRequestContext
         return this;
     }
 
+    private static final String SSE_EVENT_SINK_PROPERTY_KEY = AbstractResteasyReactiveContext.CUSTOM_RR_PROPERTIES_PREFIX
+            + "SSEEventSink";
+
     public SseEventSinkImpl getSseEventSink() {
-        return sseEventSink;
+        return (SseEventSinkImpl) getProperty(SSE_EVENT_SINK_PROPERTY_KEY);
     }
 
     public void setSseEventSink(SseEventSinkImpl sseEventSink) {
-        this.sseEventSink = sseEventSink;
+        setProperty(SSE_EVENT_SINK_PROPERTY_KEY, sseEventSink);
     }
 
     /**


### PR DESCRIPTION
Follows up on: #28204