### PR TITLE
Add ':Z' opt to volume mount in OpenTelemetry guide

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -176,7 +176,7 @@ services:
     image: otel/opentelemetry-collector:latest
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:Z
     ports:
       - "13133:13133" # Health_check extension
       - "4317:4317"   # OTLP gRPC receiver


### PR DESCRIPTION
Without the option mounting won't work on machines with `SELinux` enabled.