### PR TITLE
Add link to datasource guide for JDBC and datasource extensions

### DIFF
--- a/extensions/datasource/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/datasource/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -4,6 +4,7 @@ name: "Datasources"
 metadata:
   keywords:
   - "datasource"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-db2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-db2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,5 +6,6 @@ metadata:
   - "jdbc-db2"
   - "jdbc"
   - "db2"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"

--- a/extensions/jdbc/jdbc-derby/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-derby/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "jdbc-derby"
   - "jdbc"
   - "derby"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "jdbc-h2"
   - "jdbc"
   - "h2"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-mariadb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-mariadb/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "jdbc-mariadb"
   - "jdbc"
   - "mariadb"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,6 +7,7 @@ metadata:
   - "jdbc"
   - "mssql"
   - "sql-server"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-mysql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "jdbc-mysql"
   - "jdbc"
   - "mysql"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "stable"

--- a/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-oracle/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
   - "jdbc-oracle"
   - "jdbc"
   - "oracle"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"
   status: "preview"

--- a/extensions/jdbc/jdbc-postgresql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/jdbc/jdbc-postgresql/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,5 +6,6 @@ metadata:
   - "jdbc-postgresql"
   - "jdbc"
   - "postgresql"
+  guide: "https://quarkus.io/guides/datasource"
   categories:
   - "data"


### PR DESCRIPTION
Before this patch, there are a few missing links to guides in the dev-mode landing page and in the dev UI (see below).

While I agree this patch assigns links to the same guide to multiple extensions and that's not ideal, I think it's still better than having extensions that, at first sight, would seem undocumented.

Maybe we should do the same for other extensions, such as Vert.x - HTTP?

![nodoc](https://user-images.githubusercontent.com/412878/194050483-4e12e283-f181-4dc6-aad4-3b5d257b4703.png)

![nodoc-devui](https://user-images.githubusercontent.com/412878/194050495-8c796176-c019-48b0-a9db-57b8c7cc58ca.png)
