### PR TITLE
Deprecate SmallRye OpenTracing and SmallRye Metrics

### DIFF
--- a/docs/src/main/asciidoc/opentracing.adoc
+++ b/docs/src/main/asciidoc/opentracing.adoc
@@ -4,11 +4,21 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Using OpenTracing
+:extension-status: deprecated
 
 include::./attributes.adoc[]
 
 This guide explains how your Quarkus application can utilize OpenTracing to provide distributed tracing for
 interactive web applications.
+
+[IMPORTANT]
+====
+xref:opentelemetry.adoc[OpenTelemetry] is the recommended approach to tracing and telemetry for Quarkus.
+
+When Quarkus will upgrade to Eclipse MicroProfile 6, the SmallRye OpenTracing support will be discontinued.
+====
+
+include::{includes}/extension-status.adoc[]
 
 == Prerequisites
 

--- a/docs/src/main/asciidoc/smallrye-metrics.adoc
+++ b/docs/src/main/asciidoc/smallrye-metrics.adoc
@@ -5,6 +5,7 @@ https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 
 = SmallRye Metrics
+:extension-status: deprecated
 
 include::./attributes.adoc[]
 
@@ -15,7 +16,14 @@ SmallRye Metrics allows applications to gather metrics and statistics that provi
 
 Apart from application-specific metrics described in this guide, you may also use built-in metrics exposed by various Quarkus extensions. These are described in the guide for each particular extension that supports built-in metrics.
 
-IMPORTANT: xref:micrometer.adoc[Micrometer] is the recommended approach to metrics for Quarkus. Use the SmallRye Metrics extension when it is required to retain MicroProfile specification compatibility.
+[IMPORTANT]
+====
+xref:micrometer.adoc[Micrometer] is the recommended approach to metrics for Quarkus. Use the SmallRye Metrics extension when it is required to retain MicroProfile specification compatibility.
+
+When Quarkus will upgrade to Eclipse MicroProfile 6, the SmallRye Metrics support will be discontinued.
+====
+
+include::{includes}/extension-status.adoc[]
 
 == Prerequisites
 

--- a/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-metrics/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,7 +12,7 @@ metadata:
   guide: "https://quarkus.io/guides/microprofile-metrics"
   categories:
   - "observability"
-  status: "stable"
+  status: "deprecated"
   config:
   - "quarkus.smallrye-metrics."
   - "mp.metrics."

--- a/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/smallrye-opentracing/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -11,7 +11,7 @@ metadata:
   guide: "https://quarkus.io/guides/opentracing"
   categories:
   - "observability"
-  status: "stable"
+  status: "deprecated"
   config:
   - "quarkus.jaeger."
   - "mp.opentracing."


### PR DESCRIPTION
This is the result of a discussion with @radcortez related to the future of Eclipse MicroProfile in Quarkus.

The idea is to give ample time to users to move away from these technologies before we actually retire them.