### PR TITLE
RESTEasy client - use our provider factory when accessed statically

### DIFF
--- a/extensions/resteasy-classic/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
+++ b/extensions/resteasy-classic/rest-client/deployment/src/main/java/io/quarkus/restclient/deployment/RestClientProcessor.java
@@ -454,7 +454,7 @@ class RestClientProcessor {
             List<IgnoreClientProviderBuildItem> ignoreClientProviderBuildItems,
             CombinedIndexBuildItem combinedIndexBuildItem,
             ResteasyInjectionReadyBuildItem injectorFactory,
-            RestClientRecorder restClientRecorder) {
+            RestClientRecorder restClientRecorder, Capabilities capabilities) {
 
         for (IgnoreClientProviderBuildItem item : ignoreClientProviderBuildItems) {
             jaxrsProvidersToRegisterBuildItem.getProviders().remove(item.getProviderClassName());
@@ -464,6 +464,12 @@ class RestClientProcessor {
         restClientRecorder.initializeResteasyProviderFactory(injectorFactory.getInjectorFactory(),
                 jaxrsProvidersToRegisterBuildItem.useBuiltIn(),
                 jaxrsProvidersToRegisterBuildItem.getProviders(), jaxrsProvidersToRegisterBuildItem.getContributedProviders());
+
+        if (!capabilities.isPresent(Capability.RESTEASY)) {
+            // ResteasyProviderFactory will use our implementation when accessing instance statically. That's not
+            // necessary when RESTEasy classic is present as then provider factory with correct provider classes is generated.
+            restClientRecorder.setResteasyProviderFactoryInstance();
+        }
 
         // register the providers for reflection
         for (String providerToRegister : jaxrsProvidersToRegisterBuildItem.getProviders()) {

--- a/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientRecorder.java
+++ b/extensions/resteasy-classic/rest-client/runtime/src/main/java/io/quarkus/restclient/runtime/RestClientRecorder.java
@@ -46,6 +46,10 @@ public class RestClientRecorder {
         providerFactory = clientProviderFactory;
     }
 
+    public void setResteasyProviderFactoryInstance() {
+        ResteasyProviderFactory.setInstance(providerFactory);
+    }
+
     private static void registerProviders(ResteasyProviderFactory providerFactory, boolean useBuiltIn,
             Set<String> providersToRegister,
             Set<String> contributedProviders) {


### PR DESCRIPTION
fixes: #27277

[DefaultResponseExceptionMapper](https://github.com/resteasy/resteasy-microprofile/blob/main/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/DefaultResponseExceptionMapper.java#L51) detect whether deployment is on server, so [ResteasyProviderFActory#getInstance](https://github.com/resteasy/Resteasy/blob/main/resteasy-core-spi/src/main/java/org/jboss/resteasy/spi/ResteasyProviderFactory.java#L108) get called and different instance than our is created. This leads to loading builtin providers that, however, are removed in native mode. This PR makes sure our instance is used. The issue is not present when resteasy server is present as there [we provide ResteasyDeployment with provider classes (see line 629 and 623)](https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-classic/resteasy-server-common/deployment/src/main/java/io/quarkus/resteasy/server/common/deployment/ResteasyServerCommonProcessor.java#L629), these classes are later registered when creating a provider factory. I didn't add a test as it would require resteasy classic IT module without server that I didn't find and this fix is one liner.