### PR TITLE
Upgrade to Hibernate ORM 5.6.12.Final

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.11.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>5.6.12.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.7.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>

--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/GraalVMFeatures.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.orm.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
+
+/**
+ * Activates the native-image features included in the module
+ * org.hibernate:hibernate-graalvm.
+ */
+@BuildSteps
+public class GraalVMFeatures {
+
+    @BuildStep
+    NativeImageFeatureBuildItem staticNativeImageFeature() {
+        return new NativeImageFeatureBuildItem("org.hibernate.graalvm.internal.GraalVMStaticFeature");
+    }
+
+    @BuildStep
+    NativeImageFeatureBuildItem queryParsingSupportFeature() {
+        return new NativeImageFeatureBuildItem("org.hibernate.graalvm.internal.QueryParsingSupport");
+    }
+
+}


### PR DESCRIPTION
and paves the road for the next GraalVM release, as automatic features will no longer be an option.

Fixes #27893 

Pre-requisite for #27928 