### PR TITLE
Fixes related to using public APIs introduced in GraalVM 22.3

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -185,7 +185,7 @@ public class NativeImageFeatureStep {
                     TryBlock tryBlock = greaterThan22_2.tryBlock();
 
                     tryBlock.invokeStaticMethod(registerLambdaCapturingClass,
-                            tryBlock.load(i.getClassName()));
+                            tryBlock.loadClassFromTCCL(i.getClassName()));
 
                     CatchBlockCreator catchBlock = tryBlock.addCatch(Throwable.class);
                     catchBlock.invokeVirtualMethod(ofMethod(Throwable.class, "printStackTrace", void.class),

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/NativeImageFeatureStep.java
@@ -292,6 +292,10 @@ public class NativeImageFeatureStep {
             exports.produce(new JPMSExportBuildItem("org.graalvm.nativeimage.builder", "com.oracle.svm.core.jdk.proxy",
                     GraalVM.Version.VERSION_22_1_0, GraalVM.Version.VERSION_22_3_0));
 
+            ResultHandle versionCompareto22_3Result = overallCatch.invokeVirtualMethod(VERSION_COMPARE_TO,
+                    overallCatch.invokeStaticMethod(VERSION_CURRENT),
+                    overallCatch.marshalAsArray(int.class, overallCatch.load(22), overallCatch.load(3)));
+
             for (NativeImageProxyDefinitionBuildItem proxy : proxies) {
                 ResultHandle array = overallCatch.newArray(Class.class, overallCatch.load(proxy.getClasses().size()));
                 int i = 0;
@@ -302,10 +306,7 @@ public class NativeImageFeatureStep {
 
                 }
 
-                BranchResult graalVm22_3Test = overallCatch
-                        .ifGreaterEqualZero(overallCatch.invokeVirtualMethod(VERSION_COMPARE_TO,
-                                overallCatch.invokeStaticMethod(VERSION_CURRENT),
-                                overallCatch.marshalAsArray(int.class, overallCatch.load(22), overallCatch.load(3))));
+                BranchResult graalVm22_3Test = overallCatch.ifGreaterEqualZero(versionCompareto22_3Result);
                 /* GraalVM >= 22.3 */
                 try (BytecodeCreator greaterThan22_2 = graalVm22_3Test.trueBranch()) {
                     MethodDescriptor registerMethod = ofMethod("org.graalvm.nativeimage.hosted.RuntimeProxyCreation",

--- a/extensions/jaxp/deployment/src/main/java/io/quarkus/jaxp/deployment/JaxpProcessor.java
+++ b/extensions/jaxp/deployment/src/main/java/io/quarkus/jaxp/deployment/JaxpProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkus.jaxp.deployment;
 
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -30,6 +31,8 @@ class JaxpProcessor {
 
     @BuildStep
     void resourceBundles(BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
+        Consumer<String> resourceBundleItemProducer = bundleName -> resourceBundle
+                .produce(new NativeImageResourceBundleBuildItem(bundleName, "java.xml"));
         Stream.of(
                 "com.sun.org.apache.xml.internal.serializer.utils.SerializerMessages",
                 "com.sun.org.apache.xml.internal.res.XMLErrorResources",
@@ -37,8 +40,7 @@ class JaxpProcessor {
                 "com.sun.org.apache.xerces.internal.impl.msg.XMLMessages",
                 "com.sun.org.apache.xerces.internal.impl.msg.XMLSchemaMessages",
                 "com.sun.org.apache.xerces.internal.impl.xpath.regex.message")
-                .map(NativeImageResourceBundleBuildItem::new)
-                .forEach(resourceBundle::produce);
+                .forEach(resourceBundleItemProducer);
     }
 
     @BuildStep


### PR DESCRIPTION
* Fixes a class cast exception by actually loading the class and not just its name.
* Reduces the invocations to Version.getCurrent() in the generated native-image Feature
* Specifies (as required) the module name when registering jaxp resource bundles