### PR TITLE
Allows Linux-only extensions on Windows with Linux builder image

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/builditem/nativeimage/UnsupportedOSBuildItem.java
@@ -5,6 +5,7 @@ import static io.quarkus.dev.console.QuarkusConsole.IS_MAC;
 import static io.quarkus.dev.console.QuarkusConsole.IS_WINDOWS;
 
 import io.quarkus.builder.item.MultiBuildItem;
+import io.quarkus.deployment.pkg.NativeConfig;
 
 /**
  * Native-image might not be supported for a particular
@@ -29,5 +30,16 @@ public final class UnsupportedOSBuildItem extends MultiBuildItem {
     public UnsupportedOSBuildItem(Os os, String error) {
         this.os = os;
         this.error = error;
+    }
+
+    public boolean triggerError(NativeConfig nativeConfig) {
+        return
+        // When the host OS is unsupported, it could have helped to
+        // run in a Linux builder image (e.g. an extension unsupported on Windows).
+        (os.active && !nativeConfig.isContainerBuild()) ||
+        // If Linux is the OS the extension does not support,
+        // it fails in a container build regardless the host OS,
+        // because we have only Linux based builder images.
+                (nativeConfig.isContainerBuild() && os == Os.LINUX);
     }
 }

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -891,7 +891,9 @@ public class NativeImageBuildStep {
                 }
 
                 if (unsupportedOSes != null && !unsupportedOSes.isEmpty()) {
-                    final String errs = unsupportedOSes.stream().filter(o -> o.os.active).map(o -> o.error)
+                    final String errs = unsupportedOSes.stream()
+                            .filter(o -> o.triggerError(nativeConfig))
+                            .map(o -> o.error)
                             .collect(Collectors.joining(", "));
                     if (!errs.isEmpty()) {
                         throw new UnsupportedOperationException(errs);


### PR DESCRIPTION
fixes #28335

# Running on Windows host

There is a correct exception explaining that this is not going to work:
```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:999-SNAPSHOT:build (default) on project awt-graphics-rest-quickstart: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.deployment.pkg.steps.NativeImageBuildStep#build threw an exception: java.lang.RuntimeException: Failed to build native image
[ERROR]         at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:281)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR]         at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
[ERROR]         at io.quarkus.builder.BuildContext.run(BuildContext.java:281)
[ERROR]         at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
[ERROR]         at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
[ERROR]         at java.base/java.lang.Thread.run(Thread.java:833)
[ERROR]         at org.jboss.threads.JBossThread.run(JBossThread.java:501)
[ERROR] Caused by: java.lang.UnsupportedOperationException: Windows AWT integration is not ready in native-image and would result in java.lang.UnsatisfiedLinkError: no awt in java.library.path.
[ERROR]         at io.quarkus.deployment.pkg.steps.NativeImageBuildStep$NativeImageInvokerInfo$Builder.build(NativeImageBuildStep.java:882)
[ERROR]         at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:249)
[ERROR]         ... 11 more
[ERROR] -> [Help 1]
``` 

# Running on Windows with podman

This is allowed now because the build happens in Linux userland:

```
C:\tmp\quarkus-quickstarts\awt-graphics-rest-quickstart(development -> origin)                  
                                                                                                                          
λ mvnw package -DskipTests -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17 -Dquarkus.native.container-runtime=podman                        
```

```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on native-image 22.2.0.0-Final Mandrel Distribution (Java Version 17.0.4+8)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/awt-graphics-rest-quickstart/target/awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --name build-native-VshPN quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dlogging.initial-configurator.min-level=500 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=US -J-Dfile.encoding=UTF-8 --features=io.quarkus.runner.Feature,io.quarkus.awt.runtime.graal.AwtFeature,io.quarkus.runtime.graal.ResourcesFeature,io.quarkus.awt.runtime.graal.DarwinAwtFeature,io.quarkus.runtime.graal.DisableLoggingFeature -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.io=ALL-UNNAMED -J--add-opens=java.base/java.lang.invoke=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -H:+AllowFoldMethods -J-Djava.awt.headless=true --no-fallback --link-at-build-time -H:+ReportExceptionStackTraces -H:-AddAllCharsets --enable-url-protocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.configure=ALL-UNNAMED -J--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization=ALL-UNNAMED awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner -jar awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner.jar
========================================================================================================================
GraalVM Native Image: Generating 'awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                   (27.0s @ 0.31GB)
 Version info: 'GraalVM 22.2.0.0-Final Java 17 Mandrel Distribution'
 Java version info: '17.0.4+8'
 C compiler: gcc (redhat, x86_64, 8.5.0)
 Garbage collector: Serial GC
 6 user-specific feature(s)
 - io.quarkus.awt.runtime.graal.AwtFeature
 - io.quarkus.awt.runtime.graal.DarwinAwtFeature
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase for the [org.jboss.threads] categories
 - io.quarkus.runtime.graal.ResourcesFeature: Register each line in META-INF/quarkus-native-resources.txt as a resource on Substrate VM
 - org.graalvm.home.HomeFinderFeature: Finds GraalVM paths and its version number
[2/7] Performing analysis...  [*********]                                                               (98.1s @ 1.00GB)
  12,055 (88.91%) of 13,558 classes reachable
  20,154 (62.15%) of 32,430 fields reachable
  71,264 (60.87%) of 117,082 methods reachable
     492 classes,   120 fields, and 1,719 methods registered for reflection
     178 classes, 1,535 fields, and 2,092 methods registered for JNI access
       7 native libraries: dl, freetype, m, pthread, rt, stdc++, z
[3/7] Building universe...                                                                              (12.5s @ 1.49GB)
[4/7] Parsing methods...      [***]                                                                      (9.9s @ 1.25GB)
[5/7] Inlining methods...     [***]                                                                      (6.8s @ 2.35GB)
[6/7] Compiling methods...    [*********]                                                               (80.7s @ 1.84GB)
[7/7] Creating image...                                                                                 (23.9s @ 2.10GB)
  31.73MB (49.80%) for code area:    50,858 compilation units
  29.16MB (45.77%) for image heap:  335,899 objects and 19 resources
   2.82MB ( 4.42%) for other data
  63.70MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
   6.36MB com.oracle.svm.jni                                   6.63MB byte[] for code metadata
   1.65MB sun.security.ssl                                     3.25MB java.lang.String
   1.01MB java.util                                            3.20MB byte[] for java.lang.String
 759.95KB sun.font                                             2.93MB java.lang.Class
 732.23KB com.sun.crypto.provider                              2.86MB byte[] for general heap data
 566.26KB java.lang.invoke                                     1.28MB byte[] for embedded resources
 488.79KB java.awt.image                                       1.01MB com.oracle.svm.core.hub.DynamicHubCompanion
 472.18KB java.lang                                          701.41KB byte[] for reflection metadata
 460.85KB com.sun.imageio.plugins.tiff                       652.77KB java.lang.String[]
 458.75KB sun.security.x509                                  632.02KB java.util.HashMap$Node
  18.48MB for 438 more packages                                5.10MB for 2684 more object types
------------------------------------------------------------------------------------------------------------------------
                        13.9s (5.1% of total time) in 49 GCs | Peak RSS: 4.44GB | CPU load: 3.13
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /project/awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner (executable)
 /project/awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner.build_artifacts.txt (txt)
========================================================================================================================
Finished generating 'awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner' in 4m 27s.
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildRunner] podman run --env LANG=C --rm -v /c/tmp/quarkus-quickstarts/awt-graphics-rest-quickstart/target/awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-native-image-source-jar:/project:z --entrypoint /bin/bash quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17 -c objcopy --strip-debug awt-graphics-rest-quickstart-1.0.0-SNAPSHOT-runner
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 374199ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:19 min
[INFO] Finished at: 2022-10-05T13:36:10-07:00
[INFO] ------------------------------------------------------------------------
```
