### PR TITLE
Non-blocking CDI producer methods

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/NonBlockingProducerProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/NonBlockingProducerProcessor.java
@@ -1,0 +1,73 @@
+package io.quarkus.vertx.deployment;
+
+import static io.quarkus.arc.processor.Annotations.contains;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Type;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
+import io.quarkus.arc.processor.Annotations;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.arc.processor.DotNames;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.vertx.runtime.CompletionStageNonBlocking;
+import io.quarkus.vertx.runtime.CompletionStageNonBlockingInterceptor;
+import io.quarkus.vertx.runtime.UniNonBlocking;
+import io.quarkus.vertx.runtime.UniNonBlockingInterceptor;
+import io.smallrye.mutiny.Uni;
+
+public class NonBlockingProducerProcessor {
+
+    @BuildStep
+    AdditionalBeanBuildItem additionalBeans() {
+        return AdditionalBeanBuildItem.builder().addBeanClasses(UniNonBlockingInterceptor.class, UniNonBlocking.class,
+                CompletionStageNonBlockingInterceptor.class, CompletionStageNonBlocking.class).build();
+    }
+
+    @BuildStep
+    AnnotationsTransformerBuildItem annotationTransformer() throws Exception {
+        DotName uniName = DotName.createSimple(Uni.class.getName());
+        DotName csName = DotName.createSimple(CompletionStage.class.getName());
+        DotName cfName = DotName.createSimple(CompletableFuture.class.getName());
+        DotName uniNonBlockingName = DotName.createSimple(UniNonBlocking.class.getName());
+        DotName csNonBlockingName = DotName.createSimple(CompletionStageNonBlocking.class.getName());
+        return new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+            @Override
+            public boolean appliesTo(AnnotationTarget.Kind kind) {
+                return kind == AnnotationTarget.Kind.METHOD;
+            }
+
+            @Override
+            public int getPriority() {
+                // Make sure this annotation transformer is invoked after the AutoProducerMethodsProcessor.annotationTransformer()
+                return DEFAULT_PRIORITY - 2;
+            }
+
+            @Override
+            public void transform(TransformationContext ctx) {
+                Type returnType = ctx.getTarget().asMethod().returnType();
+                if (returnType.kind() == org.jboss.jandex.Type.Kind.VOID) {
+                    // Skip void methods
+                    return;
+                }
+                Set<AnnotationInstance> methodAnnotations = Annotations.getAnnotations(Kind.METHOD, ctx.getAnnotations());
+                if (contains(methodAnnotations, DotNames.PRODUCES)) {
+                    if (uniName.equals(returnType.name())) {
+                        ctx.transform().add(uniNonBlockingName).done();
+                    } else if (csName.equals(returnType.name()) || cfName.equals(returnType.name())) {
+                        ctx.transform().add(csNonBlockingName).done();
+                    }
+                }
+            }
+        });
+    }
+
+}

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/nonblocking/NonBlockingProducerMethodTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/nonblocking/NonBlockingProducerMethodTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.vertx.nonblocking;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+
+public class NonBlockingProducerMethodTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(Alpha.class, Bravo.class));
+
+    @Inject
+    Instance<Uni<Bravo>> bravo;
+
+    @Inject
+    Instance<CompletionStage<Charlie>> charlie;
+
+    @Test
+    public void testProducer() throws InterruptedException, ExecutionException, TimeoutException {
+        assertNotNull(bravo.get().await().atMost(Duration.ofSeconds(10)));
+        assertNotNull(charlie.get().toCompletableFuture().get(10, TimeUnit.SECONDS));
+    }
+
+    @Singleton
+    static class Alpha {
+
+        @Produces
+        Uni<Bravo> produceBravo() {
+            assertTrue(Context.isOnEventLoopThread());
+            assertTrue(VertxContext.isOnDuplicatedContext());
+            return Uni.createFrom().item(new Bravo());
+        }
+
+        @Produces
+        CompletionStage<Charlie> produceCharlie() {
+            assertTrue(Context.isOnEventLoopThread());
+            assertTrue(VertxContext.isOnDuplicatedContext());
+            return CompletableFuture.completedStage(new Charlie());
+        }
+
+    }
+
+    static class Bravo {
+
+    }
+
+    static class Charlie {
+
+    }
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/CompletionStageNonBlocking.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/CompletionStageNonBlocking.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.runtime;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ *
+ * @see CompletionStageNonBlockingInterceptor
+ */
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface CompletionStageNonBlocking {
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/CompletionStageNonBlockingInterceptor.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/CompletionStageNonBlockingInterceptor.java
@@ -1,0 +1,47 @@
+package io.quarkus.vertx.runtime;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Interceptor
+@CompletionStageNonBlocking
+@Priority(Interceptor.Priority.PLATFORM_BEFORE)
+public class CompletionStageNonBlockingInterceptor {
+
+    @Inject
+    Vertx vertx;
+
+    @AroundInvoke
+    Object aroundInvoke(InvocationContext ctx) throws Exception {
+        Context context = VertxContext.getOrCreateDuplicatedContext(vertx);
+        VertxContextSafetyToggle.setContextSafe(context, true);
+        CompletableFuture<Object> cf = new CompletableFuture<>();
+        context.runOnContext(v -> proceedWithStage(ctx).whenComplete((r, t) -> {
+            if (t != null) {
+                cf.completeExceptionally(t);
+            } else {
+                cf.complete(r);
+            }
+        }));
+        return cf;
+    }
+
+    private CompletionStage<?> proceedWithStage(InvocationContext ctx) {
+        try {
+            return (CompletionStage<?>) ctx.proceed();
+        } catch (Throwable t) {
+            return CompletableFuture.failedStage(t);
+        }
+    }
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/UniNonBlocking.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/UniNonBlocking.java
@@ -1,0 +1,21 @@
+package io.quarkus.vertx.runtime;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ *
+ * @see UniNonBlockingInterceptor
+ */
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface UniNonBlocking {
+
+}

--- a/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/UniNonBlockingInterceptor.java
+++ b/extensions/vertx/runtime/src/main/java/io/quarkus/vertx/runtime/UniNonBlockingInterceptor.java
@@ -1,0 +1,40 @@
+package io.quarkus.vertx.runtime;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle;
+import io.smallrye.common.vertx.VertxContext;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+@Interceptor
+@UniNonBlocking
+@Priority(Interceptor.Priority.PLATFORM_BEFORE)
+public class UniNonBlockingInterceptor {
+
+    @Inject
+    Vertx vertx;
+
+    @AroundInvoke
+    Object aroundInvoke(InvocationContext ctx) throws Exception {
+        Context context = VertxContext.getOrCreateDuplicatedContext(vertx);
+        VertxContextSafetyToggle.setContextSafe(context, true);
+        return Uni.createFrom().emitter(em -> {
+            context.runOnContext(v -> em.complete(proceedWithUni(ctx)));
+        });
+    }
+
+    private Uni<?> proceedWithUni(InvocationContext ctx) {
+        try {
+            return (Uni<?>) ctx.proceed();
+        } catch (Throwable t) {
+            return Uni.createFrom().failure(t);
+        }
+    }
+
+}


### PR DESCRIPTION
### Idea

I'm still trying to understand how the _async injection_ should/could work and TBH I don't see many use cases where it makes sense. There are too many sync/blocking constructs and patterns that IMO render this concept quite unusable. On the other hand, an _asynchronous producer method_ is something completely different, e.g. something along these lines makes perfect sense:

```java
@Singleton
class CurrentUser {
    
    @Inject
    CurrentIdentityAssociation identity;

    @Produces
    Uni<User> currentUser() {
       return identity.getDeferredIdentity().chain(i -> User.findByName(i.gePrincipal().getName());
    }
}
```
And the client side:
```java
@Singleton
class Service {
    
    @Inject
    Uni<User>  currentUser;

    Uni<String> getCurrentUserName() {
       return currentUser.map(u -> u.getName());
    }
}
```
NOTE: The client must be aware of the fact that the `CurrentUser#currentUser()` is a bean of an asynchronous type, i.e. the standard type-safe resolution rules apply.

However, in order to make this work we need to make sure that the producer method is invoked on the event loop (and vertx duplicated context). And that's what this pull request is about.

### Implementation

We register an `AnnotationsTransformer` that simply adds a relevant interceptor binding to producer methods returning `Uni<?>`, `CompletionStage<?>` and `CompletableFuture<?>`. The interceptors and binding are not part of the API (yet) but the functionality provided is not tied to producer methods.

### Why not `NonBlocking`

I don't think it makes any sense for producer methods because we really need an async return type here to make it work.

### Conclusion

This is not an attempt to implement anything like _async injection_. It's merely an attempt to make it easier to work with async producer methods.

CC @Ladicek @manovotn @cescoffier @FroMage @geoand 