### PR TITLE
Run the method scheduled with the Quartz scheduler on a duplicated context

### DIFF
--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicatedContextTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicatedContextTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.quartz.test;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies that the @Scheduled method are called on a duplicated context.
+ */
+public class DuplicatedContextTest {
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyScheduledClass.class));
+
+    @Inject
+    MyScheduledClass scheduled;
+
+    @Test
+    public void testBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.blockingCalled() > 0);
+    }
+
+    @Test
+    public void testNonBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.nonBlockingCalled() > 0);
+    }
+
+    public static class MyScheduledClass {
+
+        private final AtomicInteger blockingCalled = new AtomicInteger();
+        private final AtomicInteger nonBlockingCalled = new AtomicInteger();
+
+        @Scheduled(every = "1m")
+        public void blocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNotNull(context);
+            Assertions.assertTrue(VertxContext.isDuplicatedContext(context));
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+
+            blockingCalled.incrementAndGet();
+        }
+
+        @Scheduled(every = "1m")
+        public Uni<Void> nonblocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNotNull(context);
+            Assertions.assertTrue(VertxContext.isDuplicatedContext(context));
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+
+            nonBlockingCalled.incrementAndGet();
+            return Uni.createFrom().voidItem();
+        }
+
+        public int blockingCalled() {
+            return blockingCalled.get();
+        }
+
+        public int nonBlockingCalled() {
+            return nonBlockingCalled.get();
+        }
+    }
+}

--- a/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicatedContextWithRunOnQuartzThreadTest.java
+++ b/extensions/quartz/deployment/src/test/java/io/quarkus/quartz/test/DuplicatedContextWithRunOnQuartzThreadTest.java
@@ -1,0 +1,80 @@
+package io.quarkus.quartz.test;
+
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies that the non-blocking @Scheduled method are called on a duplicated context, but blocking methods are not
+ * because of the {@code quarkus.quartz.run-blocking-scheduled-method-on-quartz-thread} option.
+ */
+public class DuplicatedContextWithRunOnQuartzThreadTest {
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(MyScheduledClass.class))
+            .overrideConfigKey("quarkus.quartz.run-blocking-scheduled-method-on-quartz-thread", "true");
+
+    @Inject
+    MyScheduledClass scheduled;
+
+    @Test
+    public void testBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.blockingCalled() > 0);
+    }
+
+    @Test
+    public void testNonBlocking() {
+        await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> scheduled.nonBlockingCalled() > 0);
+    }
+
+    public static class MyScheduledClass {
+
+        private final AtomicInteger blockingCalled = new AtomicInteger();
+        private final AtomicInteger nonBlockingCalled = new AtomicInteger();
+
+        @Scheduled(every = "1m")
+        public void blocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNull(context);
+            blockingCalled.incrementAndGet();
+        }
+
+        @Scheduled(every = "1m")
+        public Uni<Void> nonblocking() {
+            Context context = Vertx.currentContext();
+            Assertions.assertNotNull(context);
+            Assertions.assertTrue(VertxContext.isDuplicatedContext(context));
+            Assertions.assertTrue(VertxContext.isOnDuplicatedContext());
+
+            nonBlockingCalled.incrementAndGet();
+            return Uni.createFrom().voidItem();
+        }
+
+        public int blockingCalled() {
+            return blockingCalled.get();
+        }
+
+        public int nonBlockingCalled() {
+            return nonBlockingCalled.get();
+        }
+    }
+}

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -66,6 +66,15 @@ public class QuartzRuntimeConfig {
     @ConfigItem(name = "misfire-policy")
     public Map<String, QuartzMisfirePolicyConfig> misfirePolicyPerJobs;
 
+    /**
+     * When set to {@code true}, blocking scheduled methods are invoked on a thread managed by Quartz instead of a
+     * thread from the regular Quarkus thread pool (default).
+     * <p>
+     * When this option is enabled, blocking scheduled methods do not run on a {@code duplicated context}.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean runBlockingScheduledMethodOnQuartzThread;
+
     @ConfigGroup
     public static class QuartzMisfirePolicyConfig {
         /**


### PR DESCRIPTION
This is the follow-up of https://github.com/quarkusio/quarkus/pull/28255.
When running the scheduled method, the lack of duplicated context can lead to contextual data loss (loss only, no leak).
This commit makes sure that the method runs with a duplicated context.

However, this is a breaking change for users expecting the method to run on a Quartz thread.
