### PR TITLE
Update kotlin.version 1.7.20

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -148,7 +148,7 @@
         <aws-lambda-java-events.version>3.11.0</aws-lambda-java-events.version>
         <aws-xray.version>2.11.2</aws-xray.version>
         <azure-functions-java-library.version>1.4.2</azure-functions-java-library.version>
-        <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.0</kotlin-serialization.version>
         <kubernetes-client.version>6.1.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -20,7 +20,7 @@
         <!-- These properties are needed in order for them to be resolvable by the generated projects -->
         <!-- Quarkus uses jboss-parent and it comes with 3.8.1-jboss-1, we don't want that in the templates -->
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <dokka.version>1.7.10</dokka.version>
         <scala.version>2.13.8</scala.version>
         <scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>

--- a/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
+++ b/devtools/gradle/gradle-application-plugin/src/test/java/io/quarkus/gradle/QuarkusPluginTest.java
@@ -97,7 +97,7 @@ public class QuarkusPluginTest {
 
     @Test
     public void shouldNotFailOnProjectDependenciesWithoutMain() throws IOException {
-        var kotlinVersion = System.getProperty("kotlin_version", "1.7.10");
+        var kotlinVersion = System.getProperty("kotlin_version", "1.7.20");
         var settingFile = testProjectDir.resolve("settings.gradle.kts");
         var mppProjectDir = testProjectDir.resolve("mpp");
         var quarkusProjectDir = testProjectDir.resolve("quarkus");

--- a/devtools/gradle/gradle.properties
+++ b/devtools/gradle/gradle.properties
@@ -1,2 +1,2 @@
 version = 999-SNAPSHOT
-kotlin_version = 1.7.10
+kotlin_version = 1.7.20

--- a/independent-projects/arc/tests/pom.xml
+++ b/independent-projects/arc/tests/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.7.10</version>
+            <version>1.7.20</version>
             <scope>test</scope>
         </dependency>
 

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -34,7 +34,7 @@ if [ "${REWRITE_OFFLINE-false}" != "true" ]; then
   # Build Kotlin Maven Plugin to allow skipping main compilation
   # (skipping test compilation is supported but not main)
   rm -rf target/kotlin
-  git clone -b v1.7.10-jakarta --depth 1 https://github.com/gsmet/kotlin.git target/kotlin
+  git clone -b v1.7.20-jakarta --depth 1 https://github.com/gsmet/kotlin.git target/kotlin
   pushd target/kotlin/libraries/tools/kotlin-maven-plugin
   mvn -B clean install -DskipTests -DskipITs
   popd


### PR DESCRIPTION
Replaces #28332. It seems dependabot missed a couple of occurences of the kotlin version. 