### PR TITLE
Redis - Add support for the probabilistic data structures

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -280,6 +280,8 @@ As mentioned above, the API is divided into groups:
 - json - `.json()` (requires the https://redis.com/modules/redis-json/[redis-json] module on the server side)
 - bloom - `.bloom()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side)
 - cuckoo - `.cuckoo()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side, which also provides the cuckoo filter commands)
+- count-min - `.countmin()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side, which also provides the count-min filter commands)
+- top-k - `.topk()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side, which also provides the top-k filter commands)
 
 Each of these methods returns an object that lets you execute the commands related to the group.
 The following snippet demonstrates how to use the _hash_ group:

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -279,6 +279,7 @@ As mentioned above, the API is divided into groups:
 - transactions - `withTransaction`
 - json - `.json()` (requires the https://redis.com/modules/redis-json/[redis-json] module on the server side)
 - bloom - `.bloom()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side)
+- cuckoo - `.cuckoo()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side, which also provides the cuckoo filter commands)
 
 Each of these methods returns an object that lets you execute the commands related to the group.
 The following snippet demonstrates how to use the _hash_ group:

--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -278,6 +278,7 @@ As mentioned above, the API is divided into groups:
 - string - `.value(valueType)`
 - transactions - `withTransaction`
 - json - `.json()` (requires the https://redis.com/modules/redis-json/[redis-json] module on the server side)
+- bloom - `.bloom()` (requires the https://redis.com/modules/redis-bloom/[redis-bloom] module on the server side)
 
 Each of these methods returns an object that lets you execute the commands related to the group.
 The following snippet demonstrates how to use the _hash_ group:

--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -64,6 +64,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <!-- Used to generate the API -->
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+import io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
@@ -445,6 +446,29 @@ public interface ReactiveRedisDataSource {
      * @return the object to manipulate Cuckoo values.
      */
     <K, V> ReactiveCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> ReactiveCountMinCommands<String, V> countmin(Class<V> valueType) {
+        return countmin(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
@@ -421,6 +422,29 @@ public interface ReactiveRedisDataSource {
      * @return the object to manipulate bloom values.
      */
     <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    default <V> ReactiveCuckooCommands<String, V> cuckoo(Class<V> valueType) {
+        return cuckoo(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    <K, V> ReactiveCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -4,6 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
+import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
@@ -399,6 +400,27 @@ public interface ReactiveRedisDataSource {
      * @return the object to manipulate JSON values.
      */
     <K> ReactiveJsonCommands<K> json(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    default <V> ReactiveBloomCommands<String, V> bloom(Class<V> valueType) {
+        return bloom(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/ReactiveRedisDataSource.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.datasource.pubsub.ReactivePubSubCommands;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
+import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
@@ -450,9 +451,9 @@ public interface ReactiveRedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     default <V> ReactiveCountMinCommands<String, V> countmin(Class<V> valueType) {
@@ -462,13 +463,36 @@ public interface ReactiveRedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
      * @param <K> the type of keys
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    default <V> ReactiveTopKCommands<String, V> topk(Class<V> valueType) {
+        return topk(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    <K, V> ReactiveTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.datasource.pubsub.PubSubCommands;
 import io.quarkus.redis.datasource.set.SetCommands;
 import io.quarkus.redis.datasource.sortedset.SortedSetCommands;
 import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
@@ -439,9 +440,9 @@ public interface RedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     default <V> CountMinCommands<String, V> countmin(Class<V> valueType) {
@@ -451,13 +452,36 @@ public interface RedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
      * @param <K> the type of keys
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     <K, V> CountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    default <V> TopKCommands<String, V> topk(Class<V> valueType) {
+        return topk(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    <K, V> TopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Gets the objects to publish and receive messages.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
+import io.quarkus.redis.datasource.bloom.BloomCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
@@ -388,6 +389,27 @@ public interface RedisDataSource {
      * @return the object to manipulate JSON values.
      */
     <K> JsonCommands<K> json(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    default <V> BloomCommands<String, V> bloom(Class<V> valueType) {
+        return bloom(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Bloom filter
+     * @return the object to manipulate bloom values.
+     */
+    <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Gets the objects to publish and receive messages.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.datasource.countmin.CountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
@@ -396,7 +397,7 @@ public interface RedisDataSource {
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
      *
      * @param <V> the type of the values added into the Bloom filter
-     * @return the object to manipulate bloom values.
+     * @return the object to manipulate bloom filters.
      */
     default <V> BloomCommands<String, V> bloom(Class<V> valueType) {
         return bloom(String.class, valueType);
@@ -408,7 +409,7 @@ public interface RedisDataSource {
      *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the Bloom filter
-     * @return the object to manipulate bloom values.
+     * @return the object to manipulate bloom filters.
      */
     <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
 
@@ -418,7 +419,7 @@ public interface RedisDataSource {
      * filter support).
      *
      * @param <V> the type of the values added into the Cuckoo filter
-     * @return the object to manipulate Cuckoo values.
+     * @return the object to manipulate Cuckoo filters.
      */
     default <V> CuckooCommands<String, V> cuckoo(Class<V> valueType) {
         return cuckoo(String.class, valueType);
@@ -431,9 +432,32 @@ public interface RedisDataSource {
      *
      * @param <K> the type of keys
      * @param <V> the type of the values added into the Cuckoo filter
-     * @return the object to manipulate Cuckoo values.
+     * @return the object to manipulate Cuckoo filters.
      */
     <K, V> CuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> CountMinCommands<String, V> countmin(Class<V> valueType) {
+        return countmin(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> CountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Gets the objects to publish and receive messages.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/RedisDataSource.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
@@ -410,6 +411,29 @@ public interface RedisDataSource {
      * @return the object to manipulate bloom values.
      */
     <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    default <V> CuckooCommands<String, V> cuckoo(Class<V> valueType) {
+        return cuckoo(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    <K, V> CuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Gets the objects to publish and receive messages.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfInsertArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfInsertArgs.java
@@ -1,0 +1,112 @@
+package io.quarkus.redis.datasource.bloom;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+public class BfInsertArgs implements RedisCommandExtraArguments {
+
+    private long capacity;
+    private double errorRate = -1.0;
+
+    private boolean nocreate;
+
+    private boolean nonScaling;
+
+    private int expansion;
+
+    /**
+     * Specifies the desired capacity for the filter to be created. This parameter is ignored if the filter already
+     * exists. If the filter is automatically created and this parameter is absent, then the module-level capacity is
+     * used.
+     *
+     * @param capacity the capacity
+     * @return the current {@link BfInsertArgs}
+     */
+    public BfInsertArgs capacity(long capacity) {
+        this.capacity = capacity;
+        return this;
+    }
+
+    /**
+     * Specifies the error ratio of the newly created filter if it does not yet exist. If the filter is automatically
+     * created and error is not specified then the module-level error rate is used.
+     *
+     * @param errorRate the error rate, must be between 0 and 1.
+     * @return the current {@link BfInsertArgs}
+     */
+    public BfInsertArgs errorRate(double errorRate) {
+        this.errorRate = errorRate;
+        return this;
+    }
+
+    /**
+     * Indicates that the filter should not be created if it does not already exist.
+     *
+     * @return the current {@link BfInsertArgs}
+     */
+    public BfInsertArgs nocreate() {
+        this.nocreate = true;
+        return this;
+    }
+
+    /**
+     * Prevents the filter from creating additional sub-filters if initial capacity is reached. Non-scaling filters
+     * requires slightly less memory than their scaling counterparts. The filter returns an error when capacity is reached.
+     *
+     * @return the current {@link BfInsertArgs}
+     */
+    public BfInsertArgs nonScaling() {
+        this.nonScaling = true;
+        return this;
+    }
+
+    /**
+     * Set the expansion factory.
+     * When capacity is reached, an additional sub-filter is created. The size of the new sub-filter is the size of
+     * the last sub-filter multiplied by expansion. If the number of elements to be stored in the filter is unknown,
+     * we recommend that you use an expansion of 2 or more to reduce the number of sub-filters. Otherwise, we recommend
+     * that you use an expansion of 1 to reduce memory consumption. The default expansion value is 2.
+     *
+     * @param expansion the expansion factor, must be positive
+     * @return the current {@link BfInsertArgs}
+     */
+    public BfInsertArgs expansion(int expansion) {
+        if (expansion <= 0) {
+            throw new IllegalArgumentException("the expansion factory must be positive");
+        }
+        this.expansion = expansion;
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+
+        if (capacity > 0) {
+            list.add("CAPACITY");
+            list.add(Long.toString(capacity));
+        }
+
+        if (errorRate != -1.0) {
+            list.add("ERROR");
+            list.add(new BigDecimal(errorRate).toPlainString()); // Prevent E notation
+        }
+
+        if (expansion > 0) {
+            list.add("EXPANSION");
+            list.add(Integer.toString(expansion));
+        }
+
+        if (nocreate) {
+            list.add("NOCREATE");
+        }
+
+        if (nonScaling) {
+            list.add("NONSCALING");
+        }
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfReserveArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BfReserveArgs.java
@@ -1,0 +1,55 @@
+package io.quarkus.redis.datasource.bloom;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+public class BfReserveArgs implements RedisCommandExtraArguments {
+
+    private boolean nonScaling;
+
+    private int expansion;
+
+    /**
+     * Prevents the filter from creating additional sub-filters if initial capacity is reached. Non-scaling filters
+     * requires slightly less memory than their scaling counterparts. The filter returns an error when capacity is reached.
+     *
+     * @return the current {@link BfReserveArgs}
+     */
+    public BfReserveArgs nonScaling() {
+        this.nonScaling = true;
+        return this;
+    }
+
+    /**
+     * Set the expansion factory.
+     * When capacity is reached, an additional sub-filter is created. The size of the new sub-filter is the size of
+     * the last sub-filter multiplied by expansion. If the number of elements to be stored in the filter is unknown,
+     * we recommend that you use an expansion of 2 or more to reduce the number of sub-filters. Otherwise, we recommend
+     * that you use an expansion of 1 to reduce memory consumption. The default expansion value is 2.
+     *
+     * @param expansion the expansion factor, must be positive
+     * @return the current {@link BfReserveArgs}
+     */
+    public BfReserveArgs expansion(int expansion) {
+        if (expansion <= 0) {
+            throw new IllegalArgumentException("the expansion factory must be positive");
+        }
+        this.expansion = expansion;
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (expansion > 0) {
+            list.add("EXPANSION");
+            list.add(Integer.toString(expansion));
+        }
+        if (nonScaling) {
+            list.add("NONSCALING");
+        }
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/BloomCommands.java
@@ -1,0 +1,112 @@
+package io.quarkus.redis.datasource.bloom;
+
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommands;
+
+/**
+ * Allows executing commands from the {@code bloom} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module to be installed in the Redis
+ * server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=bf">the bloom command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface BloomCommands<K, V> extends RedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.add">BF.ADD</a>.
+     * Summary: Adds the specified element to the specified Bloom filter.
+     * Group: bloom
+     * <p>
+     * If the bloom filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return {@code true} if the value did not exist in the filter, {@code false} otherwise.
+     **/
+    boolean bfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.exists">BF.EXISTS</a>.
+     * Summary: Determines whether an item may exist in the Bloom Filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return {@code true} if the value may exist in the filter, {@code false} means it does not exist
+     *         in the filter.
+     **/
+    boolean bfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.madd">BF.MADD</a>.
+     * Summary: Adds one or more items to the Bloom Filter and creates the filter if it does not exist yet.
+     * This command operates identically to BF.ADD except that it allows multiple inputs and returns multiple values.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return a list of booleans. {@code true} if the corresponding value did not exist in the filter,
+     *         {@code false} otherwise.
+     **/
+    List<Boolean> bfmadd(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.mexists">BF.MEXISTS</a>.
+     * Summary: Determines if one or more items may exist in the filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return a list of booleans. {@code true} if the corresponding value may exist in the filter,
+     *         {@code false} does not exist in the filter.
+     **/
+    List<Boolean> bfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     **/
+    void bfreserve(K key, double errorRate, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @param args the extra parameters
+     **/
+    void bfreserve(K key, double errorRate, long capacity, BfReserveArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.insert">BF.INSERT</a>.
+     * Summary: BF.INSERT is a sugarcoated combination of {@code BF.RESERVE} and {@code BF.ADD}. It creates a new filter
+     * if the key does not exist using the relevant arguments. Next, all {@code ITEMS} are inserted.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param args the creation parameters
+     * @param values the value to add, must not contain {@code null}, must not be {@code null}, must not be empty
+     * @return a list of booleans. {@code true} if the corresponding value may exist in the filter,
+     *         {@code false} does not exist in the filter.
+     **/
+    List<Boolean> bfinsert(K key, BfInsertArgs args, V... values);
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/ReactiveBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/ReactiveBloomCommands.java
@@ -1,0 +1,115 @@
+package io.quarkus.redis.datasource.bloom;
+
+import java.util.List;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code bloom} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module to be installed in the Redis
+ * server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=bf">the bloom command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface ReactiveBloomCommands<K, V> extends ReactiveRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.add">BF.ADD</a>.
+     * Summary: Adds the specified element to the specified Bloom filter.
+     * Group: bloom
+     * <p>
+     * If the bloom filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a uni producing {@code true} if the value did not exist in the filter, {@code false} otherwise.
+     **/
+    Uni<Boolean> bfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.exists">BF.EXISTS</a>.
+     * Summary: Determines whether an item may exist in the Bloom Filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a uni producing {@code true} if the value may exist in the filter, {@code false} means it does not exist
+     *         in the filter.
+     **/
+    Uni<Boolean> bfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.madd">BF.MADD</a>.
+     * Summary: Adds one or more items to the Bloom Filter and creates the filter if it does not exist yet.
+     * This command operates identically to BF.ADD except that it allows multiple inputs and returns multiple values.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return a uni producing a list of booleans. {@code true} if the corresponding value did not exist in the filter,
+     *         {@code false} otherwise.
+     **/
+    Uni<List<Boolean>> bfmadd(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.mexists">BF.MEXISTS</a>.
+     * Summary: Determines if one or more items may exist in the filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return a uni producing a list of booleans. {@code true} if the corresponding value may exist in the filter,
+     *         {@code false} does not exist in the filter.
+     **/
+    Uni<List<Boolean>> bfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> bfreserve(K key, double errorRate, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @param args the extra parameters
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> bfreserve(K key, double errorRate, long capacity, BfReserveArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.insert">BF.INSERT</a>.
+     * Summary: BF.INSERT is a sugarcoated combination of {@code BF.RESERVE} and {@code BF.ADD}. It creates a new filter
+     * if the key does not exist using the relevant arguments. Next, all {@code ITEMS} are inserted.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param args the creation parameters
+     * @param values the value to add, must not contain {@code null}, must not be {@code null}, must not be empty
+     * @return a uni producing a list of booleans. {@code true} if the corresponding value may exist in the filter,
+     *         {@code false} does not exist in the filter.
+     **/
+    Uni<List<Boolean>> bfinsert(K key, BfInsertArgs args, V... values);
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/ReactiveTransactionalBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/ReactiveTransactionalBloomCommands.java
@@ -1,0 +1,103 @@
+package io.quarkus.redis.datasource.bloom;
+
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+public interface ReactiveTransactionalBloomCommands<K, V> extends ReactiveTransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.add">BF.ADD</a>.
+     * Summary: Adds the specified element to the specified Bloom filter.
+     * Group: bloom
+     * <p>
+     * If the bloom filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.exists">BF.EXISTS</a>.
+     * Summary: Determines whether an item may exist in the Bloom Filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.madd">BF.MADD</a>.
+     * Summary: Adds one or more items to the Bloom Filter and creates the filter if it does not exist yet.
+     * This command operates identically to BF.ADD except that it allows multiple inputs and returns multiple values.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfmadd(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.mexists">BF.MEXISTS</a>.
+     * Summary: Determines if one or more items may exist in the filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfreserve(K key, double errorRate, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @param args the extra parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfreserve(K key, double errorRate, long capacity, BfReserveArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.insert">BF.INSERT</a>.
+     * Summary: BF.INSERT is a sugarcoated combination of {@code BF.RESERVE} and {@code BF.ADD}. It creates a new filter
+     * if the key does not exist using the relevant arguments. Next, all {@code ITEMS} are inserted.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param args the creation parameters
+     * @param values the value to add, must not contain {@code null}, must not be {@code null}, must not be empty
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     **/
+    Uni<Void> bfinsert(K key, BfInsertArgs args, V... values);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/TransactionalBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/bloom/TransactionalBloomCommands.java
@@ -1,0 +1,88 @@
+package io.quarkus.redis.datasource.bloom;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+public interface TransactionalBloomCommands<K, V> extends TransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.add">BF.ADD</a>.
+     * Summary: Adds the specified element to the specified Bloom filter.
+     * Group: bloom
+     * <p>
+     * If the bloom filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     **/
+    void bfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.exists">BF.EXISTS</a>.
+     * Summary: Determines whether an item may exist in the Bloom Filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     **/
+    void bfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.madd">BF.MADD</a>.
+     * Summary: Adds one or more items to the Bloom Filter and creates the filter if it does not exist yet.
+     * This command operates identically to BF.ADD except that it allows multiple inputs and returns multiple values.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     **/
+    void bfmadd(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.mexists">BF.MEXISTS</a>.
+     * Summary: Determines if one or more items may exist in the filter or not.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty.
+     **/
+    void bfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     **/
+    void bfreserve(K key, double errorRate, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.reserve">BF.RESERVE</a>.
+     * Summary: Creates an empty Bloom Filter with a single sub-filter for the initial capacity requested and with an
+     * upper bound {@code error_rate}.
+     * Group: bloom
+     *
+     * @param key the key
+     * @param errorRate The desired probability for false positives. The rate is a decimal value between 0 and 1.
+     * @param capacity The number of entries intended to be added to the filter.
+     * @param args the extra parameters
+     **/
+    void bfreserve(K key, double errorRate, long capacity, BfReserveArgs args);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/bf.insert">BF.INSERT</a>.
+     * Summary: BF.INSERT is a sugarcoated combination of {@code BF.RESERVE} and {@code BF.ADD}. It creates a new filter
+     * if the key does not exist using the relevant arguments. Next, all {@code ITEMS} are inserted.
+     * Group: bloom
+     * <p>
+     *
+     * @param key the key
+     * @param args the creation parameters
+     * @param values the value to add, must not contain {@code null}, must not be {@code null}, must not be empty
+     **/
+    void bfinsert(K key, BfInsertArgs args, V... values);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/CountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/CountMinCommands.java
@@ -1,0 +1,110 @@
+package io.quarkus.redis.datasource.countmin;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisCommands;
+
+/**
+ * Allows executing commands from the {@code count-min} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Count-Min Sketches) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=cms">the count-min command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface CountMinCommands<K, V> extends RedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param increment the increment
+     * @return the updated min-count for the added value
+     */
+    long cmsIncrBy(K key, V value, long increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param couples the set of value/increment pair, must not be {@code null}, must not be empty
+     * @return a map containing the updated min-count for each added value
+     */
+    Map<V, Long> cmsIncrBy(K key, Map<V, Long> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbydim">CMS.INITBYDIM</a>.
+     * Summary: Initializes a Count-Min Sketch to dimensions specified by user.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param width the number of counters in each array. Reduces the error size.
+     * @param depth the number of counter-arrays. Reduces the probability for an error of a certain size (percentage of total
+     *        count).
+     */
+    void cmsInitByDim(K key, long width, long depth);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbyprob">CMS.INITBYPROB</a>.
+     * Summary: Initializes a Count-Min Sketch to accommodate requested tolerances.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param error estimate size of error. The error is a percent of total counted items (in decimal). This
+     *        effects the width of the sketch.
+     * @param probability the desired probability for inflated count. This should be a decimal value between 0 and 1.
+     */
+    void cmsInitByProb(K key, double error, double probability);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return the count for the given item
+     */
+    long cmsQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, empty or contain {@code null}
+     * @return a list containing the count for the corresponding item
+     */
+    List<Long> cmsQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
+     * Summary: Merges several sketches into one sketch. All sketches must have identical width and depth. Weights can
+     * be used to multiply certain sketches. Default weight is 1.
+     * Group: count-min
+     * <p>
+     *
+     * @param dest The name of destination sketch. Must be initialized, must not be {@code null}
+     * @param src The names of source sketches to be merged. Must not be {@code null}, must not contain {@code null},
+     *        must not be empty.
+     * @param weight The multiple of each sketch. Default =1, can be empty, can be {@code null}
+     */
+    void cmsMerge(K dest, List<K> src, List<Integer> weight);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/ReactiveCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/ReactiveCountMinCommands.java
@@ -1,0 +1,114 @@
+package io.quarkus.redis.datasource.countmin;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code count-min} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Count-Min Sketches) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=cms">the count-min command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface ReactiveCountMinCommands<K, V> extends ReactiveRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param increment the increment
+     * @return a uni producing the updated min-count for the added value
+     **/
+    Uni<Long> cmsIncrBy(K key, V value, long increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param couples the set of value/increment pair, must not be {@code null}, must not be empty
+     * @return a uni producing a map containing the updated min-count for each added value
+     **/
+    Uni<Map<V, Long>> cmsIncrBy(K key, Map<V, Long> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbydim">CMS.INITBYDIM</a>.
+     * Summary: Initializes a Count-Min Sketch to dimensions specified by user.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param width the number of counters in each array. Reduces the error size.
+     * @param depth the number of counter-arrays. Reduces the probability for an error of a certain size (percentage of total
+     *        count).
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cmsInitByDim(K key, long width, long depth);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbyprob">CMS.INITBYPROB</a>.
+     * Summary: Initializes a Count-Min Sketch to accommodate requested tolerances.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param error estimate size of error. The error is a percent of total counted items (in decimal). This
+     *        effects the width of the sketch.
+     * @param probability the desired probability for inflated count. This should be a decimal value between 0 and 1.
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cmsInitByProb(K key, double error, double probability);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return a uni producing the count for the given item
+     **/
+    Uni<Long> cmsQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, empty or contain {@code null}
+     * @return a uni producing a list containing the count for the corresponding item
+     **/
+    Uni<List<Long>> cmsQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
+     * Summary: Merges several sketches into one sketch. All sketches must have identical width and depth. Weights can
+     * be used to multiply certain sketches. Default weight is 1.
+     * Group: count-min
+     * <p>
+     *
+     * @param dest The name of destination sketch. Must be initialized, must not be {@code null}
+     * @param src The names of source sketches to be merged. Must not be {@code null}, must not contain {@code null},
+     *        must not be empty.
+     * @param weight The multiple of each sketch. Default =1, can be empty, can be {@code null}
+     * @return a uni producing {@code null} once the operation completes
+     **/
+    Uni<Void> cmsMerge(K dest, List<K> src, List<Integer> weight);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/ReactiveTransactionalCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/ReactiveTransactionalCountMinCommands.java
@@ -1,0 +1,122 @@
+package io.quarkus.redis.datasource.countmin;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code count-min} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Count-Min Sketches) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=cms">the count-min command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code Uni<Void>}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface ReactiveTransactionalCountMinCommands<K, V> extends ReactiveTransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param increment the increment
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsIncrBy(K key, V value, long increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param couples the set of value/increment pair, must not be {@code null}, must not be empty
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsIncrBy(K key, Map<V, Long> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbydim">CMS.INITBYDIM</a>.
+     * Summary: Initializes a Count-Min Sketch to dimensions specified by user.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param width the number of counters in each array. Reduces the error size.
+     * @param depth the number of counter-arrays. Reduces the probability for an error of a certain size (percentage of total
+     *        count).
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsInitByDim(K key, long width, long depth);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbyprob">CMS.INITBYPROB</a>.
+     * Summary: Initializes a Count-Min Sketch to accommodate requested tolerances.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param error estimate size of error. The error is a percent of total counted items (in decimal). This
+     *        effects the width of the sketch.
+     * @param probability the desired probability for inflated count. This should be a decimal value between 0 and 1.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsInitByProb(K key, double error, double probability);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, empty or contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
+     * Summary: Merges several sketches into one sketch. All sketches must have identical width and depth. Weights can
+     * be used to multiply certain sketches. Default weight is 1.
+     * Group: count-min
+     * <p>
+     *
+     * @param dest The name of destination sketch. Must be initialized, must not be {@code null}
+     * @param src The names of source sketches to be merged. Must not be {@code null}, must not contain {@code null},
+     *        must not be empty.
+     * @param weight The multiple of each sketch. Default =1, can be empty, can be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cmsMerge(K dest, List<K> src, List<Integer> weight);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/TransactionalCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/countmin/TransactionalCountMinCommands.java
@@ -1,0 +1,107 @@
+package io.quarkus.redis.datasource.countmin;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+/**
+ * Allows executing commands from the {@code count-min} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Count-Min Sketches) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=cms">the count-min command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code void}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface TransactionalCountMinCommands<K, V> extends TransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param value the value, must not be {@code null}
+     * @param increment the increment
+     */
+    void cmsIncrBy(K key, V value, long increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.incrby">CMS.INCRBY</a>.
+     * Summary: Increases the count of item by increment. Multiple items can be increased with one call.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param couples the set of value/increment pair, must not be {@code null}, must not be empty
+     */
+    void cmsIncrBy(K key, Map<V, Long> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbydim">CMS.INITBYDIM</a>.
+     * Summary: Initializes a Count-Min Sketch to dimensions specified by user.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param width the number of counters in each array. Reduces the error size.
+     * @param depth the number of counter-arrays. Reduces the probability for an error of a certain size (percentage of total
+     *        count).
+     */
+    void cmsInitByDim(K key, long width, long depth);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.initbyprob">CMS.INITBYPROB</a>.
+     * Summary: Initializes a Count-Min Sketch to accommodate requested tolerances.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param error estimate size of error. The error is a percent of total counted items (in decimal). This
+     *        effects the width of the sketch.
+     * @param probability the desired probability for inflated count. This should be a decimal value between 0 and 1.
+     */
+    void cmsInitByProb(K key, double error, double probability);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     */
+    void cmsQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.query">CMS.QUERY</a>.
+     * Summary: Returns the count for one or more items in a sketch.
+     * Group: count-min
+     * <p>
+     *
+     * @param key the name of the sketch, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, empty or contain {@code null}
+     */
+    void cmsQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cms.merge/">CMS.MERGE</a>.
+     * Summary: Merges several sketches into one sketch. All sketches must have identical width and depth. Weights can
+     * be used to multiply certain sketches. Default weight is 1.
+     * Group: count-min
+     * <p>
+     *
+     * @param dest The name of destination sketch. Must be initialized, must not be {@code null}
+     * @param src The names of source sketches to be merged. Must not be {@code null}, must not contain {@code null},
+     *        must not be empty.
+     * @param weight The multiple of each sketch. Default =1, can be empty, can be {@code null}
+     */
+    void cmsMerge(K dest, List<K> src, List<Integer> weight);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfInsertArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfInsertArgs.java
@@ -1,0 +1,51 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+public class CfInsertArgs implements RedisCommandExtraArguments {
+
+    private long capacity;
+
+    private boolean nocreate;
+
+    /**
+     * Specifies the desired capacity of the new filter, if this filter does not exist yet. If the filter already exists,
+     * then this parameter is ignored. If the filter does not exist yet and this parameter is not specified, then the
+     * filter is created with the module-level default capacity which is 1024.
+     *
+     * @param capacity the capacity
+     * @return the current {@link CfInsertArgs}
+     */
+    public CfInsertArgs capacity(long capacity) {
+        this.capacity = capacity;
+        return this;
+    }
+
+    /**
+     * If specified, prevents automatic filter creation if the filter does not exist. Instead, an error is returned
+     * if the filter does not already exist. This option is mutually exclusive with {@code CAPACITY}.
+     *
+     * @return the current {@link CfInsertArgs}
+     */
+    public CfInsertArgs nocreate() {
+        this.nocreate = true;
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (capacity > 0) {
+            list.add("CAPACITY");
+            list.add(Long.toString(capacity));
+        }
+        if (nocreate) {
+            list.add("NOCREATE");
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfReserveArgs.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CfReserveArgs.java
@@ -1,0 +1,73 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommandExtraArguments;
+
+public class CfReserveArgs implements RedisCommandExtraArguments {
+
+    private long bucketSize;
+
+    private int maxIterations;
+
+    private int expansion;
+
+    /**
+     * Set the number of items in each bucket. A higher bucket size value improves the fill rate but also causes a
+     * higher error rate and slightly slower performance. The default value is 2.
+     *
+     * @param bucketSize the bucket size
+     * @return the current {@link CfReserveArgs}
+     */
+    public CfReserveArgs bucketSize(long bucketSize) {
+        this.bucketSize = bucketSize;
+        return this;
+    }
+
+    /**
+     * Sets the number of attempts to swap items between buckets before declaring filter as full and creating an
+     * additional filter. A low value is better for performance and a higher number is better for filter fill rate.
+     * The default value is 20.
+     *
+     * @param maxIterations the iterations
+     * @return the current {@link CfReserveArgs}
+     */
+    public CfReserveArgs maxIterations(int maxIterations) {
+        this.maxIterations = maxIterations;
+        return this;
+    }
+
+    /**
+     * When a new filter is created, its size is the size of the current filter multiplied by expansion. Expansion is
+     * rounded to the next 2^n number. The default value is 1.
+     *
+     * @param expansion the expansion factor
+     * @return the current {@link CfReserveArgs}
+     */
+    public CfReserveArgs expansion(int expansion) {
+        this.expansion = expansion;
+        return this;
+    }
+
+    @Override
+    public List<String> toArgs() {
+        List<String> list = new ArrayList<>();
+        if (bucketSize > 0) {
+            list.add("BUCKETSIZE");
+            list.add(Long.toString(bucketSize));
+        }
+
+        if (maxIterations > 0) {
+            list.add("MAXITERATIONS");
+            list.add(Integer.toString(maxIterations));
+        }
+
+        if (expansion > 0) {
+            list.add("EXPANSION");
+            list.add(Integer.toString(expansion));
+        }
+
+        return list;
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/CuckooCommands.java
@@ -1,0 +1,174 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisCommands;
+
+/**
+ * Allows executing commands from the {@code cuckoo} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Cuckoo filters) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=cf">the cuckoo command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface CuckooCommands<K, V> extends RedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.add">CF.ADD</a>.
+     * Summary: Adds the specified element to the specified Cuckoo filter.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.addnx">CF.ADDNX</a>.
+     * Summary: Adds an item to a cuckoo filter if the item did not exist previously.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return {@code true} if the value was added to the filter, {@code false} otherwise
+     */
+    boolean cfaddnx(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.count">CF.COUNT</a>.
+     * Summary: Returns the number of times an item may be in the filter. Because this is a probabilistic data structure,
+     * this may not necessarily be accurate.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing the count of possible matching copies of the value in the filter
+     */
+    long cfcount(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.del">CF.DEL</a>.
+     * Summary: Deletes an item once from the filter. If the item exists only once, it will be removed from the filter.
+     * If the item was added multiple times, it will still be present.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing {@code true} if the value was removed from the filter, {@code false} otherwise
+     *         (the value was not found in the filter)
+     */
+    boolean cfdel(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.exists">CF.EXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing {@code true} if the value was found in the filter, {@code false} otherwise.
+     */
+    boolean cfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsert(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsert(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a list of boolean. For each added value, the corresponding boolean is {@code true} if the
+     *         value has been added (non-existing) or {@code false} if the value was already present in the filter.
+     */
+    List<Boolean> cfinsertnx(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a list of boolean. For each added value, the corresponding boolean is {@code true} if the
+     *         value has been added (non-existing) or {@code false} if the value was already present in the filter.
+     */
+    List<Boolean> cfinsertnx(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.mexists">CF.MEXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return a list of boolean indicating, for each corresponding value, if the value exists in the
+     *         filter or not.
+     */
+    List<Boolean> cfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     */
+    void cfreserve(K key, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @param args the extra parameters
+     */
+    void cfreserve(K key, long capacity, CfReserveArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/ReactiveCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/ReactiveCuckooCommands.java
@@ -1,0 +1,181 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import java.util.List;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code cuckoo} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Cuckoo filters) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=cf">the cuckoo command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface ReactiveCuckooCommands<K, V> extends ReactiveRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.add">CF.ADD</a>.
+     * Summary: Adds the specified element to the specified Cuckoo filter.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.addnx">CF.ADDNX</a>.
+     * Summary: Adds an item to a cuckoo filter if the item did not exist previously.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing {@code true} if the value was added to the filter, {@code false} otherwise
+     **/
+    Uni<Boolean> cfaddnx(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.count">CF.COUNT</a>.
+     * Summary: Returns the number of times an item may be in the filter. Because this is a probabilistic data structure,
+     * this may not necessarily be accurate.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing the count of possible matching copies of the value in the filter
+     **/
+    Uni<Long> cfcount(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.del">CF.DEL</a>.
+     * Summary: Deletes an item once from the filter. If the item exists only once, it will be removed from the filter.
+     * If the item was added multiple times, it will still be present.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing {@code true} if the value was removed from the filter, {@code false} otherwise
+     *         (the value was not found in the filter)
+     **/
+    Uni<Boolean> cfdel(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.exists">CF.EXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return a Uni producing {@code true} if the value was found in the filter, {@code false} otherwise.
+     **/
+    Uni<Boolean> cfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cfinsert(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cfinsert(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a uni producing a list of boolean. For each added value, the corresponding boolean is {@code true} if the
+     *         value has been added (non-existing) or {@code false} if the value was already present in the filter.
+     **/
+    Uni<List<Boolean>> cfinsertnx(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a uni producing a list of boolean. For each added value, the corresponding boolean is {@code true} if the
+     *         value has been added (non-existing) or {@code false} if the value was already present in the filter.
+     **/
+    Uni<List<Boolean>> cfinsertnx(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.mexists">CF.MEXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return a uni producing a list of boolean indicating, for each corresponding value, if the value exists in the
+     *         filter or not.
+     **/
+    Uni<List<Boolean>> cfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cfreserve(K key, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @param args the extra parameters
+     * @return a uni producing {@code null} when the operation completes
+     **/
+    Uni<Void> cfreserve(K key, long capacity, CfReserveArgs args);
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/ReactiveTransactionalCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/ReactiveTransactionalCuckooCommands.java
@@ -1,0 +1,187 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code cuckoo} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Cuckoo filters) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=cf">the cuckoo command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code Uni<Void>}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface ReactiveTransactionalCuckooCommands<K, V> extends ReactiveTransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.add">CF.ADD</a>.
+     * Summary: Adds the specified element to the specified Cuckoo filter.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.addnx">CF.ADDNX</a>.
+     * Summary: Adds an item to a cuckoo filter if the item did not exist previously.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfaddnx(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.count">CF.COUNT</a>.
+     * Summary: Returns the number of times an item may be in the filter. Because this is a probabilistic data structure,
+     * this may not necessarily be accurate.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfcount(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.del">CF.DEL</a>.
+     * Summary: Deletes an item once from the filter. If the item exists only once, it will be removed from the filter.
+     * If the item was added multiple times, it will still be present.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfdel(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.exists">CF.EXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfinsert(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfinsert(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfinsertnx(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfinsertnx(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.mexists">CF.MEXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfreserve(K key, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @param args the extra parameters
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> cfreserve(K key, long capacity, CfReserveArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/TransactionalCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/cuckoo/TransactionalCuckooCommands.java
@@ -1,0 +1,162 @@
+package io.quarkus.redis.datasource.cuckoo;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+/**
+ * Allows executing commands from the {@code cuckoo} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Cuckoo filters) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?group=cf">the cuckoo command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code void}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the filter
+ */
+public interface TransactionalCuckooCommands<K, V> extends TransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.add">CF.ADD</a>.
+     * Summary: Adds the specified element to the specified Cuckoo filter.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfadd(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.addnx">CF.ADDNX</a>.
+     * Summary: Adds an item to a cuckoo filter if the item did not exist previously.
+     * Group: cuckoo
+     * <p>
+     * If the cuckoo filter does not exist, it creates a new one.
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfaddnx(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.count">CF.COUNT</a>.
+     * Summary: Returns the number of times an item may be in the filter. Because this is a probabilistic data structure,
+     * this may not necessarily be accurate.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfcount(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.del">CF.DEL</a>.
+     * Summary: Deletes an item once from the filter. If the item exists only once, it will be removed from the filter.
+     * If the item was added multiple times, it will still be present.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfdel(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.exists">CF.EXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param value the value, must not be {@code null}
+     */
+    void cfexists(K key, V value);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsert(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insert">CF.INSERT</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsert(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsertnx(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.insertnx">CF.INSERTNX</a>.
+     * Summary: Adds one or more items to a cuckoo filter, allowing the filter to be created with a custom capacity if
+     * it does not exist yet.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param args the extra arguments
+     * @param values the values, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void cfinsertnx(K key, CfInsertArgs args, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.mexists">CF.MEXISTS</a>.
+     * Summary: Check if an item exists in a Cuckoo filter
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param values the values, must not be {@code null}, must not contain {@code null}, must not be empty
+     */
+    void cfmexists(K key, V... values);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     */
+    void cfreserve(K key, long capacity);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/cf.reserve">CF.RESERVE</a>.
+     * Summary: Create a Cuckoo Filter as key with a single sub-filter for the initial amount of capacity for items.
+     * Group: cuckoo
+     * <p>
+     *
+     * @param key the key
+     * @param capacity the capacity
+     * @param args the extra parameters
+     */
+    void cfreserve(K key, long capacity, CfReserveArgs args);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/HyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/HyperLogLogCommands.java
@@ -21,7 +21,7 @@ public interface HyperLogLogCommands<K, V> extends RedisCommands {
      *
      * @param key the key
      * @param values the values
-     * @return {@code true} at least 1 HyperLogLog internal register was altered. 0 otherwise.
+     * @return {@code true} at least 1 HyperLogLog internal register was altered. {@code false} otherwise.
      **/
     boolean pfadd(K key, V... values);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveHyperLogLogCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/hyperloglog/ReactiveHyperLogLogCommands.java
@@ -22,7 +22,7 @@ public interface ReactiveHyperLogLogCommands<K, V> extends ReactiveRedisCommands
      *
      * @param key the key
      * @param values the values
-     * @return {@code true} at least 1 HyperLogLog internal register was altered. 0 otherwise.
+     * @return {@code true} at least 1 HyperLogLog internal register was altered. {@code false} otherwise.
      **/
     Uni<Boolean> pfadd(K key, V... values);
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/ReactiveTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/ReactiveTopKCommands.java
@@ -1,0 +1,156 @@
+package io.quarkus.redis.datasource.topk;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code top-k} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Top-K list support) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=topk.">the top-k command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface ReactiveTopKCommands<K, V> extends ReactiveRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @return a uni producing the item that get expelled if any, emit {@code null} otherwise
+     **/
+    Uni<V> topkAdd(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param items the items to add, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a uni producing a list containing for each corresponding added item the expelled item if any,
+     *         {@code null} otherwise.
+     **/
+    Uni<List<V>> topkAdd(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @param increment increment to current item score. Increment must be greater or equal to 1. Increment is
+     *        limited to 100,000 to avoid server freeze.
+     * @return a uni producing the item that get expelled if any, emit {@code null} otherwise
+     **/
+    Uni<V> topkIncrBy(K key, V item, int increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param couples The map containing the item / increment, must not be {@code null}, must not be empty
+     * @return a uni producing a map containing for each added item the expelled item if any, {@code null} otherwise
+     **/
+    Uni<Map<V, V>> topkIncrBy(K key, Map<V, Integer> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return a uni producing the list of items
+     **/
+    Uni<List<V>> topkList(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return a uni producing the Map of items with the associated count
+     **/
+    Uni<Map<V, Integer>> topkListWithCount(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return a uni producing {@code true} if the item is in the list, {@code false} otherwise
+     **/
+    Uni<Boolean> topkQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return a uni producing a list containing {@code true} if the corresponding item is in the list, {@code false}
+     *         otherwise
+     **/
+    Uni<List<Boolean>> topkQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @return a uni producing {@code null} once the operation completes
+     **/
+    Uni<Void> topkReserve(K key, int topk);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @param width the number of counters kept in each array. (Default 8)
+     * @param depth the number of arrays. (Default 7)
+     * @param decay the probability of reducing a counter in an occupied bucket. It is raised to power of it's counter
+     *        (decay ^ bucket[i].counter). Therefore, as the counter gets higher, the chance of a reduction is
+     *        being reduced. (Default 0.9)
+     * @return a uni producing {@code null} once the operation completes
+     **/
+    Uni<Void> topkReserve(K key, int topk, int width, int depth, double decay);
+
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/ReactiveTransactionalTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/ReactiveTransactionalTopKCommands.java
@@ -1,0 +1,163 @@
+package io.quarkus.redis.datasource.topk;
+
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Allows executing commands from the {@code top-k} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Top-K list support) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=topk.">the top-k command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code Uni<Void>}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface ReactiveTransactionalTopKCommands<K, V> extends ReactiveTransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkAdd(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param items the items to add, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkAdd(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @param increment increment to current item score. Increment must be greater or equal to 1. Increment is
+     *        limited to 100,000 to avoid server freeze.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkIncrBy(K key, V item, int increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param couples The map containing the item / increment, must not be {@code null}, must not be empty
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkIncrBy(K key, Map<V, Integer> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkList(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkListWithCount(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkReserve(K key, int topk);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @param width the number of counters kept in each array. (Default 8)
+     * @param depth the number of arrays. (Default 7)
+     * @param decay the probability of reducing a counter in an occupied bucket. It is raised to power of it's counter
+     *        (decay ^ bucket[i].counter). Therefore, as the counter gets higher, the chance of a reduction is
+     *        being reduced. (Default 0.9)
+     * @return A {@code Uni} emitting {@code null} when the command has been enqueued successfully in the transaction, a failure
+     *         otherwise. In the case of failure, the transaction is discarded.
+     */
+    Uni<Void> topkReserve(K key, int topk, int width, int depth, double decay);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/TopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/TopKCommands.java
@@ -1,0 +1,153 @@
+package io.quarkus.redis.datasource.topk;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.redis.datasource.RedisCommands;
+
+/**
+ * Allows executing commands from the {@code top-k} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Top-K list support) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=topk.">the top-k command list</a> for further information about
+ * these commands.
+ * <p>
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface TopKCommands<K, V> extends RedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @return an optional containing the item that get expelled if any, empty otherwise
+     */
+    Optional<V> topkAdd(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param items the items to add, must not be {@code null}, must not be empty, must not contain {@code null}
+     * @return a list containing for each corresponding added item the expelled item if any,
+     *         {@code null} otherwise.
+     */
+    List<V> topkAdd(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @param increment increment to current item score. Increment must be greater or equal to 1. Increment is
+     *        limited to 100,000 to avoid server freeze.
+     * @return an optional containing the item that get expelled if any, empty otherwise
+     */
+    Optional<V> topkIncrBy(K key, V item, int increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param couples The map containing the item / increment, must not be {@code null}, must not be empty
+     * @return a map containing for each added item the expelled item if any, {@code null} otherwise
+     */
+    Map<V, V> topkIncrBy(K key, Map<V, Integer> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return the list of items
+     */
+    List<V> topkList(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @return the Map of items with the associated count
+     */
+    Map<V, Integer> topkListWithCount(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     * @return {@code true} if the item is in the list, {@code false} otherwise
+     */
+    boolean topkQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, must not contain {@code null}, must not be empty
+     * @return a list containing {@code true} if the corresponding item is in the list, {@code false}
+     *         otherwise
+     */
+    List<Boolean> topkQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     */
+    void topkReserve(K key, int topk);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @param width the number of counters kept in each array. (Default 8)
+     * @param depth the number of arrays. (Default 7)
+     * @param decay the probability of reducing a counter in an occupied bucket. It is raised to power of it's counter
+     *        (decay ^ bucket[i].counter). Therefore, as the counter gets higher, the chance of a reduction is
+     *        being reduced. (Default 0.9)
+     */
+    void topkReserve(K key, int topk, int width, int depth, double decay);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/TransactionalTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/topk/TransactionalTopKCommands.java
@@ -1,0 +1,142 @@
+package io.quarkus.redis.datasource.topk;
+
+import java.util.Map;
+
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+
+/**
+ * Allows executing commands from the {@code top-k} group.
+ * These commands require the <a href="https://redis.io/docs/stack/bloom/">Redis Bloom</a> module (this modules also
+ * include Top-K list support) to be installed in the Redis server.
+ * <p>
+ * See <a href="https://redis.io/commands/?name=topk.">the top-k command list</a> for further information about
+ * these commands.
+ * <p>
+ * This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code void}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value stored in the sketch
+ */
+public interface TransactionalTopKCommands<K, V> extends TransactionalRedisCommands {
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     */
+    void topkAdd(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.add">TOPK.ADD</a>.
+     * Summary: Adds an item to the data structure. Multiple items can be added at once.
+     * If an item enters the Top-K list, the item which is expelled is returned. This allows dynamic heavy-hitter
+     * detection of items being entered or expelled from Top-K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param items the items to add, must not be {@code null}, must not be empty, must not contain {@code null}
+     */
+    void topkAdd(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param item the item to add, must not be {@code null}
+     * @param increment increment to current item score. Increment must be greater or equal to 1. Increment is
+     *        limited to 100,000 to avoid server freeze.
+     */
+    void topkIncrBy(K key, V item, int increment);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.incrby">TOPK.INCRBY</a>.
+     * Summary: Increase the score of an item in the data structure by increment. Multiple items' score can be increased
+     * at once. If an item enters the Top-K list, the item which is expelled is returned.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list where item is added, must not be {@code null}
+     * @param couples The map containing the item / increment, must not be {@code null}, must not be empty
+     */
+    void topkIncrBy(K key, Map<V, Integer> couples);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     */
+    void topkList(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.list/">TOPK.LIST</a>.
+     * Summary: Return full list of items in Top K list.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     */
+    void topkListWithCount(K key);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param item the item to check, must not be {@code null}
+     */
+    void topkQuery(K key, V item);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.query/">TOPK.QUERY</a>.
+     * Summary: Checks whether an item is one of Top-K items. Multiple items can be checked at once.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param items the items to check, must not be {@code null}, must not contain {@code null}, must not be empty
+     */
+    void topkQuery(K key, V... items);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     */
+    void topkReserve(K key, int topk);
+
+    /**
+     * Execute the command <a href="https://redis.io/commands/topk.reserve/">TOPK.RESERVE</a>.
+     * Summary: Initializes a TopK with specified parameters.
+     * Group: top-k
+     * <p>
+     *
+     * @param key the name of list, must not be {@code null}
+     * @param topk the number of top occurring items to keep.
+     * @param width the number of counters kept in each array. (Default 8)
+     * @param depth the number of arrays. (Default 7)
+     * @param decay the probability of reducing a counter in an occupied bucket. It is raised to power of it's counter
+     *        (decay ^ bucket[i].counter). Therefore, as the counter gets higher, the chance of a reduction is
+     *        being reduced. (Default 0.9)
+     */
+    void topkReserve(K key, int topk, int width, int depth, double decay);
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.countmin.ReactiveTransactionalCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
@@ -326,6 +327,29 @@ public interface ReactiveTransactionalRedisDataSource {
     default <V> ReactiveTransactionalCuckooCommands<String, V> cuckoo(Class<V> valueType) {
         return cuckoo(String.class, valueType);
     }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> ReactiveTransactionalCountMinCommands<String, V> countmin(Class<V> valueType) {
+        return countmin(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> ReactiveTransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Gets the object to manipulate Cuckoo filters.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -13,6 +13,7 @@ import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
+import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
@@ -329,29 +330,6 @@ public interface ReactiveTransactionalRedisDataSource {
     }
 
     /**
-     * Gets the object to manipulate Count-Min sketches.
-     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
-     *
-     * @param <V> the type of the values added into the count-min filter
-     * @return the object to manipulate count-min sketches.
-     */
-    default <V> ReactiveTransactionalCountMinCommands<String, V> countmin(Class<V> valueType) {
-        return countmin(String.class, valueType);
-    }
-
-    /**
-     * Gets the object to manipulate Count-Min sketches.
-     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
-     *
-     * @param <K> the type of keys
-     * @param <V> the type of the values added into the count-min filter
-     * @return the object to manipulate count-min sketches.
-     */
-    <K, V> ReactiveTransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
-
-    /**
      * Gets the object to manipulate Cuckoo filters.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
      * filter support).
@@ -361,6 +339,52 @@ public interface ReactiveTransactionalRedisDataSource {
      * @return the object to manipulate Cuckoo values.
      */
     <K, V> ReactiveTransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * sketches support).
+     *
+     * @param <V> the type of the values added into the count-min sketches
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> ReactiveTransactionalCountMinCommands<String, V> countmin(Class<V> valueType) {
+        return countmin(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * sketches support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min sketches
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> ReactiveTransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    default <V> ReactiveTransactionalTopKCommands<String, V> topk(Class<V> valueType) {
+        return topk(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    <K, V> ReactiveTransactionalTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
@@ -313,6 +314,29 @@ public interface ReactiveTransactionalRedisDataSource {
      * @return the object to manipulate Bloom filters
      */
     <K, V> ReactiveTransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    default <V> ReactiveTransactionalCuckooCommands<String, V> cuckoo(Class<V> valueType) {
+        return cuckoo(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    <K, V> ReactiveTransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/ReactiveTransactionalRedisDataSource.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
+import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
@@ -288,6 +289,30 @@ public interface ReactiveTransactionalRedisDataSource {
      * @return the object to manipulate JSON values.
      */
     <K> ReactiveTransactionalJsonCommands<K> json(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param valueType the type of value to store in the filters
+     * @param <V> the type of value
+     * @return the object to manipulate Bloom filters
+     */
+    default <V> ReactiveTransactionalBloomCommands<String, V> bloom(Class<V> valueType) {
+        return bloom(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param redisKeyType the type of the key
+     * @param valueType the type of value to store in the filters
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return the object to manipulate Bloom filters
+     */
+    <K, V> ReactiveTransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -13,6 +13,7 @@ import io.quarkus.redis.datasource.list.TransactionalListCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.vertx.mutiny.redis.client.Command;
 
@@ -340,9 +341,9 @@ public interface TransactionalRedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     default <V> TransactionalCountMinCommands<String, V> countmin(Class<V> valueType) {
@@ -352,13 +353,36 @@ public interface TransactionalRedisDataSource {
     /**
      * Gets the object to manipulate Count-Min sketches.
      * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
-     * filter support).
+     * sketches support).
      *
      * @param <K> the type of keys
-     * @param <V> the type of the values added into the count-min filter
+     * @param <V> the type of the values added into the count-min sketches
      * @return the object to manipulate count-min sketches.
      */
     <K, V> TransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    default <V> TransactionalTopKCommands<String, V> topk(Class<V> valueType) {
+        return topk(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Top-K list.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the top-k
+     * list support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the top-k lists
+     * @return the object to manipulate top-k lists.
+     */
+    <K, V> TransactionalTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.countmin.TransactionalCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
@@ -335,6 +336,29 @@ public interface TransactionalRedisDataSource {
      * @return the object to manipulate Cuckoo values.
      */
     <K, V> TransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    default <V> TransactionalCountMinCommands<String, V> countmin(Class<V> valueType) {
+        return countmin(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Count-Min sketches.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the count-min
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the count-min filter
+     * @return the object to manipulate count-min sketches.
+     */
+    <K, V> TransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -2,6 +2,7 @@ package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.TransactionalHyperLogLogCommands;
@@ -311,6 +312,29 @@ public interface TransactionalRedisDataSource {
      * @return the object to manipulate Bloom filters
      */
     <K, V> TransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    default <V> TransactionalCuckooCommands<String, V> cuckoo(Class<V> valueType) {
+        return cuckoo(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Cuckoo filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a> (including the Cuckoo
+     * filter support).
+     *
+     * @param <K> the type of keys
+     * @param <V> the type of the values added into the Cuckoo filter
+     * @return the object to manipulate Cuckoo values.
+     */
+    <K, V> TransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/datasource/transactions/TransactionalRedisDataSource.java
@@ -1,6 +1,7 @@
 package io.quarkus.redis.datasource.transactions;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
+import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.TransactionalHyperLogLogCommands;
@@ -286,6 +287,30 @@ public interface TransactionalRedisDataSource {
      * @return the object to manipulate JSON values.
      */
     <K> TransactionalJsonCommands<K> json(Class<K> redisKeyType);
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param valueType the type of value to store in the filters
+     * @param <V> the type of value
+     * @return the object to manipulate Bloom filters
+     */
+    default <V> TransactionalBloomCommands<String, V> bloom(Class<V> valueType) {
+        return bloom(String.class, valueType);
+    }
+
+    /**
+     * Gets the object to manipulate Bloom filters.
+     * This group requires the <a href="https://redis.io/docs/stack/bloom/">RedisBloom module</a>.
+     *
+     * @param redisKeyType the type of the key
+     * @param valueType the type of value to store in the filters
+     * @param <K> the type of key
+     * @param <V> the type of value
+     * @return the object to manipulate Bloom filters
+     */
+    <K, V> TransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType);
 
     /**
      * Executes a command.

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractBloomCommands.java
@@ -1,0 +1,106 @@
+package io.quarkus.redis.runtime.datasource;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+class AbstractBloomCommands<K, V> extends AbstractRedisCommands {
+
+    AbstractBloomCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+        super(redis, new Marshaller(k, v));
+    }
+
+    Uni<Response> _bfadd(K key, V value) {
+        nonNull(key, "key");
+        nonNull(value, "value");
+
+        RedisCommand command = RedisCommand.of(Command.BF_ADD)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+
+        return execute(command);
+    }
+
+    Uni<Response> _bfexists(K key, V value) {
+        nonNull(key, "key");
+        nonNull(value, "value");
+
+        RedisCommand command = RedisCommand.of(Command.BF_EXISTS)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+
+        return execute(command);
+    }
+
+    Uni<Response> _bfmadd(K key, V... values) {
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+
+        RedisCommand command = RedisCommand.of(Command.BF_MADD)
+                .put(marshaller.encode(key));
+
+        for (V value : values) {
+            command.put(marshaller.encode(value));
+        }
+
+        return execute(command);
+    }
+
+    Uni<Response> _bfmexists(K key, V... values) {
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+
+        RedisCommand command = RedisCommand.of(Command.BF_MEXISTS)
+                .put(marshaller.encode(key));
+
+        for (V value : values) {
+            command.put(marshaller.encode(value));
+        }
+
+        return execute(command);
+    }
+
+    Uni<Response> _bfreserve(K key, double errorRate, long capacity, BfReserveArgs args) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+
+        RedisCommand command = RedisCommand.of(Command.BF_RESERVE)
+                .put(marshaller.encode(key))
+                .put(errorRate)
+                .put(capacity)
+                .putArgs(args);
+
+        return execute(command);
+    }
+
+    Uni<Response> _bfinsert(K key, BfInsertArgs args, V... values) {
+        nonNull(key, "key");
+        nonNull(args, "args");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+
+        RedisCommand command = RedisCommand.of(Command.BF_INSERT)
+                .put(marshaller.encode(key))
+                .putArgs(args);
+
+        command.put("ITEMS");
+        for (V value : values) {
+            command.put(marshaller.encode(value));
+        }
+
+        return execute(command);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
@@ -7,7 +7,6 @@ import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.redis.datasource.countmin.*;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Response;

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCountMinCommands.java
@@ -1,0 +1,123 @@
+package io.quarkus.redis.runtime.datasource;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.isNotEmpty;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.countmin.*;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+public class AbstractCountMinCommands<K, V> extends AbstractRedisCommands {
+
+    AbstractCountMinCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+        super(redis, new Marshaller(k, v));
+    }
+
+    Uni<Response> _cmsIncrBy(K key, V value, long increment) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_INCRBY)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value))
+                .put(increment);
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsIncrBy(K key, Map<V, Long> couples) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(couples, "couples");
+        if (couples.isEmpty()) {
+            throw new IllegalArgumentException("`couples` must not be empty");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_INCRBY)
+                .put(marshaller.encode(key));
+        for (Map.Entry<V, Long> entry : couples.entrySet()) {
+            cmd.put(marshaller.encode(entry.getKey()));
+            cmd.put(entry.getValue());
+        }
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsInitByDim(K key, long width, long depth) {
+        // Validation
+        nonNull(key, "key");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_INITBYDIM)
+                .put(marshaller.encode(key))
+                .put(width)
+                .put(depth);
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsInitByProb(K key, double error, double probability) {
+        // Validation
+        nonNull(key, "key");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_INITBYPROB)
+                .put(marshaller.encode(key))
+                .put(error)
+                .put(probability);
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsQuery(K key, V item) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(item, "item");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_QUERY)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(item));
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsQuery(K key, V... items) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(items, "items");
+        if (items.length == 0) {
+            throw new IllegalArgumentException("`items` must not be empty");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_QUERY)
+                .put(marshaller.encode(key));
+        for (V item : items) {
+            cmd.put(marshaller.encode(item));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cmsMerge(K dest, List<K> src, List<Integer> weight) {
+        // Validation
+        nonNull(dest, "dest");
+        doesNotContainNull(src, "src");
+        isNotEmpty(src, "src");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CMS_MERGE)
+                .put(marshaller.encode(dest))
+                .put(src.size());
+
+        for (K k : src) {
+            cmd.put(marshaller.encode(k));
+        }
+
+        if (weight != null) {
+            cmd.put("WEIGHTS");
+            for (Integer w : weight) {
+                cmd.put(w);
+            }
+        }
+
+        return execute(cmd);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractCuckooCommands.java
@@ -1,0 +1,183 @@
+package io.quarkus.redis.runtime.datasource;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+public class AbstractCuckooCommands<K, V> extends AbstractRedisCommands {
+
+    AbstractCuckooCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+        super(redis, new Marshaller(k, v));
+    }
+
+    Uni<Response> _cfadd(K key, V value) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_ADD)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfaddnx(K key, V value) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_ADDNX)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfcount(K key, V value) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_COUNT)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfdel(K key, V value) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_DEL)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfexists(K key, V value) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(value, "value");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_EXISTS)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(value));
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfinsert(K key, V... values) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_INSERT)
+                .put(marshaller.encode(key));
+        for (V value : values) {
+            cmd.put(marshaller.encode(value));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfinsert(K key, CfInsertArgs args, V... values) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(args, "args");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_INSERT)
+                .put(marshaller.encode(key))
+                .putArgs(args)
+                .put("ITEMS");
+        for (V value : values) {
+            cmd.put(marshaller.encode(value));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfinsertnx(K key, V... values) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_INSERTNX)
+                .put(marshaller.encode(key))
+                .put("ITEMS");
+        for (V value : values) {
+            cmd.put(marshaller.encode(value));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfinsertnx(K key, CfInsertArgs args, V... values) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        nonNull(args, "args");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_INSERTNX)
+                .put(marshaller.encode(key))
+                .putArgs(args)
+                .put("ITEMS");
+        for (V value : values) {
+            cmd.put(marshaller.encode(value));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfmexists(K key, V... values) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(values, "values");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("`values` must contain at least one item");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_MEXISTS)
+                .put(marshaller.encode(key));
+        for (V value : values) {
+            cmd.put(marshaller.encode(value));
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfreserve(K key, long capacity) {
+        // Validation
+        nonNull(key, "key");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_RESERVE)
+                .put(marshaller.encode(key))
+                .put(capacity);
+        return execute(cmd);
+    }
+
+    Uni<Response> _cfreserve(K key, long capacity, CfReserveArgs args) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(args, "args");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.CF_RESERVE)
+                .put(marshaller.encode(key))
+                .put(capacity)
+                .putArgs(args);
+        return execute(cmd);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/AbstractTopKCommands.java
@@ -1,0 +1,142 @@
+package io.quarkus.redis.runtime.datasource;
+
+import static io.smallrye.mutiny.helpers.ParameterValidation.doesNotContainNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.isNotEmpty;
+import static io.smallrye.mutiny.helpers.ParameterValidation.nonNull;
+import static io.smallrye.mutiny.helpers.ParameterValidation.positive;
+
+import java.util.Map;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+public class AbstractTopKCommands<K, V> extends AbstractRedisCommands {
+
+    AbstractTopKCommands(RedisCommandExecutor redis, Class<K> k, Class<V> v) {
+        super(redis, new Marshaller(k, v));
+    }
+
+    Uni<Response> _topkAdd(K key, V item) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(item, "item");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_ADD)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(item));
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkAdd(K key, V... items) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(items, "items");
+        if (items.length == 0) {
+            throw new IllegalArgumentException("`items` must not be empty");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_ADD)
+                .put(marshaller.encode(key))
+                .putAll(marshaller.encode(items));
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkIncrBy(K key, V item, int increment) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(item, "item");
+        positive(increment, "increment");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_INCRBY)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(item))
+                .put(increment);
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkIncrBy(K key, Map<V, Integer> couples) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(couples, "couples");
+        isNotEmpty(couples.keySet(), "couples");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_INCRBY)
+                .put(marshaller.encode(key));
+        for (Map.Entry<V, Integer> entry : couples.entrySet()) {
+            cmd.put(marshaller.encode(entry.getKey()));
+            cmd.put(entry.getValue());
+        }
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkList(K key) {
+        // Validation
+        nonNull(key, "key");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_LIST)
+                .put(marshaller.encode(key));
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkListWithCount(K key) {
+        // Validation
+        nonNull(key, "key");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_LIST)
+                .put(marshaller.encode(key))
+                .put("WITHCOUNT");
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkQuery(K key, V item) {
+        // Validation
+        nonNull(key, "key");
+        nonNull(item, "item");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_QUERY)
+                .put(marshaller.encode(key))
+                .put(marshaller.encode(item));
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkQuery(K key, V... items) {
+        // Validation
+        nonNull(key, "key");
+        doesNotContainNull(items, "items");
+        if (items.length == 0) {
+            throw new IllegalArgumentException("`items` must not be empty");
+        }
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_QUERY)
+                .put(marshaller.encode(key))
+                .putAll(marshaller.encode(items));
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkReserve(K key, int topk) {
+        // Validation
+        nonNull(key, "key");
+        positive(topk, "topk");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_RESERVE)
+                .put(marshaller.encode(key))
+                .put(topk);
+
+        return execute(cmd);
+    }
+
+    Uni<Response> _topkReserve(K key, int topk, int width, int depth, double decay) {
+        // Validation
+        nonNull(key, "key");
+        positive(topk, "topk");
+        // Create command
+        RedisCommand cmd = RedisCommand.of(Command.TOPK_RESERVE)
+                .put(marshaller.encode(key))
+                .put(topk)
+                .put(width)
+                .put(depth)
+                .put(decay);
+        return execute(cmd);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingBloomCommandsImpl.java
@@ -1,0 +1,62 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+
+public class BlockingBloomCommandsImpl<K, V> extends AbstractRedisCommandGroup implements BloomCommands<K, V> {
+
+    private final ReactiveBloomCommands<K, V> reactive;
+
+    public BlockingBloomCommandsImpl(RedisDataSource ds, ReactiveBloomCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public boolean bfadd(K key, V value) {
+        return reactive.bfadd(key, value)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public boolean bfexists(K key, V value) {
+        return reactive.bfexists(key, value)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> bfmadd(K key, V... values) {
+        return reactive.bfmadd(key, values)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> bfmexists(K key, V... values) {
+        return reactive.bfmexists(key, values)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public void bfreserve(K key, double errorRate, long capacity) {
+        reactive.bfreserve(key, errorRate, capacity)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public void bfreserve(K key, double errorRate, long capacity, BfReserveArgs args) {
+        reactive.bfreserve(key, errorRate, capacity, args)
+                .await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> bfinsert(K key, BfInsertArgs args, V... values) {
+        return reactive.bfinsert(key, args, values)
+                .await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingCountMinCommandsImpl.java
@@ -1,0 +1,54 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.countmin.CountMinCommands;
+import io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands;
+
+public class BlockingCountMinCommandsImpl<K, V> extends AbstractRedisCommandGroup implements CountMinCommands<K, V> {
+
+    private final ReactiveCountMinCommands<K, V> reactive;
+
+    public BlockingCountMinCommandsImpl(RedisDataSource ds, ReactiveCountMinCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public long cmsIncrBy(K key, V value, long increment) {
+        return reactive.cmsIncrBy(key, value, increment).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<V, Long> cmsIncrBy(K key, Map<V, Long> couples) {
+        return reactive.cmsIncrBy(key, couples).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsInitByDim(K key, long width, long depth) {
+        reactive.cmsInitByDim(key, width, depth).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsInitByProb(K key, double error, double probability) {
+        reactive.cmsInitByProb(key, error, probability).await().atMost(timeout);
+    }
+
+    @Override
+    public long cmsQuery(K key, V item) {
+        return reactive.cmsQuery(key, item).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Long> cmsQuery(K key, V... items) {
+        return reactive.cmsQuery(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsMerge(K dest, List<K> src, List<Integer> weight) {
+        reactive.cmsMerge(dest, src, weight).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingCuckooCommandsImpl.java
@@ -1,0 +1,80 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
+import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
+
+public class BlockingCuckooCommandsImpl<K, V> extends AbstractRedisCommandGroup implements CuckooCommands<K, V> {
+
+    private final ReactiveCuckooCommands<K, V> reactive;
+
+    public BlockingCuckooCommandsImpl(RedisDataSource ds, ReactiveCuckooCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void cfadd(K key, V value) {
+        reactive.cfadd(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public boolean cfaddnx(K key, V value) {
+        return reactive.cfaddnx(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public long cfcount(K key, V value) {
+        return reactive.cfcount(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public boolean cfdel(K key, V value) {
+        return reactive.cfdel(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public boolean cfexists(K key, V value) {
+        return reactive.cfexists(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsert(K key, V... values) {
+        reactive.cfinsert(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsert(K key, CfInsertArgs args, V... values) {
+        reactive.cfinsert(key, args, values).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> cfinsertnx(K key, V... values) {
+        return reactive.cfinsertnx(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> cfinsertnx(K key, CfInsertArgs args, V... values) {
+        return reactive.cfinsertnx(key, args, values).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> cfmexists(K key, V... values) {
+        return reactive.cfmexists(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfreserve(K key, long capacity) {
+        reactive.cfreserve(key, capacity).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfreserve(K key, long capacity, CfReserveArgs args) {
+        reactive.cfreserve(key, capacity, args).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -11,6 +11,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
@@ -231,6 +232,11 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     @Override
     public <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> CuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingCuckooCommandsImpl<>(this, reactive.cuckoo(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
+import io.quarkus.redis.datasource.bloom.BloomCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.hyperloglog.HyperLogLogCommands;
@@ -225,6 +226,11 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     @Override
     public <K> JsonCommands<K> json(Class<K> redisKeyType) {
         return new BlockingJsonCommandsImpl<>(this, reactive.json(redisKeyType), timeout);
+    }
+
+    @Override
+    public <K, V> BloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -23,6 +23,7 @@ import io.quarkus.redis.datasource.pubsub.PubSubCommands;
 import io.quarkus.redis.datasource.set.SetCommands;
 import io.quarkus.redis.datasource.sortedset.SortedSetCommands;
 import io.quarkus.redis.datasource.string.StringCommands;
+import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
@@ -243,6 +244,11 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     @Override
     public <K, V> CountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTopKCommandsImpl<>(this, reactive.topk(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingRedisDataSourceImpl.java
@@ -11,6 +11,7 @@ import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.bitmap.BitMapCommands;
 import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.datasource.countmin.CountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
 import io.quarkus.redis.datasource.geo.GeoCommands;
 import io.quarkus.redis.datasource.hash.HashCommands;
@@ -237,6 +238,11 @@ public class BlockingRedisDataSourceImpl implements RedisDataSource {
     @Override
     public <K, V> CuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingCuckooCommandsImpl<>(this, reactive.cuckoo(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> CountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTopKCommandsImpl.java
@@ -1,0 +1,70 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
+import io.quarkus.redis.datasource.topk.TopKCommands;
+
+public class BlockingTopKCommandsImpl<K, V> extends AbstractRedisCommandGroup implements TopKCommands<K, V> {
+
+    private final ReactiveTopKCommands<K, V> reactive;
+
+    public BlockingTopKCommandsImpl(RedisDataSource ds, ReactiveTopKCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Optional<V> topkAdd(K key, V item) {
+        return Optional.ofNullable(reactive.topkAdd(key, item).await().atMost(timeout));
+    }
+
+    @Override
+    public List<V> topkAdd(K key, V... items) {
+        return reactive.topkAdd(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public Optional<V> topkIncrBy(K key, V item, int increment) {
+        return Optional.ofNullable(reactive.topkIncrBy(key, item, increment).await().atMost(timeout));
+    }
+
+    @Override
+    public Map<V, V> topkIncrBy(K key, Map<V, Integer> couples) {
+        return reactive.topkIncrBy(key, couples).await().atMost(timeout);
+    }
+
+    @Override
+    public List<V> topkList(K key) {
+        return reactive.topkList(key).await().atMost(timeout);
+    }
+
+    @Override
+    public Map<V, Integer> topkListWithCount(K key) {
+        return reactive.topkListWithCount(key).await().atMost(timeout);
+    }
+
+    @Override
+    public boolean topkQuery(K key, V item) {
+        return reactive.topkQuery(key, item).await().atMost(timeout);
+    }
+
+    @Override
+    public List<Boolean> topkQuery(K key, V... items) {
+        return reactive.topkQuery(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkReserve(K key, int topk) {
+        reactive.topkReserve(key, topk).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkReserve(K key, int topk, int width, int depth, double decay) {
+        reactive.topkReserve(key, topk, width, depth, decay).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalBloomCommandsImpl.java
@@ -1,0 +1,64 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class BlockingTransactionalBloomCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalBloomCommands<K, V> {
+
+    private final ReactiveTransactionalBloomCommands<K, V> reactive;
+
+    public BlockingTransactionalBloomCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalBloomCommands<K, V> reactive,
+            Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void bfadd(K key, V value) {
+        this.reactive.bfadd(key, value)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfexists(K key, V value) {
+        this.reactive.bfexists(key, value)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfmadd(K key, V... values) {
+        this.reactive.bfmadd(key, values)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfmexists(K key, V... values) {
+        this.reactive.bfmexists(key, values)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfreserve(K key, double errorRate, long capacity) {
+        this.reactive.bfreserve(key, errorRate, capacity)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfreserve(K key, double errorRate, long capacity, BfReserveArgs args) {
+        this.reactive.bfreserve(key, errorRate, capacity, args)
+                .await().atMost(this.timeout);
+    }
+
+    @Override
+    public void bfinsert(K key, BfInsertArgs args, V... values) {
+        this.reactive.bfinsert(key, args, values)
+                .await().atMost(this.timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalCountMinCommandsImpl.java
@@ -1,0 +1,56 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.countmin.ReactiveTransactionalCountMinCommands;
+import io.quarkus.redis.datasource.countmin.TransactionalCountMinCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class BlockingTransactionalCountMinCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalCountMinCommands<K, V> {
+
+    private final ReactiveTransactionalCountMinCommands<K, V> reactive;
+
+    public BlockingTransactionalCountMinCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalCountMinCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void cmsIncrBy(K key, V value, long increment) {
+        reactive.cmsIncrBy(key, value, increment).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsIncrBy(K key, Map<V, Long> couples) {
+        reactive.cmsIncrBy(key, couples).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsInitByDim(K key, long width, long depth) {
+        reactive.cmsInitByDim(key, width, depth).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsInitByProb(K key, double error, double probability) {
+        reactive.cmsInitByProb(key, error, probability).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsQuery(K key, V item) {
+        reactive.cmsQuery(key, item).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsQuery(K key, V... items) {
+        reactive.cmsQuery(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public void cmsMerge(K dest, List<K> src, List<Integer> weight) {
+        reactive.cmsMerge(dest, src, weight).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalCuckooCommandsImpl.java
@@ -1,0 +1,81 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
+import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class BlockingTransactionalCuckooCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalCuckooCommands<K, V> {
+
+    private final ReactiveTransactionalCuckooCommands<K, V> reactive;
+
+    public BlockingTransactionalCuckooCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalCuckooCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void cfadd(K key, V value) {
+        reactive.cfadd(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfaddnx(K key, V value) {
+        reactive.cfaddnx(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfcount(K key, V value) {
+        reactive.cfcount(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfdel(K key, V value) {
+        reactive.cfdel(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfexists(K key, V value) {
+        reactive.cfexists(key, value).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsert(K key, V... values) {
+        reactive.cfinsert(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsert(K key, CfInsertArgs args, V... values) {
+        reactive.cfinsert(key, args, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsertnx(K key, V... values) {
+        reactive.cfinsertnx(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfinsertnx(K key, CfInsertArgs args, V... values) {
+        reactive.cfinsertnx(key, args, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfmexists(K key, V... values) {
+        reactive.cfmexists(key, values).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfreserve(K key, long capacity) {
+        reactive.cfreserve(key, capacity).await().atMost(timeout);
+    }
+
+    @Override
+    public void cfreserve(K key, long capacity, CfReserveArgs args) {
+        reactive.cfreserve(key, capacity, args).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -3,6 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import java.time.Duration;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
+import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.TransactionalHyperLogLogCommands;
@@ -93,6 +94,11 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K> TransactionalJsonCommands<K> json(Class<K> redisKeyType) {
         return new BlockingTransactionalJsonCommandsImpl<>(this, reactive.json(redisKeyType), timeout);
+    }
+
+    @Override
+    public <K, V> TransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTransactionalBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.countmin.TransactionalCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
@@ -105,6 +106,11 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K, V> TransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingTransactionalCuckooCommandsImpl<>(this, reactive.cuckoo(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTransactionalCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -15,6 +15,7 @@ import io.quarkus.redis.datasource.list.TransactionalListCommands;
 import io.quarkus.redis.datasource.set.TransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.TransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.TransactionalStringCommands;
+import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.TransactionalValueCommands;
@@ -111,6 +112,11 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K, V> TransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingTransactionalCountMinCommandsImpl<>(this, reactive.countmin(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TransactionalTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTransactionalTopKCommandsImpl<>(this, reactive.topk(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalRedisDataSourceImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 
 import io.quarkus.redis.datasource.bitmap.TransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.TransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.TransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.TransactionalHyperLogLogCommands;
@@ -99,6 +100,11 @@ public class BlockingTransactionalRedisDataSourceImpl implements TransactionalRe
     @Override
     public <K, V> TransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
         return new BlockingTransactionalBloomCommandsImpl<>(this, reactive.bloom(redisKeyType, valueType), timeout);
+    }
+
+    @Override
+    public <K, V> TransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
+        return new BlockingTransactionalCuckooCommandsImpl<>(this, reactive.cuckoo(redisKeyType, valueType), timeout);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/BlockingTransactionalTopKCommandsImpl.java
@@ -1,0 +1,70 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.time.Duration;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
+import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+
+public class BlockingTransactionalTopKCommandsImpl<K, V> extends AbstractTransactionalRedisCommandGroup
+        implements TransactionalTopKCommands<K, V> {
+
+    private final ReactiveTransactionalTopKCommands<K, V> reactive;
+
+    public BlockingTransactionalTopKCommandsImpl(TransactionalRedisDataSource ds,
+            ReactiveTransactionalTopKCommands<K, V> reactive, Duration timeout) {
+        super(ds, timeout);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public void topkAdd(K key, V item) {
+        reactive.topkAdd(key, item).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkAdd(K key, V... items) {
+        reactive.topkAdd(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkIncrBy(K key, V item, int increment) {
+        reactive.topkIncrBy(key, item, increment).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkIncrBy(K key, Map<V, Integer> couples) {
+        reactive.topkIncrBy(key, couples).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkList(K key) {
+        reactive.topkList(key).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkListWithCount(K key) {
+        reactive.topkListWithCount(key).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkQuery(K key, V item) {
+        reactive.topkQuery(key, item).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkQuery(K key, V... items) {
+        reactive.topkQuery(key, items).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkReserve(K key, int topk) {
+        reactive.topkReserve(key, topk).await().atMost(timeout);
+    }
+
+    @Override
+    public void topkReserve(K key, int topk, int width, int depth, double decay) {
+        reactive.topkReserve(key, topk, width, depth, decay).await().atMost(timeout);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/Marshaller.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 import io.quarkus.redis.datasource.codecs.Codec;
 import io.quarkus.redis.datasource.codecs.Codecs;
 import io.vertx.mutiny.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
 
 public class Marshaller {
 
@@ -79,6 +80,9 @@ public class Marshaller {
     final <T> T decode(Class<T> clazz, Response r) {
         if (r == null) {
             return null;
+        }
+        if (r.type() == ResponseType.SIMPLE) {
+            return decode(clazz, r.toString().getBytes());
         }
         return decode(clazz, r.toBytes());
     }

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveBloomCommandsImpl.java
@@ -1,0 +1,79 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveBloomCommandsImpl<K, V> extends AbstractBloomCommands<K, V>
+        implements ReactiveBloomCommands<K, V> {
+
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveBloomCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+        super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
+    }
+
+    @Override
+    public Uni<Boolean> bfadd(K key, V value) {
+        return _bfadd(key, value)
+                .map(Response::toBoolean);
+    }
+
+    @Override
+    public Uni<Boolean> bfexists(K key, V value) {
+        return _bfexists(key, value)
+                .map(Response::toBoolean);
+    }
+
+    @Override
+    public Uni<List<Boolean>> bfmadd(K key, V... values) {
+        return _bfmadd(key, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+
+    static List<Boolean> decodeAsListOfBooleans(Response r) {
+        List<Boolean> results = new ArrayList<>();
+        if (r == null) {
+            return results;
+        }
+        for (Response nested : r) {
+            results.add(nested.toBoolean());
+        }
+        return results;
+    }
+
+    @Override
+    public Uni<List<Boolean>> bfmexists(K key, V... values) {
+        return _bfmexists(key, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+
+    @Override
+    public Uni<Void> bfreserve(K key, double errorRate, long capacity) {
+        return bfreserve(key, errorRate, capacity, new BfReserveArgs());
+    }
+
+    @Override
+    public Uni<Void> bfreserve(K key, double errorRate, long capacity, BfReserveArgs args) {
+        return _bfreserve(key, errorRate, capacity, args)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<List<Boolean>> bfinsert(K key, BfInsertArgs args, V... values) {
+        return _bfinsert(key, args, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCountMinCommandsImpl.java
@@ -1,0 +1,87 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveCountMinCommandsImpl<K, V> extends AbstractCountMinCommands<K, V>
+        implements ReactiveCountMinCommands<K, V>, ReactiveRedisCommands {
+
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveCountMinCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+        super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
+    }
+
+    @Override
+    public Uni<Long> cmsIncrBy(K key, V value, long increment) {
+        return super._cmsIncrBy(key, value, increment)
+                .map(r -> r.get(0).toLong());
+    }
+
+    @Override
+    public Uni<Map<V, Long>> cmsIncrBy(K key, Map<V, Long> couples) {
+        return super._cmsIncrBy(key, couples)
+                .map(r -> decodeAsMapVL(couples, r));
+    }
+
+    Map<V, Long> decodeAsMapVL(Map<V, Long> couples, Response r) {
+        Map<V, Long> result = new LinkedHashMap<>();
+        var iterator = couples.keySet().iterator();
+        for (Response response : r) {
+            result.put(iterator.next(), response.toLong());
+        }
+        return result;
+    }
+
+    @Override
+    public Uni<Void> cmsInitByDim(K key, long width, long depth) {
+        return super._cmsInitByDim(key, width, depth)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsInitByProb(K key, double error, double probability) {
+        return super._cmsInitByProb(key, error, probability)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Long> cmsQuery(K key, V item) {
+        return super._cmsQuery(key, item)
+                .map(r -> decodeAListOfLongs(r).get(0));
+    }
+
+    @Override
+    public Uni<List<Long>> cmsQuery(K key, V... items) {
+        return super._cmsQuery(key, items)
+                .map(this::decodeAListOfLongs);
+    }
+
+    List<Long> decodeAListOfLongs(Response r) {
+        List<Long> results = new ArrayList<>();
+        for (Response response : r) {
+            results.add(response.toLong());
+        }
+        return results;
+    }
+
+    @Override
+    public Uni<Void> cmsMerge(K dest, List<K> src, List<Integer> weight) {
+        return super._cmsMerge(dest, src, weight)
+                .replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveCuckooCommandsImpl.java
@@ -1,0 +1,99 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.List;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveCuckooCommandsImpl<K, V> extends AbstractCuckooCommands<K, V>
+        implements ReactiveCuckooCommands<K, V>, ReactiveRedisCommands {
+
+    private final ReactiveRedisDataSource reactive;
+
+    public ReactiveCuckooCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+        super(redis, k, v);
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
+    }
+
+    @Override
+    public Uni<Void> cfadd(K key, V value) {
+        return super._cfadd(key, value)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Boolean> cfaddnx(K key, V value) {
+        return super._cfaddnx(key, value)
+                .map(Response::toBoolean);
+    }
+
+    @Override
+    public Uni<Long> cfcount(K key, V value) {
+        return super._cfcount(key, value)
+                .map(Response::toLong);
+    }
+
+    @Override
+    public Uni<Boolean> cfdel(K key, V value) {
+        return super._cfdel(key, value)
+                .map(Response::toBoolean);
+    }
+
+    @Override
+    public Uni<Boolean> cfexists(K key, V value) {
+        return super._cfexists(key, value)
+                .map(Response::toBoolean);
+    }
+
+    @Override
+    public Uni<Void> cfinsert(K key, V... values) {
+        return super._cfinsert(key, values)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfinsert(K key, CfInsertArgs args, V... values) {
+        return super._cfinsert(key, args, values)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<List<Boolean>> cfinsertnx(K key, V... values) {
+        return super._cfinsertnx(key, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+
+    @Override
+    public Uni<List<Boolean>> cfinsertnx(K key, CfInsertArgs args, V... values) {
+        return super._cfinsertnx(key, args, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+
+    @Override
+    public Uni<List<Boolean>> cfmexists(K key, V... values) {
+        return super._cfmexists(key, values)
+                .map(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+    }
+
+    @Override
+    public Uni<Void> cfreserve(K key, long capacity) {
+        return super._cfreserve(key, capacity)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfreserve(K key, long capacity, CfReserveArgs args) {
+        return super._cfreserve(key, capacity, args)
+                .replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -24,6 +24,7 @@ import io.quarkus.redis.datasource.pubsub.ReactivePubSubCommands;
 import io.quarkus.redis.datasource.set.ReactiveSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveStringCommands;
+import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.quarkus.redis.datasource.transactions.OptimisticLockingTransactionResult;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionResult;
@@ -299,6 +300,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     @Override
     public <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveCountMinCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTopKCommandsImpl<>(this, redisKeyType, valueType);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
+import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
@@ -281,6 +282,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     @Override
     public <K> ReactiveJsonCommands<K> json(Class<K> redisKeyType) {
         return new ReactiveJsonCommandsImpl<>(this, redisKeyType);
+    }
+
+    @Override
+    public <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveBloomCommandsImpl<>(this, redisKeyType, valueType);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveHyperLogLogCommands;
@@ -287,6 +288,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     @Override
     public <K, V> ReactiveBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveBloomCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveCuckooCommandsImpl<>(this, redisKeyType, valueType);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveRedisDataSourceImpl.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveBloomCommands;
+import io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.ReactiveCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveHashCommands;
@@ -293,6 +294,11 @@ public class ReactiveRedisDataSourceImpl implements ReactiveRedisDataSource, Red
     @Override
     public <K, V> ReactiveCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveCuckooCommandsImpl<>(this, redisKeyType, valueType);
+    }
+
+    @Override
+    public <K, V> ReactiveCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveCountMinCommandsImpl<>(this, redisKeyType, valueType);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTopKCommandsImpl.java
@@ -1,0 +1,117 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveTopKCommandsImpl<K, V> extends AbstractTopKCommands<K, V>
+        implements ReactiveTopKCommands<K, V>, ReactiveRedisCommands {
+
+    private final ReactiveRedisDataSource reactive;
+    final Class<V> typeOfValue;
+
+    public ReactiveTopKCommandsImpl(ReactiveRedisDataSourceImpl redis, Class<K> k, Class<V> v) {
+        super(redis, k, v);
+        this.typeOfValue = v;
+        this.reactive = redis;
+    }
+
+    @Override
+    public ReactiveRedisDataSource getDataSource() {
+        return reactive;
+    }
+
+    @Override
+    public Uni<V> topkAdd(K key, V item) {
+        return super._topkAdd(key, item)
+                .map(r -> marshaller.decodeAsList(r, typeOfValue).get(0));
+    }
+
+    @Override
+    public Uni<List<V>> topkAdd(K key, V... items) {
+        return super._topkAdd(key, items)
+                .map(r -> marshaller.decodeAsList(r, typeOfValue));
+    }
+
+    @Override
+    public Uni<V> topkIncrBy(K key, V item, int increment) {
+        return super._topkIncrBy(key, item, increment)
+                .map(r -> marshaller.decodeAsList(r, typeOfValue).get(0));
+    }
+
+    @Override
+    public Uni<Map<V, V>> topkIncrBy(K key, Map<V, Integer> couples) {
+        return super._topkIncrBy(key, couples)
+                .map(r -> decodeAsMapVV(couples, r));
+    }
+
+    Map<V, V> decodeAsMapVV(Map<V, Integer> couples, Response r) {
+        Map<V, V> map = new LinkedHashMap<>();
+        Iterator<V> iterator = couples.keySet().iterator();
+        for (Response response : r) {
+            map.put(iterator.next(), marshaller.decode(typeOfValue, response));
+        }
+        return map;
+    }
+
+    @Override
+    public Uni<List<V>> topkList(K key) {
+        return super._topkList(key)
+                .map(r -> marshaller.decodeAsList(r, typeOfValue));
+    }
+
+    @Override
+    public Uni<Map<V, Integer>> topkListWithCount(K key) {
+        return super._topkListWithCount(key)
+                .map(this::decodeAsMapVInt);
+    }
+
+    Map<V, Integer> decodeAsMapVInt(Response r) {
+        Map<V, Integer> map = new LinkedHashMap<>();
+        V current = null;
+        for (Response response : r) {
+            if (current == null) {
+                current = decodeV(response);
+            } else {
+                map.put(current, response.toInteger());
+                current = null;
+            }
+        }
+        return map;
+    }
+
+    @Override
+    public Uni<Boolean> topkQuery(K key, V item) {
+        return super._topkQuery(key, item)
+                .map(r -> marshaller.decodeAsList(r, Response::toBoolean).get(0));
+    }
+
+    @Override
+    public Uni<List<Boolean>> topkQuery(K key, V... items) {
+        return super._topkQuery(key, items)
+                .map(r -> marshaller.decodeAsList(r, Response::toBoolean));
+    }
+
+    @Override
+    public Uni<Void> topkReserve(K key, int topk) {
+        return super._topkReserve(key, topk)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkReserve(K key, int topk, int width, int depth, double decay) {
+        return super._topkReserve(key, topk, width, depth, decay)
+                .replaceWithVoid();
+    }
+
+    V decodeV(Response r) {
+        return marshaller.decode(typeOfValue, r);
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBloomCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalBloomCommandsImpl.java
@@ -1,0 +1,73 @@
+package io.quarkus.redis.runtime.datasource;
+
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveTransactionalBloomCommandsImpl<K, V> extends AbstractTransactionalCommands
+        implements ReactiveTransactionalBloomCommands<K, V> {
+
+    private final ReactiveBloomCommandsImpl<K, V> reactive;
+
+    public ReactiveTransactionalBloomCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveBloomCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Uni<Void> bfadd(K key, V value) {
+        this.tx.enqueue(Response::toBoolean);
+        return this.reactive._bfadd(key, value)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> bfexists(K key, V value) {
+        this.tx.enqueue(Response::toBoolean);
+        return this.reactive._bfexists(key, value)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> bfmadd(K key, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+        return this.reactive._bfmadd(key, values)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> bfmexists(K key, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+        return this.reactive._bfmexists(key, values)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> bfreserve(K key, double errorRate, long capacity) {
+        return bfreserve(key, errorRate, capacity, new BfReserveArgs());
+    }
+
+    @Override
+    public Uni<Void> bfreserve(K key, double errorRate, long capacity, BfReserveArgs args) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._bfreserve(key, errorRate, capacity, args)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> bfinsert(K key, BfInsertArgs args, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans);
+        return this.reactive._bfinsert(key, args, values)
+                .invoke(this::queuedOrDiscard)
+                .replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCountMinCommandsImpl.java
@@ -1,0 +1,62 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.redis.datasource.countmin.*;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.smallrye.mutiny.Uni;
+
+public class ReactiveTransactionalCountMinCommandsImpl<K, V> extends AbstractTransactionalCommands
+        implements ReactiveTransactionalCountMinCommands<K, V> {
+
+    private final ReactiveCountMinCommandsImpl<K, V> reactive;
+
+    public ReactiveTransactionalCountMinCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveCountMinCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Uni<Void> cmsIncrBy(K key, V value, long increment) {
+        this.tx.enqueue(r -> r.get(0).toLong()); // Uni<Long>
+        return this.reactive._cmsIncrBy(key, value, increment).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsIncrBy(K key, Map<V, Long> couples) {
+        this.tx.enqueue(reactive::decodeAListOfLongs);
+        return this.reactive._cmsIncrBy(key, couples).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsInitByDim(K key, long width, long depth) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._cmsInitByDim(key, width, depth).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsInitByProb(K key, double error, double probability) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._cmsInitByProb(key, error, probability).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsQuery(K key, V item) {
+        this.tx.enqueue(r -> reactive.decodeAListOfLongs(r).get(0));
+        return this.reactive._cmsQuery(key, item).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsQuery(K key, V... items) {
+        this.tx.enqueue(reactive::decodeAListOfLongs);
+        return this.reactive._cmsQuery(key, items).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cmsMerge(K dest, List<K> src, List<Integer> weight) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._cmsMerge(dest, src, weight).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCountMinCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCountMinCommandsImpl.java
@@ -3,7 +3,7 @@ package io.quarkus.redis.runtime.datasource;
 import java.util.List;
 import java.util.Map;
 
-import io.quarkus.redis.datasource.countmin.*;
+import io.quarkus.redis.datasource.countmin.ReactiveTransactionalCountMinCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.smallrye.mutiny.Uni;
 

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCuckooCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalCuckooCommandsImpl.java
@@ -1,0 +1,92 @@
+package io.quarkus.redis.runtime.datasource;
+
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveTransactionalCuckooCommandsImpl<K, V> extends AbstractTransactionalCommands
+        implements ReactiveTransactionalCuckooCommands<K, V> {
+
+    private final ReactiveCuckooCommandsImpl<K, V> reactive;
+
+    public ReactiveTransactionalCuckooCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveCuckooCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Uni<Void> cfadd(K key, V value) {
+        this.tx.enqueue(r -> null); // Uni<Void>
+        return this.reactive._cfadd(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfaddnx(K key, V value) {
+        this.tx.enqueue(Response::toBoolean); // Uni<Boolean>
+        return this.reactive._cfaddnx(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfcount(K key, V value) {
+        this.tx.enqueue(Response::toLong); // Uni<Long>
+        return this.reactive._cfcount(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfdel(K key, V value) {
+        this.tx.enqueue(Response::toBoolean); // Uni<Boolean>
+        return this.reactive._cfdel(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfexists(K key, V value) {
+        this.tx.enqueue(Response::toBoolean); // Uni<Boolean>
+        return this.reactive._cfexists(key, value).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfinsert(K key, V... values) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._cfinsert(key, values).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfinsert(K key, CfInsertArgs args, V... values) {
+        this.tx.enqueue(r -> null);
+        return this.reactive._cfinsert(key, args, values).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfinsertnx(K key, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans); // Uni<List<Boolean>>
+        return this.reactive._cfinsertnx(key, values).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfinsertnx(K key, CfInsertArgs args, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans); // Uni<List<Boolean>>
+        return this.reactive._cfinsertnx(key, args, values).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfmexists(K key, V... values) {
+        this.tx.enqueue(ReactiveBloomCommandsImpl::decodeAsListOfBooleans); // Uni<List<Boolean>>
+        return this.reactive._cfmexists(key, values).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfreserve(K key, long capacity) {
+        this.tx.enqueue(r -> null); // Uni<Void>
+        return this.reactive._cfreserve(key, capacity).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> cfreserve(K key, long capacity, CfReserveArgs args) {
+        this.tx.enqueue(r -> null); // Uni<Void>
+        return this.reactive._cfreserve(key, capacity, args).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
@@ -109,6 +110,12 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     public <K, V> ReactiveTransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveTransactionalBloomCommandsImpl<>(this,
                 (ReactiveBloomCommandsImpl<K, V>) this.reactive.bloom(redisKeyType), tx);
+    }
+
+    @Override
+    public <K, V> ReactiveTransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTransactionalCuckooCommandsImpl<>(this,
+                (ReactiveCuckooCommandsImpl<K, V>) this.reactive.cuckoo(redisKeyType, valueType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
+import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
 import io.quarkus.redis.datasource.hyperloglog.ReactiveTransactionalHyperLogLogCommands;
@@ -102,6 +103,12 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     public <K> ReactiveTransactionalJsonCommands<K> json(Class<K> redisKeyType) {
         return new ReactiveTransactionalJsonCommandsImpl<>(this,
                 (ReactiveJsonCommandsImpl<K>) this.reactive.json(redisKeyType), tx);
+    }
+
+    @Override
+    public <K, V> ReactiveTransactionalBloomCommands<K, V> bloom(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTransactionalBloomCommandsImpl<>(this,
+                (ReactiveBloomCommandsImpl<K, V>) this.reactive.bloom(redisKeyType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.datasource.list.ReactiveTransactionalListCommands;
 import io.quarkus.redis.datasource.set.ReactiveTransactionalSetCommands;
 import io.quarkus.redis.datasource.sortedset.ReactiveTransactionalSortedSetCommands;
 import io.quarkus.redis.datasource.string.ReactiveTransactionalStringCommands;
+import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.value.ReactiveTransactionalValueCommands;
 import io.smallrye.mutiny.Uni;
@@ -123,6 +124,12 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     public <K, V> ReactiveTransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveTransactionalCountMinCommandsImpl<>(this,
                 (ReactiveCountMinCommandsImpl<K, V>) this.reactive.countmin(redisKeyType, valueType), tx);
+    }
+
+    @Override
+    public <K, V> ReactiveTransactionalTopKCommands<K, V> topk(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTransactionalTopKCommandsImpl<>(this,
+                (ReactiveTopKCommandsImpl<K, V>) this.reactive.topk(redisKeyType, valueType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalRedisDataSourceImpl.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 import io.quarkus.redis.datasource.bitmap.ReactiveTransactionalBitMapCommands;
 import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.countmin.ReactiveTransactionalCountMinCommands;
 import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
 import io.quarkus.redis.datasource.geo.ReactiveTransactionalGeoCommands;
 import io.quarkus.redis.datasource.hash.ReactiveTransactionalHashCommands;
@@ -116,6 +117,12 @@ public class ReactiveTransactionalRedisDataSourceImpl implements ReactiveTransac
     public <K, V> ReactiveTransactionalCuckooCommands<K, V> cuckoo(Class<K> redisKeyType, Class<V> valueType) {
         return new ReactiveTransactionalCuckooCommandsImpl<>(this,
                 (ReactiveCuckooCommandsImpl<K, V>) this.reactive.cuckoo(redisKeyType, valueType), tx);
+    }
+
+    @Override
+    public <K, V> ReactiveTransactionalCountMinCommands<K, V> countmin(Class<K> redisKeyType, Class<V> valueType) {
+        return new ReactiveTransactionalCountMinCommandsImpl<>(this,
+                (ReactiveCountMinCommandsImpl<K, V>) this.reactive.countmin(redisKeyType, valueType), tx);
     }
 
     @Override

--- a/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTopKCommandsImpl.java
+++ b/extensions/redis-client/runtime/src/main/java/io/quarkus/redis/runtime/datasource/ReactiveTransactionalTopKCommandsImpl.java
@@ -1,0 +1,80 @@
+package io.quarkus.redis.runtime.datasource;
+
+import java.util.Map;
+
+import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+
+public class ReactiveTransactionalTopKCommandsImpl<K, V> extends AbstractTransactionalCommands
+        implements ReactiveTransactionalTopKCommands<K, V> {
+
+    private final ReactiveTopKCommandsImpl<K, V> reactive;
+
+    public ReactiveTransactionalTopKCommandsImpl(ReactiveTransactionalRedisDataSource ds,
+            ReactiveTopKCommandsImpl<K, V> reactive, TransactionHolder tx) {
+        super(ds, tx);
+        this.reactive = reactive;
+    }
+
+    @Override
+    public Uni<Void> topkAdd(K key, V item) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive.typeOfValue).get(0)); // Uni<V>
+        return this.reactive._topkAdd(key, item).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkAdd(K key, V... items) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive.typeOfValue)); // Uni<List<V>>
+        return this.reactive._topkAdd(key, items).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkIncrBy(K key, V item, int increment) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive.typeOfValue).get(0)); // Uni<V>
+        return this.reactive._topkIncrBy(key, item, increment).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkIncrBy(K key, Map<V, Integer> couples) {
+        this.tx.enqueue(r -> reactive.decodeAsMapVV(couples, r)); // Uni<Map<V,V>>
+        return this.reactive._topkIncrBy(key, couples).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkList(K key) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, reactive.typeOfValue)); // Uni<List<V>>
+        return this.reactive._topkList(key).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkListWithCount(K key) {
+        this.tx.enqueue(reactive::decodeAsMapVInt); // Uni<Map<V,Integer>>
+        return this.reactive._topkListWithCount(key).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkQuery(K key, V item) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, Response::toBoolean).get(0)); // Uni<Boolean>
+        return this.reactive._topkQuery(key, item).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkQuery(K key, V... items) {
+        this.tx.enqueue(r -> reactive.marshaller.decodeAsList(r, Response::toBoolean)); // Uni<List<Boolean>>
+        return this.reactive._topkQuery(key, items).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkReserve(K key, int topk) {
+        this.tx.enqueue(r -> null); // Uni<Void>
+        return this.reactive._topkReserve(key, topk).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+
+    @Override
+    public Uni<Void> topkReserve(K key, int topk, int width, int depth, double decay) {
+        this.tx.enqueue(r -> null); // Uni<Void>
+        return this.reactive._topkReserve(key, topk, width, depth, decay).invoke(this::queuedOrDiscard).replaceWithVoid();
+    }
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BloomCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BloomCommandsTest.java
@@ -1,0 +1,105 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.BfReserveArgs;
+import io.quarkus.redis.datasource.bloom.BloomCommands;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+public class BloomCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    private BloomCommands<String, Person> bloom;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        bloom = ds.bloom(Person.class);
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(bloom.getDataSource());
+    }
+
+    @Test
+    void bfadd() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        assertThat(bloom.bfadd(key, luke)).isTrue();
+
+        assertThat(bloom.bfexists(key, luke)).isTrue();
+        assertThat(bloom.bfexists(key, leia)).isFalse();
+
+        assertThat(bloom.bfadd(key, luke)).isFalse();
+    }
+
+    @Test
+    void bfmadd() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        assertThat(bloom.bfmadd(key, luke, leia)).containsExactly(true, true);
+        assertThat(bloom.bfexists(key, luke)).isTrue();
+        assertThat(bloom.bfexists(key, leia)).isTrue();
+
+        assertThat(bloom.bfmexists(key, luke, anakin, leia)).containsExactly(true, false, true);
+        assertThat(bloom.bfmadd(key, luke, anakin)).containsExactly(false, true);
+    }
+
+    @Test
+    void bfreserve() {
+        bloom.bfreserve(key, 0.0001, 600000);
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+        assertThat(bloom.bfmadd(key, luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(bloom.bfmexists(key, luke, anakin, leia)).containsExactly(true, true, true);
+
+        assertThatThrownBy(() -> bloom.bfreserve(key, 0.0001, 6000, new BfReserveArgs().nonScaling()));
+
+        bloom.bfreserve("key2", 0.0001, 6000, new BfReserveArgs().nonScaling());
+        assertThat(bloom.bfmadd("key2", luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(bloom.bfmexists("key2", luke, anakin, leia)).containsExactly(true, true, true);
+
+        bloom.bfreserve("key3", 0.0001, 6000, new BfReserveArgs().expansion(5));
+        assertThat(bloom.bfmadd("key3", luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(bloom.bfmexists("key3", luke, anakin, leia)).containsExactly(true, true, true);
+    }
+
+    @Test
+    void bfinsert() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        assertThat(bloom.bfinsert(key, new BfInsertArgs().capacity(600000).errorRate(0.0001).nonScaling(), luke, leia))
+                .containsExactly(true, true);
+
+        assertThat(bloom.bfexists(key, luke)).isTrue();
+        assertThat(bloom.bfexists(key, leia)).isTrue();
+        assertThat(bloom.bfexists(key, anakin)).isFalse();
+        assertThat(bloom.bfadd(key, luke)).isFalse();
+
+        assertThatThrownBy(() -> bloom.bfinsert("key2",
+                new BfInsertArgs().capacity(600000).errorRate(0.0001).nonScaling().nocreate(), luke, leia, anakin));
+        assertThatThrownBy(() -> bloom.bfinsert("key3", new BfInsertArgs().capacity(600000).errorRate(0.0001).expansion(1)));
+
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CountMinCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CountMinCommandsTest.java
@@ -1,0 +1,106 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.countmin.CountMinCommands;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+public class CountMinCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    private CountMinCommands<String, Person> cm;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        cm = ds.countmin(Person.class);
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(cm.getDataSource());
+    }
+
+    @Test
+    void incrbyAndQuery() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        cm.cmsInitByDim(key, 10, 2);
+        assertThat(cm.cmsIncrBy(key, leia, 10)).isEqualTo(10);
+        assertThat(cm.cmsIncrBy(key, Map.of(leia, 2L, luke, 5L, anakin, 3L)))
+                .contains(entry(leia, 12L), entry(luke, 5L), entry(anakin, 3L))
+                .hasSize(3);
+
+        assertThat(cm.cmsQuery(key, anakin)).isEqualTo(3);
+        assertThat(cm.cmsQuery(key, leia, luke)).containsExactly(12L, 5L);
+    }
+
+    @Test
+    void creation() {
+        cm.cmsInitByDim(key, 10, 2);
+        cm.cmsInitByProb(key + "1", 0.0001, 0.05);
+        assertThatThrownBy(() -> cm.cmsInitByProb(key, 0.1, 0.2));
+        assertThatThrownBy(() -> cm.cmsInitByDim(key + "1", 10, 2));
+    }
+
+    @Test
+    void mergeWithWeights() {
+        String key1 = key + "1";
+        String key2 = key + "2";
+        cm.cmsInitByDim(key1, 10, 2);
+        cm.cmsInitByDim(key2, 10, 2);
+
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        cm.cmsIncrBy(key1, leia, 2);
+        cm.cmsIncrBy(key2, Map.of(leia, 2L, luke, 5L, anakin, 10L));
+
+        cm.cmsInitByDim(key, 10, 2);
+        cm.cmsMerge(key, List.of(key1, key2), List.of(2, 1));
+        assertThat(cm.cmsQuery(key, anakin)).isEqualTo(10L);
+        assertThat(cm.cmsQuery(key, leia)).isEqualTo(6L);
+        assertThat(cm.cmsQuery(key, luke)).isEqualTo(5L);
+    }
+
+    @Test
+    void mergeWithoutWeights() {
+        String key1 = key + "1";
+        String key2 = key + "2";
+        cm.cmsInitByDim(key1, 10, 2);
+        cm.cmsInitByDim(key2, 10, 2);
+
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        cm.cmsIncrBy(key1, leia, 2);
+        cm.cmsIncrBy(key2, Map.of(leia, 2L, luke, 5L, anakin, 10L));
+
+        cm.cmsInitByDim(key, 10, 2);
+        cm.cmsMerge(key, List.of(key1, key2), null);
+        assertThat(cm.cmsQuery(key, anakin)).isEqualTo(10L);
+        assertThat(cm.cmsQuery(key, leia)).isEqualTo(4L);
+        assertThat(cm.cmsQuery(key, luke)).isEqualTo(5L);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CuckooCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CuckooCommandsTest.java
@@ -1,0 +1,147 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
+import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+public class CuckooCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    private CuckooCommands<String, Person> cuckoo;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        cuckoo = ds.cuckoo(Person.class);
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(cuckoo.getDataSource());
+    }
+
+    @Test
+    void cfadd() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+        cuckoo.cfadd(key, luke);
+        cuckoo.cfadd(key, luke);
+        cuckoo.cfadd(key, leia);
+
+        assertThat(cuckoo.cfexists(key, luke)).isTrue();
+        assertThat(cuckoo.cfexists(key, leia)).isTrue();
+        assertThat(cuckoo.cfexists(key, anakin)).isFalse();
+
+        assertThat(cuckoo.cfaddnx(key, leia)).isFalse();
+        assertThat(cuckoo.cfaddnx(key, anakin)).isTrue();
+        assertThat(cuckoo.cfexists(key, anakin)).isTrue();
+
+        assertThat(cuckoo.cfcount(key, leia)).isEqualTo(1);
+        assertThat(cuckoo.cfcount(key, luke)).isEqualTo(2);
+        assertThat(cuckoo.cfcount(key, anakin)).isEqualTo(1);
+        assertThat(cuckoo.cfcount(key, new Person("john", "doe"))).isEqualTo(0);
+    }
+
+    @Test
+    void cfdel() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+        cuckoo.cfadd(key, luke);
+        cuckoo.cfadd(key, luke);
+        cuckoo.cfadd(key, leia);
+
+        assertThat(cuckoo.cfexists(key, luke)).isTrue();
+        assertThat(cuckoo.cfexists(key, leia)).isTrue();
+        assertThat(cuckoo.cfexists(key, anakin)).isFalse();
+        assertThat(cuckoo.cfmexists(key, leia, luke, anakin)).containsExactly(true, true, false);
+
+        assertThat(cuckoo.cfdel(key, luke)).isTrue();
+        assertThat(cuckoo.cfdel(key, luke)).isTrue();
+        assertThat(cuckoo.cfdel(key, luke)).isFalse();
+
+        assertThat(cuckoo.cfdel(key, anakin)).isFalse();
+
+        assertThatThrownBy(() -> cuckoo.cfdel("missing", anakin))
+                .hasMessageContaining("Not found");
+    }
+
+    @Test
+    void cfinsert() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        cuckoo.cfinsert(key, new CfInsertArgs().capacity(600000), luke, leia, leia);
+
+        assertThat(cuckoo.cfexists(key, luke)).isTrue();
+        assertThat(cuckoo.cfexists(key, leia)).isTrue();
+        assertThat(cuckoo.cfexists(key, anakin)).isFalse();
+        assertThat(cuckoo.cfcount(key, leia)).isEqualTo(2);
+        assertThat(cuckoo.cfcount(key, luke)).isEqualTo(1);
+        assertThat(cuckoo.cfaddnx(key, luke)).isFalse();
+
+        assertThatThrownBy(() -> cuckoo.cfinsert("key2",
+                new CfInsertArgs().capacity(600000).nocreate(), luke, leia, anakin));
+        assertThatThrownBy(() -> cuckoo.cfinsert("key3", new CfInsertArgs().capacity(600000)));
+    }
+
+    @Test
+    void cfinsertnx() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        assertThat(cuckoo.cfinsertnx(key, new CfInsertArgs().capacity(600000), luke, leia, leia))
+                .containsExactly(true, true, false);
+
+        assertThat(cuckoo.cfexists(key, luke)).isTrue();
+        assertThat(cuckoo.cfexists(key, leia)).isTrue();
+        assertThat(cuckoo.cfexists(key, anakin)).isFalse();
+        assertThat(cuckoo.cfcount(key, leia)).isEqualTo(1);
+        assertThat(cuckoo.cfcount(key, luke)).isEqualTo(1);
+        assertThat(cuckoo.cfaddnx(key, luke)).isFalse();
+
+        assertThatThrownBy(() -> cuckoo.cfinsertnx("key2",
+                new CfInsertArgs().capacity(600000).nocreate(), luke, leia, anakin));
+        assertThatThrownBy(() -> cuckoo.cfinsertnx("key3", new CfInsertArgs().capacity(600000)));
+    }
+
+    @Test
+    void cfreserve() {
+        cuckoo.cfreserve(key, 600000);
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+        assertThat(cuckoo.cfinsertnx(key, luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(cuckoo.cfmexists(key, luke, anakin, leia)).containsExactly(true, true, true);
+
+        assertThatThrownBy(() -> cuckoo.cfreserve(key, 6000, new CfReserveArgs().bucketSize(10)));
+
+        cuckoo.cfreserve("key2", 6000, new CfReserveArgs().maxIterations(1));
+        assertThat(cuckoo.cfinsertnx("key2", luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(cuckoo.cfmexists("key2", luke, anakin, leia)).containsExactly(true, true, true);
+
+        cuckoo.cfreserve("key3", 6000, new CfReserveArgs().expansion(5).bucketSize(1));
+        assertThat(cuckoo.cfinsertnx("key3", luke, leia, anakin)).containsExactly(true, true, true);
+        assertThat(cuckoo.cfmexists("key3", luke, anakin, leia)).containsExactly(true, true, true);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Person.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Person.java
@@ -25,6 +25,14 @@ public class Person {
     }
 
     @Override
+    public String toString() {
+        return "Person{" +
+                "firstname='" + firstname + '\'' +
+                ", lastname='" + lastname + '\'' +
+                '}';
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o)
             return true;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresCommand.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresCommand.java
@@ -1,6 +1,10 @@
 package io.quarkus.redis.datasource;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.topk.TopKCommands;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+
+public class TopKCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource ds;
+
+    private TopKCommands<String, Person> topk;
+
+    @BeforeEach
+    void initialize() {
+        ds = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(1));
+        topk = ds.topk(Person.class);
+    }
+
+    @AfterEach
+    void clear() {
+        ds.flushall();
+    }
+
+    @Test
+    void getDataSource() {
+        assertThat(ds).isEqualTo(topk.getDataSource());
+    }
+
+    @Test
+    void addAndGet() {
+        Person luke = new Person("luke", "skywalker");
+        Person leia = new Person("leia", "ordana");
+        Person anakin = new Person("anakin", "skywalker");
+
+        assertThatThrownBy(() -> topk.topkAdd(key, luke))
+                .hasMessageContaining("TopK");
+
+        topk.topkReserve(key, 2);
+        assertThat(topk.topkAdd(key, luke)).isEmpty();
+        assertThat(topk.topkAdd(key, luke)).isEmpty();
+        assertThat(topk.topkAdd(key, leia)).isEmpty();
+        assertThat(topk.topkAdd(key, anakin)).contains(leia);
+
+        assertThat(topk.topkAdd(key, luke, luke, leia, leia, leia, luke)).containsExactly(null, null, anakin, null, null, null);
+
+        assertThat(topk.topkList(key)).containsExactly(luke, leia);
+        assertThat(topk.topkListWithCount(key)).contains(entry(luke, 5), entry(leia, 4));
+
+        assertThat(topk.topkIncrBy(key, anakin, 6)).contains(leia);
+        assertThat(topk.topkListWithCount(key)).contains(entry(anakin, 7), entry(luke, 5));
+
+        assertThat(topk.topkIncrBy(key, Map.of(leia, 20, luke, 20))).hasSize(2);
+        assertThat(topk.topkQuery(key, anakin)).isFalse();
+        assertThat(topk.topkQuery(key, luke)).isTrue();
+        assertThat(topk.topkQuery(key, luke, leia, anakin)).containsExactly(true, true, false);
+    }
+
+    @Test
+    void creation() {
+        topk.topkReserve(key, 10);
+        topk.topkReserve(key + "1", 100, 2, 4, 0.5);
+        assertThatThrownBy(() -> topk.topkReserve(key, 100, 3, 4, .01));
+        assertThatThrownBy(() -> topk.topkReserve(key + "1", 20));
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBloomCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBloomCommandsTest.java
@@ -1,0 +1,76 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.bloom.BfInsertArgs;
+import io.quarkus.redis.datasource.bloom.ReactiveTransactionalBloomCommands;
+import io.quarkus.redis.datasource.bloom.TransactionalBloomCommands;
+import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+@SuppressWarnings("unchecked")
+public class TransactionalBloomCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void bloomBlocking() {
+        TransactionResult result = blocking.withTransaction(tx -> {
+            TransactionalBloomCommands<String, String> bloom = tx.bloom(String.class);
+            assertThat(bloom.getDataSource()).isEqualTo(tx);
+            bloom.bfmadd(key, "a", "b", "c", "d", "a"); // 0 -> 4 true, 1 false
+            bloom.bfadd(key, "x"); // 1 -> true
+            bloom.bfexists(key, "a"); // 2 -> true
+            bloom.bfmexists(key, "a", "b", "z"); // 3 -> true, true, false
+            bloom.bfinsert(key, new BfInsertArgs(), "v", "w", "b"); // 4 -> true, true, false
+        });
+        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.discarded()).isFalse();
+        assertThat((List<Boolean>) result.get(0)).containsExactly(true, true, true, true, false);
+        assertThat((boolean) result.get(1)).isTrue();
+        assertThat((boolean) result.get(2)).isTrue();
+        assertThat((List<Boolean>) result.get(3)).containsExactly(true, true, false);
+        assertThat((List<Boolean>) result.get(4)).containsExactly(true, true, false);
+    }
+
+    @Test
+    public void bloomReactive() {
+        TransactionResult result = reactive.withTransaction(tx -> {
+            ReactiveTransactionalBloomCommands<String, String> bloom = tx.bloom(String.class);
+            assertThat(bloom.getDataSource()).isEqualTo(tx);
+            return bloom.bfmadd(key, "a", "b", "c", "d", "a") // 0 -> 4 true, 1 false
+                    .chain(() -> bloom.bfadd(key, "x")) // 1 -> true
+                    .chain(() -> bloom.bfexists(key, "a")) // 2 -> true
+                    .chain(() -> bloom.bfmexists(key, "a", "b", "z")) // 3 -> true, true, false
+                    .chain(() -> bloom.bfinsert(key, new BfInsertArgs(), "v", "w", "b")); // 4 -> true, true, false
+        }).await().indefinitely();
+        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.discarded()).isFalse();
+        assertThat((List<Boolean>) result.get(0)).containsExactly(true, true, true, true, false);
+        assertThat((boolean) result.get(1)).isTrue();
+        assertThat((boolean) result.get(2)).isTrue();
+        assertThat((List<Boolean>) result.get(3)).containsExactly(true, true, false);
+        assertThat((List<Boolean>) result.get(4)).containsExactly(true, true, false);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCountMinCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCountMinCommandsTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.countmin.ReactiveTransactionalCountMinCommands;
+import io.quarkus.redis.datasource.countmin.TransactionalCountMinCommands;
+import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+@SuppressWarnings({ "unchecked", "ConstantConditions" })
+public class TransactionalCountMinCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void countMinBlocking() {
+        TransactionResult result = blocking.withTransaction(tx -> {
+            TransactionalCountMinCommands<String, String> cm = tx.countmin(String.class);
+            assertThat(cm.getDataSource()).isEqualTo(tx);
+            cm.cmsInitByDim(key, 10, 10);
+            cm.cmsIncrBy(key, Map.of("a", 5L, "b", 2L, "c", 4L)); // 1 -> [5,2,4]
+            cm.cmsIncrBy(key, "a", 2); // 2 -> 7
+            cm.cmsQuery(key, "a"); // 3 -> 7
+            cm.cmsQuery(key, "b", "c"); // 4 -> [2, 4]
+        });
+        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Void) result.get(0)).isNull();
+        assertThat((List<Long>) result.get(1)).containsExactlyInAnyOrder(5L, 2L, 4L);
+        assertThat((Long) result.get(2)).isEqualTo(7);
+        assertThat((Long) result.get(3)).isEqualTo(7);
+        assertThat((List<Long>) result.get(4)).containsExactly(2L, 4L);
+    }
+
+    @Test
+    public void countMinReactive() {
+        TransactionResult result = reactive.withTransaction(tx -> {
+            ReactiveTransactionalCountMinCommands<String, String> cm = tx.countmin(String.class);
+            assertThat(cm.getDataSource()).isEqualTo(tx);
+            return cm.cmsInitByDim(key, 10, 10)
+                    .chain(() -> cm.cmsIncrBy(key, Map.of("a", 5L, "b", 2L, "c", 4L)))
+                    .chain(() -> cm.cmsIncrBy(key, "a", 2))
+                    .chain(() -> cm.cmsQuery(key, "a"))
+                    .chain(() -> cm.cmsQuery(key, "b", "c"))
+                    .replaceWithVoid();
+        }).await().indefinitely();
+        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Void) result.get(0)).isNull();
+        assertThat((List<Long>) result.get(1)).containsExactlyInAnyOrder(5L, 2L, 4L);
+        assertThat((Long) result.get(2)).isEqualTo(7);
+        assertThat((Long) result.get(3)).isEqualTo(7);
+        assertThat((List<Long>) result.get(4)).containsExactly(2L, 4L);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCuckooCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCuckooCommandsTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.cuckoo.CfInsertArgs;
+import io.quarkus.redis.datasource.cuckoo.ReactiveTransactionalCuckooCommands;
+import io.quarkus.redis.datasource.cuckoo.TransactionalCuckooCommands;
+import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+@SuppressWarnings("unchecked")
+public class TransactionalCuckooCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void cuckooBlocking() {
+        TransactionResult result = blocking.withTransaction(tx -> {
+            TransactionalCuckooCommands<String, String> cuckoo = tx.cuckoo(String.class);
+            assertThat(cuckoo.getDataSource()).isEqualTo(tx);
+            cuckoo.cfinsertnx(key, "a", "b", "c", "d", "a"); // 0 -> 4 true, 1 false
+            cuckoo.cfadd(key, "x"); // 1 -> void
+            cuckoo.cfexists(key, "a"); // 2 -> true
+            cuckoo.cfmexists(key, "a", "b", "z"); // 3 -> true, true, false
+            cuckoo.cfinsert(key, new CfInsertArgs(), "v", "w", "b"); // 4 -> void
+            cuckoo.cfadd(key, "a"); // 5 -> void
+            cuckoo.cfcount(key, "a"); // 6 -> 2
+            cuckoo.cfdel(key, "a"); // 7 -> true
+            cuckoo.cfcount(key, "a"); // 8 -> 1
+        });
+        assertThat(result.size()).isEqualTo(9);
+        assertThat(result.discarded()).isFalse();
+        assertThat((List<Boolean>) result.get(0)).containsExactly(true, true, true, true, false);
+        assertThat((Void) result.get(1)).isNull();
+        assertThat((boolean) result.get(2)).isTrue();
+        assertThat((List<Boolean>) result.get(3)).containsExactly(true, true, false);
+        assertThat((long) result.get(6)).isEqualTo(2L);
+        assertThat((boolean) result.get(7)).isTrue();
+        assertThat((long) result.get(8)).isEqualTo(1L);
+    }
+
+    @Test
+    public void cuckooReactive() {
+        TransactionResult result = reactive.withTransaction(tx -> {
+            ReactiveTransactionalCuckooCommands<String, String> cuckoo = tx.cuckoo(String.class);
+            assertThat(cuckoo.getDataSource()).isEqualTo(tx);
+            return cuckoo.cfinsertnx(key, "a", "b", "c", "d", "a") // 0 -> 4 true, 1 false
+                    .chain(() -> cuckoo.cfadd(key, "x")) // 1 -> void
+                    .chain(() -> cuckoo.cfexists(key, "a")) // 2 -> true
+                    .chain(() -> cuckoo.cfmexists(key, "a", "b", "z")) // 3 -> true, true, false
+                    .chain(() -> cuckoo.cfinsert(key, new CfInsertArgs(), "v", "w", "b")) // 4 -> void
+                    .chain(() -> cuckoo.cfadd(key, "a")) // 5 -> void
+                    .chain(() -> cuckoo.cfcount(key, "a")) // 6 -> 2
+                    .chain(() -> cuckoo.cfdel(key, "a")) // 7 -> true
+                    .chain(() -> cuckoo.cfcount(key, "a")); // 8 -> 1
+        }).await().indefinitely();
+        assertThat(result.size()).isEqualTo(9);
+        assertThat(result.discarded()).isFalse();
+        assertThat((List<Boolean>) result.get(0)).containsExactly(true, true, true, true, false);
+        assertThat((Void) result.get(1)).isNull();
+        assertThat((boolean) result.get(2)).isTrue();
+        assertThat((List<Boolean>) result.get(3)).containsExactly(true, true, false);
+        assertThat((long) result.get(6)).isEqualTo(2L);
+        assertThat((boolean) result.get(7)).isTrue();
+        assertThat((long) result.get(8)).isEqualTo(1L);
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTopKCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTopKCommandsTest.java
@@ -1,0 +1,88 @@
+package io.quarkus.redis.datasource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.redis.datasource.topk.ReactiveTransactionalTopKCommands;
+import io.quarkus.redis.datasource.topk.TransactionalTopKCommands;
+import io.quarkus.redis.datasource.transactions.TransactionResult;
+import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+
+@SuppressWarnings({ "unchecked", "ConstantConditions" })
+public class TransactionalTopKCommandsTest extends DatasourceTestBase {
+
+    private RedisDataSource blocking;
+    private ReactiveRedisDataSource reactive;
+
+    @BeforeEach
+    void initialize() {
+        blocking = new BlockingRedisDataSourceImpl(vertx, redis, api, Duration.ofSeconds(60));
+        reactive = new ReactiveRedisDataSourceImpl(vertx, redis, api);
+    }
+
+    @AfterEach
+    public void clear() {
+        blocking.flushall();
+    }
+
+    @Test
+    public void topKBlocking() {
+        TransactionResult result = blocking.withTransaction(tx -> {
+            TransactionalTopKCommands<String, String> topk = tx.topk(String.class);
+            assertThat(topk.getDataSource()).isEqualTo(tx);
+            topk.topkReserve(key, 3);
+            topk.topkAdd(key, "a", "a", "b", "b", "a", "c", "a", "b", "c", "d", "d", "d");
+            topk.topkIncrBy(key, "c", 10);
+            topk.topkQuery(key, "a");
+            topk.topkQuery(key, "a", "b", "c");
+            topk.topkList(key);
+            topk.topkListWithCount(key);
+        });
+        assertThat(result.size()).isEqualTo(7);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Void) result.get(0)).isNull();
+        assertThat((List<String>) result.get(1)).containsExactly(null, null, null, null, null, null, null, null, null, null,
+                "c", null);
+        assertThat((String) result.get(2)).isEqualTo("b");
+        assertThat((boolean) result.get(3)).isEqualTo(true);
+        assertThat((List<Boolean>) result.get(4)).containsExactly(true, false, true);
+        assertThat((List<String>) result.get(5)).containsExactly("c", "a", "d");
+        assertThat((Map<String, Integer>) result.get(6)).containsExactly(entry("c", 12), entry("a", 4), entry("d", 3));
+    }
+
+    @Test
+    public void topKReactive() {
+        TransactionResult result = reactive.withTransaction(tx -> {
+            ReactiveTransactionalTopKCommands<String, String> topk = tx.topk(String.class);
+            assertThat(topk.getDataSource()).isEqualTo(tx);
+            return topk.topkReserve(key, 3)
+                    .chain(() -> topk.topkAdd(key, "a", "a", "b", "b", "a", "c", "a", "b", "c", "d", "d", "d"))
+                    .chain(() -> topk.topkIncrBy(key, "c", 10))
+                    .chain(() -> topk.topkQuery(key, "a"))
+                    .chain(() -> topk.topkQuery(key, "a", "b", "c"))
+                    .chain(() -> topk.topkList(key))
+                    .chain(() -> topk.topkListWithCount(key))
+                    .replaceWithVoid();
+        }).await().indefinitely();
+        assertThat(result.size()).isEqualTo(7);
+        assertThat(result.discarded()).isFalse();
+        assertThat((Void) result.get(0)).isNull();
+        assertThat((List<String>) result.get(1)).containsExactly(null, null, null, null, null, null, null, null, null, null,
+                "c", null);
+        assertThat((String) result.get(2)).isEqualTo("b");
+        assertThat((boolean) result.get(3)).isEqualTo(true);
+        assertThat((List<Boolean>) result.get(4)).containsExactly(true, false, true);
+        assertThat((List<String>) result.get(5)).containsExactly("c", "a", "d");
+        assertThat((Map<String, Integer>) result.get(6)).containsExactly(entry("c", 12), entry("a", 4), entry("d", 3));
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/ClassGeneratorHelper.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/ClassGeneratorHelper.java
@@ -1,0 +1,94 @@
+package io.quarkus.redis.generator;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.VoidType;
+import com.github.javaparser.javadoc.Javadoc;
+import com.github.javaparser.javadoc.description.JavadocDescription;
+
+import io.smallrye.mutiny.Uni;
+
+public class ClassGeneratorHelper {
+
+    private ClassGeneratorHelper() {
+        // Avoid direct instantiation
+    }
+
+    public static Type getUniOfVoid() {
+        JavaParser parser = new JavaParser();
+        return parser.parseClassOrInterfaceType("Uni<Void>").getResult().get();
+    }
+
+    public static Type getUniOfResponse() {
+        JavaParser parser = new JavaParser();
+        return parser.parseClassOrInterfaceType("Uni<Response>").getResult().get();
+    }
+
+    public static void copyClassJavadocAndAppendContent(ClassOrInterfaceDeclaration api,
+            ClassOrInterfaceDeclaration blockingTxApi, String append) {
+        JavadocComment copy = api.getJavadocComment().orElseThrow().clone();
+        Javadoc javadoc = copy.parse();
+        JavadocDescription description = javadoc.getDescription();
+        if (append != null) {
+            String newJavadocDescription = javadoc.getDescription().toText() + "\n" + append + "\n";
+            description = JavadocDescription.parseText(newJavadocDescription);
+        }
+        Javadoc updatedJavadoc = new Javadoc(description);
+        updatedJavadoc.getBlockTags().addAll(javadoc.getBlockTags());
+        blockingTxApi.setJavadocComment(updatedJavadoc);
+    }
+
+    public static void copyImportsExceptUni(CompilationUnit unit, CompilationUnit cu) {
+        for (ImportDeclaration is : unit.getImports()) {
+            if (!is.toString().contains(Uni.class.getName())) {
+                cu.addImport(is);
+            }
+        }
+    }
+
+    public static void copyImports(CompilationUnit unit, CompilationUnit cu) {
+        cu.setImports(unit.getImports());
+    }
+
+    public static void setPackage(CompilationUnit unit, CompilationUnit cu) {
+        cu.setPackageDeclaration(unit.getPackageDeclaration().orElseThrow());
+    }
+
+    public static Type getBlockingType(Type type) {
+        ClassOrInterfaceType asClass = type.asClassOrInterfaceType();
+        Type param = asClass.getTypeArguments().orElseThrow().get(0);
+        if (param.asString().equals(Void.class.getSimpleName())) {
+            return new VoidType();
+        }
+        if (param.isClassOrInterfaceType()) {
+            if (param.asClassOrInterfaceType().isBoxedType()) {
+                return param.asClassOrInterfaceType().toUnboxedType();
+            }
+        }
+        return param;
+    }
+
+    public static boolean isReturningUniOfVoid(Type type) {
+        if (!type.isClassOrInterfaceType()) {
+            return false;
+        }
+        ClassOrInterfaceType r = type.asClassOrInterfaceType();
+        if (!r.getName().asString().equals(Uni.class.getSimpleName())) {
+            return false;
+        }
+        if (r.getTypeArguments().isEmpty()) {
+            return false;
+        }
+        if (r.getTypeArguments().get().size() != 1) {
+            return false;
+        }
+        Type param = r.getTypeArguments().get().get(0);
+        return param.asClassOrInterfaceType().getName().asString().equals(Void.class.getSimpleName());
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
@@ -1,0 +1,610 @@
+package io.quarkus.redis.generator;
+
+import static io.quarkus.redis.generator.ClassGeneratorHelper.copyClassJavadocAndAppendContent;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.copyImports;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.copyImportsExceptUni;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.getBlockingType;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.getUniOfResponse;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.isReturningUniOfVoid;
+import static io.quarkus.redis.generator.ClassGeneratorHelper.setPackage;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+import org.jboss.logging.Logger;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.type.VoidType;
+import com.github.javaparser.javadoc.Javadoc;
+import com.github.javaparser.javadoc.JavadocBlockTag;
+
+import io.quarkus.redis.datasource.ReactiveRedisCommands;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
+import io.quarkus.redis.datasource.RedisCommands;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
+import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
+import io.quarkus.redis.runtime.datasource.AbstractRedisCommandGroup;
+import io.quarkus.redis.runtime.datasource.AbstractRedisCommands;
+import io.quarkus.redis.runtime.datasource.AbstractTransactionalCommands;
+import io.quarkus.redis.runtime.datasource.AbstractTransactionalRedisCommandGroup;
+import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
+import io.quarkus.redis.runtime.datasource.RedisCommandExecutor;
+import io.quarkus.redis.runtime.datasource.TransactionHolder;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Response;
+
+/**
+ * A tools generating the various interface and implementation from the existing reactive API.
+ */
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class RedisApiGenerator {
+
+    private static final Logger LOGGER = Logger.getLogger("redis-api-generator");
+
+    public static void main(String[] args) throws FileNotFoundException {
+        // PARAMETERS
+        String reactiveApi = "io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands";
+        String prefix = "cms";
+        // ---------
+
+        File out = new File("extensions/redis-client/runtime/target/generation");
+        out.mkdirs();
+
+        // Read existing API
+        CompilationUnit cu = StaticJavaParser.parse(toFile(reactiveApi));
+        ClassOrInterfaceDeclaration reactiveAPI = (ClassOrInterfaceDeclaration) cu.getPrimaryType().orElseThrow();
+
+        // Generate APIs
+        ClassOrInterfaceDeclaration blockingAPI = generateBlockingInterface(cu, reactiveAPI, out);
+        ClassOrInterfaceDeclaration txBlockingAPI = generateBlockingTransactionalInterface(cu, reactiveAPI, out);
+        ClassOrInterfaceDeclaration txReactiveAPI = generateBlockingReactiveTransactionalInterface(cu, reactiveAPI, out);
+
+        // Generate Implementations
+        generateBlockingImplementation(cu, reactiveAPI, blockingAPI, out);
+        generateBlockingTransactionalImplementation(cu, txReactiveAPI, txBlockingAPI, out);
+
+        // Generate skeletons
+        ClassOrInterfaceDeclaration abstractImpl = generateAbstractSkeleton(cu, reactiveAPI, out, prefix);
+        generateReactiveImplSkeleton(cu, reactiveAPI, abstractImpl, out);
+        generateReactiveTransactionalImplSkeleton(cu, reactiveAPI, txReactiveAPI, out);
+    }
+
+    private static void generateReactiveImplSkeleton(CompilationUnit unit, ClassOrInterfaceDeclaration reactiveAPI,
+            ClassOrInterfaceDeclaration abstractImpl, File dir) {
+        String classname = reactiveAPI.getNameAsString() + "Impl";
+        CompilationUnit cu = new CompilationUnit();
+        cu.setPackageDeclaration("io.quarkus.redis.runtime.datasource");
+        copyImports(unit, cu);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString() + "." + reactiveAPI.getNameAsString());
+        cu.addImport(Response.class);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString(), false, true);
+
+        String itf = reactiveAPI.getNameAsString();
+        String ac = abstractImpl.getNameAsString();
+        if (!reactiveAPI.getTypeParameters().isEmpty()) {
+            itf += "<";
+            itf += reactiveAPI.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(","));
+            itf += ">";
+            ac += "<";
+            ac += reactiveAPI.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(","));
+            ac += ">";
+        }
+
+        ClassOrInterfaceDeclaration clazz = cu
+                .addClass(classname)
+                .addExtendedType(ac)
+                .addImplementedType(itf)
+                .addImplementedType(ReactiveRedisCommands.class)
+                .setTypeParameters(reactiveAPI.getTypeParameters());
+
+        clazz.addField(ReactiveRedisDataSource.class, "reactive")
+                .setPrivate(true)
+                .setFinal(true);
+        ConstructorDeclaration cst = clazz.addConstructor(Modifier.Keyword.PUBLIC)
+                .addParameter(ReactiveRedisDataSourceImpl.class, "redis");
+        for (TypeParameter tp : reactiveAPI.getTypeParameters()) {
+            cst.addParameter("Class<" + tp.getNameAsString() + ">", tp.getNameAsString().toLowerCase());
+        }
+        String cstLine1 = "super(redis, " + reactiveAPI.getTypeParameters().stream()
+                .map(tp -> tp.getNameAsString().toLowerCase()).collect(Collectors.joining(",")) + ");";
+        String cstLine2 = "this.reactive = redis;";
+        cst.getBody().addStatement(cstLine1).addStatement(cstLine2);
+
+        clazz.addMethod("getDataSource")
+                .addMarkerAnnotation(Override.class)
+                .setType(ReactiveRedisDataSource.class)
+                .setPublic(true)
+                .getBody().get().addStatement("return reactive;");
+
+        for (MethodDeclaration method : reactiveAPI.getMethods()) {
+            MethodDeclaration declaration = clazz.addMethod(method.getNameAsString())
+                    .setModifiers(method.getModifiers())
+                    .setParameters(method.getParameters())
+                    .setPublic(true)
+                    .setType(method.getType())
+                    .addMarkerAnnotation(Override.class);
+
+            String block = "{" + "// TODO IMPLEMENT ME\n" +
+                    "// return super._" +
+                    method.getNameAsString() +
+                    "("
+                    + method.getParameters().stream().map(NodeWithSimpleName::getNameAsString).collect(Collectors.joining(","))
+                    + ")\n" +
+                    "// .map(r -> decode(r));\n" +
+                    "return null;" +
+                    "\n}";
+            declaration.setBody(new JavaParser().parseBlock(block).getResult().get());
+        }
+
+        try {
+            File file = new File(dir, classname + ".java");
+            LOGGER.infof("Generating reactive implementation for %s into %s", reactiveAPI.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write reactive implementation %s", classname, e);
+        }
+
+    }
+
+    private static void generateReactiveTransactionalImplSkeleton(CompilationUnit unit, ClassOrInterfaceDeclaration reactiveAPI,
+            ClassOrInterfaceDeclaration reactiveTxAPI, File dir) {
+        String classname = reactiveTxAPI.getNameAsString() + "Impl";
+        String impl = reactiveAPI.getNameAsString() + "Impl";
+        CompilationUnit cu = new CompilationUnit();
+        cu.setPackageDeclaration("io.quarkus.redis.runtime.datasource");
+        copyImports(unit, cu);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString() + "." + reactiveTxAPI.getNameAsString());
+        cu.addImport(Response.class);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString(), false, true);
+
+        String rx = reactiveTxAPI.getNameAsString();
+        if (!reactiveTxAPI.getTypeParameters().isEmpty()) {
+            rx = rx + "<" + reactiveTxAPI.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(",")) + ">";
+            impl = impl + "<" + reactiveTxAPI.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(",")) + ">";
+        }
+
+        ClassOrInterfaceDeclaration clazz = cu
+                .addClass(classname)
+                .addExtendedType(AbstractTransactionalCommands.class)
+                .addImplementedType(rx)
+                .setTypeParameters(reactiveTxAPI.getTypeParameters());
+
+        clazz.addField(impl, "reactive").setPrivate(true).setFinal(true);
+        ConstructorDeclaration cst = clazz.addConstructor(Modifier.Keyword.PUBLIC)
+                .addParameter(ReactiveTransactionalRedisDataSource.class, "ds")
+                .addParameter(impl, "reactive")
+                .addParameter(TransactionHolder.class, "tx");
+        String cstLine1 = "super(ds, tx);";
+        String cstLine2 = "this.reactive = reactive;";
+        cst.getBody().addStatement(cstLine1).addStatement(cstLine2);
+
+        for (MethodDeclaration method : reactiveTxAPI.getMethods()) {
+            MethodDeclaration rxDecl = findMethod(reactiveAPI, method);
+            MethodDeclaration declaration = clazz.addMethod(method.getNameAsString())
+                    .setModifiers(method.getModifiers())
+                    .setPublic(true)
+                    .setParameters(method.getParameters())
+                    .setType(method.getType())
+                    .addMarkerAnnotation(Override.class);
+
+            String expectedType = "";
+            if (rxDecl != null) {
+                expectedType = rxDecl.getType().asClassOrInterfaceType().asString();
+            }
+            String block = "{" + "// TODO IMPLEMENT ME\n" +
+                    "// this.tx.enqueue(decoding); // " + expectedType + "\n" +
+                    "return this.reactive._" + method.getNameAsString() +
+                    "("
+                    + method.getParameters().stream().map(NodeWithSimpleName::getNameAsString).collect(Collectors.joining(","))
+                    + ")\n" +
+                    "    .invoke(this::queuedOrDiscard).replaceWithVoid();\n" +
+                    "\n}";
+            declaration.setBody(new JavaParser().parseBlock(block).getResult().get());
+        }
+
+        try {
+            File file = new File(dir, classname + ".java");
+            LOGGER.infof("Generating transactional reactive implementation for %s into %s", reactiveTxAPI.getName(),
+                    file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write transactional reactive implementation %s", classname, e);
+        }
+
+    }
+
+    private static MethodDeclaration findMethod(ClassOrInterfaceDeclaration reactiveAPI, MethodDeclaration method) {
+        for (MethodDeclaration m : reactiveAPI.getMethods()) {
+            if (m.getNameAsString().equals(method.getNameAsString())
+                    && m.getParameters().equals(method.getParameters())) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    private static ClassOrInterfaceDeclaration generateAbstractSkeleton(CompilationUnit unit,
+            ClassOrInterfaceDeclaration reactiveAPI, File dir, String prefix) {
+        String classname = "Abstract" + reactiveAPI.getNameAsString().replace("Reactive", "");
+        CompilationUnit cu = new CompilationUnit();
+        cu.setPackageDeclaration("io.quarkus.redis.runtime.datasource");
+        copyImports(unit, cu);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString() + "." + reactiveAPI.getNameAsString());
+        cu.addImport(Response.class);
+        cu.addImport(Command.class);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString(), false, true);
+        cu.addImport("io.smallrye.mutiny.helpers.ParameterValidation.nonNull", true, false);
+
+        ClassOrInterfaceDeclaration clazz = cu
+                .addClass(classname)
+                .addExtendedType(AbstractRedisCommands.class)
+                .setTypeParameters(reactiveAPI.getTypeParameters());
+
+        // Constructor
+        ConstructorDeclaration cst = clazz.addConstructor()
+                .addParameter(RedisCommandExecutor.class, "redis");
+        for (TypeParameter tp : reactiveAPI.getTypeParameters()) {
+            cst.addParameter("Class<" + tp.getNameAsString() + ">", tp.getNameAsString().toLowerCase());
+        }
+        String statement = "super(redis, new Marshaller(" + reactiveAPI.getTypeParameters().stream()
+                .map(tp -> tp.getNameAsString().toLowerCase()).collect(Collectors.joining(",")) + "));";
+        cst.getBody().addStatement(statement);
+
+        for (MethodDeclaration method : reactiveAPI.getMethods()) {
+            MethodDeclaration declaration = clazz.addMethod("_" + method.getNameAsString())
+                    .setParameters(method.getParameters())
+                    .setType(getUniOfResponse());
+
+            StringBuilder block = new StringBuilder("{");
+            block.append("// Validation\n");
+            boolean keyAsFirstParam = method.getParameter(0).getNameAsString().equalsIgnoreCase("key");
+            if (keyAsFirstParam) {
+                block.append("nonNull(key, \"key\");\n");
+            }
+            block.append("// Create command\n");
+            String cmd = method.getNameAsString().toUpperCase();
+            if (cmd.startsWith(prefix.toUpperCase())) {
+                cmd = prefix.toUpperCase() + "_" + cmd.substring(prefix.length());
+            }
+            block.append("RedisCommand cmd = RedisCommand.of(Command.").append(cmd).append(");\n");
+            if (keyAsFirstParam) {
+                block.append("//        .put(marshaller.encode(key));\n");
+            }
+            block.append("return execute(cmd);\n");
+            block.append("\n}");
+
+            ParseResult<BlockStmt> result = new JavaParser().parseBlock(block.toString());
+            declaration.setBody(result.getResult().get());
+        }
+
+        try {
+            File file = new File(dir, classname + ".java");
+            LOGGER.infof("Generating abstract implementation for %s into %s", reactiveAPI.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write abstract implementation %s", classname, e);
+        }
+
+        return clazz;
+
+    }
+
+    private static void generateBlockingImplementation(CompilationUnit unit, ClassOrInterfaceDeclaration reactiveAPI,
+            ClassOrInterfaceDeclaration blockingApi, File dir) {
+        String classname = "Blocking" + blockingApi.getNameAsString() + "Impl";
+        CompilationUnit cu = new CompilationUnit();
+        cu.setPackageDeclaration("io.quarkus.redis.runtime.datasource");
+        copyImportsExceptUni(unit, cu);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString(), false, true);
+
+        String itf = blockingApi.getNameAsString();
+        String rx = reactiveAPI.getNameAsString();
+        if (!blockingApi.getTypeParameters().isEmpty()) {
+            itf = itf + "<" + blockingApi.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(",")) + ">";
+            rx = rx + "<" + blockingApi.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(",")) + ">";
+        }
+
+        ClassOrInterfaceDeclaration impl = cu
+                .addClass(classname)
+                .addExtendedType(AbstractRedisCommandGroup.class)
+                .addImplementedType(itf)
+                .setTypeParameters(reactiveAPI.getTypeParameters())
+                .setPublic(true);
+
+        // reactive field
+        impl.addField(rx, "reactive", Modifier.Keyword.PRIVATE, Modifier.Keyword.FINAL);
+
+        // constructor
+        ConstructorDeclaration cst = impl.addConstructor(Modifier.Keyword.PUBLIC)
+                .addParameter(RedisDataSource.class, "ds")
+                .addParameter(rx, "reactive")
+                .addParameter(Duration.class, "timeout");
+        cst.getBody()
+                .addStatement("super(ds, timeout);")
+                .addStatement("this.reactive = reactive;");
+
+        // For each method, implement
+        for (MethodDeclaration method : blockingApi.getMethods()) {
+            MethodDeclaration declaration = impl.addMethod(method.getNameAsString());
+            declaration.setModifiers(method.getModifiers());
+            declaration.setPublic(true);
+            declaration.setParameters(method.getParameters());
+            declaration.setDefault(method.isDefault());
+            declaration.addMarkerAnnotation(Override.class);
+            declaration.setType(method.getType());
+            BlockStmt body = getBlockingImplBody(method);
+            declaration.setBody(body);
+        }
+
+        try {
+            File file = new File(dir, classname + ".java");
+            LOGGER.infof("Generating blocking implementation for %s into %s", reactiveAPI.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write blocking implementation %s", classname, e);
+        }
+
+    }
+
+    private static void generateBlockingTransactionalImplementation(CompilationUnit unit,
+            ClassOrInterfaceDeclaration reactiveTxAPI, ClassOrInterfaceDeclaration txblockingApi, File dir) {
+        String classname = "Blocking" + txblockingApi.getNameAsString() + "Impl";
+        CompilationUnit cu = new CompilationUnit();
+        cu.setPackageDeclaration("io.quarkus.redis.runtime.datasource");
+        copyImportsExceptUni(unit, cu);
+        cu.addImport(unit.getPackageDeclaration().orElseThrow().getNameAsString(), false, true);
+
+        String itf = txblockingApi.getNameAsString();
+        String rx = reactiveTxAPI.getNameAsString();
+        if (!txblockingApi.getTypeParameters().isEmpty()) {
+            itf += "<";
+            itf += txblockingApi.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(","));
+            itf += ">";
+            rx = rx + "<" + txblockingApi.getTypeParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                    .collect(Collectors.joining(",")) + ">";
+        }
+
+        ClassOrInterfaceDeclaration impl = cu
+                .addClass(classname)
+                .addExtendedType(AbstractTransactionalRedisCommandGroup.class)
+                .addImplementedType(itf)
+                .setTypeParameters(reactiveTxAPI.getTypeParameters())
+                .setPublic(true);
+
+        // reactive field
+        impl.addField(rx, "reactive", Modifier.Keyword.PRIVATE, Modifier.Keyword.FINAL);
+
+        // constructor
+        ConstructorDeclaration cst = impl.addConstructor(Modifier.Keyword.PUBLIC)
+                .addParameter(TransactionalRedisDataSource.class, "ds")
+                .addParameter(rx, "reactive")
+                .addParameter(Duration.class, "timeout");
+        cst.getBody()
+                .addStatement("super(ds, timeout);")
+                .addStatement("this.reactive = reactive;");
+
+        // For each method, implement
+        for (MethodDeclaration method : txblockingApi.getMethods()) {
+            MethodDeclaration declaration = impl.addMethod(method.getNameAsString());
+            declaration.setModifiers(method.getModifiers());
+            declaration.setPublic(true);
+            declaration.setParameters(method.getParameters());
+            declaration.setDefault(method.isDefault());
+            declaration.addMarkerAnnotation(Override.class);
+            declaration.setType(new VoidType());
+            BlockStmt body = getBlockingImplBody(method);
+            declaration.setBody(body);
+        }
+
+        try {
+            File file = new File(dir, classname + ".java");
+            LOGGER.infof("Generating transactional blocking implementation for %s into %s", reactiveTxAPI.getName(),
+                    file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write blocking implementation %s", classname, e);
+        }
+    }
+
+    private static BlockStmt getBlockingImplBody(MethodDeclaration method) {
+        JavaParser parser = new JavaParser();
+        String parameters = method.getParameters().stream().map(NodeWithSimpleName::getNameAsString)
+                .collect(Collectors.joining(", "));
+        if (method.getType().isVoidType()) {
+            String statement = "{ reactive." + method.getNameAsString() + "(" + parameters
+                    + ")\n        .await().atMost(timeout); }";
+            ParseResult<BlockStmt> block = parser.parseBlock(statement);
+            return block.getResult().get();
+        } else {
+            String statement = "{ return reactive." + method.getNameAsString() + "(" + parameters
+                    + ")\n        .await().atMost(timeout); }";
+            return parser.parseBlock(statement).getResult().get();
+        }
+    }
+
+    private static ClassOrInterfaceDeclaration generateBlockingTransactionalInterface(CompilationUnit unit,
+            ClassOrInterfaceDeclaration api, File dir) {
+        String blockingTxApiName = api.getNameAsString().replace("Reactive", "Transactional");
+        CompilationUnit cu = new CompilationUnit();
+        setPackage(unit, cu);
+        copyImportsExceptUni(unit, cu);
+
+        ClassOrInterfaceDeclaration blockingTxApi = cu
+                .addInterface(blockingTxApiName)
+                .addExtendedType(TransactionalRedisCommands.class)
+                .setTypeParameters(api.getTypeParameters())
+                .setPublic(true);
+        copyClassJavadocAndAppendContent(api, blockingTxApi,
+                "This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code void}.");
+
+        // For each method, produce the "transactional blocking" variant - always return void
+        for (MethodDeclaration method : api.getMethods()) {
+            MethodDeclaration declaration = blockingTxApi.addMethod(method.getNameAsString());
+            declaration.setModifiers(method.getModifiers());
+            declaration.setParameters(method.getParameters());
+            declaration.setDefault(method.isDefault());
+            declaration.removeBody();
+            declaration.setType(new VoidType());
+
+            // Edit javadoc to remove the @return tag is any.
+            JavadocComment comment = method.getJavadocComment().orElseThrow();
+            Javadoc javadoc = comment.parse();
+            Javadoc copy = new Javadoc(javadoc.getDescription());
+            for (JavadocBlockTag tag : javadoc.getBlockTags()) {
+                if (tag.getType() != JavadocBlockTag.Type.RETURN) {
+                    copy.addBlockTag(tag);
+                }
+            }
+            declaration.setJavadocComment(copy);
+        }
+
+        try {
+            File file = new File(dir, blockingTxApiName + ".java");
+            LOGGER.infof("Generating transactional blocking API for %s into %s", api.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write transactional blocking API %s", blockingTxApiName, e);
+        }
+
+        return blockingTxApi;
+    }
+
+    private static ClassOrInterfaceDeclaration generateBlockingReactiveTransactionalInterface(CompilationUnit unit,
+            ClassOrInterfaceDeclaration api, File dir) {
+        String name = api.getNameAsString().replace("Reactive", "ReactiveTransactional");
+        CompilationUnit cu = new CompilationUnit();
+        setPackage(unit, cu);
+        copyImports(unit, cu);
+
+        ClassOrInterfaceDeclaration gen = cu
+                .addInterface(name)
+                .setTypeParameters(api.getTypeParameters())
+                .addExtendedType(ReactiveTransactionalRedisCommands.class)
+                .setPublic(true);
+        copyClassJavadocAndAppendContent(api, gen,
+                "This API is intended to be used in a Redis transaction ({@code MULTI}), thus, all command methods return {@code Uni<Void>}.");
+
+        // For each method, produce the "transactional blocking" variant - always return Uni<Void>
+        for (MethodDeclaration method : api.getMethods()) {
+            MethodDeclaration declaration = gen.addMethod(method.getNameAsString());
+            declaration.setModifiers(method.getModifiers());
+            declaration.setParameters(method.getParameters());
+            declaration.setDefault(method.isDefault());
+            declaration.removeBody();
+            declaration.setType(ClassGeneratorHelper.getUniOfVoid());
+
+            // Edit javadoc to remove the @return tag is any.
+            JavadocComment comment = method.getJavadocComment().orElseThrow();
+            Javadoc javadoc = comment.parse();
+            Javadoc copy = new Javadoc(javadoc.getDescription());
+            for (JavadocBlockTag tag : javadoc.getBlockTags()) {
+                if (tag.getType() != JavadocBlockTag.Type.RETURN) {
+                    copy.addBlockTag(tag);
+                } else {
+                    copy.addBlockTag(new JavadocBlockTag(JavadocBlockTag.Type.RETURN,
+                            " A {@code Uni} emitting {@code null} when the command has been enqueued" +
+                                    " successfully in the transaction, a failure otherwise. In the case of failure, the transaction is discarded."));
+                }
+            }
+            declaration.setJavadocComment(copy);
+        }
+
+        try {
+            File file = new File(dir, name + ".java");
+            LOGGER.infof("Generating reactive transactional API for %s into %s", api.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write reactive transactional API %s", name, e);
+        }
+
+        return gen;
+    }
+
+    private static ClassOrInterfaceDeclaration generateBlockingInterface(CompilationUnit unit, ClassOrInterfaceDeclaration api,
+            File dir) {
+        String blockingApiName = api.getNameAsString().replace("Reactive", "");
+        CompilationUnit cu = new CompilationUnit();
+        setPackage(unit, cu);
+        copyImportsExceptUni(unit, cu);
+        ClassOrInterfaceDeclaration blockingApi = cu
+                .addInterface(blockingApiName)
+                .addExtendedType(RedisCommands.class)
+                .setJavadocComment(api.getJavadocComment().orElseThrow())
+                .setTypeParameters(api.getTypeParameters())
+                .setPublic(true);
+
+        // For each method, produce the "blocking" variant
+        for (MethodDeclaration method : api.getMethods()) {
+            MethodDeclaration declaration = blockingApi.addMethod(method.getNameAsString());
+            declaration.setModifiers(method.getModifiers());
+            declaration.setParameters(method.getParameters());
+            declaration.setDefault(method.isDefault());
+            declaration.removeBody();
+
+            boolean isVoid = isReturningUniOfVoid(method.getType());
+            declaration.setType(getBlockingType(method.getType()));
+
+            // Copy javadoc and update the return tag
+            JavadocComment comment = method.getJavadocComment().orElseThrow();
+            Javadoc javadoc = comment.parse();
+            Javadoc copy = new Javadoc(javadoc.getDescription());
+            for (JavadocBlockTag tag : javadoc.getBlockTags()) {
+                if (tag.getType() == JavadocBlockTag.Type.RETURN) {
+                    if (!isVoid) {
+                        String text = tag.getContent().toText();
+                        JavadocBlockTag newReturn = new JavadocBlockTag(JavadocBlockTag.Type.RETURN,
+                                text.replace("a uni producing ", " ").trim());
+                        copy.addBlockTag(newReturn);
+                    }
+                } else {
+                    copy.addBlockTag(tag);
+                }
+            }
+            declaration.setJavadocComment(copy);
+        }
+
+        try {
+            File file = new File(dir, blockingApiName + ".java");
+            LOGGER.infof("Generating blocking API for %s into %s", api.getName(), file.getAbsolutePath());
+            Files.writeString(file.toPath(), cu.toString());
+        } catch (IOException e) {
+            LOGGER.errorf("Unable to write blocking API %s", blockingApiName, e);
+        }
+
+        return blockingApi;
+
+    }
+
+    public static File toFile(String classname) {
+        File file = new File("extensions/redis-client/runtime/src/main/java/" + classname.replace(".", "/") + ".java");
+        RedisApiGenerator.LOGGER.infof("Reading %s", file.getAbsolutePath());
+        return file;
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/generator/RedisApiGenerator.java
@@ -39,6 +39,7 @@ import io.quarkus.redis.datasource.ReactiveTransactionalRedisCommands;
 import io.quarkus.redis.datasource.RedisCommands;
 import io.quarkus.redis.datasource.RedisDataSource;
 import io.quarkus.redis.datasource.TransactionalRedisCommands;
+import io.quarkus.redis.datasource.topk.ReactiveTopKCommands;
 import io.quarkus.redis.datasource.transactions.ReactiveTransactionalRedisDataSource;
 import io.quarkus.redis.datasource.transactions.TransactionalRedisDataSource;
 import io.quarkus.redis.runtime.datasource.AbstractRedisCommandGroup;
@@ -62,8 +63,8 @@ public class RedisApiGenerator {
 
     public static void main(String[] args) throws FileNotFoundException {
         // PARAMETERS
-        String reactiveApi = "io.quarkus.redis.datasource.countmin.ReactiveCountMinCommands";
-        String prefix = "cms";
+        String reactiveApi = ReactiveTopKCommands.class.getName();
+        String prefix = "topk";
         // ---------
 
         File out = new File("extensions/redis-client/runtime/target/generation");


### PR DESCRIPTION
This PR adds the commands from the Redis-Bloom module (probabilistic data structures).
It provides support for:

- Bloom filters
- Cuckoo filters
- Count-min sketches
- Top-K sketches

_What about T-digest_? The `t-digest` group is not implemented as it does not seem to be provided by the Redis stack at the moment (while the commands are listed on the doc). 
