### PR TITLE
Record inside panache

### DIFF
--- a/docs/src/main/asciidoc/hibernate-orm-panache.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm-panache.adoc
@@ -733,7 +733,7 @@ Hibernate will use **DTO projection** and generate a SELECT clause with the attr
 This is also called **dynamic instantiation** or **constructor expression**, more info can be found on the Hibernate guide:
 link:https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#hql-select-clause[hql select clause]
 
-The projection class needs to be a valid Java Bean and have a constructor that contains all its attributes, this constructor will be used to
+The projection class needs to have a constructor that contains all its attributes, this constructor will be used to
 instantiate the projection DTO instead of using the entity class. This class must have a matching constructor with all the class attributes as parameters.
 
 
@@ -764,6 +764,8 @@ The implementation of the `project(Class)` method uses the constructor's paramet
 so the compiler must be configured to store parameter names inside the compiled class.
 This is enabled by default if you are using the Quarkus Maven archetype. If you are not using it, add the property `<maven.compiler.parameters>true</maven.compiler.parameters>` to your `pom.xml`.
 ====
+
+TIP: If you run Java 17+, records are a good fit for projection classes.
 
 If in the DTO projection object you have a field from a referenced entity, you can use the `@ProjectedFieldName` annotation to provide the path for the SELECT statement.
 

--- a/docs/src/main/asciidoc/mongodb-panache.adoc
+++ b/docs/src/main/asciidoc/mongodb-panache.adoc
@@ -734,6 +734,8 @@ TIP: Using `@BsonProperty` is not needed to define custom column mappings, as th
 
 TIP: You can have your projection class extends from another class. In this case, the parent class also needs to have use `@ProjectionFor` annotation.
 
+TIP: If you run Java 17+, records are a good fit for projection classes.
+
 == Query debugging
 
 As MongoDB with Panache allows writing simplified queries, it is sometimes handy to log the generated native queries for debugging purpose.

