### PR TITLE
Incorporate quickstart changes in security-openid-connect-client guide

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -31,7 +31,7 @@ In this example, we will build an application which consists of two JAX-RS resou
 * `/frontend/user-name-with-propagated-token`
 * `/frontend/admin-name-with-propagated-token`
 
-`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client` or `/frontend/admin-name-with-oidc-client` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
+`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client-token` or `/frontend/admin-name-with-oidc-client-token` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
 
 `ProtecedResource` has 2 endpoints:
 
@@ -264,7 +264,7 @@ public class FrontendResource {
 }
 ----
 
-`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client` or `/frontend/admin-name-with-oidc-client` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
+`FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client-token` or `/frontend/admin-name-with-oidc-client-token` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
 
 Finally, lets add a JAX-RS `ExceptionMapper`:
 
@@ -485,7 +485,7 @@ Now lets check `FrontendResource` methods which do not propagate the existing to
 [source,bash]
 ----
 curl -v -X GET \
-  http://localhost:8080/frontend/user-name-with-oidc-client`
+  http://localhost:8080/frontend/user-name-with-oidc-client-token`
 ----
 
 will return `200` status code and the name `alice`, but
@@ -493,7 +493,7 @@ will return `200` status code and the name `alice`, but
 [source,bash]
 ----
 curl -v -X GET \
