### PR TITLE
OIDC: Fix wait strategy not respecting timeout

### DIFF
--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/devservices/keycloak/KeycloakDevServicesProcessor.java
@@ -410,6 +410,8 @@ public class KeycloakDevServicesProcessor {
             this.fixedExposedPort = fixedExposedPort;
             this.startCommand = startCommand;
             this.showLogs = showLogs;
+
+            super.setWaitStrategy(Wait.forLogMessage(".*Keycloak.*started.*", 1));
         }
 
         @Override
@@ -482,7 +484,6 @@ public class KeycloakDevServicesProcessor {
             }
 
             LOG.infof("Using %s powered Keycloak distribution", keycloakX ? "Quarkus" : "WildFly");
-            super.setWaitStrategy(Wait.forLogMessage(".*Keycloak.*started.*", 1));
         }
 
         private Integer findRandomPort() {


### PR DESCRIPTION
As the log message wait strategy for Keycloak container was defined in the `QuarkusOidcContainer#configure` method, the global Dev Services timeout was not being respected correctly.

By having it defined in the GenericContainer constructor, and as the container startup timeout is set at `KeycloakDevServicesProcessor.java:341`, the global timeout is not being wrongly overrided anymore.

To reproduce this issue, set the global timeout to 1 second with the following configuration in the `application.properties`:
`quarkus.devservices.timeout=PT1S`

And then run an application with Keycloak using Dev Services enabled in dev mode with the following command:
`quarkus dev`

The application will fail to start after the default Testcontainers timeout, which is 1 minute, instead of the configured timeout of 1 second.