### PR TITLE
Make sure the app model is initialized from the POMs provided by the Maven plugin

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -419,7 +419,6 @@ public abstract class QuarkusDevModeLauncher {
         devModeContext.setReleaseJavaVersion(releaseJavaVersion);
         devModeContext.setSourceJavaVersion(sourceJavaVersion);
         devModeContext.setTargetJvmVersion(targetJavaVersion);
-
         devModeContext.getLocalArtifacts().addAll(localArtifacts);
         devModeContext.setApplicationRoot(main);
         devModeContext.getAdditionalModules().addAll(dependencies);

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -43,6 +43,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Profile;
@@ -90,6 +91,8 @@ import io.quarkus.bootstrap.devmode.DependenciesFilter;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContextConfig;
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
 import io.quarkus.bootstrap.util.BootstrapUtils;
@@ -759,7 +762,6 @@ public class DevMojo extends AbstractMojo {
     }
 
     private void addProject(MavenDevModeLauncher.Builder builder, ResolvedDependency module, boolean root) throws Exception {
-
         if (!module.isJar()) {
             return;
         }
@@ -1084,30 +1086,37 @@ public class DevMojo extends AbstractMojo {
         if (appModel != null) {
             bootstrapProvider.close();
         } else {
-            final MavenArtifactResolver.Builder resolverBuilder = MavenArtifactResolver.builder()
+            final BootstrapMavenContextConfig<?> mvnConfig = BootstrapMavenContext.config()
                     .setRemoteRepositories(repos)
                     .setRemoteRepositoryManager(remoteRepositoryManager)
                     .setWorkspaceDiscovery(true)
                     .setPreferPomsFromWorkspace(true)
                     .setCurrentProject(project.getFile().toString());
 
-            // if it already exists, it may be a reload triggered by a change in a POM
-            // in which case we should not be using the original Maven session
-            boolean reinitializeMavenSession = Files.exists(appModelLocation);
-            if (reinitializeMavenSession) {
+            // if a serialized model is found, it may be a reload triggered by a change in a POM
+            // in which case we should not be using the original Maven session initialized with the previous POM version
+            if (Files.exists(appModelLocation)) {
                 Files.delete(appModelLocation);
                 // we can't re-use the repo system because we want to use our interpolating model builder
                 // a use-case where it fails with the original repo system is when dev mode is launched with -Dquarkus.platform.version=xxx
                 // overriding the version of the quarkus-bom in the pom.xml
             } else {
-                // we can re-use the original Maven session
-                resolverBuilder.setRepositorySystemSession(repoSession).setRepositorySystem(repoSystem);
+                // we can re-use the original Maven session and the system
+                mvnConfig.setRepositorySystemSession(repoSession).setRepositorySystem(repoSystem);
+                // there could be Maven extensions manipulating the project versions and models
+                // the ones returned from the Maven API could be different from the original pom.xml files
+                final Map<Path, Model> projectModels = new HashMap<>(session.getAllProjects().size());
+                for (MavenProject mp : session.getAllProjects()) {
+                    projectModels.put(mp.getBasedir().toPath(), mp.getOriginalModel());
+                }
+                mvnConfig.setProjectModelProvider(projectModels::get);
             }
 
-            appModel = new BootstrapAppModelResolver(resolverBuilder.build())
+            final BootstrapMavenContext mvnCtx = new BootstrapMavenContext(mvnConfig);
+            appModel = new BootstrapAppModelResolver(new MavenArtifactResolver(mvnCtx))
                     .setDevMode(true)
                     .setCollectReloadableDependencies(!noDeps)
-                    .resolveModel(ArtifactCoords.jar(project.getGroupId(), project.getArtifactId(), project.getVersion()));
+                    .resolveModel(mvnCtx.getCurrentProject().getAppArtifact());
         }
 
         // serialize the app model to avoid re-resolving it in the dev process

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContext.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.StringUtils;
@@ -169,7 +170,7 @@ public class BootstrapMavenContext {
             this.currentPom = currentProject.getRawModel().getPomFile().toPath();
             this.workspace = config.currentProject.getWorkspace();
         } else if (config.workspaceDiscovery) {
-            currentProject = resolveCurrentProject();
+            currentProject = resolveCurrentProject(config.modelProvider);
             this.workspace = currentProject == null ? null : currentProject.getWorkspace();
             if (workspace != null) {
                 if (config.repoSession == null && repoSession != null && repoSession.getWorkspaceReader() == null) {
@@ -315,9 +316,9 @@ public class BootstrapMavenContext {
         return localRepo == null ? localRepo = resolveLocalRepo(getEffectiveSettings()) : localRepo;
     }
 
-    private LocalProject resolveCurrentProject() throws BootstrapMavenException {
+    private LocalProject resolveCurrentProject(Function<Path, Model> modelProvider) throws BootstrapMavenException {
         try {
-            return LocalProject.loadWorkspace(this);
+            return LocalProject.loadWorkspace(this, modelProvider);
         } catch (Exception e) {
             throw new BootstrapMavenException("Failed to load current project at " + getCurrentProjectPomOrNull(), e);
         }

--- a/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
+++ b/independent-projects/bootstrap/maven-resolver/src/main/java/io/quarkus/bootstrap/resolver/maven/BootstrapMavenContextConfig.java
@@ -5,7 +5,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.function.Function;
 
+import org.apache.maven.model.Model;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.impl.RemoteRepositoryManager;
@@ -33,6 +35,7 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     protected boolean preferPomsFromWorkspace;
     protected Boolean effectiveModelBuilder;
     protected Boolean wsModuleParentHierarchy;
+    protected Function<Path, Model> modelProvider;
 
     /**
      * Local repository location
@@ -261,6 +264,20 @@ public class BootstrapMavenContextConfig<T extends BootstrapMavenContextConfig<?
     @SuppressWarnings("unchecked")
     public T setWorkspaceModuleParentHierarchy(boolean wsModuleParentHierarchy) {
         this.wsModuleParentHierarchy = wsModuleParentHierarchy;
+        return (T) this;
+    }
+
+    /**
+     * When workspace discovery is enabled, this method allows to set a POM
+     * provider that would return a {@link org.apache.maven.model.Model} for
+     * a given workspace module directory.
+     *
+     * @param modelProvider POM provider
+     * @return this instance
+     */
+    @SuppressWarnings("unchecked")
+    public T setProjectModelProvider(Function<Path, Model> modelProvider) {
+        this.modelProvider = modelProvider;
         return (T) this;
     }
 


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/28375

This change makes sure the `quarkus-maven-plugin` can bootstrap an app using POMs manipulated by Maven extensions.

There are a couple of cases when we can't re-use the POMs provided by the Maven plugin API. For example, when we launched an app in dev mode and POM file was modified, which triggered a reload. In this case, the POMs provided by the Maven plugin API have to be abandoned and we need to read the new versions of the POMs directly from the disk bypassing the enabled Maven extensions. The other one would be bootstrapping apps for tests, where we don't have access to the original POMs provided by the Maven plugin API.