-  http://localhost:8080/frontend/admin-name-with-oidc-client`
+  http://localhost:8080/frontend/admin-name-with-oidc-client-token`
 ----
 
 will return `403` status code.

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -139,7 +139,7 @@ public class ProtectedResource {
 
 As you can see `ProtectedResource` returns a name from both `userName()` and `adminName()` methods. The name is extracted from the current `JsonWebToken`.
 
-Next lets add REST Client with `OpenID Connect Client Reactive Filter` and another REST Client with `OpenID Connect Token Propagation Filter`, `FrontendResource` will use these two clients to call `ProtectedResource`:
+Next let's add a REST Client with `OpenID Connect Client Reactive Filter` and another REST Client with `OpenID Connect Token Propagation Filter`. `FrontendResource` will use these two clients to call `ProtectedResource`:
 
 [source,java]
 ----
@@ -266,7 +266,7 @@ public class FrontendResource {
 
 `FrontendResource` will use REST Client with `OpenID Connect Client Reactive Filter` to acquire and propagate an access token to `ProtectedResource` when either `/frontend/user-name-with-oidc-client-token` or `/frontend/admin-name-with-oidc-client-token` is called. And it will use REST Client with `OpenID Connect Token Propagation Reactive Filter` to propagate the current incoming access token to `ProtectedResource` when either `/frontend/user-name-with-propagated-token` or `/frontend/admin-name-with-propagated-token` is called.
 
-Finally, lets add a JAX-RS `ExceptionMapper`:
+Finally, let's add a JAX-RS `ExceptionMapper`:
 
 [source,java]
 ----
@@ -431,8 +431,8 @@ Now use this token to call `/frontend/user-name-with-propagated-token` and `/fro
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/user-name-with-propagated-token` \
+curl -i -X GET \
+  http://localhost:8080/frontend/user-name-with-propagated-token \
   -H "Authorization: Bearer "$access_token
 ----
 
@@ -440,8 +440,8 @@ will return `200` status code and the name `alice` while
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/admin-name-with-propagated-token` \
+curl -i -X GET \
+  http://localhost:8080/frontend/admin-name-with-propagated-token \
   -H "Authorization: Bearer "$access_token
 ----
 
@@ -463,8 +463,8 @@ and use this token to call `/frontend/user-name-with-propagated-token` and `/fro
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/user-name-with-propagated-token` \
+curl -i -X GET \
+  http://localhost:8080/frontend/user-name-with-propagated-token \
   -H "Authorization: Bearer "$access_token
 ----
 
@@ -472,28 +472,28 @@ will return `200` status code and the name `admin`, and
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/admin-name-with-propagated-token` \
+curl -i -X GET \
+  http://localhost:8080/frontend/admin-name-with-propagated-token \
   -H "Authorization: Bearer "$access_token
 ----
 
 will also return `200` status code and the name `admin`, as `admin` has both `user` and `admin` roles.
 
 
-Now lets check `FrontendResource` methods which do not propagate the existing tokens but use `OidcClient` to acquire and propagate the tokens. You have seen that `OidcClient` is configured to acquire the tokens for the `alice` user, so:
+Now let's check `FrontendResource` methods which do not propagate the existing tokens but use `OidcClient` to acquire and propagate the tokens. You have seen that `OidcClient` is configured to acquire the tokens for the `alice` user, so:
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/user-name-with-oidc-client-token`
+curl -i -X GET \
+  http://localhost:8080/frontend/user-name-with-oidc-client-token
 ----
 
 will return `200` status code and the name `alice`, but
 
 [source,bash]
 ----
-curl -v -X GET \
-  http://localhost:8080/frontend/admin-name-with-oidc-client-token`
+curl -i -X GET \
+  http://localhost:8080/frontend/admin-name-with-oidc-client-token
 ----
 
 will return `403` status code.

--- a/docs/src/main/asciidoc/security-openid-connect-client.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-client.adoc
@@ -158,7 +158,7 @@ import io.smallrye.mutiny.Uni;
 @RegisterRestClient
 @RegisterProvider(OidcClientRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceOidcClientFilter {
+public interface RestClientWithOidcClientFilter {
 
     @GET
     @Produces("text/plain")
@@ -172,7 +172,7 @@ public interface ProtectedResourceOidcClientFilter {
 }
 ----
 
-where `ProtectedResourceOidcClientFilter` will depend on `OidcClientRequestReactiveFilter` to acquire and propagate the tokens and
+where `RestClientWithOidcClientFilter` will depend on `OidcClientRequestReactiveFilter` to acquire and propagate the tokens and
 
 [source,java]
 ----
@@ -191,7 +191,7 @@ import io.smallrye.mutiny.Uni;
 @RegisterRestClient
 @RegisterProvider(AccessTokenRequestReactiveFilter.class)
 @Path("/")
-public interface ProtectedResourceTokenPropagationFilter {
+public interface RestClientWithTokenPropagationFilter {
 
     @GET
     @Produces("text/plain")
@@ -205,9 +205,9 @@ public interface ProtectedResourceTokenPropagationFilter {
 }
 ----
 
-where `ProtectedResourceTokenPropagationFilter` will depend on `AccessTokenRequestReactiveFilter` to propagate the incoming, already existing tokens.
+where `RestClientWithTokenPropagationFilter` will depend on `AccessTokenRequestReactiveFilter` to propagate the incoming, already existing tokens.
 
-Note that both `ProtectedResourceOidcClientFilter` and `ProtectedResourceTokenPropagationFilter` interfaces are identical - the reason behind it is that combining `OidcClientRequestReactiveFilter` and `AccessTokenRequestReactiveFilter` on the same REST Client will cause side effects as both filters can interfere with other, for example, `OidcClientRequestReactiveFilter` may override the token propagated by `AccessTokenRequestReactiveFilter` or `AccessTokenRequestReactiveFilter` can fail if it is called when no token is available to propagate and `OidcClientRequestReactiveFilter` is expected to acquire a new token instead.
+Note that both `RestClientWithOidcClientFilter` and `RestClientWithTokenPropagationFilter` interfaces are identical - the reason behind it is that combining `OidcClientRequestReactiveFilter` and `AccessTokenRequestReactiveFilter` on the same REST Client will cause side effects as both filters can interfere with other, for example, `OidcClientRequestReactiveFilter` may override the token propagated by `AccessTokenRequestReactiveFilter` or `AccessTokenRequestReactiveFilter` can fail if it is called when no token is available to propagate and `OidcClientRequestReactiveFilter` is expected to acquire a new token instead.
 
 Now let's complete creating the application with adding `FrontendResource`:
 
@@ -219,7 +219,6 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -229,38 +228,38 @@ import io.smallrye.mutiny.Uni;
 public class FrontendResource {
     @Inject
     @RestClient
-    ProtectedResourceOidcClientFilter protectedResourceOidcClientFilter;
+    RestClientWithOidcClientFilter restClientWithOidcClientFilter;
 
     @Inject
     @RestClient
-    ProtectedResourceTokenPropagationFilter protectedResourceTokenPropagationFilter;
+    RestClientWithTokenPropagationFilter restClientWithTokenPropagationFilter;
 
     @GET
     @Path("user-name-with-oidc-client-token")
     @Produces("text/plain")
     public Uni<String> getUserNameWithOidcClientToken() {
-        return protectedResourceOidcClientFilter.getUserName();
+        return restClientWithOidcClientFilter.getUserName();
     }
 
     @GET
     @Path("admin-name-with-oidc-client-token")
     @Produces("text/plain")
     public Uni<String> getAdminNameWithOidcClientToken() {
-	    return protectedResourceOidcClientFilter.getAdminName();
+	    return restClientWithOidcClientFilter.getAdminName();
     }
 
     @GET
     @Path("user-name-with-propagated-token")
     @Produces("text/plain")
     public Uni<String> getUserNameWithPropagatedToken() {
-        return protectedResourceTokenPropagationFilter.getUserName();
+        return restClientWithTokenPropagationFilter.getUserName();
     }
 
     @GET
     @Path("admin-name-with-propagated-token")
     @Produces("text/plain")
     public Uni<String> getAdminNameWithPropagatedToken() {
-        return protectedResourceTokenPropagationFilter.getAdminName();
+        return restClientWithTokenPropagationFilter.getAdminName();
     }
 }
 ----
@@ -324,8 +323,8 @@ quarkus.oidc-client.grant-options.password.password=alice
 %dev.port=8080
 %test.port=8081
 
-org.acme.security.openid.connect.client.ProtectedResourceOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
-org.acme.security.openid.connect.client.ProtectedResourceTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.RestClientWithOidcClientFilter/mp-rest/url=http://localhost:${port}/protected
+org.acme.security.openid.connect.client.RestClientWithTokenPropagationFilter/mp-rest/url=http://localhost:${port}/protected
 ----
 
 This configuration references Keycloak which will be used by `ProtectedResource` to verify the incoming access tokens and by `OidcClient` to get the tokens for a user `alice` using a `password` grant. Both RESTClients point to `ProtectedResource`'s HTTP address.


### PR DESCRIPTION
https://github.com/quarkusio/quarkus-quickstarts/pull/1140 renamed two classes and two fields so that the demo more clearly communicates the usage of the RequestFilters.

This PR aligns the corresponding guide to these changes.

It also fixes some occurrances of wrong endpoints that #26372 missed.

A third commit brings unrelated small improvements (boy scout rule).

The reason for my change in the curl options (`-i` instead `-v`) is: `-v` produces a lot of output and is more tailored to debugging purposes. In this example, we want so see the response codes, which can be seen more easily when using the `-i` option, which adds the headers to the output.

**with `-v`**
```shell session
$ curl -v http://localhost:8080/frontend/user-name-with-oidc-client-token
* STATE: INIT => CONNECT handle 0x80008f0f8; line 1835 (connection #-5000)
* Added connection 0. The cache now contains 1 members
* family0 == v4, family1 == v6
*   Trying 127.0.0.1:8080...
* STATE: CONNECT => CONNECTING handle 0x80008f0f8; line 1896 (connection #0)
* Connected to localhost (127.0.0.1) port 8080 (#0)
* STATE: CONNECTING => PROTOCONNECT handle 0x80008f0f8; line 2028 (connection #0)
* STATE: PROTOCONNECT => DO handle 0x80008f0f8; line 2051 (connection #0)
> GET /frontend/user-name-with-oidc-client-token HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
>
* STATE: DO => DID handle 0x80008f0f8; line 2147 (connection #0)
* STATE: DID => PERFORMING handle 0x80008f0f8; line 2266 (connection #0)
* Mark bundle as not supporting multiuse
* HTTP 1.1 or later with persistent connection
< HTTP/1.1 200 OK
< content-length: 5
< Content-Type: text/plain;charset=UTF-8
<
* STATE: PERFORMING => DONE handle 0x80008f0f8; line 2465 (connection #0)
* multi_done: status: 0 prem: 0 done: 0
* Connection #0 to host localhost left intact
* Expire cleared (transfer 0x80008f0f8)
alice
```
**with `-i`**
```shell session
$ curl -i http://localhost:8080/frontend/user-name-with-oidc-client-token
HTTP/1.1 200 OK
content-length: 5
Content-Type: text/plain;charset=UTF-8

alice
```

I'm fine with a squashed merge. I separated the changes by concern for easier reviewability.

Please let me know if I should drop certain changes from this PR.