### PR TITLE
Avoid Maven imports in core/deployment

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -701,6 +701,11 @@
                     <artifactId>asciidoctor-maven-plugin</artifactId>
                     <version>${asciidoctor-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <version>${forbiddenapis-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/core/deployment/banned-signatures.txt
+++ b/core/deployment/banned-signatures.txt
@@ -1,0 +1,3 @@
+@defaultMessage Don't use Maven classes. They won't be available when using Gradle.
+org.apache.maven.**
+org.codehaus.plexus.**

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -196,6 +196,28 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify-forbidden-apis</id>
+                        <configuration>
+                            <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                            <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                            <signaturesFiles>
+                                <signaturesFile>./banned-signatures.txt</signaturesFile>
+                            </signaturesFiles>
+                            <failOnMissingClasses>false</failOnMissingClasses>
+                            <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
+                        </configuration>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java
@@ -22,8 +22,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.apache.maven.shared.utils.cli.CommandLineException;
-import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.logging.Logger;
 import org.jboss.logmanager.formatters.ColorPatternFormatter;
@@ -47,6 +45,7 @@ import io.quarkus.deployment.console.ConsoleStateManager;
 import io.quarkus.deployment.dev.testing.MessageFormat;
 import io.quarkus.deployment.dev.testing.TestSupport;
 import io.quarkus.deployment.steps.ClassTransformingBuildStep;
+import io.quarkus.deployment.util.CommandLineUtil;
 import io.quarkus.dev.appstate.ApplicationStartException;
 import io.quarkus.dev.console.DevConsoleManager;
 import io.quarkus.dev.spi.DeploymentFailedStartHandler;
@@ -122,8 +121,8 @@ public class IsolatedDevModeMain implements BiConsumer<CuratedApplication, Map<S
                                                     public void accept(String args) {
                                                         try {
                                                             context.setArgs(
-                                                                    CommandLineUtils.translateCommandline(args));
-                                                        } catch (CommandLineException e) {
+                                                                    CommandLineUtil.translateCommandline(args));
+                                                        } catch (Exception e) {
                                                             log.error("Failed to parse command line", e);
                                                             return;
                                                         }

--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -28,11 +28,11 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.deployment.dev.DevModeContext.ModuleInfo;
+import io.quarkus.deployment.util.CommandLineUtil;
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.runtime.logging.JBossVersion;
 import io.quarkus.runtime.util.JavaVersionUtil;
@@ -476,7 +476,7 @@ public abstract class QuarkusDevModeLauncher {
         args.add("-jar");
         args.add(tempFile.getAbsolutePath());
         if (applicationArgs != null) {
-            args.addAll(Arrays.asList(CommandLineUtils.translateCommandline(applicationArgs)));
+            args.addAll(Arrays.asList(CommandLineUtil.translateCommandline(applicationArgs)));
         }
     }
 

--- a/core/deployment/src/main/java/io/quarkus/deployment/util/CommandLineUtil.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/util/CommandLineUtil.java
@@ -1,0 +1,107 @@
+package io.quarkus.deployment.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * This class contains code coming from org.apache.maven.shared.utils.cli.CommandLineUtils.
+ * <p>
+ * We don't want to directly use code coming from Maven as this artifact should be Maven-agnostic.
+ *
+ * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l </a>
+ */
+public final class CommandLineUtil {
+
+    private CommandLineUtil() {
+    }
+
+    /**
+     * @param toProcess The command line to translate.
+     * @return The array of translated parts.
+     * @throws IllegalStateException in case of unbalanced quotes.
+     */
+    public static String[] translateCommandline(String toProcess) {
+        if ((toProcess == null) || (toProcess.length() == 0)) {
+            return new String[0];
+        }
+
+        // parse with a simple finite state machine
+
+        final int normal = 0;
+        final int inQuote = 1;
+        final int inDoubleQuote = 2;
+        boolean inEscape = false;
+        int state = normal;
+        final StringTokenizer tok = new StringTokenizer(toProcess, "\"\' \\", true);
+        List<String> tokens = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+
+        while (tok.hasMoreTokens()) {
+            String nextTok = tok.nextToken();
+            switch (state) {
+                case inQuote:
+                    if ("\'".equals(nextTok)) {
+                        if (inEscape) {
+                            current.append(nextTok);
+                            inEscape = false;
+                        } else {
+                            state = normal;
+                        }
+                    } else {
+                        current.append(nextTok);
+                        inEscape = "\\".equals(nextTok);
+                    }
+                    break;
+                case inDoubleQuote:
+                    if ("\"".equals(nextTok)) {
+                        if (inEscape) {
+                            current.append(nextTok);
+                            inEscape = false;
+                        } else {
+                            state = normal;
+                        }
+                    } else {
+                        current.append(nextTok);
+                        inEscape = "\\".equals(nextTok);
+                    }
+                    break;
+                default:
+                    if ("\'".equals(nextTok)) {
+                        if (inEscape) {
+                            inEscape = false;
+                            current.append(nextTok);
+                        } else {
+                            state = inQuote;
+                        }
+                    } else if ("\"".equals(nextTok)) {
+                        if (inEscape) {
+                            inEscape = false;
+                            current.append(nextTok);
+                        } else {
+                            state = inDoubleQuote;
+                        }
+                    } else if (" ".equals(nextTok)) {
+                        if (current.length() != 0) {
+                            tokens.add(current.toString());
+                            current.setLength(0);
+                        }
+                    } else {
+                        current.append(nextTok);
+                        inEscape = "\\".equals(nextTok);
+                    }
+                    break;
+            }
+        }
+
+        if (current.length() != 0) {
+            tokens.add(current.toString());
+        }
+
+        if ((state == inQuote) || (state == inDoubleQuote)) {
+            throw new IllegalStateException("unbalanced quotes in " + toProcess);
+        }
+
+        return tokens.toArray(new String[tokens.size()]);
+    }
+}

--- a/extensions/hibernate-orm/pom.xml
+++ b/extensions/hibernate-orm/pom.xml
@@ -25,7 +25,6 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>${forbiddenapis-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>verify-forbidden-apis</id>


### PR DESCRIPTION
The Maven classes won't be available in a Gradle environment. Also install forbiddenapis to make sure they don't come back.

Relates to #28301