### PR TITLE
Fix RESTEasy Reactive match bug

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -91,6 +91,9 @@ public class RequestMapper<T> {
                             break;
                         }
                     }
+                    if (!matched) {
+                        break;
+                    }
                 } else if (segment.type == URITemplate.Type.DEFAULT_REGEX) {
                     if (matchPos == pathLength) {
                         matched = false;
@@ -103,6 +106,9 @@ public class RequestMapper<T> {
                     params[paramCount++] = URIDecoder.decodeURIComponent(path.substring(start, matchPos), false);
                 }
             }
+            if (!matched) {
+                continue;
+            }
             if (paramCount < params.length) {
                 params[paramCount] = null;
             }
@@ -113,7 +119,7 @@ public class RequestMapper<T> {
                 doPrefixMatch = (matchPos == 1 || path.charAt(matchPos) == '/') //matchPos == 1 corresponds to '/' as a root level match
                         && (prefixAllowed || matchPos == pathLength - 1); //if prefix is allowed, or the remainder is only a trailing /
             }
-            if (matched && (fullMatch || doPrefixMatch)) {
+            if (fullMatch || doPrefixMatch) {
                 String remaining;
                 if (fullMatch) {
                     remaining = "";

--- a/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/CloseDelegateInputStream.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/main/java/org/jboss/resteasy/reactive/server/vertx/CloseDelegateInputStream.java
@@ -1,0 +1,52 @@
+package org.jboss.resteasy.reactive.server.vertx;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CloseDelegateInputStream extends InputStream {
+
+    final InputStream delegate;
+    final Closeable closeable;
+
+    public CloseDelegateInputStream(InputStream delegate, Closeable closeable) {
+        this.delegate = delegate;
+        this.closeable = closeable;
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        int ret = delegate.read(b);
+        if (ret == -1) {
+            delegate.close();
+        }
+        return ret;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int ret = delegate.read(b, off, len);
+        if (ret == -1) {
+            delegate.close();
+        }
+        return ret;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            delegate.close();
+        } finally {
+            closeable.close();
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        int ret = delegate.read();
+        if (ret == -1) {
+            delegate.close();
+        }
+        return ret;
+    }
+}

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexMatchTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexMatchTest.java
@@ -35,4 +35,15 @@ public class RegexMatchTest {
                 .statusCode(404);
     }
 
+    @Test
+    public void testLiteralInRegex() {
+        RestAssured.get("/regex/abb/foo/alongpathtotriggerbug")
+                .then()
+                .statusCode(200)
+                .body(equalTo("plain:abb/foo/alongpathtotriggerbug"));
+        RestAssured.get("/regex/abb/literal/ddc")
+                .then()
+                .statusCode(200)
+                .body(equalTo("literal:abb/ddc"));
+    }
 }

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexResource.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/matching/RegexResource.java
@@ -13,4 +13,15 @@ public class RegexResource {
         return "pin " + name;
     }
 
+    @GET
+    @Path("{p1}/{p2:.*}/{p3:.*}")
+    public String noliteral(@PathParam("p1") String p1, @PathParam("p2") String p2, @PathParam("p3") String p3) {
+        return "plain:" + p1 + "/" + p2 + "/" + p3;
+    }
+
+    @GET
+    @Path("{p1}/literal/{p2:.*}")
+    public String literal(@PathParam("p1") String p1, @PathParam("p2") String p2) {
+        return "literal:" + p1 + "/" + p2;
+    }
 }


### PR DESCRIPTION
When matching literals we break out of the wrong loop