### PR TITLE
Honour DOCKER_CONFIG env var in jib the same way as in jib-core

### DIFF
--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -335,7 +335,13 @@ public class JibProcessor {
             registryImage.addCredentialRetriever(credentialRetrieverFactory.dockerConfig());
             String dockerConfigEnv = System.getenv().get("DOCKER_CONFIG");
             if (dockerConfigEnv != null) {
-                registryImage.addCredentialRetriever(credentialRetrieverFactory.dockerConfig(Path.of(dockerConfigEnv)));
+                Path dockerConfigPath = Path.of(dockerConfigEnv);
+                if (Files.isDirectory(dockerConfigPath)) {
+                    // this matches jib's behaviour,
+                    // see https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md#authentication-methods
+                    dockerConfigPath = dockerConfigPath.resolve("config.json");
+                }
+                registryImage.addCredentialRetriever(credentialRetrieverFactory.dockerConfig(dockerConfigPath));
             }
         }
         return registryImage;


### PR DESCRIPTION
Support for DOCKER_CONFIG has been added in #27460. However, in jib, the DOCKER_CONFIG should point to a directory containing a `config.json`, while in the quarkus implementation it must point to the `config.json` file itself. This is very confusing, especially since there is no documentation.

This commit fixes the `JibProcessor`, so it behave exactly as described in the jib documentation (see
https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md#authentication-methods). That is, if `DOCKER_CONFIG` is set, it is expected to point to a folder.

See also `com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers.java`.

Fixes #28354