### PR TITLE
Chance SR CP tests to use RestEasy Reactive instead of classic and remove tests using rx java

### DIFF
--- a/integration-tests/smallrye-context-propagation/pom.xml
+++ b/integration-tests/smallrye-context-propagation/pom.xml
@@ -32,60 +32,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- For RX Java tests -->
-        <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-rxjava2</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.ws.rs</groupId>
-                    <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-context-propagation-propagators-rxjava2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-reactive-converter-rxjava2</artifactId>
-            <scope>test</scope>
-        </dependency>
- 
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny-smallrye-context-propagation</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
-            <scope>test</scope>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
 
         <dependency>
@@ -117,6 +64,19 @@
         </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/ContextEndpoint.java
@@ -4,11 +4,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.Transactional;
@@ -23,16 +20,11 @@ import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
-import org.jboss.resteasy.annotations.Stream;
-import org.jboss.resteasy.annotations.Stream.MODE;
 import org.junit.jupiter.api.Assertions;
-import org.reactivestreams.Publisher;
 import org.wildfly.common.Assert;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.orm.panache.Panache;
-import io.reactivex.Single;
-import io.smallrye.mutiny.Multi;
 
 @Path("/context")
 @Produces(MediaType.TEXT_PLAIN)
@@ -44,8 +36,6 @@ public class ContextEndpoint {
     ManagedExecutor all;
     @Inject
     ThreadContext allTc;
-    @Inject
-    HttpServletRequest servletRequest;
 
     @GET
     @Path("/resteasy")
@@ -72,8 +62,11 @@ public class ContextEndpoint {
     @Path("/servlet")
     public CompletionStage<String> servletTest(@Context UriInfo uriInfo) {
         CompletableFuture<String> ret = all.completedFuture("OK");
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
         return ret.thenApplyAsync(text -> {
-            servletRequest.getContentType();
+            RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+            Assertions.assertEquals(previousValue, instance2.callMe());
             return text;
         });
     }
@@ -83,8 +76,11 @@ public class ContextEndpoint {
     public CompletionStage<String> servletThreadContextTest(@Context UriInfo uriInfo) {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
         return ret.thenApplyAsync(text -> {
-            servletRequest.getContentType();
+            RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+            Assertions.assertEquals(previousValue, instance2.callMe());
             return text;
         }, executor);
     }
@@ -260,85 +256,6 @@ public class ContextEndpoint {
 
         // We should see the transaction already committed even if we're async
         Assertions.assertEquals(1, ContextEntity.deleteAll());
-        return ret;
-    }
-
-    @Transactional
-    @GET
-    @Path("/transaction-single")
-    public Single<String> transactionSingle() throws SystemException {
-        ContextEntity entity = new ContextEntity();
-        entity.name = "Stef";
-        entity.persist();
-        Transaction t1 = Panache.getTransactionManager().getTransaction();
-        Assertions.assertNotNull(t1);
-        // our entity
-        Assertions.assertEquals(1, ContextEntity.count());
-
-        return txBean.doInTxSingle()
-                // this makes sure we get executed in another scheduler
-                .delay(100, TimeUnit.MILLISECONDS)
-                .map(text -> {
-                    // make sure we don't see the other transaction's entity
-                    Transaction t2;
-                    try {
-                        t2 = Panache.getTransactionManager().getTransaction();
-                    } catch (SystemException e) {
-                        throw new RuntimeException(e);
-                    }
-                    Assertions.assertEquals(t1, t2);
-                    Assertions.assertEquals(Status.STATUS_ACTIVE, t2.getStatus());
-                    return text;
-                });
-    }
-
-    @Transactional
-    @GET
-    @Path("/transaction-single2")
-    public Single<String> transactionSingle2() throws SystemException {
-        Single<String> ret = Single.just("OK");
-        // now delete both entities
-        Assertions.assertEquals(2, ContextEntity.deleteAll());
-        return ret;
-    }
-
-    @Transactional
-    @GET
-    @Path("/transaction-publisher")
-    @Stream(value = MODE.RAW)
-    public Publisher<String> transactionPublisher() throws SystemException {
-        ContextEntity entity = new ContextEntity();
-        entity.name = "Stef";
-        entity.persist();
-        Transaction t1 = Panache.getTransactionManager().getTransaction();
-        Assertions.assertNotNull(t1);
-        // our entity
-        Assertions.assertEquals(1, ContextEntity.count());
-
-        return txBean.doInTxPublisher()
-                // this makes sure we get executed in another scheduler
-                .delay(100, TimeUnit.MILLISECONDS)
-                .map(text -> {
-                    // make sure we don't see the other transaction's entity
-                    Transaction t2;
-                    try {
-                        t2 = Panache.getTransactionManager().getTransaction();
-                    } catch (SystemException e) {
-                        throw new RuntimeException(e);
-                    }
-                    Assertions.assertEquals(t1, t2);
-                    Assertions.assertEquals(Status.STATUS_ACTIVE, t2.getStatus());
-                    return text;
-                });
-    }
-
-    @Transactional
-    @GET
-    @Path("/transaction-publisher2")
-    public Publisher<String> transactionPublisher2() {
-        Publisher<String> ret = Multi.createFrom().item("OK");
-        // now delete both entities
-        Assertions.assertEquals(2, ContextEntity.deleteAll());
         return ret;
     }
 }

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/SimpleContextPropagationTest.java
@@ -1,7 +1,5 @@
 package io.quarkus.context.test;
 
-import static org.hamcrest.Matchers.equalTo;
-
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Response;
@@ -9,7 +7,6 @@ import javax.ws.rs.core.Response;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -76,7 +73,6 @@ public class SimpleContextPropagationTest {
     }
 
     @Test()
-    @Disabled("flaky")
     public void testArcMEContextPropagationDisabled() throws InterruptedException {
         // reset state
         RequestBean.initState();
@@ -124,23 +120,5 @@ public class SimpleContextPropagationTest {
     public void testTransactionNewContextPropagation() {
         RestAssured.when().get("/context/transaction-new").then()
                 .statusCode(Response.Status.OK.getStatusCode());
-    }
-
-    @Test()
-    public void testTransactionContextPropagationSingle() {
-        RestAssured.when().get("/context/transaction-single").then()
-                .statusCode(Response.Status.OK.getStatusCode())
-                .body(equalTo("OK"));
-        awaitState(() -> RestAssured.when().get("/context/transaction-single2").then()
-                .statusCode(Response.Status.OK.getStatusCode()));
-    }
-
-    @Test()
-    public void testTransactionContextPropagationPublisher() {
-        RestAssured.when().get("/context/transaction-publisher").then()
-                .statusCode(Response.Status.OK.getStatusCode())
-                .body(equalTo("OK"));
-        awaitState(() -> RestAssured.when().get("/context/transaction-publisher2").then()
-                .statusCode(Response.Status.OK.getStatusCode()));
     }
 }

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TransactionalBean.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/TransactionalBean.java
@@ -8,9 +8,6 @@ import javax.transaction.Transactional.TxType;
 
 import org.junit.jupiter.api.Assertions;
 
-import io.reactivex.Flowable;
-import io.reactivex.Single;
-
 @ApplicationScoped
 public class TransactionalBean {
 
@@ -24,27 +21,5 @@ public class TransactionalBean {
         ContextEntity entity = new ContextEntity();
         entity.name = "Stef";
         entity.persist();
-    }
-
-    @Transactional(value = TxType.REQUIRES_NEW)
-    public Single<String> doInTxSingle() {
-        Assertions.assertEquals(0, ContextEntity.count());
-
-        ContextEntity entity = new ContextEntity();
-        entity.name = "Stef";
-        entity.persist();
-
-        return Single.just("OK");
-    }
-
-    @Transactional(value = TxType.REQUIRES_NEW)
-    public Flowable<String> doInTxPublisher() {
-        Assertions.assertEquals(0, ContextEntity.count());
-
-        ContextEntity entity = new ContextEntity();
-        entity.name = "Stef";
-        entity.persist();
-
-        return Flowable.fromArray("OK");
     }
 }

--- a/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
+++ b/integration-tests/smallrye-context-propagation/src/test/java/io/quarkus/context/test/mutiny/MutinyContextEndpoint.java
@@ -7,7 +7,6 @@ import java.util.concurrent.Executors;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -23,8 +22,6 @@ import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
-import org.jboss.resteasy.annotations.Stream;
-import org.jboss.resteasy.annotations.Stream.MODE;
 import org.junit.jupiter.api.Assertions;
 import org.reactivestreams.Publisher;
 import org.wildfly.common.Assert;
@@ -46,8 +43,6 @@ public class MutinyContextEndpoint {
     ManagedExecutor all;
     @Inject
     ThreadContext allTc;
-    @Inject
-    HttpServletRequest servletRequest;
 
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -106,10 +101,13 @@ public class MutinyContextEndpoint {
     @GET
     @Path("/servlet-uni")
     public Uni<String> servletContextPropagation(@Context UriInfo uriInfo) {
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
         return Uni.createFrom().item("OK")
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .map(text -> {
-                    Assertions.assertNotNull(servletRequest.getContentType());
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
                     return text;
                 })
                 .onFailure().invoke(t -> System.out.println("Got failure " + t.getMessage()));
@@ -119,10 +117,13 @@ public class MutinyContextEndpoint {
     @Path("/servlet-uni-cs")
     public Uni<String> servletContextPropagationWithUniCreatedFromCSWithManagedExecutor(@Context UriInfo uriInfo) {
         CompletableFuture<String> ret = all.completedFuture("OK");
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
         return Uni.createFrom().completionStage(() -> ret)
                 .emitOn(Infrastructure.getDefaultExecutor())
                 .map(text -> {
-                    Assertions.assertNotNull(servletRequest.getContentType());
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
                     return text;
                 });
     }
@@ -131,10 +132,13 @@ public class MutinyContextEndpoint {
     @Path("/servlet-tc-uni-cs")
     public Uni<String> servletThreadContext(@Context UriInfo uriInfo) {
         CompletableFuture<String> ret = allTc.withContextCapture(CompletableFuture.completedFuture("OK"));
+        RequestBean instance = Arc.container().instance(RequestBean.class).get();
+        String previousValue = instance.callMe();
         return Uni.createFrom().completionStage(() -> ret)
                 .emitOn(executor)
                 .map(text -> {
-                    Assertions.assertNotNull(servletRequest.getContentType());
+                    RequestBean instance2 = Arc.container().instance(RequestBean.class).get();
+                    Assertions.assertEquals(previousValue, instance2.callMe());
                     return text;
                 });
     }
@@ -418,7 +422,6 @@ public class MutinyContextEndpoint {
     @Transactional
     @GET
     @Path("/transaction-multi")
-    @Stream(value = MODE.RAW)
     public Multi<String> transactionPropagationWithMulti() throws SystemException {
         Person entity = new Person();
         entity.name = "Stef";


### PR DESCRIPTION
Fixes #28129 

SR CP tests are now using resteasy reactive and I have simply removed rx java tests.
With these changes, I have the tests passing and I am not seeing any flaky results (where I could previously get some).