### PR TITLE
Add DbTestClient

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -806,6 +806,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-test-db-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-oidc-deployment</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/integration-tests/jpa-h2/pom.xml
+++ b/integration-tests/jpa-h2/pom.xml
@@ -41,6 +41,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-db-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/Artwork.java
+++ b/integration-tests/jpa-h2/src/main/java/io/quarkus/it/jpa/h2/Artwork.java
@@ -1,0 +1,33 @@
+package io.quarkus.it.jpa.h2;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Artwork {
+
+    @Id
+    @GeneratedValue
+    private Integer id;
+
+    private String name;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Artwork setId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Artwork setName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/ResetDatabaseTestCase.java
+++ b/integration-tests/jpa-h2/src/test/java/io/quarkus/it/jpa/h2/ResetDatabaseTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.it.jpa.h2;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.db.client.DbTestClient;
+import io.quarkus.test.junit.QuarkusTest;
+
+//if the DB was not cleaned between method invocations then one of these tests would fail
+@QuarkusTest
+@Transactional
+public class ResetDatabaseTestCase {
+
+    @Inject
+    EntityManager entityManager;
+
+    DbTestClient client = new DbTestClient();
+
+    @AfterEach
+    public void resetDatabase() {
+        client.resetAllDatabases();
+    }
+
+    @Test
+    public void test1() {
+        Assertions.assertEquals(0, entityManager.createQuery("from Artwork").getResultList().size());
+        Artwork d = new Artwork();
+        d.setName("Mona Lisa");
+        entityManager.persist(d);
+    }
+
+    @Test
+    public void test2() {
+        Assertions.assertEquals(0, entityManager.createQuery("from Artwork").getResultList().size());
+        Artwork d = new Artwork();
+        d.setName("Mona Lisa");
+        entityManager.persist(d);
+    }
+}

--- a/test-framework/db-client/pom.xml
+++ b/test-framework/db-client/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-framework</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-test-db-client</artifactId>
+    <name>Quarkus - Test Framework - DB test client support</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jakarta-rewrite</id>
+            <activation>
+                <property>
+                    <name>jakarta-rewrite</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <configuration>
+                            <activeRecipes>
+                                <recipe>io.quarkus.jakarta-angus-activation-exclude-add</recipe>
+                            </activeRecipes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/test-framework/db-client/src/main/java/io/quarkus/test/db/client/DbTestClient.java
+++ b/test-framework/db-client/src/main/java/io/quarkus/test/db/client/DbTestClient.java
@@ -1,0 +1,46 @@
+package io.quarkus.test.db.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import io.quarkus.datasource.runtime.DatabaseSchemaProvider;
+import io.quarkus.test.common.DevServicesContext;
+
+public class DbTestClient implements DevServicesContext.ContextAware {
+
+    private static final String DEFAULT_DB = "<default>";
+
+    private DevServicesContext testContext;
+    private final List<DatabaseSchemaProvider> providers = new ArrayList<>();
+
+    public DbTestClient() {
+    }
+
+    public void resetDefaultDatabase() {
+        resetDatabase(DEFAULT_DB);
+    }
+
+    public void resetDatabase(String dbName) {
+        for (DatabaseSchemaProvider i : providers) {
+            i.resetDatabase(dbName);
+        }
+    }
+
+    public void resetAllDatabases() {
+        for (DatabaseSchemaProvider i : providers) {
+            i.resetAllDatabases();
+        }
+    }
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.testContext = context;
+
+        ServiceLoader<DatabaseSchemaProvider> dbs = ServiceLoader.load(DatabaseSchemaProvider.class,
+                Thread.currentThread().getContextClassLoader());
+        for (DatabaseSchemaProvider i : dbs) {
+            providers.add(i);
+        }
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -20,6 +20,7 @@
 
     <modules>
         <module>common</module>
+        <module>db-client</module>
         <module>h2</module>
         <module>derby</module>
         <module>kubernetes-client</module>


### PR DESCRIPTION
This PR adds `DbTestClient` for users to reset DB whenever they want during the test.
`DbTestClient` can also have more useful methods going forward as it has a `DevServicesContext` injected.
I'll link to the issues and other PRs from Stuart if approved.
Typical use:
```
class MyTest {
   DbTestClient client = new DbTestClient();

   @Test
   public void testIt() {
      client.resetDatabase("quarkus");
   }
}
```

I'm interested to use such a client to have security tests with DB side-effects run for different roles and demo it.
I can copy some tests from Stuart's PRs and add something to verify it works as expected.

It is not meant to be be solution for all the complex cases, just a simple tool to reset DB during the tests