### PR TITLE
Fix unmodifiableList handling of parameterized tests

### DIFF
--- a/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ParamsTest.java
+++ b/integration-tests/test-extension/tests/src/test/java/io/quarkus/it/extension/ParamsTest.java
@@ -121,6 +121,15 @@ public class ParamsTest {
     }
 
     @ParameterizedTest
+    @MethodSource("testDataUnmodifiableListArguments")
+    public void methodUnmodifiableListArguments(Object list) {
+    }
+
+    static Stream<Arguments> testDataUnmodifiableListArguments() {
+        return Stream.of(Arguments.of(Collections.unmodifiableList(List.of(new TestObject3()))));
+    }
+
+    @ParameterizedTest
     @MethodSource("testStreamOfMapEntryArguments")
     public void methodList(Map.Entry<String, String> ignore) {
     }
@@ -163,6 +172,12 @@ public class ParamsTest {
         Map<String, String> getMap() {
             return map;
         }
+
+    }
+
+    static class TestObject3 {
+
+        static final String value = "one";
 
     }
 }

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/CustomListConverter.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/internal/CustomListConverter.java
@@ -25,6 +25,7 @@ public class CustomListConverter extends CollectionConverter {
             List.of().getClass().getName(),
             List.of(Integer.MAX_VALUE).getClass().getName(),
             Arrays.asList(Integer.MAX_VALUE).getClass().getName(),
+            Collections.unmodifiableList(List.of()).getClass().getName(),
             Collections.emptyList().getClass().getName());
 
     public CustomListConverter(Mapper mapper) {


### PR DESCRIPTION
In java 17 an unmodifiable list of custom objects as part of an Arguments stream used to result in the below error.
This does not occur when the unmodifiable list contains e.g. a list of strings.

```
[ERROR] Errors: 
[ERROR]   ParamsTest.methodUnmodifiableListArguments(Object)[1] » Conversion No converter available
---- Debugging information ----
message             : No converter available
type                : java.util.Collections$UnmodifiableRandomAccessList
converter           : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
message[1]          : Unable to make field private static final long java.util.Collections$UnmodifiableCollection.serialVersionUID accessible: module java.base does not "opens java.util" to unnamed module @2d58d9ed
-------------------------------
```

By adding Collections.unmodifiableList to the CustomListConverter this use case is supported as well.
