### PR TITLE
Retry the admin token acquisition in DevServices for Keycloak

### DIFF
--- a/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/OidcTokenReactivePropagationTest.java
+++ b/integration-tests/oidc-token-propagation-reactive/src/test/java/io/quarkus/it/keycloak/OidcTokenReactivePropagationTest.java
@@ -2,7 +2,6 @@ package io.quarkus.it.keycloak;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
@@ -18,8 +17,6 @@ import io.restassured.RestAssured;
 public class OidcTokenReactivePropagationTest {
 
     @Test
-    // See https://github.com/quarkusio/quarkus/issues/27900
-    @Disabled("flaky")
     public void testGetUserNameWithAccessTokenPropagation() throws Exception {
         try (final WebClient webClient = createWebClient()) {
             HtmlPage page = webClient.getPage("http://localhost:8081/frontend/access-token-propagation");
@@ -39,8 +36,6 @@ public class OidcTokenReactivePropagationTest {
     }
 
     @Test
-    // See https://github.com/quarkusio/quarkus/issues/27900
-    @Disabled("flaky")
     public void testNoToken() {
         RestAssured.given().when().redirects().follow(false)
                 .get("/frontend/access-token-propagation")


### PR DESCRIPTION
Hi @gsmet, it is the only try I'd like to make to address both `oidc-client-reactive` and (re-enabled) `oidc-token-propagation-reactive` test failures - both fail unexpectedly when an attempt it made to acquire an admin token using the `admin:admin` default admin credentials provided to Keycloak at startup, with the error message that these credentials are invalid.

The only thing I can think of is that the admin realm/users data have not been initialized yet in Keycloak. Keycloak 19.0.2 (Quarkus based) has done some significant refactorings around the way the various data are handled, so it might explain why. Other tests which use legacy Keycloak 19.0.2 images are not affected with such an error...

So I've just moved the code dedicated to acquiring the admin token in its own function, and added a retry of up to 10 secs to the code which uses a password grant to get such tokens.

Will disable both of these tests if it does not help