### PR TITLE
Bump testcontainers to 1.17.5 and fix Elasticsearch devservices min heap

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -195,7 +195,7 @@
         <apicurio-registry.version>2.3.1.Final</apicurio-registry.version>
         <apicurio-common-rest-client.version>0.1.13.Final</apicurio-common-rest-client.version> <!-- must be the version Apicurio Registry uses -->
         <jacoco.version>0.8.8</jacoco.version>
-        <testcontainers.version>1.17.3</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
+        <testcontainers.version>1.17.5</testcontainers.version> <!-- Make sure to also update docker-java.version to match its needs -->
         <docker-java.version>3.2.13</docker-java.version> <!-- must be the version Testcontainers use -->
         <aesh-readline.version>2.2</aesh-readline.version>
         <aesh.version>2.6</aesh.version>

--- a/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
+++ b/extensions/elasticsearch-rest-client-common/deployment/src/main/java/io/quarkus/elasticsearch/restclient/common/deployment/ElasticsearchDevServicesBuildTimeConfig.java
@@ -34,9 +34,9 @@ public class ElasticsearchDevServicesBuildTimeConfig {
 
     /**
      * The value for the ES_JAVA_OPTS env variable.
-     * Defaults to setting the heap to 1GB.
+     * Defaults to setting the heap to 512MB min - 1GB max.
      */
-    @ConfigItem(defaultValue = "-Xmx1g")
+    @ConfigItem(defaultValue = "-Xms512m -Xmx1g")
     public String javaOpts;
 
     /**


### PR DESCRIPTION
Superseed #28388