### PR TITLE
Restore the query when redirecting to the OIDC error path

### DIFF
--- a/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
+++ b/integration-tests/oidc-code-flow/src/main/java/io/quarkus/it/keycloak/TenantHttps.java
@@ -33,7 +33,8 @@ public class TenantHttps {
 
     @GET
     @Path("error")
-    public String getError(@QueryParam("error") String error, @QueryParam("error_description") String errorDescription) {
-        return "error: " + error + ", error_description: " + errorDescription;
+    public String getError(@QueryParam("error") String error, @QueryParam("error_description") String errorDescription,
+            @QueryParam("code") String value) {
+        return "code: " + value + ", error: " + error + ", error_description: " + errorDescription;
     }
 }

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -148,7 +148,7 @@ public class CodeFlowTest {
             endpointErrorLocation = "http" + endpointErrorLocation.substring(5);
 
             HtmlPage page = webClient.getPage(URI.create(endpointErrorLocation).toURL());
-            assertEquals("error: invalid_scope, error_description: Invalid scopes: unknown",
+            assertEquals("code: b, error: invalid_scope, error_description: Invalid scopes: unknown",
                     page.getBody().asText());
             webClient.getCookieManager().clearCookies();
         }


### PR DESCRIPTION
Fixes #28246

Minor update to OIDC to have the custom user query which was provided before the authorization code flow has started be restored after the user authentication has failed in Keycloak/etc and the user is redirected back to Quarkus and then to the configured error path page, I've just copied the code from a few lines above which restores such queries when the authentication has been successful.
Also removed a duplicate line removing the state cookie as it is already done just above this code.
Updated the error path test to verify the custom query is restored