### PR TITLE
Centralized support for suspend/resume

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/PostResumeBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/PostResumeBuildItem.java
@@ -1,0 +1,11 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+import io.quarkus.deployment.annotations.Consume;
+
+/**
+ * A build item for scheduling post-resume tasks.
+ * Use with {@link Consume} to cause a step to run after resume.
+ */
+public final class PostResumeBuildItem extends EmptyBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreSuspendBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/PreSuspendBuildItem.java
@@ -1,0 +1,11 @@
+package io.quarkus.deployment.builditem;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+import io.quarkus.deployment.annotations.Produce;
+
+/**
+ * A build item that pre-suspend steps must produce.
+ * Use with {@link Produce}.
+ */
+public final class PreSuspendBuildItem extends EmptyBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/SuspendAtStartupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/SuspendAtStartupBuildStep.java
@@ -5,6 +5,7 @@ import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationStartBuildItem;
 import io.quarkus.deployment.builditem.PostResumeBuildItem;
 import io.quarkus.deployment.builditem.PreSuspendBuildItem;
 import io.quarkus.runtime.suspend.SuspendPointRecorder;
@@ -23,6 +24,18 @@ public class SuspendAtStartupBuildStep {
     @Produce(PostResumeBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     public void suspendResumeStep(SuspendPointRecorder recorder) {
-        recorder.startupComplete();
+        recorder.readyToSuspend();
+    }
+
+    /**
+     * Unblock the resume thread when we're ready for requests.
+     *
+     * @param recorder the suspend point recorder
+     */
+    @Consume(PostResumeBuildItem.class)
+    @Consume(ApplicationStartBuildItem.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void resumeCompleteStep(SuspendPointRecorder recorder) {
+        recorder.readyForRequests();
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/SuspendAtStartupBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/SuspendAtStartupBuildStep.java
@@ -1,0 +1,28 @@
+package io.quarkus.deployment.steps;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.PostResumeBuildItem;
+import io.quarkus.deployment.builditem.PreSuspendBuildItem;
+import io.quarkus.runtime.suspend.SuspendPointRecorder;
+
+/**
+ * Build steps which relate to suspend-at-startup capabilities.
+ */
+public class SuspendAtStartupBuildStep {
+    /**
+     * Implement the suspend-resume step.
+     *
+     * @param recorder the suspend point recorder
+     */
+    @BuildStep
+    @Consume(PreSuspendBuildItem.class)
+    @Produce(PostResumeBuildItem.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public void suspendResumeStep(SuspendPointRecorder recorder) {
+        recorder.startupComplete();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPoint.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPoint.java
@@ -11,12 +11,13 @@ public final class SuspendPoint {
 
     private static final CountDownLatch waitForStartup = new CountDownLatch(1);
     private static final CountDownLatch waitForResume = new CountDownLatch(1);
+    private static final CountDownLatch waitForComplete = new CountDownLatch(1);
 
     /**
      * Indicate that startup is complete and that it is safe to suspend the VM.
      * Called from the main thread.
      */
-    public static void startupComplete() {
+    public static void readyToSuspend() {
         waitForStartup.countDown();
         awaitUninterruptibly(waitForResume);
     }
@@ -35,6 +36,14 @@ public final class SuspendPoint {
      */
     public static void resume() {
         waitForResume.countDown();
+        awaitUninterruptibly(waitForComplete);
+    }
+
+    /**
+     * Indicate that the environment is ready to service requests.
+     */
+    public static void readyForRequests() {
+        waitForComplete.countDown();
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPoint.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPoint.java
@@ -1,0 +1,82 @@
+package io.quarkus.runtime.suspend;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Utilities for supporting generalized post-startup suspend at run time using CRaC or a similar API.
+ */
+public final class SuspendPoint {
+    private SuspendPoint() {
+    }
+
+    private static final CountDownLatch waitForStartup = new CountDownLatch(1);
+    private static final CountDownLatch waitForResume = new CountDownLatch(1);
+
+    /**
+     * Indicate that startup is complete and that it is safe to suspend the VM.
+     * Called from the main thread.
+     */
+    public static void startupComplete() {
+        waitForStartup.countDown();
+        awaitUninterruptibly(waitForResume);
+    }
+
+    /**
+     * Indicate that the environment is ready to suspend the VM once startup completes.
+     * Called from a dedicated suspend/resume control thread (i.e. not the main thread).
+     */
+    public static void suspend() {
+        awaitUninterruptibly(waitForStartup);
+    }
+
+    /**
+     * Indicate that the VM has been unsuspended and can now resume execution.
+     * Called from a dedicated suspend/resume control thread (i.e. not the main thread).
+     */
+    public static void resume() {
+        waitForResume.countDown();
+    }
+
+    /**
+     * An implementation of {@code org.crac.Resource} which uses this API to suspend/restore.
+     */
+    public static final org.crac.Resource ORG_CRAC_RESOURCE = new org.crac.Resource() {
+        public void beforeCheckpoint(final org.crac.Context<? extends org.crac.Resource> context) {
+            suspend();
+        }
+
+        public void afterRestore(final org.crac.Context<? extends org.crac.Resource> context) {
+            resume();
+        }
+    };
+
+//    /**
+//     * An implementation of {@code jdk.crac.Resource} which uses this API to suspend/restore.
+//     */
+//    public static final jdk.crac.Resource JDK_CRAC_RESOURCE = new jdk.crac.Resource() {
+//        public void beforeCheckpoint(final jdk.crac.Context<? extends jdk.crac.Resource> context) {
+//            suspend();
+//        }
+//
+//        public void afterRestore(final jdk.crac.Context<? extends jdk.crac.Resource> context) {
+//            resume();
+//        }
+//    };
+
+    private static void awaitUninterruptibly(final CountDownLatch cdl) {
+        boolean intr = false;
+        try {
+            for (; ; )
+                try {
+                    cdl.await();
+                    break;
+                } catch (InterruptedException e) {
+                    intr = true;
+                }
+        } finally {
+            if (intr) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPointRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPointRecorder.java
@@ -9,8 +9,12 @@ import io.quarkus.runtime.annotations.Recorder;
 public final class SuspendPointRecorder {
     public SuspendPointRecorder() {}
 
-    public void startupComplete() {
-        SuspendPoint.startupComplete();
+    public void readyToSuspend() {
+        SuspendPoint.readyToSuspend();
+    }
+
+    public void readyForRequests() {
+        SuspendPoint.readyForRequests();
     }
 
     public void initialize(String className) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPointRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/suspend/SuspendPointRecorder.java
@@ -1,0 +1,22 @@
+package io.quarkus.runtime.suspend;
+
+import io.quarkus.runtime.annotations.Recorder;
+
+/**
+ * A recorder proxy for {@link SuspendPoint} and related utilities.
+ */
+@Recorder
+public final class SuspendPointRecorder {
+    public SuspendPointRecorder() {}
+
+    public void startupComplete() {
+        SuspendPoint.startupComplete();
+    }
+
+    public void initialize(String className) {
+        try {
+            Class.forName(className, true, SuspendPointRecorder.class.getClassLoader());
+        } catch (ClassNotFoundException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
Create a centralized coordination point for suspend/resume coordination, with initial support for CRaC-style suspend/resume. At present, this PR only shows the API points and is not yet ready for integration.

TODO:
- [ ] Update essential services to coordinate around the suspend/resume point.
- [ ] Figure out where to put the hook to register the `Resource`.
- [ ] Look at merging with, or removing, the existing CRaC integration with Vert.x web introduced by #23950.
- [ ] Investigate eager pre-suspend class initialization based on the list of project classes (only in suspend/resume case).
- [ ] Add a config flag to enable suspend/resume which causes `PostResumeBuildItem` to be consumed. Ensure that it is not possible to accidentally include the suspend step otherwise there will be problems.
- [ ] Maybe meta-annotation support e.g. `@Consume(PostResumeBuildItem.class) public @interface PostResume {}`??
