### PR TITLE
Default to Java 17 in tooling

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProjectHelper.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/commands/CreateProjectHelper.java
@@ -34,7 +34,7 @@ public class CreateProjectHelper {
 
     // ordering is important here, so let's keep them ordered
     public static final SortedSet<Integer> JAVA_VERSIONS_LTS = new TreeSet<>(List.of(11, 17));
-    private static final int DEFAULT_JAVA_VERSION = 11;
+    private static final int DEFAULT_JAVA_VERSION = 17;
     private static final int MAX_LTS_SUPPORTED_BY_KOTLIN = 17;
     public static final String DETECT_JAVA_RUNTIME_VERSION = "<<detect java runtime version>>";
     private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("(\\d+)(?:\\..*)?");


### PR DESCRIPTION
This makes Java 17 as default in the CLI and in the Maven plugin.

For code.quarkus.io, it's another PR: https://github.com/quarkusio/code.quarkus.io/pull/1035