### PR TITLE
Upgrade protobuf to 3.19.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.49.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
-        <protoc.version>3.19.3</protoc.version>
+        <protoc.version>3.19.6</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <proto-google-common-protos.version>2.9.6</proto-google-common-protos.version>
 


### PR DESCRIPTION
This is a security update.

@cescoffier we're lagging a bit on the protobuf version but I chose the safe path as I want to backport this.