### PR TITLE
Bump kubernetes-client-bom from 5.12.3 to 5.12.4

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -151,7 +151,7 @@
         <kotlin.version>1.7.10</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.0</kotlin-serialization.version>
-        <kubernetes-client.version>5.12.3</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>5.12.4</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
         <dekorate.version>2.11.3</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
Bump Kubernetes Client version for 2.13 branch (RHBQ?).

The patched version contains fixes to some of the reported problems regarding informers and their usage in operators.

I'm leaving it as a draft until the affected parties confirm that this should be merged.

/cc @metacosm @csviri @andreaTP @shawkins 