### PR TITLE
Tolerate failed cleanup causing build failures on M1

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -119,7 +119,7 @@ jobs:
           fetch-depth: 0
       - name: Add quarkusio remote
         shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
+        run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - uses: n1hility/cancel-previous-runs@v2
         # quarkus-bot will handle this much more efficiently, but it's not active in/for forks
         if: github.repository != 'quarkusio/quarkus'

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -167,7 +167,7 @@ Then add the following:
 Finally, run 
 
 ```shell
-sudo launchctl load -w /Library/LaunchDaemons/github.runner.startup.plist
+sudo launchctl load -w /Library/LaunchDaemons/actions.runner.quarkusio-quarkus.macstadium-m1.plist
 ```
 
 You can check the logs in `/tmp/github.runner.plist.stdout` to confirm everything is working.

--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -88,11 +88,6 @@ If you forget the label, it will need to be added [through the UI](https://docs.
 #### Cleanup and setup logic
 
 Self-hosted runners do not run on ephemeral hardware, and so workflow runs may need to clean up. 
-In this case, the main cleanup is a fresh workspace checkout, to ensure `git remote add` in the workflow step does not fail with `error: remote quarkusio already exists`.:
-
-(If the machine crashes, cleanup will not run, and the next run may fail. 
-If this becomes a common issue, we can update the workflow to run `git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git`.)
-
 We also need to start a podman machine before the job if one is not already running. 
 
 To create cleanup and setup scripts and hooks, run:


### PR DESCRIPTION
``````
Run git remote add quarkusio https://github.com/quarkusio/quarkus.git
error: remote quarkusio already exists.
Error: Process completed with exit code 3.
```

See https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/M1.20CI.20error/near/301258373.