### PR TITLE
Register Resource methods for reflection if ResourceInfo#getMethod is used in filters

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerRequestFilterBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerRequestFilterBuildItem.java
@@ -1,16 +1,21 @@
 package io.quarkus.resteasy.reactive.spi;
 
+import org.jboss.jandex.MethodInfo;
+
 public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBuildItem {
 
     private final boolean preMatching;
     private final boolean nonBlockingRequired;
     private final boolean readBody;
 
+    private final MethodInfo filterSourceMethod;
+
     protected ContainerRequestFilterBuildItem(Builder builder) {
         super(builder);
         this.preMatching = builder.preMatching;
         this.nonBlockingRequired = builder.nonBlockingRequired;
         this.readBody = builder.readBody;
+        this.filterSourceMethod = builder.filterSourceMethod;
     }
 
     public ContainerRequestFilterBuildItem(String className) {
@@ -18,6 +23,7 @@ public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBu
         this.preMatching = false;
         this.nonBlockingRequired = false;
         this.readBody = false;
+        this.filterSourceMethod = null;
     }
 
     public boolean isPreMatching() {
@@ -32,10 +38,16 @@ public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBu
         return readBody;
     }
 
+    public MethodInfo getFilterSourceMethod() {
+        return filterSourceMethod;
+    }
+
     public static final class Builder extends AbstractInterceptorBuildItem.Builder<ContainerRequestFilterBuildItem, Builder> {
         boolean preMatching = false;
         boolean nonBlockingRequired = false;
         boolean readBody = false;
+
+        MethodInfo filterSourceMethod = null;
 
         public Builder(String className) {
             super(className);
@@ -53,6 +65,11 @@ public final class ContainerRequestFilterBuildItem extends AbstractInterceptorBu
 
         public Builder setReadBody(boolean readBody) {
             this.readBody = readBody;
+            return this;
+        }
+
+        public Builder setFilterSourceMethod(MethodInfo filterSourceMethod) {
+            this.filterSourceMethod = filterSourceMethod;
             return this;
         }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerResponseFilterBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/spi/ContainerResponseFilterBuildItem.java
@@ -1,15 +1,31 @@
 package io.quarkus.resteasy.reactive.spi;
 
+import org.jboss.jandex.MethodInfo;
+
 public final class ContainerResponseFilterBuildItem extends AbstractInterceptorBuildItem {
 
-    protected ContainerResponseFilterBuildItem(AbstractInterceptorBuildItem.Builder<?, ?> builder) {
+    private final MethodInfo filterSourceMethod;
+
+    protected ContainerResponseFilterBuildItem(ContainerResponseFilterBuildItem.Builder builder) {
         super(builder);
+        this.filterSourceMethod = builder.filterSourceMethod;
+    }
+
+    public MethodInfo getFilterSourceMethod() {
+        return filterSourceMethod;
     }
 
     public static final class Builder extends AbstractInterceptorBuildItem.Builder<ContainerResponseFilterBuildItem, Builder> {
 
+        private MethodInfo filterSourceMethod = null;
+
         public Builder(String className) {
             super(className);
+        }
+
+        public Builder setFilterSourceMethod(MethodInfo filterSourceMethod) {
+            this.filterSourceMethod = filterSourceMethod;
+            return this;
         }
 
         public ContainerResponseFilterBuildItem build() {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FilterClassIntrospector.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/FilterClassIntrospector.java
@@ -1,0 +1,78 @@
+package io.quarkus.resteasy.reactive.server.deployment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import org.jboss.jandex.MethodInfo;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import io.quarkus.deployment.util.AsmUtil;
+import io.quarkus.gizmo.Gizmo;
+
+public class FilterClassIntrospector {
+
+    private final ClassLoader classLoader;
+
+    public FilterClassIntrospector(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    public boolean usesGetResourceMethod(MethodInfo methodInfo) {
+        String className = methodInfo.declaringClass().name().toString();
+        try (InputStream is = classLoader.getResourceAsStream(className.replace('.', '/') + ".class")) {
+            ClassReader configClassReader = new ClassReader(is);
+            FilterClassVisitor classVisitor = new FilterClassVisitor(AsmUtil.getDescriptor(methodInfo, null));
+            configClassReader.accept(classVisitor, 0);
+            return classVisitor.usesGetResourceMethod();
+        } catch (IOException e) {
+            throw new UncheckedIOException(className + " class reading failed", e);
+        }
+    }
+
+    private static class FilterClassVisitor extends ClassVisitor {
+
+        private final String methodDescriptor;
+        private final UsesGetResourceMethodVisitor methodVisitor = new UsesGetResourceMethodVisitor();
+
+        private FilterClassVisitor(String methodDescriptor) {
+            super(Gizmo.ASM_API_VERSION);
+            this.methodDescriptor = methodDescriptor;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            MethodVisitor superMethodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+            if (methodDescriptor.equals(descriptor)) {
+                return methodVisitor;
+            }
+            return superMethodVisitor;
+        }
+
+        public boolean usesGetResourceMethod() {
+            return methodVisitor.usesGetResourceMethod;
+        }
+    }
+
+    private static class UsesGetResourceMethodVisitor extends MethodVisitor {
+
+        private boolean usesGetResourceMethod = false;
+
+        private UsesGetResourceMethodVisitor() {
+            super(Gizmo.ASM_API_VERSION);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            if ((opcode == Opcodes.INVOKEINTERFACE) && "javax/ws/rs/container/ResourceInfo".equals(owner)
+                    && "getResourceMethod".equals(name)) {
+                usesGetResourceMethod = true;
+            }
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+        }
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -34,6 +35,8 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.Produces;
 import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.MessageBodyReader;
@@ -57,6 +60,7 @@ import org.jboss.resteasy.reactive.common.model.InjectableBean;
 import org.jboss.resteasy.reactive.common.model.ResourceClass;
 import org.jboss.resteasy.reactive.common.model.ResourceDynamicFeature;
 import org.jboss.resteasy.reactive.common.model.ResourceFeature;
+import org.jboss.resteasy.reactive.common.model.ResourceInterceptor;
 import org.jboss.resteasy.reactive.common.model.ResourceInterceptors;
 import org.jboss.resteasy.reactive.common.model.ResourceMethod;
 import org.jboss.resteasy.reactive.common.model.ResourceReader;
@@ -381,6 +385,7 @@ public class ResteasyReactiveProcessor {
             List<AnnotationsTransformerBuildItem> annotationTransformerBuildItems,
             List<ContextTypeBuildItem> contextTypeBuildItems,
             CompiledJavaVersionBuildItem compiledJavaVersionBuildItem,
+            ResourceInterceptorsBuildItem resourceInterceptorsBuildItem,
             Capabilities capabilities)
             throws NoSuchMethodException {
 
@@ -412,6 +417,9 @@ public class ResteasyReactiveProcessor {
                 beanContainerBuildItem);
         paramConverterProviders.initializeDefaultFactories(factoryFunction);
         paramConverterProviders.sort();
+
+        boolean filtersAccessResourceMethod = filtersAccessResourceMethod(
+                resourceInterceptorsBuildItem.getResourceInterceptors());
 
         GeneratedClassGizmoAdaptor classOutput = new GeneratedClassGizmoAdaptor(generatedClassBuildItemBuildProducer, true);
         try (ClassCreator c = new ClassCreator(classOutput,
@@ -523,6 +531,11 @@ public class ResteasyReactiveProcessor {
                                             .produce(new ReflectiveClassBuildItem(false, true, false,
                                                     entry.getActualEndpointInfo().name().toString()));
                                 }
+                            }
+
+                            if (filtersAccessResourceMethod) {
+                                reflectiveClassBuildItemBuildProducer.produce(new ReflectiveClassBuildItem(false, true, false,
+                                        entry.getActualEndpointInfo().name().toString()));
                             }
                         }
 
@@ -649,6 +662,60 @@ public class ResteasyReactiveProcessor {
         }
 
         handleDateFormatReflection(reflectiveClassBuildItemBuildProducer, index);
+    }
+
+    private boolean filtersAccessResourceMethod(ResourceInterceptors resourceInterceptors) {
+        AtomicBoolean ab = new AtomicBoolean(false);
+        ResourceInterceptors.FiltersVisitor visitor = new ResourceInterceptors.FiltersVisitor() {
+
+            @Override
+            public VisitResult visitPreMatchRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor) {
+                return inspect(interceptor);
+            }
+
+            @Override
+            public VisitResult visitGlobalRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor) {
+                return inspect(interceptor);
+            }
+
+            @Override
+            public VisitResult visitNamedRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor) {
+                return inspect(interceptor);
+            }
+
+            @Override
+            public VisitResult visitGlobalResponseFilter(ResourceInterceptor<ContainerResponseFilter> interceptor) {
+                return inspect(interceptor);
+            }
+
+            @Override
+            public VisitResult visitNamedResponseFilter(ResourceInterceptor<ContainerResponseFilter> interceptor) {
+                return inspect(interceptor);
+            }
+
+            private VisitResult inspect(ResourceInterceptor<?> interceptor) {
+                Map<String, Object> metadata = interceptor.metadata;
+                if (metadata == null) {
+                    return VisitResult.CONTINUE;
+                }
+                MethodInfo methodInfo = (MethodInfo) metadata.get(ResourceInterceptor.FILTER_SOURCE_METHOD_METADATA_KEY);
+                if (methodInfo == null) {
+                    return VisitResult.CONTINUE;
+                }
+                boolean result = createFilterClassIntrospector().usesGetResourceMethod(methodInfo);
+                if (result) {
+                    ab.set(true);
+                    return VisitResult.ABORT;
+                }
+                return VisitResult.CONTINUE;
+            }
+
+            private FilterClassIntrospector createFilterClassIntrospector() {
+                return new FilterClassIntrospector(Thread.currentThread().getContextClassLoader());
+            }
+        };
+        resourceInterceptors.visitFilters(visitor);
+        return ab.get();
     }
 
     private Collection<DotName> additionalContextTypes(List<ContextTypeBuildItem> contextTypeBuildItems) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -101,7 +101,8 @@ public class ResteasyReactiveScanningProcessor {
         return new ResourceInterceptorsContributorBuildItem(new Consumer<ResourceInterceptors>() {
             @Override
             public void accept(ResourceInterceptors interceptors) {
-                ResteasyReactiveInterceptorScanner.scanForInterceptors(interceptors, combinedIndexBuildItem.getIndex(),
+                ResteasyReactiveInterceptorScanner.scanForContainerRequestFilters(interceptors,
+                        combinedIndexBuildItem.getIndex(),
                         applicationResultBuildItem.getResult());
             }
         });
@@ -323,7 +324,8 @@ public class ResteasyReactiveScanningProcessor {
                         .setPriority(generated.getPriority())
                         .setPreMatching(generated.isPreMatching())
                         .setNonBlockingRequired(generated.isNonBlocking())
-                        .setReadBody(generated.isReadBody());
+                        .setReadBody(generated.isReadBody())
+                        .setFilterSourceMethod(generated.getFilterSourceMethod());
                 if (!generated.getNameBindingNames().isEmpty()) {
                     builder.setNameBindingNames(generated.getNameBindingNames());
                 }
@@ -335,7 +337,8 @@ public class ResteasyReactiveScanningProcessor {
                 ContainerResponseFilterBuildItem.Builder builder = new ContainerResponseFilterBuildItem.Builder(
                         generated.getGeneratedClassName())
                         .setRegisterAsBean(false)// it has already been made a bean
-                        .setPriority(generated.getPriority());
+                        .setPriority(generated.getPriority())
+                        .setFilterSourceMethod(generated.getFilterSourceMethod());
                 if (!generated.getNameBindingNames().isEmpty()) {
                     builder.setNameBindingNames(generated.getNameBindingNames());
                 }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -249,10 +249,14 @@ public final class ResteasyReactiveDotNames {
 
     public static final DotName ENCODED = DotName.createSimple(Encoded.class.getName());
 
-    public static final DotName QUARKUS_REST_CONTAINER_RESPONSE_FILTER = DotName
+    public static final DotName RESTEASY_REACTIVE_CONTAINER_RESPONSE_FILTER = DotName
             .createSimple("org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerResponseFilter");
-    public static final DotName QUARKUS_REST_CONTAINER_REQUEST_FILTER = DotName
+    public static final DotName RESTEASY_REACTIVE_CONTAINER_REQUEST_FILTER = DotName
             .createSimple("org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestFilter");
+
+    public static final DotName RESTEASY_REACTIVE_CONTAINER_REQUEST_CONTEXT = DotName
+            .createSimple("org.jboss.resteasy.reactive.server.spi.ResteasyReactiveContainerRequestContext");
+
     public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
 
     public static final DotName CONTINUATION = DotName.createSimple("kotlin.coroutines.Continuation");

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/scanning/ResteasyReactiveInterceptorScanner.java
@@ -1,20 +1,29 @@
 package org.jboss.resteasy.reactive.common.processor.scanning;
 
+import static org.jboss.resteasy.reactive.common.model.ResourceInterceptor.FILTER_SOURCE_METHOD_METADATA_KEY;
+import static org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames.*;
+
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 import org.jboss.resteasy.reactive.common.model.InterceptorContainer;
 import org.jboss.resteasy.reactive.common.model.PreMatchInterceptorContainer;
 import org.jboss.resteasy.reactive.common.model.ResourceInterceptor;
 import org.jboss.resteasy.reactive.common.model.ResourceInterceptors;
 import org.jboss.resteasy.reactive.common.processor.NameBindingUtil;
-import org.jboss.resteasy.reactive.common.processor.ResteasyReactiveDotNames;
 import org.jboss.resteasy.reactive.spi.BeanFactory;
 
 /**
@@ -39,7 +48,7 @@ public class ResteasyReactiveInterceptorScanner {
     public static ResourceInterceptors createResourceInterceptors(IndexView indexView, ApplicationScanningResult result,
             Function<String, BeanFactory<?>> factoryCreator) {
         ResourceInterceptors interceptors = new ResourceInterceptors();
-        scanForInterceptors(interceptors, indexView, result);
+        scanForContainerRequestFilters(interceptors, indexView, result);
         scanForIOInterceptors(interceptors, indexView, result);
         if (factoryCreator != null) {
             interceptors.initializeDefaultFactories(factoryCreator);
@@ -47,34 +56,131 @@ public class ResteasyReactiveInterceptorScanner {
         return interceptors;
     }
 
-    public static void scanForInterceptors(ResourceInterceptors interceptors, IndexView index,
+    public static void scanForContainerRequestFilters(ResourceInterceptors interceptors, IndexView index,
             ApplicationScanningResult applicationScanningResult) {
         //the quarkus version of these filters will not be in the index
         //so you need an explicit check for both
-        Collection<ClassInfo> containerResponseFilters = new HashSet<>(index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.CONTAINER_RESPONSE_FILTER));
-        containerResponseFilters.addAll(index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.QUARKUS_REST_CONTAINER_RESPONSE_FILTER));
-        Collection<ClassInfo> containerRequestFilters = new HashSet<>(index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.CONTAINER_REQUEST_FILTER));
-        containerRequestFilters.addAll(index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.QUARKUS_REST_CONTAINER_REQUEST_FILTER));
-        for (ClassInfo filterClass : containerRequestFilters) {
-            handleDiscoveredInterceptor(applicationScanningResult, interceptors.getContainerRequestFilters(),
+
+        Collection<ClassInfo> specReqFilters = new HashSet<>(index
+                .getAllKnownImplementors(CONTAINER_REQUEST_FILTER));
+        Collection<ClassInfo> allReqFilters = new HashSet<>(specReqFilters);
+        allReqFilters.addAll(index
+                .getAllKnownImplementors(RESTEASY_REACTIVE_CONTAINER_REQUEST_FILTER));
+        for (var filterClass : allReqFilters) {
+            var interceptor = handleDiscoveredInterceptor(applicationScanningResult, interceptors.getContainerRequestFilters(),
                     index, filterClass);
+            if (interceptor == null) {
+                continue;
+            }
+            setFilterMethodSourceForReqFilter(index, specReqFilters, filterClass, interceptor);
         }
-        for (ClassInfo filterClass : containerResponseFilters) {
-            handleDiscoveredInterceptor(applicationScanningResult, interceptors.getContainerResponseFilters(),
+
+        Collection<ClassInfo> specRespFilters = new HashSet<>(index
+                .getAllKnownImplementors(CONTAINER_RESPONSE_FILTER));
+        Collection<ClassInfo> allRespFilters = new HashSet<>(specRespFilters);
+        allRespFilters.addAll(index
+                .getAllKnownImplementors(RESTEASY_REACTIVE_CONTAINER_RESPONSE_FILTER));
+
+        for (var filterClass : allRespFilters) {
+            var interceptor = handleDiscoveredInterceptor(applicationScanningResult, interceptors.getContainerResponseFilters(),
                     index, filterClass);
+            if (interceptor == null) {
+                continue;
+            }
+            setFilterMethodSourceForRespFilter(index, specRespFilters, filterClass, interceptor);
+        }
+    }
+
+    private static void setFilterMethodSourceForReqFilter(IndexView index, Collection<ClassInfo> specRequestFilters,
+            ClassInfo filterClass, ResourceInterceptor<ContainerRequestFilter> interceptor) {
+        boolean isSpecFilter = specRequestFilters.contains(filterClass);
+        ClassInfo ci = filterClass;
+        MethodInfo filterSourceMethod = null;
+        do {
+            for (var method : ci.methods()) {
+                if (!method.name().equals("filter") || method.parametersCount() != 1) {
+                    continue;
+                }
+                List<Type> parameterTypes = method.parameterTypes();
+                if (isSpecFilter) {
+                    if (parameterTypes.get(0).name().equals(CONTAINER_REQUEST_CONTEXT)) {
+                        filterSourceMethod = method;
+                        break;
+                    }
+                } else {
+                    if (parameterTypes.get(0).name().equals(RESTEASY_REACTIVE_CONTAINER_REQUEST_CONTEXT)) {
+                        filterSourceMethod = method;
+                        break;
+                    }
+                }
+            }
+            if (filterSourceMethod != null) {
+                break;
+            }
+
+            if (OBJECT.equals(ci.superName())) {
+                break;
+            }
+            ci = index.getClassByName(ci.superName());
+            if (ci == null) {
+                break;
+            }
+
+        } while (true);
+        if (filterSourceMethod != null) {
+            interceptor.metadata = Map.of(FILTER_SOURCE_METHOD_METADATA_KEY, filterSourceMethod);
+        }
+    }
+
+    private static void setFilterMethodSourceForRespFilter(IndexView index, Collection<ClassInfo> specResponseFilters,
+            ClassInfo filterClass, ResourceInterceptor<ContainerResponseFilter> interceptor) {
+        boolean isSpecFilter = specResponseFilters.contains(filterClass);
+        ClassInfo ci = filterClass;
+        MethodInfo filterSourceMethod = null;
+        do {
+            for (var method : ci.methods()) {
+                if (!method.name().equals("filter") || method.parametersCount() != 2) {
+                    continue;
+                }
+                List<Type> parameterTypes = method.parameterTypes();
+                if (isSpecFilter) {
+                    if (parameterTypes.get(0).name().equals(CONTAINER_REQUEST_CONTEXT) &&
+                            parameterTypes.get(1).name().equals(CONTAINER_RESPONSE_CONTEXT)) {
+                        filterSourceMethod = method;
+                        break;
+                    }
+                } else {
+                    if (parameterTypes.get(0).name().equals(RESTEASY_REACTIVE_CONTAINER_REQUEST_CONTEXT) &&
+                            parameterTypes.get(1).name().equals(CONTAINER_RESPONSE_CONTEXT)) {
+                        filterSourceMethod = method;
+                        break;
+                    }
+                }
+            }
+            if (filterSourceMethod != null) {
+                break;
+            }
+
+            if (OBJECT.equals(ci.superName())) {
+                break;
+            }
+            ci = index.getClassByName(ci.superName());
+            if (ci == null) {
+                break;
+            }
+
+        } while (true);
+        if (filterSourceMethod != null) {
+            interceptor.metadata = Map.of(FILTER_SOURCE_METHOD_METADATA_KEY, filterSourceMethod);
         }
     }
 
     public static void scanForIOInterceptors(ResourceInterceptors interceptors, IndexView index,
             ApplicationScanningResult applicationScanningResult) {
         Collection<ClassInfo> readerInterceptors = index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.READER_INTERCEPTOR);
+                .getAllKnownImplementors(READER_INTERCEPTOR);
         Collection<ClassInfo> writerInterceptors = index
-                .getAllKnownImplementors(ResteasyReactiveDotNames.WRITER_INTERCEPTOR);
+                .getAllKnownImplementors(WRITER_INTERCEPTOR);
 
         for (ClassInfo filterClass : writerInterceptors) {
             handleDiscoveredInterceptor(applicationScanningResult, interceptors.getWriterInterceptors(), index, filterClass);
@@ -84,27 +190,27 @@ public class ResteasyReactiveInterceptorScanner {
         }
     }
 
-    private static <T> void handleDiscoveredInterceptor(
+    private static <T> ResourceInterceptor<T> handleDiscoveredInterceptor(
             ApplicationScanningResult applicationResultBuildItem, InterceptorContainer<T> interceptorContainer, IndexView index,
             ClassInfo filterClass) {
         if (Modifier.isAbstract(filterClass.flags())) {
-            return;
+            return null;
         }
         ApplicationScanningResult.KeepProviderResult keepProviderResult = applicationResultBuildItem.keepProvider(filterClass);
         if (keepProviderResult != ApplicationScanningResult.KeepProviderResult.DISCARD) {
             ResourceInterceptor<T> interceptor = interceptorContainer.create();
             interceptor.setClassName(filterClass.name().toString());
             interceptor.setNameBindingNames(NameBindingUtil.nameBindingNames(index, filterClass));
-            AnnotationInstance priorityInstance = filterClass.classAnnotation(ResteasyReactiveDotNames.PRIORITY);
+            AnnotationInstance priorityInstance = filterClass.classAnnotation(PRIORITY);
             if (priorityInstance != null) {
                 interceptor.setPriority(priorityInstance.value().asInt());
             }
-            AnnotationInstance nonBlockingInstance = filterClass.classAnnotation(ResteasyReactiveDotNames.NON_BLOCKING);
+            AnnotationInstance nonBlockingInstance = filterClass.classAnnotation(NON_BLOCKING);
             if (nonBlockingInstance != null) {
                 interceptor.setNonBlockingRequired(true);
             }
             if (interceptorContainer instanceof PreMatchInterceptorContainer
-                    && filterClass.classAnnotation(ResteasyReactiveDotNames.PRE_MATCHING) != null) {
+                    && filterClass.classAnnotation(PRE_MATCHING) != null) {
                 ((PreMatchInterceptorContainer<T>) interceptorContainer).addPreMatchInterceptor(interceptor);
             } else {
                 Set<String> nameBindingNames = interceptor.getNameBindingNames();
@@ -115,7 +221,10 @@ public class ResteasyReactiveInterceptorScanner {
                     interceptorContainer.addNameRequestInterceptor(interceptor);
                 }
             }
+            return interceptor;
         }
+
+        return null;
     }
 
     private static boolean namePresent(Set<String> nameBindingNames, Set<String> globalNameBindings) {

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptor.java
@@ -1,6 +1,7 @@
 package org.jboss.resteasy.reactive.common.model;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.Priorities;
@@ -9,6 +10,8 @@ import org.jboss.resteasy.reactive.spi.BeanFactory;
 
 public class ResourceInterceptor<T>
         implements Comparable<ResourceInterceptor<T>>, SettableResourceInterceptor<T>, HasPriority {
+
+    public static final String FILTER_SOURCE_METHOD_METADATA_KEY = "filterSourceMethod";
 
     private BeanFactory<T> factory;
     private int priority = Priorities.USER; // default priority as defined by spec
@@ -21,6 +24,8 @@ public class ResourceInterceptor<T>
     private Set<String> nameBindingNames = Collections.emptySet();
 
     private String className;
+
+    public transient Map<String, Object> metadata; // by using 'public transient' we ensure that this field will not be populated at runtime
 
     public void setFactory(BeanFactory<T> factory) {
         this.factory = factory;

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptors.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceInterceptors.java
@@ -71,4 +71,57 @@ public class ResourceInterceptors {
         return this;
     }
 
+    public void visitFilters(FiltersVisitor visitor) {
+        for (var f : containerRequestFilters.getPreMatchInterceptors()) {
+            var visitResult = visitor.visitPreMatchRequestFilter(f);
+            if (visitResult == FiltersVisitor.VisitResult.ABORT) {
+                return;
+            }
+        }
+        for (var f : containerRequestFilters.getGlobalResourceInterceptors()) {
+            var visitResult = visitor.visitGlobalRequestFilter(f);
+            if (visitResult == FiltersVisitor.VisitResult.ABORT) {
+                return;
+            }
+
+        }
+        for (var f : containerRequestFilters.getNameResourceInterceptors()) {
+            var visitResult = visitor.visitNamedRequestFilter(f);
+            if (visitResult == FiltersVisitor.VisitResult.ABORT) {
+                return;
+            }
+        }
+
+        for (var f : containerResponseFilters.getGlobalResourceInterceptors()) {
+            var visitResult = visitor.visitGlobalResponseFilter(f);
+            if (visitResult == FiltersVisitor.VisitResult.ABORT) {
+                return;
+            }
+        }
+        for (var f : containerResponseFilters.getNameResourceInterceptors()) {
+            var visitResult = visitor.visitNamedResponseFilter(f);
+            if (visitResult == FiltersVisitor.VisitResult.ABORT) {
+                return;
+            }
+        }
+    }
+
+    public interface FiltersVisitor {
+
+        VisitResult visitPreMatchRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor);
+
+        VisitResult visitGlobalRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor);
+
+        VisitResult visitNamedRequestFilter(ResourceInterceptor<ContainerRequestFilter> interceptor);
+
+        VisitResult visitGlobalResponseFilter(ResourceInterceptor<ContainerResponseFilter> interceptor);
+
+        VisitResult visitNamedResponseFilter(ResourceInterceptor<ContainerResponseFilter> interceptor);
+
+        enum VisitResult {
+            CONTINUE,
+            ABORT
+        }
+    }
+
 }

--- a/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
+++ b/independent-projects/resteasy-reactive/server/processor/src/main/java/org/jboss/resteasy/reactive/server/processor/generation/filters/FilterGeneration.java
@@ -77,7 +77,7 @@ public class FilterGeneration {
             }
 
             ret.add(new GeneratedFilter(output.getOutput(), generatedClassName, methodInfo.declaringClass().name().toString(),
-                    true, priority, preMatching, nonBlockingRequired, nameBindingNames, readBody));
+                    true, priority, preMatching, nonBlockingRequired, nameBindingNames, readBody, methodInfo));
         }
         for (AnnotationInstance instance : index
                 .getAnnotations(SERVER_RESPONSE_FILTER)) {
@@ -111,7 +111,7 @@ public class FilterGeneration {
             }
 
             ret.add(new GeneratedFilter(output.getOutput(), generatedClassName, methodInfo.declaringClass().name().toString(),
-                    false, priority, false, false, nameBindingNames, false));
+                    false, priority, false, false, nameBindingNames, false, methodInfo));
 
         }
         return ret;
@@ -128,10 +128,12 @@ public class FilterGeneration {
         final Set<String> nameBindingNames;
         final boolean readBody;
 
+        final MethodInfo filterSourceMethod;
+
         public GeneratedFilter(List<GeneratedClass> generatedClasses, String generatedClassName,
                 String declaringClassName,
                 boolean requestFilter, Integer priority, boolean preMatching, boolean nonBlocking,
-                Set<String> nameBindingNames, boolean readBody) {
+                Set<String> nameBindingNames, boolean readBody, MethodInfo filterSourceMethod) {
             this.generatedClasses = generatedClasses;
             this.generatedClassName = generatedClassName;
             this.declaringClassName = declaringClassName;
@@ -141,6 +143,7 @@ public class FilterGeneration {
             this.nonBlocking = nonBlocking;
             this.nameBindingNames = nameBindingNames;
             this.readBody = readBody;
+            this.filterSourceMethod = filterSourceMethod;
         }
 
         public String getGeneratedClassName() {
@@ -177,6 +180,10 @@ public class FilterGeneration {
 
         public boolean isReadBody() {
             return readBody;
+        }
+
+        public MethodInfo getFilterSourceMethod() {
+            return filterSourceMethod;
         }
     }
 

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/Filters.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/main/kotlin/io/quarkus/it/resteasy/reactive/kotlin/Filters.kt
@@ -7,6 +7,7 @@ import org.jboss.resteasy.reactive.server.SimpleResourceInfo
 import java.security.SecureRandom
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerResponseContext
+import javax.ws.rs.container.ResourceInfo
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriInfo
 
@@ -33,9 +34,10 @@ class Filters {
     }
 
     @ServerResponseFilter
-    suspend fun addResponseHeader(context: ContainerResponseContext, simpleResourceInfo: SimpleResourceInfo) {
+    suspend fun addResponseHeader(context: ContainerResponseContext, simpleResourceInfo: SimpleResourceInfo, resourceInfo: ResourceInfo) {
         delay(100)
         context.headers.add("method", simpleResourceInfo.methodName)
+        context.headers.add("method2", resourceInfo.resourceMethod.name)
         delay(100)
     }
 }

--- a/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
+++ b/integration-tests/resteasy-reactive-kotlin/standard/src/test/kotlin/io/quarkus/it/resteasy/reactive/kotlin/GreetingResourceTest.kt
@@ -20,6 +20,7 @@ class GreetingResourceTest {
             contentType(ContentType.JSON)
             body("message", CoreMatchers.`is`("hello foo bar"))
             header("method", "testSuspend")
+            header("method2", "testSuspend")
         }
     }
 


### PR DESCRIPTION
`ResourceInfo#getMethod` is used in order to retrieve the Resource method that is handles the HTTP request, and it obviously uses reflection. Resource methods are not by default registered for reflection, but this change introduces a way for Quarkus to read the bytecode of all filter methods and checks whether any of them uses the `ResourceInfo#getMethod` API and if so, forces the registration for reflection of all Resource methods.

Fixes: #28182