### PR TITLE
ArC RequestContext - get rid of LazyValue for container lifecycle events

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
@@ -223,7 +223,7 @@ class EventImpl<T> implements Event<T> {
 
         private final Class<?> runtimeType;
         private final List<ObserverMethod<? super T>> observerMethods;
-        private final EventMetadata eventMetadata;
+        final EventMetadata eventMetadata;
         private final boolean hasTxObservers;
         private final boolean activateRequestContext;
 


### PR DESCRIPTION
- to speed up the request context activation/deactivation in majority of cases