### PR TITLE
Support record inside JandexUtil

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassType;
@@ -289,25 +290,32 @@ public final class JandexUtil {
     }
 
     /**
-     * Returns the enclosing class of the given annotation instance. For field or method annotations this
-     * will return the enclosing class. For parameters, this will return the enclosing class of the enclosing
-     * method. For classes, it will return the class itself.
+     * Returns the enclosing class of the given annotation instance. For field, method or record component annotations,
+     * this will return the enclosing class. For parameters, this will return the enclosing class of the enclosing
+     * method. For classes, it will return the class itself. For type annotations, it will return the class enclosing
+     * the annotated type usage.
      *
-     * @param annotationInstance the annotation whose enclosing class to look up.
-     * @return the enclosing class.
+     * @param annotationInstance the annotation whose enclosing class to look up
+     * @return the enclosing class
      */
     public static ClassInfo getEnclosingClass(AnnotationInstance annotationInstance) {
-        switch (annotationInstance.target().kind()) {
+        return getEnclosingClass(annotationInstance.target());
+    }
+
+    private static ClassInfo getEnclosingClass(AnnotationTarget annotationTarget) {
+        switch (annotationTarget.kind()) {
             case FIELD:
-                return annotationInstance.target().asField().declaringClass();
+                return annotationTarget.asField().declaringClass();
             case METHOD:
-                return annotationInstance.target().asMethod().declaringClass();
+                return annotationTarget.asMethod().declaringClass();
             case METHOD_PARAMETER:
-                return annotationInstance.target().asMethodParameter().method().declaringClass();
+                return annotationTarget.asMethodParameter().method().declaringClass();
+            case RECORD_COMPONENT:
+                return annotationTarget.asRecordComponent().declaringClass();
             case CLASS:
-                return annotationInstance.target().asClass();
+                return annotationTarget.asClass();
             case TYPE:
-                return annotationInstance.target().asType().asClass(); // TODO is it legal here or should I throw ?
+                return getEnclosingClass(annotationTarget.asType().enclosingTarget());
             default:
                 throw new RuntimeException(); // this should not occur
         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/JandexUtil.java
@@ -29,6 +29,7 @@ import io.quarkus.builder.BuildException;
 public final class JandexUtil {
 
     public final static DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
+    public final static DotName DOTNAME_RECORD = DotName.createSimple("java.lang.Record");
 
     private JandexUtil() {
     }
@@ -119,8 +120,8 @@ public final class JandexUtil {
             return null;
         }
 
-        // always end at Object
-        if (DOTNAME_OBJECT.equals(name)) {
+        // always end at Object or Record
+        if (DOTNAME_OBJECT.equals(name) || DOTNAME_RECORD.equals(name)) {
             return null;
         }
 
@@ -323,7 +324,7 @@ public final class JandexUtil {
      * @throws BuildException if one of the superclasses is not indexed.
      */
     public static boolean isSubclassOf(IndexView index, ClassInfo info, DotName parentName) throws BuildException {
-        if (info.superName().equals(DOTNAME_OBJECT)) {
+        if (info.superName().equals(DOTNAME_OBJECT) || info.superName().equals(DOTNAME_RECORD)) {
             return false;
         }
         if (info.superName().equals(parentName)) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
@@ -35,6 +35,7 @@ import org.jboss.jandex.TypeVariable;
 public final class JandexUtil {
 
     public final static DotName DOTNAME_OBJECT = DotName.createSimple(Object.class.getName());
+    public final static DotName DOTNAME_RECORD = DotName.createSimple("java.lang.Record");
 
     private JandexUtil() {
     }
@@ -143,7 +144,7 @@ public final class JandexUtil {
         }
 
         // always end at Object
-        if (DOTNAME_OBJECT.equals(name)) {
+        if (DOTNAME_OBJECT.equals(name) || DOTNAME_RECORD.equals(name)) {
             return null;
         }
 
@@ -338,7 +339,7 @@ public final class JandexUtil {
      * @throws RuntimeException if one of the superclasses is not indexed.
      */
     public static boolean isSubclassOf(IndexView index, ClassInfo info, DotName parentName) {
-        if (info.superName().equals(DOTNAME_OBJECT)) {
+        if (info.superName().equals(DOTNAME_OBJECT) || info.superName().equals(DOTNAME_RECORD)) {
             return false;
         }
         if (info.superName().equals(parentName)) {

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/JandexUtil.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ArrayType;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.ClassType;
@@ -304,25 +305,32 @@ public final class JandexUtil {
     }
 
     /**
-     * Returns the enclosing class of the given annotation instance. For field or method annotations this
-     * will return the enclosing class. For parameters, this will return the enclosing class of the enclosing
-     * method. For classes it will return the class itself.
+     * Returns the enclosing class of the given annotation instance. For field, method or record component annotations,
+     * this will return the enclosing class. For parameters, this will return the enclosing class of the enclosing
+     * method. For classes, it will return the class itself. For type annotations, it will return the class enclosing
+     * the annotated type usage.
      *
-     * @param annotationInstance the annotation whose enclosing class to look up.
-     * @return the enclosing class.
+     * @param annotationInstance the annotation whose enclosing class to look up
+     * @return the enclosing class
      */
     public static ClassInfo getEnclosingClass(AnnotationInstance annotationInstance) {
-        switch (annotationInstance.target().kind()) {
+        return getEnclosingClass(annotationInstance.target());
+    }
+
+    private static ClassInfo getEnclosingClass(AnnotationTarget annotationTarget) {
+        switch (annotationTarget.kind()) {
             case FIELD:
-                return annotationInstance.target().asField().declaringClass();
+                return annotationTarget.asField().declaringClass();
             case METHOD:
-                return annotationInstance.target().asMethod().declaringClass();
+                return annotationTarget.asMethod().declaringClass();
             case METHOD_PARAMETER:
-                return annotationInstance.target().asMethodParameter().method().declaringClass();
+                return annotationTarget.asMethodParameter().method().declaringClass();
+            case RECORD_COMPONENT:
+                return annotationTarget.asRecordComponent().declaringClass();
             case CLASS:
-                return annotationInstance.target().asClass();
+                return annotationTarget.asClass();
             case TYPE:
-                return annotationInstance.target().asType().asClass(); // TODO is it legal here or should I throw ?
+                return getEnclosingClass(annotationTarget.asType().enclosingTarget());
             default:
                 throw new RuntimeException(); // this should not occur
         }


### PR DESCRIPTION
Improve Java records support.

The only place where I tested it is with MongoDB with Panache, thanks to this PR MongoDB entity can now be declared as records. Other places should require more work.

There is no test as there is no facility in Quarkus yet to test functionalities provided by java version different than the one we build with.