### PR TITLE
Container image registry is ignored when using quarkus-openshift

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeDeploymentTriggerDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeDeploymentTriggerDecorator.java
@@ -1,0 +1,16 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.openshift.decorator.ApplyDeploymentTriggerDecorator;
+
+public class ChangeDeploymentTriggerDecorator extends ApplyDeploymentTriggerDecorator {
+
+    public ChangeDeploymentTriggerDecorator(String containerName, String imageStreamTag) {
+        super(containerName, imageStreamTag);
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { ApplyDeploymentTriggerDecorator.class, RemoveDeploymentTriggerDecorator.class };
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerAndImageTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithDockerAndImageTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentTriggerImageChangeParams;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithDockerAndImageTest {
+
+    private static final String APP_NAME = "openshift-with-docker-and-image";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+
+        assertThat(kubernetesDir).isDirectoryContaining(p -> p.getFileName().endsWith("openshift.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"));
+        List<HasMetadata> openshiftList = DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml"));
+
+        assertThat(openshiftList).filteredOn(h -> "DeploymentConfig".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APP_NAME);
+            });
+            assertThat(h).isInstanceOfSatisfying(DeploymentConfig.class, d -> {
+                Container container = d.getSpec().getTemplate().getSpec().getContainers().get(0);
+                assertThat(container.getImage()).isEqualTo(APP_NAME + ":1.0");
+
+                DeploymentTriggerImageChangeParams imageTriggerParams = d.getSpec().getTriggers().get(0).getImageChangeParams();
+                assertThat(imageTriggerParams.getFrom().getKind()).isEqualTo("ImageStreamTag");
+                assertThat(imageTriggerParams.getFrom().getName()).isEqualTo(APP_NAME + ":1.0");
+            });
+        });
+
+        assertThat(openshiftList).filteredOn(h -> "ImageStream".equals(h.getKind())).singleElement().satisfies(h -> {
+            assertThat(h.getMetadata()).satisfies(m -> {
+                assertThat(m.getName()).isEqualTo(APP_NAME);
+            });
+            assertThat(h).isInstanceOfSatisfying(ImageStream.class, i -> {
+                assertThat(i.getSpec().getDockerImageRepository()).isEqualTo("quay.io/user/app");
+            });
+        });
+
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-docker-and-image.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-docker-and-image.properties
@@ -1,0 +1,2 @@
+quarkus.container-image.image=quay.io/user/app:1.0
+quarkus.container-image.builder=docker


### PR DESCRIPTION
This commit fixes several issues when using the `quarkus-openshift` extension:
- When providing the registry using the property `quarkus.container-image.image` (for example, quay.io/user/app:version, the registry is `quay.io`), the extension `quarkus-openshift` ignores the registry and uses the fallback property which is `docker.io`.

- The `quarkus-openshift` extension always creates the ImageStream resource regardless of the container image builder used (s2i, docker, jib, ...). However, when the user provides a docker image, it was using it for the container image of the Deployment resource, and this ImageStream was never in use. After these changes, the Deployment resource always uses the ImageStream resource, so no changes in the documentation are necessary. 

- When the user provides a docker image and the deployment kind is "DeploymentConfig" (the default option), the `quarkus-openshift` extension removes the trigger image change params, so when deploying the application, the application is not automatically started.