### PR TITLE
Revisit the non-standard behavior of ArcContainer#instanceSupplier()

### DIFF
--- a/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
+++ b/extensions/amazon-lambda/runtime/src/main/java/io/quarkus/amazon/lambda/runtime/AmazonLambdaRecorder.java
@@ -77,11 +77,11 @@ public class AmazonLambdaRecorder {
      */
     public static void handle(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
         if (streamHandlerClass != null) {
-            RequestStreamHandler handler = beanContainer.instance(streamHandlerClass);
+            RequestStreamHandler handler = beanContainer.beanInstance(streamHandlerClass);
             handler.handleRequest(inputStream, outputStream, context);
         } else {
             Object request = objectReader.readValue(inputStream);
-            RequestHandler handler = beanContainer.instance(handlerClass);
+            RequestHandler handler = beanContainer.beanInstance(handlerClass);
             Object response = handler.handleRequest(request, context);
             objectWriter.writeValue(outputStream, response);
         }
@@ -166,7 +166,7 @@ public class AmazonLambdaRecorder {
 
             @Override
             protected Object processRequest(Object input, AmazonLambdaContext context) throws Exception {
-                RequestHandler handler = beanContainer.instance(handlerClass);
+                RequestHandler handler = beanContainer.beanInstance(handlerClass);
                 return handler.handleRequest(input, context);
             }
 
@@ -188,7 +188,7 @@ public class AmazonLambdaRecorder {
             @Override
             protected void processRequest(InputStream input, OutputStream output, AmazonLambdaContext context)
                     throws Exception {
-                RequestStreamHandler handler = beanContainer.instance(streamHandlerClass);
+                RequestStreamHandler handler = beanContainer.beanInstance(streamHandlerClass);
                 handler.handleRequest(input, output, context);
 
             }

--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/unused/UnusedExclusionTest.java
@@ -74,7 +74,7 @@ public class UnusedExclusionTest {
 
         public void test(BeanContainer beanContainer) {
             // This should trigger the warning - Gama was removed
-            Gama gama = beanContainer.instance(Gama.class);
+            Gama gama = beanContainer.beanInstance(Gama.class);
             // Test that fallback was used - no injection was performed
             Assertions.assertNull(gama.beanManager);
         }

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
@@ -10,11 +10,33 @@ import io.quarkus.arc.ManagedContext;
 public interface BeanContainer {
 
     /**
+     * Returns a bean instance for given bean type and qualifiers.
+     * <p/>
+     * This method follows standard CDI rules meaning that if there are two or more eligible beans, an ambiguous
+     * dependency exception is thrown.
+     * Note that the method is allowed to return {@code null} if there is no matching bean which allows
+     * for fallback implementations.
      *
      * @param type
      * @param qualifiers
      * @return a bean instance or {@code null} if no matching bean is found
      */
+    default <T> T beanInstance(Class<T> type, Annotation... qualifiers) {
+        return beanInstanceFactory(type, qualifiers).create().get();
+    }
+
+    /**
+     * This method is deprecated and will be removed in future versions.
+     * Use {@link #beanInstance(Class, Annotation...)} instead.
+     * </p>
+     * As opposed to {@link #beanInstance(Class, Annotation...)}, this method does <b>NOT</b> follow CDI
+     * resolution rules and in case of ambiguous resolution performs a choice based on the class type parameter.
+     *
+     * @param type
+     * @param qualifiers
+     * @return a bean instance or {@code null} if no matching bean is found
+     */
+    @Deprecated
     default <T> T instance(Class<T> type, Annotation... qualifiers) {
         return instanceFactory(type, qualifiers).create().get();
     }
@@ -31,6 +53,20 @@ public interface BeanContainer {
      * @param qualifiers
      * @return a bean instance factory, never {@code null}
      */
+    <T> Factory<T> beanInstanceFactory(Class<T> type, Annotation... qualifiers);
+
+    /**
+     * This method is deprecated and will be removed in future versions.
+     * Use {@link #beanInstanceFactory(Class, Annotation...)} instead.
+     * </p>
+     * As opposed to {@link #beanInstanceFactory(Class, Annotation...)}, this method does <b>NOT</b> follow CDI
+     * resolution rules and in case of ambiguous resolution performs a choice based on the class type parameter.
+     *
+     * @param type
+     * @param qualifiers
+     * @return a bean instance factory, never {@code null}
+     */
+    @Deprecated
     <T> Factory<T> instanceFactory(Class<T> type, Annotation... qualifiers);
 
     /**

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainer.java
@@ -20,9 +20,12 @@ public interface BeanContainer {
     }
 
     /**
-     * Note that if there are multiple sub classes of the given type this will return the exact match. This means
-     * that this can be used to directly instantiate superclasses of other beans without causing problems. This behavior differs
-     * to standard CDI rules where an ambiguous dependency would exist.
+     * Returns an instance factory for given bean type and qualifiers.
+     * <p/>
+     * This method follows standard CDI rules meaning that if there are two or more beans, an ambiguous dependency
+     * exception is thrown.
+     * Note that the factory itself is still allowed to return {@code null} if there is no matching bean which allows
+     * for fallback implementations.
      *
      * @param type
      * @param qualifiers

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainerImpl.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/BeanContainerImpl.java
@@ -22,8 +22,18 @@ public class BeanContainerImpl implements BeanContainer {
     }
 
     @Override
+    public <T> Factory<T> beanInstanceFactory(Class<T> type, Annotation... qualifiers) {
+        Supplier<InstanceHandle<T>> handleSupplier = container.beanInstanceSupplier(type, qualifiers);
+        return createFactory(handleSupplier, type, qualifiers);
+    }
+
+    @Override
     public <T> Factory<T> instanceFactory(Class<T> type, Annotation... qualifiers) {
         Supplier<InstanceHandle<T>> handleSupplier = container.instanceSupplier(type, qualifiers);
+        return createFactory(handleSupplier, type, qualifiers);
+    }
+
+    private <T> Factory<T> createFactory(Supplier<InstanceHandle<T>> handleSupplier, Class<T> type, Annotation... qualifiers) {
         if (handleSupplier == null) {
             LOGGER.debugf(
                     "No matching bean found for type %s and qualifiers %s. The bean might have been marked as unused and removed during build.",

--- a/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronRecorder.java
+++ b/extensions/elytron-security/runtime/src/main/java/io/quarkus/elytron/security/runtime/ElytronRecorder.java
@@ -31,7 +31,7 @@ public class ElytronRecorder {
     }
 
     public void setDomainForIdentityProvider(BeanContainer bc, RuntimeValue<SecurityDomain> domain) {
-        bc.instance(ElytronSecurityDomainManager.class).setDomain(domain.getValue());
+        bc.beanInstance(ElytronSecurityDomainManager.class).setDomain(domain.getValue());
     }
 
     /**

--- a/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
+++ b/extensions/funqy/funqy-google-cloud-functions/runtime/src/main/java/io/quarkus/funqy/gcp/functions/FunqyCloudFunctionsBindingRecorder.java
@@ -32,7 +32,7 @@ public class FunqyCloudFunctionsBindingRecorder {
 
     public void init(BeanContainer bc) {
         beanContainer = bc;
-        objectMapper = beanContainer.instance(ObjectMapper.class);
+        objectMapper = beanContainer.beanInstance(ObjectMapper.class);
 
         for (FunctionInvoker invoker : FunctionRecorder.registry.invokers()) {
             if (invoker.hasInput()) {

--- a/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionConstructor.java
+++ b/extensions/funqy/funqy-server-common/runtime/src/main/java/io/quarkus/funqy/runtime/FunctionConstructor.java
@@ -14,7 +14,7 @@ public class FunctionConstructor<T> {
 
     public T construct() {
         if (factory == null)
-            factory = CONTAINER.instanceFactory(cls);
+            factory = CONTAINER.beanInstanceFactory(cls);
         return factory.create().get();
     }
 }

--- a/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
+++ b/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/HibernateOrmRecorder.java
@@ -92,7 +92,7 @@ public class HibernateOrmRecorder {
     }
 
     public void startAllPersistenceUnits(BeanContainer beanContainer) {
-        beanContainer.instance(JPAConfig.class).startAll();
+        beanContainer.beanInstance(JPAConfig.class).startAll();
     }
 
     public Supplier<SessionFactory> sessionFactorySupplier(String persistenceUnitName) {

--- a/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
+++ b/extensions/infinispan-client/runtime/src/main/java/io/quarkus/infinispan/client/runtime/InfinispanRecorder.java
@@ -11,7 +11,7 @@ public class InfinispanRecorder {
 
     public BeanContainerListener configureInfinispan(@RelaxedValidation Properties properties) {
         return container -> {
-            InfinispanClientProducer instance = container.instance(InfinispanClientProducer.class);
+            InfinispanClientProducer instance = container.beanInstance(InfinispanClientProducer.class);
             instance.configure(properties);
         };
     }

--- a/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/QuarkusConstructorInjector.java
+++ b/extensions/resteasy-classic/resteasy-common/runtime/src/main/java/io/quarkus/resteasy/common/runtime/QuarkusConstructorInjector.java
@@ -32,7 +32,7 @@ public class QuarkusConstructorInjector implements ConstructorInjector {
         if (factory != null) {
             return factory.get().get();
         }
-        factory = Arc.container().instanceSupplier(this.ctor.getDeclaringClass());
+        factory = Arc.container().beanInstanceSupplier(this.ctor.getDeclaringClass());
         if (factory == null) {
             return delegate.construct(unwrapAsync);
         }
@@ -45,7 +45,7 @@ public class QuarkusConstructorInjector implements ConstructorInjector {
         if (factory != null) {
             return factory.get().get();
         }
-        factory = Arc.container().instanceSupplier(this.ctor.getDeclaringClass());
+        factory = Arc.container().beanInstanceSupplier(this.ctor.getDeclaringClass());
         if (factory == null) {
             return delegate.construct(request, response, unwrapAsync);
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcBeanFactory.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-common/runtime/src/main/java/io/quarkus/resteasy/reactive/common/runtime/ArcBeanFactory.java
@@ -12,7 +12,7 @@ public class ArcBeanFactory<T> implements BeanFactory<T> {
 
     public ArcBeanFactory(Class<T> target, BeanContainer beanContainer) {
         targetClassName = target.getName();
-        factory = beanContainer.instanceFactory(target);
+        factory = beanContainer.beanInstanceFactory(target);
     }
 
     @Override

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/ChunkedResponseTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/response/ChunkedResponseTest.java
@@ -30,7 +30,7 @@ public class ChunkedResponseTest {
     static QuarkusUnitTest runner = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(HelloResource.class)
-                    .addAsResource(new StringAsset("quarkus.rest.output-buffer-size = 256"),
+                    .addAsResource(new StringAsset("quarkus.resteasy-reactive.output-buffer-size = 256"),
                             "application.properties"));
 
     @Test
@@ -68,7 +68,22 @@ public class ChunkedResponseTest {
     }
 
     @Provider
-    public static final class CustomStringMessageBodyWriter extends ServerStringMessageBodyHandler {
+    public static class CustomStringMessageBodyWriter extends ServerStringMessageBodyHandler {
+
+        @Override
+        public void writeResponse(Object o, Type genericType, ServerRequestContext context)
+                throws WebApplicationException {
+
+            try (OutputStream stream = context.getOrCreateOutputStream()) {
+                stream.write(((String) o).getBytes());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    @Provider
+    public static final class CustomStringMessageBodyWriter2 extends CustomStringMessageBodyWriter {
 
         @Override
         public void writeResponse(Object o, Type genericType, ServerRequestContext context)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -133,7 +133,7 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         }
 
         CurrentRequestManager
-                .setCurrentRequestInstance(new QuarkusCurrentRequest(beanContainer.instance(CurrentVertxRequest.class)));
+                .setCurrentRequestInstance(new QuarkusCurrentRequest(beanContainer.beanInstance(CurrentVertxRequest.class)));
 
         BlockingOperationSupport.setIoThreadDetector(new BlockingOperationSupport.IOThreadDetector() {
             @Override

--- a/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
+++ b/extensions/security-webauthn/runtime/src/main/java/io/quarkus/security/webauthn/WebAuthnRecorder.java
@@ -32,9 +32,9 @@ public class WebAuthnRecorder {
     }
 
     public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue, String prefix) {
-        WebAuthnSecurity security = beanContainer.instance(WebAuthnSecurity.class);
-        WebAuthnAuthenticationMechanism authMech = beanContainer.instance(WebAuthnAuthenticationMechanism.class);
-        IdentityProviderManager identityProviderManager = beanContainer.instance(IdentityProviderManager.class);
+        WebAuthnSecurity security = beanContainer.beanInstance(WebAuthnSecurity.class);
+        WebAuthnAuthenticationMechanism authMech = beanContainer.beanInstance(WebAuthnAuthenticationMechanism.class);
+        IdentityProviderManager identityProviderManager = beanContainer.beanInstance(IdentityProviderManager.class);
         WebAuthnController controller = new WebAuthnController(security, config.getValue(), identityProviderManager, authMech);
         Router router = routerValue.getValue();
         BodyHandler bodyHandler = BodyHandler.create();

--- a/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
+++ b/extensions/smallrye-graphql/runtime/src/main/java/io/quarkus/smallrye/graphql/runtime/SmallRyeGraphQLRecorder.java
@@ -26,7 +26,7 @@ import io.vertx.ext.web.RoutingContext;
 public class SmallRyeGraphQLRecorder {
 
     public RuntimeValue<Boolean> createExecutionService(BeanContainer beanContainer, Schema schema) {
-        GraphQLProducer graphQLProducer = beanContainer.instance(GraphQLProducer.class);
+        GraphQLProducer graphQLProducer = beanContainer.beanInstance(GraphQLProducer.class);
         GraphQLSchema graphQLSchema = graphQLProducer.initialize(schema);
         return new RuntimeValue<>(graphQLSchema != null);
     }

--- a/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
+++ b/extensions/smallrye-metrics/runtime/src/main/java/io/quarkus/smallrye/metrics/runtime/SmallRyeMetricsRecorder.java
@@ -194,7 +194,7 @@ public class SmallRyeMetricsRecorder {
         //HACK: registration is done via statics, but cleanup is done via pre destroy
         //however if the bean is not used it will not be created, so no cleanup will be done
         //we force bean creation here to make sure the container can restart correctly
-        container.instance(MetricRegistries.class).getApplicationRegistry();
+        container.beanInstance(MetricRegistries.class).getApplicationRegistry();
     }
 
     public void dropRegistriesAtShutdown(ShutdownContext shutdownContext) {

--- a/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
+++ b/extensions/undertow/runtime/src/main/java/io/quarkus/undertow/runtime/UndertowDeploymentRecorder.java
@@ -252,7 +252,7 @@ public class UndertowDeploymentRecorder {
             InstanceFactory<? extends Servlet> instanceFactory) throws Exception {
 
         InstanceFactory<? extends Servlet> factory = instanceFactory != null ? instanceFactory
-                : new QuarkusInstanceFactory(beanContainer.instanceFactory(servletClass));
+                : new QuarkusInstanceFactory(beanContainer.beanInstanceFactory(servletClass));
         ServletInfo servletInfo = new ServletInfo(name, (Class<? extends Servlet>) servletClass,
                 factory);
         deploymentInfo.getValue().addServlet(servletInfo);
@@ -304,7 +304,7 @@ public class UndertowDeploymentRecorder {
             InstanceFactory<? extends Filter> instanceFactory) throws Exception {
 
         InstanceFactory<? extends Filter> factory = instanceFactory != null ? instanceFactory
-                : new QuarkusInstanceFactory(beanContainer.instanceFactory(filterClass));
+                : new QuarkusInstanceFactory(beanContainer.beanInstanceFactory(filterClass));
         FilterInfo filterInfo = new FilterInfo(name, (Class<? extends Filter>) filterClass, factory);
         info.getValue().addFilter(filterInfo);
         filterInfo.setAsyncSupported(asyncSupported);
@@ -329,7 +329,7 @@ public class UndertowDeploymentRecorder {
         info.getValue()
                 .addListener(new ListenerInfo((Class<? extends EventListener>) listenerClass,
                         (InstanceFactory<? extends EventListener>) new QuarkusInstanceFactory<>(
-                                factory.instanceFactory(listenerClass))));
+                                factory.beanInstanceFactory(listenerClass))));
     }
 
     public void addMimeMapping(RuntimeValue<DeploymentInfo> info, String extension,
@@ -457,7 +457,7 @@ public class UndertowDeploymentRecorder {
             info.getValue().setClassIntrospecter(new ClassIntrospecter() {
                 @Override
                 public <T> InstanceFactory<T> createInstanceFactory(Class<T> clazz) throws NoSuchMethodException {
-                    BeanContainer.Factory<T> res = beanContainer.instanceFactory(clazz);
+                    BeanContainer.Factory<T> res = beanContainer.beanInstanceFactory(clazz);
                     if (res == null) {
                         return defaultVal.createInstanceFactory(clazz);
                     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -241,7 +241,7 @@ public class HttpSecurityRecorder {
         return new BeanContainerListener() {
             @Override
             public void created(BeanContainer container) {
-                container.instance(PathMatchingHttpSecurityPolicy.class).init(permissions, policies);
+                container.beanInstance(PathMatchingHttpSecurityPolicy.class).init(permissions, policies);
             }
         };
     }

--- a/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/WebsocketCoreRecorder.java
+++ b/extensions/websockets/client/runtime/src/main/java/io/quarkus/websockets/client/runtime/WebsocketCoreRecorder.java
@@ -125,7 +125,7 @@ public class WebsocketCoreRecorder {
         ServerWebSocketContainer container = serverContainerFactory.create(new ObjectIntrospecter() {
             @Override
             public <T> ObjectFactory<T> createInstanceFactory(Class<T> clazz) {
-                BeanContainer.Factory<T> factory = beanContainer.instanceFactory(clazz);
+                BeanContainer.Factory<T> factory = beanContainer.beanInstanceFactory(clazz);
                 return new ObjectFactory<T>() {
                     @Override
                     public ObjectHandle<T> createInstance() {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcContainer.java
@@ -99,6 +99,21 @@ public interface ArcContainer {
      * @param <T>
      * @return
      */
+    <T> Supplier<InstanceHandle<T>> beanInstanceSupplier(Class<T> type, Annotation... qualifiers);
+
+    /**
+     * This method is deprecated and will be removed in future versions.
+     * Use {@link #beanInstanceSupplier(Class, Annotation...)} instead.
+     * </p>
+     * As opposed to {@link #beanInstanceSupplier(Class, Annotation...)}, this method does <b>NOT</b> follow CDI
+     * resolution rules and in case of ambiguous resolution performs a choice based on the class type parameter.
+     *
+     * @param type
+     * @param qualifiers
+     * @return
+     * @param <T>
+     */
+    @Deprecated
     <T> Supplier<InstanceHandle<T>> instanceSupplier(Class<T> type, Annotation... qualifiers);
 
     /**

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -236,16 +236,40 @@ public class ArcContainerImpl implements ArcContainer {
 
     @SuppressWarnings("unchecked")
     @Override
+    public <T> Supplier<InstanceHandle<T>> beanInstanceSupplier(Class<T> type, Annotation... qualifiers) {
+        return createInstanceSupplier(false, type, qualifiers);
+    }
+
+    @Override
     public <T> Supplier<InstanceHandle<T>> instanceSupplier(Class<T> type, Annotation... qualifiers) {
+        return createInstanceSupplier(true, type, qualifiers);
+    }
+
+    private <T> Supplier<InstanceHandle<T>> createInstanceSupplier(boolean resolveAmbiguities, Class<T> type,
+            Annotation... qualifiers) {
         if (qualifiers == null || qualifiers.length == 0) {
             qualifiers = new Annotation[] { Default.Literal.INSTANCE };
         }
         Set<InjectableBean<?>> resolvedBeans = resolved.getValue(new Resolvable(type, qualifiers));
+        Set<InjectableBean<?>> filteredBean = resolvedBeans;
         if (resolvedBeans.size() > 1) {
-            throw new AmbiguousResolutionException("Beans: " + resolvedBeans);
+            if (resolveAmbiguities) {
+                // this is non-standard CDI behavior that we momentarily keep to retain compatibility
+                // if there are multiple beans we look for an exact match
+                // this method is only called with the exact type required
+                // so ignoring subclasses is the correct behaviour
+                filteredBean = new HashSet<>();
+                for (InjectableBean<?> i : resolvedBeans) {
+                    if (i.getBeanClass().equals(type)) {
+                        filteredBean.add(i);
+                    }
+                }
+            } else {
+                throw new AmbiguousResolutionException("Beans: " + resolvedBeans);
+            }
         }
-        InjectableBean<T> bean = resolvedBeans.size() != 1 ? null
-                : (InjectableBean<T>) resolvedBeans.iterator().next();
+        InjectableBean<T> bean = filteredBean.size() != 1 ? null
+                : (InjectableBean<T>) filteredBean.iterator().next();
         if (bean == null) {
             return null;
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ArcContainerImpl.java
@@ -241,20 +241,11 @@ public class ArcContainerImpl implements ArcContainer {
             qualifiers = new Annotation[] { Default.Literal.INSTANCE };
         }
         Set<InjectableBean<?>> resolvedBeans = resolved.getValue(new Resolvable(type, qualifiers));
-        Set<InjectableBean<?>> filteredBean = resolvedBeans;
         if (resolvedBeans.size() > 1) {
-            //if there are multiple beans we look for an exact match
-            //this method is only called with the exact type required
-            //so ignoring subclasses is the correct behaviour
-            filteredBean = new HashSet<>();
-            for (InjectableBean<?> i : resolvedBeans) {
-                if (i.getBeanClass().equals(type)) {
-                    filteredBean.add(i);
-                }
-            }
+            throw new AmbiguousResolutionException("Beans: " + resolvedBeans);
         }
-        InjectableBean<T> bean = filteredBean.size() != 1 ? null
-                : (InjectableBean<T>) filteredBean.iterator().next();
+        InjectableBean<T> bean = resolvedBeans.size() != 1 ? null
+                : (InjectableBean<T>) resolvedBeans.iterator().next();
         if (bean == null) {
             return null;
         }

--- a/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
+++ b/independent-projects/resteasy-reactive/common/processor/src/main/java/org/jboss/resteasy/reactive/common/processor/ResteasyReactiveDotNames.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionStage;
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Typed;
 import javax.enterprise.inject.Vetoed;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -166,6 +167,7 @@ public final class ResteasyReactiveDotNames {
     public static final DotName DEFAULT_VALUE = DotName.createSimple(DefaultValue.class.getName());
     public static final DotName NAME_BINDING = DotName.createSimple(NameBinding.class.getName());
     public static final DotName VETOED = DotName.createSimple(Vetoed.class.getName());
+    public static final DotName TYPED = DotName.createSimple(Typed.class.getName());
     public static final DotName APPLICATION_SCOPED = DotName.createSimple(ApplicationScoped.class.getName());
     public static final DotName SINGLETON = DotName.createSimple(Singleton.class.getName());
     public static final DotName REQUEST_SCOPED = DotName.createSimple(RequestScoped.class.getName());

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
@@ -151,7 +151,11 @@ public abstract class Serialisers {
             }
 
         }
-        return toMessageBodyWriters(findResourceWriters(writers, klass, produces, runtimeType));
+
+        var resourceWriters = findResourceWriters(writers, klass, produces, runtimeType);
+        // we must NOT sort here because the spec mentions that the writers closer to the requested java type are tried first
+        // and the list has already been built up in this way
+        return toMessageBodyWriters(resourceWriters);
     }
 
     protected List<ResourceWriter> findResourceWriters(QuarkusMultivaluedMap<Class<?>, ResourceWriter> writers, Class<?> klass,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerBooleanMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerBooleanMessageBodyHandler.java
@@ -5,14 +5,12 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.BooleanMessageBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerBooleanMessageBodyHandler extends BooleanMessageBodyHandler
         implements ServerMessageBodyReader<Boolean> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerByteArrayMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerByteArrayMessageBodyHandler.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.ByteArrayMessageBodyHandler;
 import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
@@ -14,7 +13,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerByteArrayMessageBodyHandler extends ByteArrayMessageBodyHandler
         implements ServerMessageBodyWriter<byte[]>, ServerMessageBodyReader<byte[]> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharArrayMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharArrayMessageBodyHandler.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.CharArrayMessageBodyHandler;
 import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
@@ -14,7 +13,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerCharArrayMessageBodyHandler extends CharArrayMessageBodyHandler
         implements ServerMessageBodyWriter<char[]>, ServerMessageBodyReader<char[]> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharacterMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerCharacterMessageBodyHandler.java
@@ -5,14 +5,12 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.CharacterMessageBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerCharacterMessageBodyHandler extends CharacterMessageBodyHandler
         implements ServerMessageBodyReader<Character> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerDefaultTextPlainBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerDefaultTextPlainBodyHandler.java
@@ -9,14 +9,12 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.DefaultTextPlainBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 @Consumes("text/plain")
 public class ServerDefaultTextPlainBodyHandler extends DefaultTextPlainBodyHandler implements ServerMessageBodyReader<Object> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFileBodyHandler.java
@@ -8,14 +8,12 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.FileBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 @Produces("*/*")
 @Consumes("*/*")
 public class ServerFileBodyHandler extends FileBodyHandler implements ServerMessageBodyWriter<File> {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFilePartBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFilePartBodyHandler.java
@@ -7,7 +7,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.FilePart;
 import org.jboss.resteasy.reactive.common.providers.serialisers.FilePartBodyHandler;
@@ -18,7 +17,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
 // TODO: this is very simplistic at the moment
 
-@Provider
 @Produces("*/*")
 @Consumes("*/*")
 public class ServerFilePartBodyHandler extends FilePartBodyHandler implements ServerMessageBodyWriter<FilePart> {

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFormUrlEncodedProvider.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerFormUrlEncodedProvider.java
@@ -11,7 +11,6 @@ import javax.ws.rs.RuntimeType;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.MapAsFormUrlEncodedProvider;
 import org.jboss.resteasy.reactive.common.providers.serialisers.MessageReaderUtil;
@@ -25,7 +24,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
  * @version $Revision: 1 $
  */
 @SuppressWarnings("rawtypes")
-@Provider
 @Produces("application/x-www-form-urlencoded")
 @Consumes("application/x-www-form-urlencoded")
 @ConstrainedTo(RuntimeType.CLIENT)

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerInputStreamMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerInputStreamMessageBodyHandler.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.InputStreamMessageBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
@@ -15,7 +14,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerInputStreamMessageBodyHandler extends InputStreamMessageBodyHandler
         implements ServerMessageBodyReader<InputStream>, ServerMessageBodyWriter<InputStream> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerNumberMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerNumberMessageBodyHandler.java
@@ -5,14 +5,12 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.NumberMessageBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerNumberMessageBodyHandler extends NumberMessageBodyHandler
         implements ServerMessageBodyReader<Number> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerPathBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerPathBodyHandler.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.PathBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
@@ -17,7 +16,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 @Produces("*/*")
 public class ServerPathBodyHandler extends PathBodyHandler implements ServerMessageBodyWriter<java.nio.file.Path> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerPathPartBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerPathPartBodyHandler.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.PathPart;
 import org.jboss.resteasy.reactive.common.providers.serialisers.PathPartBodyHandler;
@@ -18,7 +17,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerHttpResponse;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 @Produces("*/*")
 public class ServerPathPartBodyHandler extends PathPartBodyHandler implements ServerMessageBodyWriter<PathPart> {
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerStringMessageBodyHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/providers/serialisers/ServerStringMessageBodyHandler.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Type;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.StringMessageBodyHandler;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
@@ -13,7 +12,6 @@ import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
 
-@Provider
 public class ServerStringMessageBodyHandler extends StringMessageBodyHandler
         implements ServerMessageBodyWriter<Object>, ServerMessageBodyReader<String> {
 

--- a/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRecorder.java
+++ b/integration-tests/test-extension/extension/runtime/src/main/java/io/quarkus/extest/runtime/TestRecorder.java
@@ -54,7 +54,7 @@ public class TestRecorder {
      * @param beanContainer - CDI bean container
      */
     public void loadDSAPublicKeyProducer(DSAPublicKey publicKey, BeanContainer beanContainer) {
-        PublicKeyProducer keyProducer = beanContainer.instance(PublicKeyProducer.class);
+        PublicKeyProducer keyProducer = beanContainer.beanInstance(PublicKeyProducer.class);
         keyProducer.setPublicKey(publicKey);
     }
 


### PR DESCRIPTION
Fixes #28115 

This would be a breaking change in `ArcContainer#instanceSupplier()` because there can be other extensions (outside of this repo) that use this method unknowingly via `BeanContainer#instanceFactory` and those might rely on the non-CDI behavior that the underlying resolution performed.

Theoretically, we could instead deprecate `instanceSupplier()` method (as well as the method on `BeanContainer`) and keep their current behavior while introducing new ones with similar names that would behave per spec. That'd give extension creators time to adapt. WDYT @mkouba?

As for our own extensions, I am stuck with RE reactive and its handling of `@Provider`. The second commit shows the issue - the altered test would lead to ambig. exception (expected due to changes in `BeanContainer#instanceFactory`) but I am adding `@Typed` to all providers. Despite the fact that RE will register such provider, but will not use it during test execution. I might need someone with RE internals knowledge to take a look and tell me what I am missing...