### PR TITLE
RESTEasy Reactive - fix exception mapping for security exceptions when proactive security is disabled

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -52,6 +52,8 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -184,7 +186,20 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
     public Handler<RoutingContext> handler(RuntimeValue<Deployment> deploymentRuntimeValue) {
         Deployment deployment = deploymentRuntimeValue.getValue();
         RestInitialHandler initialHandler = new RestInitialHandler(deployment);
-        return new ResteasyReactiveVertxHandler(initialHandler);
+
+        // ensure our ex. mappers are called when security exceptions are thrown and proactive auth is disabled
+        final Consumer<RoutingContext> eventCustomizer = new Consumer<>() {
+
+            @Override
+            public void accept(RoutingContext routingContext) {
+                // remove default auth failure handler
+                if (routingContext.get(QuarkusHttpUser.AUTH_FAILURE_HANDLER) instanceof DefaultAuthFailureHandler) {
+                    routingContext.remove(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
+                }
+            }
+        };
+
+        return new ResteasyReactiveVertxHandler(eventCustomizer, initialHandler);
     }
 
     /**

--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DisabledProactiveAuthFailedExceptionMappingTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/DisabledProactiveAuthFailedExceptionMappingTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.jwt.test;
+
+import javax.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.RoutingContext;
+
+public class DisabledProactiveAuthFailedExceptionMappingTest {
+
+    private static final String CUSTOMIZED_RESPONSE = "AuthenticationFailedException";
+    protected static final Class<?>[] classes = { JsonValuejectionEndpoint.class, TokenUtils.class,
+            AuthFailedExceptionMapper.class };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(classes)
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"), "application.properties"));
+
+    @Test
+    public void testExMapperCustomizedResponse() {
+        RestAssured
+                .given()
+                .auth().oauth2("absolute-nonsense")
+                .get("/endp/verifyInjectedIssuer").then()
+                .statusCode(401)
+                .body(Matchers.equalTo(CUSTOMIZED_RESPONSE));
+    }
+
+    public static class AuthFailedExceptionMapper {
+
+        @ServerExceptionMapper(value = AuthenticationFailedException.class)
+        public Response handle(RoutingContext routingContext) {
+            return Response
+                    .status(401)
+                    .entity(CUSTOMIZED_RESPONSE).build();
+        }
+
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveVertxHandler.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/ResteasyReactiveVertxHandler.java
@@ -1,5 +1,7 @@
 package org.jboss.resteasy.reactive.server.vertx;
 
+import java.util.function.Consumer;
+
 import org.jboss.resteasy.reactive.server.handlers.RestInitialHandler;
 
 import io.vertx.core.Handler;
@@ -8,13 +10,16 @@ import io.vertx.ext.web.RoutingContext;
 public class ResteasyReactiveVertxHandler implements Handler<RoutingContext> {
 
     private final RestInitialHandler handler;
+    private final Consumer<RoutingContext> eventCustomizer;
 
-    public ResteasyReactiveVertxHandler(RestInitialHandler handler) {
+    public ResteasyReactiveVertxHandler(Consumer<RoutingContext> eventCustomizer, RestInitialHandler handler) {
         this.handler = handler;
+        this.eventCustomizer = eventCustomizer;
     }
 
     @Override
     public void handle(RoutingContext event) {
+        eventCustomizer.accept(event);
         handler.beginProcessing(event);
     }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/framework/ResteasyReactiveUnitTest.java
@@ -396,7 +396,8 @@ public class ResteasyReactiveUnitTest implements BeforeAllCallback, AfterAllCall
                 new VertxRequestContextFactory(), executor);
         fieldInjectionSupport.runtimeInit(testClassLoader, application.getDeployment());
 
-        ResteasyReactiveVertxHandler handler = new ResteasyReactiveVertxHandler(application.getInitialHandler());
+        ResteasyReactiveVertxHandler handler = new ResteasyReactiveVertxHandler(ev -> {
+        }, application.getInitialHandler());
         String path = application.getPath();
         Route route = router.route(path);
         for (Consumer<Route> customizer : routeCustomisers) {


### PR DESCRIPTION
fixes: #26922

Currently the default auth failure handler sends response after it has sent challenge. However RESTEasy Reactive abort handlers still process the exception, pass it to exception mappers and tries to end event with response, which leads to an exception and impossibility to customize response. I've removed default auth failure handler when proactive security is disabled as RR already handles `AuthenticationFailedException`, `AuthenticationCompletionException`, `AuthenticationRedirectException` with built in mappers. This will give user an option to catch exception with custom ex. mapper and make reactive and classic extensions behave same.