### PR TITLE
Ignore transient fields when performing bytecode recording

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java
@@ -1224,7 +1224,8 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 }
                 // check if the matching field is ignored
                 try {
-                    if (param.getClass().getDeclaredField(i.getName()).getAnnotation(IgnoreProperty.class) != null) {
+                    Field field = param.getClass().getDeclaredField(i.getName());
+                    if (ignoreField(field)) {
                         continue;
                     }
                 } catch (NoSuchFieldException ignored) {
@@ -1414,7 +1415,7 @@ public class BytecodeRecorderImpl implements RecorderContext {
         //now handle accessible fields
         for (Field field : param.getClass().getFields()) {
             // check if the field is ignored
-            if (field.getAnnotation(IgnoreProperty.class) != null) {
+            if (ignoreField(field)) {
                 continue;
             }
             if (!handledProperties.contains(field.getName())) {
@@ -1549,6 +1550,13 @@ public class BytecodeRecorderImpl implements RecorderContext {
                 return context.loadDeferred(objectValue);
             }
         };
+    }
+
+    /**
+     * Returns {@code true} iff the field is annotated {@link IgnoreProperty} or the field is marked as {@code transient}
+     */
+    private static boolean ignoreField(Field field) {
+        return (field.getAnnotation(IgnoreProperty.class) != null) || Modifier.isTransient(field.getModifiers());
     }
 
     private DeferredParameter findLoaded(final Object param) {

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/BytecodeRecorderTestCase.java
@@ -166,8 +166,9 @@ public class BytecodeRecorderTestCase {
             IgnoredProperties ignoredProperties = new IgnoredProperties();
             ignoredProperties.setNotIgnored("Shows up");
             ignoredProperties.setIgnoredField("Does not show up");
+            ignoredProperties.setAnotherIgnoredField("Does not show up either");
             recorder.ignoredProperties(ignoredProperties);
-        }, new IgnoredProperties("Shows up", null));
+        }, new IgnoredProperties("Shows up", null, null));
     }
 
     @Test

--- a/core/deployment/src/test/java/io/quarkus/deployment/recording/IgnoredProperties.java
+++ b/core/deployment/src/test/java/io/quarkus/deployment/recording/IgnoredProperties.java
@@ -10,12 +10,15 @@ public class IgnoredProperties {
     @IgnoreProperty
     private String ignoredField;
 
+    private transient String anotherIgnoredField;
+
     public IgnoredProperties() {
     }
 
-    public IgnoredProperties(String notIgnored, String ignoredField) {
+    public IgnoredProperties(String notIgnored, String ignoredField, String anotherIgnoredField) {
         this.notIgnored = notIgnored;
         this.ignoredField = ignoredField;
+        this.anotherIgnoredField = anotherIgnoredField;
     }
 
     public String getNotIgnored() {
@@ -34,6 +37,14 @@ public class IgnoredProperties {
         this.ignoredField = ignoredField;
     }
 
+    public String getAnotherIgnoredField() {
+        return anotherIgnoredField;
+    }
+
+    public void setAnotherIgnoredField(String anotherIgnoredField) {
+        this.anotherIgnoredField = anotherIgnoredField;
+    }
+
     @IgnoreProperty
     public String getSomethingElse() {
         throw new IllegalStateException("This should not have been called");
@@ -47,12 +58,13 @@ public class IgnoredProperties {
             return false;
         IgnoredProperties that = (IgnoredProperties) o;
         return Objects.equals(notIgnored, that.notIgnored) &&
-                Objects.equals(ignoredField, that.ignoredField);
+                Objects.equals(ignoredField, that.ignoredField) &&
+                Objects.equals(anotherIgnoredField, that.anotherIgnoredField);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(notIgnored, ignoredField);
+        return Objects.hash(notIgnored, ignoredField, anotherIgnoredField);
     }
 
     @Override


### PR DESCRIPTION
The idea behind this is that we can't always use `@IgnoreProperty` (for example in the core RR code), so reusing Java serialization semantics makes for a good alternative.