### PR TITLE
Executes scheduled methods on duplicated contexts

### DIFF
--- a/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SchedulerContext.java
+++ b/extensions/scheduler/common/src/main/java/io/quarkus/scheduler/common/runtime/SchedulerContext.java
@@ -2,13 +2,10 @@ package io.quarkus.scheduler.common.runtime;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import com.cronutils.model.CronType;
 
 public interface SchedulerContext {
-
-    ExecutorService getExecutor();
 
     CronType getCronType();
 

--- a/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
+++ b/extensions/scheduler/deployment/src/main/java/io/quarkus/scheduler/deployment/SchedulerProcessor.java
@@ -61,7 +61,6 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AnnotationProxyBuildItem;
-import io.quarkus.deployment.builditem.ExecutorBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -277,7 +276,7 @@ public class SchedulerProcessor {
     public FeatureBuildItem build(SchedulerConfig config, BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             SchedulerRecorder recorder, List<ScheduledBusinessMethodItem> scheduledMethods,
             BuildProducer<GeneratedClassBuildItem> generatedClasses, BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            AnnotationProxyBuildItem annotationProxy, ExecutorBuildItem executor) {
+            AnnotationProxyBuildItem annotationProxy) {
 
         List<ScheduledMethodMetadata> scheduledMetadata = new ArrayList<>();
         ClassOutput classOutput = new GeneratedClassGizmoAdaptor(generatedClasses, new Function<String, String>() {
@@ -311,7 +310,7 @@ public class SchedulerProcessor {
         }
 
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(SchedulerContext.class).setRuntimeInit()
-                .supplier(recorder.createContext(config, executor.getExecutorProxy(), scheduledMetadata))
+                .supplier(recorder.createContext(config, scheduledMetadata))
                 .done());
 
         return new FeatureBuildItem(Feature.SCHEDULER);

--- a/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicatedContextTest.java
+++ b/extensions/scheduler/deployment/src/test/java/io/quarkus/scheduler/test/DuplicatedContextTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.scheduler.test;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies that the @Scheduled method are called on a duplicated context.
+ */
+public class DuplicatedContextTest {
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyScheduledClass.class));
+
+    @Inject
+    MyScheduledClass scheduled;
+
+    @Test
+    public void testBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.blockingCalled() > 0);
+    }
+
+    @Test
+    public void testNonBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.nonBlockingCalled() > 0);
+    }
+
+    public static class MyScheduledClass {
+
+        private final AtomicInteger blockingCalled = new AtomicInteger();
+        private final AtomicInteger nonBlockingCalled = new AtomicInteger();
+
+        @Scheduled(every = "1m")
+        public void blocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNotNull(context);
+            Assertions.assertTrue(VertxContext.isDuplicatedContext(context));
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+
+            blockingCalled.incrementAndGet();
+        }
+
+        @Scheduled(every = "1m")
+        public Uni<Void> nonblocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNotNull(context);
+            Assertions.assertTrue(VertxContext.isDuplicatedContext(context));
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+
+            nonBlockingCalled.incrementAndGet();
+            return Uni.createFrom().voidItem();
+        }
+
+        public int blockingCalled() {
+            return blockingCalled.get();
+        }
+
+        public int nonBlockingCalled() {
+            return nonBlockingCalled.get();
+        }
+    }
+}

--- a/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
+++ b/extensions/scheduler/runtime/src/main/java/io/quarkus/scheduler/runtime/SchedulerRecorder.java
@@ -1,7 +1,6 @@
 package io.quarkus.scheduler.runtime;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
 import com.cronutils.model.CronType;
@@ -13,17 +12,12 @@ import io.quarkus.scheduler.common.runtime.SchedulerContext;
 @Recorder
 public class SchedulerRecorder {
 
-    public Supplier<Object> createContext(SchedulerConfig config, ExecutorService executorService,
+    public Supplier<Object> createContext(SchedulerConfig config,
             List<ScheduledMethodMetadata> scheduledMethods) {
         return new Supplier<Object>() {
             @Override
             public Object get() {
                 return new SchedulerContext() {
-
-                    @Override
-                    public ExecutorService getExecutor() {
-                        return executorService;
-                    }
 
                     @Override
                     public CronType getCronType() {


### PR DESCRIPTION
- Remove the executor from the ScheduledContext as it was confusing and can only be used for blocking methods
- Create a duplicated context for both blocking and non-blocking invocation
- Blocking invocation use executeBlocking, which uses the same thread pool as the previous executor
- It is not possible to create the duplicated context in the thread factory (an idea discussed with Bruno and Martin because it creates a chicken-and-egg problem)
- Simplify the dev console @Scheduled support to use the same strategy - no need to play with the classloader anymore as there is no more in-thread direct invocation and the Vert.x thread that will be used has the right TCCL configured

Fix https://github.com/quarkusio/quarkus/issues/28017

A follow-up for Quartz will be implemented later.