### PR TITLE
Fix ConfigDescriptionsManager misinterpreting a double-quote alone (`"`) as a quoted part

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devconsole/DevConsoleConfigMisinterpretedDoubleUnderscoreTest.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/devconsole/DevConsoleConfigMisinterpretedDoubleUnderscoreTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.vertx.http.devconsole;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+/**
+ * Tests that a system property such as {@code %.intellij.command.histfile."}
+ * doesn't lead to an exception because {@code "} is incorrectly seen as a quoted property.
+ * <p>
+ * Originally the bug stemmed from an environment property {@code __INTELLIJ_COMMAND_HISTFILE__}
+ * which was (weirdly) interpreted as {@code %.intellij.command.histfile."},
+ * but it's much easier to test system properties (which are mutable)
+ * than environment properties.
+ */
+public class DevConsoleConfigMisinterpretedDoubleUnderscoreTest {
+
+    @RegisterExtension
+    static final QuarkusDevModeTest config = new QuarkusDevModeTest()
+            .setBuildSystemProperty("%.intellij.command.histfile.\"", "foo")
+            .withEmptyApplication();
+
+    @Test
+    public void testNoFailure() {
+        RestAssured.get("q/dev/io.quarkus.quarkus-vertx-http/config")
+                .then()
+                .statusCode(200).body(Matchers.containsString("Config Editor"));
+    }
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/ConfigDescriptionsManager.java
@@ -297,7 +297,7 @@ public class ConfigDescriptionsManager extends DevConsolePostHandler implements 
     }
 
     private boolean isQuoted(String part) {
-        return part.charAt(0) == '\"' && part.charAt(part.length() - 1) == '\"';
+        return part.length() >= 2 && part.charAt(0) == '\"' && part.charAt(part.length() - 1) == '\"';
     }
 
     @Override


### PR DESCRIPTION
Fixes #28334

In particular the environment variable `__INTELLIJ_COMMAND_HISTFILE__`,
translated to `%.intellij.command.histfile."`, seems to be giving `ConfigDescriptionsManager` a hard time.

Without this patch, I get an exception like this if I start quarkus:dev from the IDEA terminal, then try to see the config editor (http://localhost:8080/q/dev/io.quarkus.quarkus-vertx-http/config):

```
java.util.concurrent.CompletionException: io.quarkus.qute.TemplateException
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
        at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:674)
        at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
        at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168)
        at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:144)
        at io.quarkus.qute.TemplateImpl$TemplateInstanceImpl.renderAsyncNoTimeout(TemplateImpl.java:218)
        at io.quarkus.qute.TemplateImpl$TemplateInstanceImpl.renderAsync(TemplateImpl.java:191)
        at io.quarkus.vertx.http.deployment.devmode.console.DevConsole.renderTemplate(DevConsole.java:173)
        at io.quarkus.vertx.http.deployment.devmode.console.DevConsole.handle(DevConsole.java:137)
        at io.quarkus.vertx.http.deployment.devmode.console.DevConsole.handle(DevConsole.java:39)
        at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
        at io.vertx.ext.web.impl.RoutingContextWrapper.next(RoutingContextWrapper.java:200)
        at io.quarkus.vertx.http.deployment.devmode.console.FlashScopeHandler.handle(FlashScopeHandler.java:12)
        at io.quarkus.vertx.http.deployment.devmode.console.FlashScopeHandler.handle(FlashScopeHandler.java:7)
        at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
        at io.vertx.ext.web.impl.RoutingContextWrapper.next(RoutingContextWrapper.java:200)
        at io.vertx.ext.web.impl.RouterImpl.handleContext(RouterImpl.java:250)
        at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:140)
        at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:68)
        at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:37)
        at io.quarkus.vertx.http.deployment.devmode.console.DevConsoleProcessor$2$1.handle(DevConsoleProcessor.java:194)
        at io.quarkus.vertx.http.deployment.devmode.console.DevConsoleProcessor$2$1.handle(DevConsoleProcessor.java:191)
        at io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:55)
        at io.vertx.core.impl.EventLoopContext.lambda$emit$1(EventLoopContext.java:62)
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: io.quarkus.qute.TemplateException
        at io.quarkus.qute.CompletedStage.get(CompletedStage.java:48)
        at io.quarkus.qute.MultiResultNode.process(MultiResultNode.java:20)
        at io.quarkus.qute.MultiResultNode.process(MultiResultNode.java:20)
        at io.quarkus.qute.TemplateImpl$TemplateInstanceImpl.lambda$renderData$5(TemplateImpl.java:233)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:887)
        at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2325)
        at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:144)
        at io.quarkus.qute.TemplateImpl$TemplateInstanceImpl.renderData(TemplateImpl.java:227)
        ... 31 more
Caused by: java.lang.IllegalStateException: Reflection invocation error
        at io.quarkus.qute.GetterAccessor.getValue(GetterAccessor.java:29)
        at io.quarkus.qute.ReflectionValueResolver.resolve(ReflectionValueResolver.java:59)
        at io.quarkus.qute.EvaluatorImpl.resolve(EvaluatorImpl.java:209)
        at io.quarkus.qute.EvaluatorImpl.resolveReference(EvaluatorImpl.java:129)
        at io.quarkus.qute.EvaluatorImpl.lambda$evaluate$0(EvaluatorImpl.java:76)
        at io.quarkus.qute.CompletedStage.thenCompose(CompletedStage.java:232)
        at io.quarkus.qute.EvaluatorImpl.evaluate(EvaluatorImpl.java:74)
        at io.quarkus.qute.ResolutionContextImpl$ChildResolutionContext.evaluate(ResolutionContextImpl.java:87)
        at io.quarkus.qute.LoopSectionHelper.resolve(LoopSectionHelper.java:45)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:53)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:58)
        at io.quarkus.qute.SectionNode$SectionResolutionContextImpl.execute(SectionNode.java:223)
        at io.quarkus.qute.InsertSectionHelper.resolve(InsertSectionHelper.java:20)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:53)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:58)
        at io.quarkus.qute.SectionNode$SectionResolutionContextImpl.execute(SectionNode.java:223)
        at io.quarkus.qute.SectionHelper$SectionResolutionContext.execute(SectionHelper.java:46)
        at io.quarkus.qute.Parser$1.resolve(Parser.java:1243)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:53)
        at io.quarkus.qute.IncludeSectionHelper.lambda$resolve$1(IncludeSectionHelper.java:71)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:887)
        at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2325)
        at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:144)
        at io.quarkus.qute.IncludeSectionHelper.resolve(IncludeSectionHelper.java:54)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:53)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:58)
        at io.quarkus.qute.SectionNode$SectionResolutionContextImpl.execute(SectionNode.java:219)
        at io.quarkus.qute.SectionHelper$SectionResolutionContext.execute(SectionHelper.java:46)
        at io.quarkus.qute.Parser$1.resolve(Parser.java:1243)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:53)
        at io.quarkus.qute.SectionNode.resolve(SectionNode.java:58)
        ... 32 more
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at io.quarkus.qute.GetterAccessor.getValue(GetterAccessor.java:22)
        ... 63 more
Caused by: java.lang.StringIndexOutOfBoundsException: begin 1, end 0, length 1
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4601)
        at java.base/java.lang.String.substring(String.java:2704)
        at io.quarkus.vertx.http.runtime.devmode.ConfigDescriptionsManager.calculate(ConfigDescriptionsManager.java:110)
        at io.quarkus.vertx.http.runtime.devmode.ConfigDescriptionsManager.values(ConfigDescriptionsManager.java:62)
        ... 68 more
```