### PR TITLE
Ensure that build time writers are properly sorted

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/core/Serialisers.java
@@ -151,7 +151,9 @@ public abstract class Serialisers {
             }
 
         }
-        return toMessageBodyWriters(findResourceWriters(writers, klass, produces, runtimeType));
+        var resourceWriters = findResourceWriters(writers, klass, produces, runtimeType);
+        resourceWriters.sort(new ResourceWriter.ResourceWriterComparator(produces));
+        return toMessageBodyWriters(resourceWriters);
     }
 
     protected List<ResourceWriter> findResourceWriters(QuarkusMultivaluedMap<Class<?>, ResourceWriter> writers, Class<?> klass,


### PR DESCRIPTION
This is needed because there were cases where the built-in providers could be returned before the application ones.