--- a/extensions/panache/hibernate-orm-panache-common/deployment/src/main/java/io/quarkus/hibernate/orm/panache/common/deployment/PanacheJpaCommonResourceProcessor.java
+++ b/extensions/panache/hibernate-orm-panache-common/deployment/src/main/java/io/quarkus/hibernate/orm/panache/common/deployment/PanacheJpaCommonResourceProcessor.java
@@ -54,7 +54,7 @@ public final class PanacheJpaCommonResourceProcessor {
     }
 
     private void lookupNamedQueries(CombinedIndexBuildItem index, DotName name, Set<String> namedQueries) {
-        ClassInfo classInfo = index.getIndex().getClassByName(name);
+        ClassInfo classInfo = index.getComputingIndex().getClassByName(name);
         if (classInfo == null) {
             return;
         }
@@ -80,7 +80,7 @@ public final class PanacheJpaCommonResourceProcessor {
         // climb up the hierarchy of types
         if (!classInfo.superClassType().name().equals(JandexUtil.DOTNAME_OBJECT)) {
             Type superType = classInfo.superClassType();
-            ClassInfo superClass = index.getIndex().getClassByName(superType.name());
+            ClassInfo superClass = index.getComputingIndex().getClassByName(superType.name());
             if (superClass != null) {
                 lookupNamedQueries(index, superClass.name(), namedQueries);
             }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/main/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/HibernateOrmPanacheRestProcessor.java
@@ -67,11 +67,11 @@ class HibernateOrmPanacheRestProcessor {
     void findEntityResources(CombinedIndexBuildItem index,
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer) {
-        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getIndex()));
+        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getComputingIndex()));
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(PANACHE_ENTITY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+        for (ClassInfo classInfo : index.getComputingIndex().getKnownDirectImplementors(PANACHE_ENTITY_RESOURCE_INTERFACE)) {
+            validateResource(index.getComputingIndex(), classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();
@@ -95,11 +95,12 @@ class HibernateOrmPanacheRestProcessor {
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer) {
-        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getIndex()));
+        ResourceImplementor resourceImplementor = new ResourceImplementor(new EntityClassHelper(index.getComputingIndex()));
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex().getKnownDirectImplementors(PANACHE_REPOSITORY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+        for (ClassInfo classInfo : index.getComputingIndex()
+                .getKnownDirectImplementors(PANACHE_REPOSITORY_RESOURCE_INTERFACE)) {
+            validateResource(index.getComputingIndex(), classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();

--- a/extensions/panache/hibernate-reactive-panache-common/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheJpaCommonResourceProcessor.java
+++ b/extensions/panache/hibernate-reactive-panache-common/deployment/src/main/java/io/quarkus/hibernate/reactive/panache/deployment/PanacheJpaCommonResourceProcessor.java
@@ -89,7 +89,7 @@ public final class PanacheJpaCommonResourceProcessor {
     }
 
     private void lookupNamedQueries(CombinedIndexBuildItem index, DotName name, Set<String> namedQueries) {
-        ClassInfo classInfo = index.getIndex().getClassByName(name);
+        ClassInfo classInfo = index.getComputingIndex().getClassByName(name);
         if (classInfo == null) {
             return;
         }
@@ -115,7 +115,7 @@ public final class PanacheJpaCommonResourceProcessor {
         // climb up the hierarchy of types
         if (!classInfo.superClassType().name().equals(JandexUtil.DOTNAME_OBJECT)) {
             Type superType = classInfo.superClassType();
-            ClassInfo superClass = index.getIndex().getClassByName(superType.name());
+            ClassInfo superClass = index.getComputingIndex().getClassByName(superType.name());
             if (superClass != null) {
                 lookupNamedQueries(index, superClass.name(), namedQueries);
             }

--- a/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
+++ b/extensions/panache/mongodb-rest-data-panache/deployment/src/main/java/io/quarkus/mongodb/rest/data/panache/deployment/MongoPanacheRestProcessor.java
@@ -71,13 +71,13 @@ class MongoPanacheRestProcessor {
             BuildProducer<GeneratedBeanBuildItem> implementationsProducer,
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformersProducer) {
-        EntityClassHelper entityClassHelper = new EntityClassHelper(index.getIndex());
+        EntityClassHelper entityClassHelper = new EntityClassHelper(index.getComputingIndex());
         ResourceImplementor resourceImplementor = new ResourceImplementor(entityClassHelper);
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex()
+        for (ClassInfo classInfo : index.getComputingIndex()
                 .getKnownDirectImplementors(PANACHE_MONGO_ENTITY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+            validateResource(index.getComputingIndex(), classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();
@@ -103,13 +103,13 @@ class MongoPanacheRestProcessor {
             BuildProducer<RestDataResourceBuildItem> restDataResourceProducer,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeansProducer,
             BuildProducer<BytecodeTransformerBuildItem> bytecodeTransformersProducer) {
-        EntityClassHelper entityClassHelper = new EntityClassHelper(index.getIndex());
+        EntityClassHelper entityClassHelper = new EntityClassHelper(index.getComputingIndex());
         ResourceImplementor resourceImplementor = new ResourceImplementor(entityClassHelper);
         ClassOutput classOutput = new GeneratedBeanGizmoAdaptor(implementationsProducer);
 
-        for (ClassInfo classInfo : index.getIndex()
+        for (ClassInfo classInfo : index.getComputingIndex()
                 .getKnownDirectImplementors(PANACHE_MONGO_REPOSITORY_RESOURCE_INTERFACE)) {
-            validateResource(index.getIndex(), classInfo);
+            validateResource(index.getComputingIndex(), classInfo);
 
             List<Type> generics = getGenericTypes(classInfo);
             String resourceInterface = classInfo.name().toString();

--- a/integration-tests/java-17/pom.xml
+++ b/integration-tests/java-17/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-integration-tests-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-integration-test-java-17</artifactId>
+
+    <name>Quarkus - Integration Tests - Java 17</name>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-mongodb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mongodb-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/Person.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/Person.java
@@ -1,0 +1,12 @@
+package io.quarkus.it.hibernate.panache.person;
+
+import javax.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Person extends PanacheEntity {
+    public String firstname;
+    public String lastname;
+    public Status status = Status.ALIVE;
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonName.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonName.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.hibernate.panache.person;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record PersonName(String firstname, String lastname) {
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonResource.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/PersonResource.java
@@ -1,0 +1,27 @@
+package io.quarkus.it.hibernate.panache.person;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/hibernate/persons")
+@Transactional
+public class PersonResource {
+    @GET
+    public List<PersonName> getPersons() {
+        return Person.findAll().project(PersonName.class).list();
+    }
+
+    @POST
+    public Response addPerson(Person person) {
+        person.persist();
+        String id = person.id.toString();
+        return Response.created(URI.create("/persons/entity/" + id)).build();
+    }
+
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/Status.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/hibernate/panache/person/Status.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.hibernate.panache.person;
+
+public enum Status {
+    DEAD("I'm a Zombie"),
+    ALIVE("I alive!");
+
+    private final String value;
+
+    private Status(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/Person.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/Person.java
@@ -1,0 +1,9 @@
+package io.quarkus.it.mongodb.panache.person;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntity;
+
+public class Person extends PanacheMongoEntity {
+    public String firstname;
+    public String lastname;
+    public Status status = Status.ALIVE;
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/PersonName.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/PersonName.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.mongodb.panache.person;
+
+import io.quarkus.mongodb.panache.common.ProjectionFor;
+
+@ProjectionFor(Person.class)
+public record PersonName(String firstName, String lastName) {
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/PersonResource.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/PersonResource.java
@@ -1,0 +1,24 @@
+package io.quarkus.it.mongodb.panache.person;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/mongo/persons")
+public class PersonResource {
+    @GET
+    public List<PersonName> getPersons() {
+        return Person.findAll().project(PersonName.class).list();
+    }
+
+    @POST
+    public Response addPerson(Person person) {
+        person.persist();
+        String id = person.id.toString();
+        return Response.created(URI.create("/persons/entity/" + id)).build();
+    }
+}

--- a/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/Status.java
+++ b/integration-tests/java-17/src/main/java/io/quarkus/it/mongodb/panache/person/Status.java
@@ -1,0 +1,21 @@
+package io.quarkus.it.mongodb.panache.person;
+
+public enum Status {
+    DEAD("I'm a Zombie"),
+    ALIVE("I alive!");
+
+    private final String value;
+
+    private Status(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/integration-tests/java-17/src/main/resources/application.properties
+++ b/integration-tests/java-17/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.mongodb.connection-string=mongodb://localhost:27017
+quarkus.mongodb.database=persons
+
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
+quarkus.datasource.jdbc.max-size=8
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/integration-tests/java-17/src/test/java/io/quarkus/it/hibernate/panache/person/PersonResourceTest.java
+++ b/integration-tests/java-17/src/test/java/io/quarkus/it/hibernate/panache/person/PersonResourceTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.it.hibernate.panache.person;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.it.mongodb.panache.person.Person;
+import io.quarkus.it.mongodb.panache.person.Status;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@QuarkusTestResource(H2DatabaseTestResource.class)
+class PersonResourceTest {
+    private static final String ROOT_URL = "/hibernate/persons";
+
+    @Test
+    void testRecordInPanache() {
+        var person1 = new Person();
+        person1.firstname = "Loïc";
+        person1.lastname = "Mathieu";
+        person1.status = Status.ALIVE;
+        var person2 = new Person();
+        person1.firstname = "Zombie";
+        person2.lastname = "Zombie";
+        person2.status = Status.DEAD;
+
+        given().body(person1).contentType(ContentType.JSON)
+                .when().post(ROOT_URL)
+                .then().statusCode(201);
+        given().body(person2).contentType(ContentType.JSON)
+                .when().post(ROOT_URL)
+                .then().statusCode(201);
+
+        when().get(ROOT_URL)
+                .then()
+                .statusCode(200)
+                .body("size()", is(2));
+    }
+
+}

--- a/integration-tests/java-17/src/test/java/io/quarkus/it/mongodb/panache/person/PersonResourceTest.java
+++ b/integration-tests/java-17/src/test/java/io/quarkus/it/mongodb/panache/person/PersonResourceTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.it.mongodb.panache.person;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.mongodb.MongoTestResource;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@QuarkusTestResource(MongoTestResource.class)
+class PersonResourceTest {
+    private static final String ROOT_URL = "/mongo/persons";
+
+    @Test
+    void testRecordInPanache() {
+        var person1 = new Person();
+        person1.firstname = "Loïc";
+        person1.lastname = "Mathieu";
+        person1.status = Status.ALIVE;
+        var person2 = new Person();
+        person1.firstname = "Zombie";
+        person2.lastname = "Zombie";
+        person2.status = Status.DEAD;
+
+        given().body(person1).contentType(ContentType.JSON)
+                .when().post(ROOT_URL)
+                .then().statusCode(201);
+        given().body(person2).contentType(ContentType.JSON)
+                .when().post(ROOT_URL)
+                .then().statusCode(201);
+
+        when().get(ROOT_URL)
+                .then()
+                .statusCode(200)
+                .body("size()", is(2));
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -342,6 +342,20 @@
             </modules>
         </profile>
 
+        <!-- Java 17 test profile that restricts running in 17+ JVM version -->
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <property>
+                    <name>!no-test-modules</name>
+                </property>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>java-17</module>
+            </modules>
+        </profile>
+
         <!-- Common native image test profile
              WARNING: In this parent profile, you cannot override properties in a submodule!
                       Plugin config can only be overridden (to a certain point) via pluginManagement!


### PR DESCRIPTION
This PR move Panache build steps to use the Computing index to handle `java.lang.Record` this is a recommandation of @Ladicek .

This PR document that records are supported and a good match for projection classes.

This PR adds a Java 17 integration test, it contains 2 tests for using record as projection class for both MongoDB with Panache and Hibernate with Panache, more tests could be added for more Java 17 functionalities later if needed.