### PR TITLE
Quartz - make it possible to obtain the underlying scheduler instance

### DIFF
--- a/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
+++ b/extensions/quartz/deployment/src/main/java/io/quarkus/quartz/deployment/QuartzProcessor.java
@@ -55,7 +55,7 @@ import io.quarkus.quartz.runtime.QuartzBuildTimeConfig;
 import io.quarkus.quartz.runtime.QuartzExtensionPointConfig;
 import io.quarkus.quartz.runtime.QuartzRecorder;
 import io.quarkus.quartz.runtime.QuartzRuntimeConfig;
-import io.quarkus.quartz.runtime.QuartzScheduler;
+import io.quarkus.quartz.runtime.QuartzSchedulerImpl;
 import io.quarkus.quartz.runtime.QuartzSupport;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
@@ -73,7 +73,7 @@ public class QuartzProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem beans() {
-        return new AdditionalBeanBuildItem(QuartzScheduler.class);
+        return new AdditionalBeanBuildItem(QuartzSchedulerImpl.class);
     }
 
     @BuildStep
@@ -165,7 +165,7 @@ public class QuartzProcessor {
             reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, SimpleTriggerImpl.class.getName()));
             reflectiveClasses.add(new ReflectiveClassBuildItem(true, false, driverDialect.getDriver().get()));
             reflectiveClasses
-                    .add(new ReflectiveClassBuildItem(true, true, "io.quarkus.quartz.runtime.QuartzScheduler$InvokerJob"));
+                    .add(new ReflectiveClassBuildItem(true, true, "io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob"));
             reflectiveClasses
                     .add(new ReflectiveClassBuildItem(true, false, QuarkusQuartzConnectionPoolProvider.class.getName()));
         }

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InjectQuartzSchedulerTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/InjectQuartzSchedulerTest.java
@@ -21,6 +21,7 @@ import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 
+import io.quarkus.quartz.QuartzScheduler;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -42,7 +43,9 @@ public class InjectQuartzSchedulerTest {
 
         static final CountDownLatch LATCH = new CountDownLatch(2);
 
-        void onStart(@Observes StartupEvent event, Scheduler quartz) throws SchedulerException {
+        void onStart(@Observes StartupEvent event, Scheduler quartz, QuartzScheduler quartzScheduler)
+                throws SchedulerException {
+            assertTrue(quartz == quartzScheduler.getScheduler());
             JobDetail job = JobBuilder.newJob(Starter.class)
                     .withIdentity("myJob", "myGroup")
                     .build();

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/QuartzScheduler.java
@@ -1,0 +1,16 @@
+package io.quarkus.quartz;
+
+import io.quarkus.scheduler.Scheduler;
+
+/**
+ * Quartz-specific implementation of {@link Scheduler}.
+ */
+public interface QuartzScheduler extends Scheduler {
+
+    /**
+     *
+     * @return the underlying {@link org.quartz.Scheduler} instance, or {@code null} if the scheduler was not started
+     */
+    org.quartz.Scheduler getScheduler();
+
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -26,6 +26,7 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Typed;
 import javax.inject.Singleton;
 import javax.interceptor.Interceptor;
 import javax.transaction.SystemException;
@@ -60,6 +61,7 @@ import com.cronutils.parser.CronParser;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.Subclass;
+import io.quarkus.quartz.QuartzScheduler;
 import io.quarkus.runtime.StartupEvent;
 import io.quarkus.scheduler.FailedExecution;
 import io.quarkus.scheduler.Scheduled;
@@ -83,10 +85,11 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
+@Typed({ QuartzScheduler.class, Scheduler.class })
 @Singleton
-public class QuartzScheduler implements Scheduler {
+public class QuartzSchedulerImpl implements QuartzScheduler {
 
-    private static final Logger LOGGER = Logger.getLogger(QuartzScheduler.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(QuartzSchedulerImpl.class.getName());
     private static final String INVOKER_KEY = "invoker";
 
     private final org.quartz.Scheduler scheduler;
@@ -95,7 +98,8 @@ public class QuartzScheduler implements Scheduler {
     private final Duration shutdownWaitTime;
     private final Map<String, QuartzTrigger> scheduledTasks = new HashMap<>();
 
-    public QuartzScheduler(SchedulerContext context, QuartzSupport quartzSupport, SchedulerRuntimeConfig schedulerRuntimeConfig,
+    public QuartzSchedulerImpl(SchedulerContext context, QuartzSupport quartzSupport,
+            SchedulerRuntimeConfig schedulerRuntimeConfig,
             Event<SkippedExecution> skippedExecutionEvent, Event<SuccessfulExecution> successfulExecutionEvent,
             Event<FailedExecution> failedExecutionEvent, Instance<Job> jobs, Instance<UserTransaction> userTransaction,
             Vertx vertx) {
@@ -345,6 +349,11 @@ public class QuartzScheduler implements Scheduler {
             throw new IllegalStateException(
                     "Quartz scheduler is either explicitly disabled through quarkus.scheduler.enabled=false or no @Scheduled methods were found. If you only need to schedule a job programmatically you can force the start of the scheduler by setting 'quarkus.quartz.start-mode=forced'.");
         }
+        return scheduler;
+    }
+
+    @Override
+    public org.quartz.Scheduler getScheduler() {
         return scheduler;
     }
 


### PR DESCRIPTION
- introduce io.quarkus.quartz.QuartzScheduler and QuartzScheduler#getScheduler()
- rename io.quarkus.quartz.runtime.QuartzScheduler to io.quarkus.quartz.runtime.QuartzSchedulerImpl
- resolves #27929

This pr can supersede https://github.com/quarkusio/quarkus/pull/28168.

CC @JiriOndrusek @machi1990 @gsmet 