### PR TITLE
Docs & Tests - migrate SSL certificate files property from deprecated

### DIFF
--- a/docs/src/main/asciidoc/http-reference.adoc
+++ b/docs/src/main/asciidoc/http-reference.adoc
@@ -127,8 +127,8 @@ Your `application.properties` would then look like this:
 
 [source,properties]
 ----
-quarkus.http.ssl.certificate.file=/path/to/certificate
-quarkus.http.ssl.certificate.key-file=/path/to/key
+quarkus.http.ssl.certificate.files=/path/to/certificate
+quarkus.http.ssl.certificate.key-files=/path/to/key
 ----
 
 === Providing a keystore

--- a/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
+++ b/extensions/vertx-http/deployment/src/test/resources/conf/disable-http.conf
@@ -1,4 +1,4 @@
 # Enable SSL, configure the key store
 quarkus.http.insecure-requests=REDIRECT
-quarkus.http.ssl.certificate.file=server-cert.pem
-quarkus.http.ssl.certificate.key-file=server-key.pem
+quarkus.http.ssl.certificate.files=server-cert.pem
+quarkus.http.ssl.certificate.key-files=server-key.pem

--- a/integration-tests/elytron-undertow/src/main/resources/application.properties
+++ b/integration-tests/elytron-undertow/src/main/resources/application.properties
@@ -9,8 +9,8 @@ quarkus.security.users.embedded.users.poul=poul
 quarkus.security.users.embedded.roles.poul=interns
 quarkus.security.users.embedded.plain-text=true
 quarkus.servlet.context-path=/foo
-quarkus.http.ssl.certificate.file=target/server-cert.pem
-quarkus.http.ssl.certificate.key-file=target/server-key.pem
+quarkus.http.ssl.certificate.files=target/server-cert.pem
+quarkus.http.ssl.certificate.key-files=target/server-key.pem
 # Test that server starts with this option
 # See https://github.com/quarkusio/quarkus/issues/8336
 quarkus.http.insecure-requests=disabled


### PR DESCRIPTION
[CertificateConfig#keyFile](https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java#L65) and [CertificateConfig#file](https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/CertificateConfig.java#L50) are deprecated, let's do what JavaDoc suggests. While I understand there is an advantage to test also deprecated way to set these files, there were no tests using `files` style, so I migrated tests too.