### PR TITLE
Fix support for rootless docker context

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildLocalContainerRunner.java
@@ -87,7 +87,7 @@ public class NativeImageBuildLocalContainerRunner extends NativeImageBuildContai
         OutputFilter outputFilter = new OutputFilter();
         if (!ExecUtil.execWithTimeout(new File("."), outputFilter, Duration.ofMillis(3000),
                 "docker", "context", "ls", "--format",
-                "'{{- if .Current -}} {{- .DockerEndpoint -}} {{- end -}}'")) {
+                "{{- if .Current -}} {{- .DockerEndpoint -}} {{- end -}}")) {
             LOGGER.debug("Docker context lookup didn't succeed in time");
             return null;
         }


### PR DESCRIPTION
With the `'` it returns `'''unix:///run/user/1000/docker.sock'` which fails the startsWith("unix://") check.

Fix up #26892

Despite being discussed in https://github.com/quarkusio/quarkus/pull/26892#discussion_r968120982 it slipped through.