### PR TITLE
Execute QuarkusTest**Callback when running QuarkusIntegrationTest

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/testing/TestConfig.java
@@ -234,6 +234,12 @@ public class TestConfig {
     @ConfigItem
     public Optional<String> excludeModulePattern;
 
+    /**
+     * If the test callbacks should be invoked for the integration tests (tests annotated with {@code @QuarkusIntegrationTest}).
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enableCallbacksForIntegrationTests;
+
     @ConfigGroup
     public static class Profile {
 

--- a/docs/src/main/asciidoc/getting-started-testing.adoc
+++ b/docs/src/main/asciidoc/getting-started-testing.adoc
@@ -431,6 +431,8 @@ Alternatively or additionally to an interceptor, you can enrich *all* your `@Qua
 * `io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback`
 * `io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback`
 
+Optionally, you can enable these callbacks also for the `@QuarkusIntegrationTest` tests if the property `quarkus.test.enable-callbacks-for-integration-tests` is `true`. 
+
 Such a callback implementation has to be registered as a "service provider" as defined by `java.util.ServiceLoader`.
 
 E.g. the following sample callback:

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -57,3 +57,5 @@ quarkus.log.metrics.enabled=true
 quarkus.native.additional-build-args =-H:ReflectionConfigurationFiles=reflection-config.json
 quarkus.class-loading.removed-resources."io.quarkus\:quarkus-integration-test-shared-library"=io/quarkus/it/shared/RemovedResource.class
 quarkus.class-loading.removed-resources."io.quarkus\:quarkus-integration-test-main"=io/quarkus/it/rest/RemovedJaxRsApplication.class
+# Enable callbacks for integration tests
+quarkus.test.enable-callbacks-for-integration-tests=true

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksITCase.java
@@ -1,0 +1,71 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.junit.QuarkusIntegrationTestExtension;
+
+/**
+ * The purpose of this test is simply to ensure that {@link TestContextCheckerBeforeEachCallback}
+ * can read {@code @TestAnnotation} without issue.
+ * Also checks that {@link SimpleAnnotationCheckerBeforeClassCallback} is executed properly
+ */
+@ExtendWith({ QuarkusTestCallbacksTestCase.IgnoreCustomExceptions.class, QuarkusIntegrationTestExtension.class })
+public class QuarkusTestCallbacksITCase {
+
+    private static boolean throwsCustomException = false;
+
+    @AfterEach
+    void afterEachWithTestInfo() {
+        if (throwsCustomException) {
+            throw new QuarkusTestCallbacksTestCase.CustomException();
+        }
+    }
+
+    @Test
+    @QuarkusTestCallbacksTestCase.TestAnnotation
+    @Order(1)
+    public void testTestMethodHasAnnotation() {
+        assertTrue(TestContextCheckerBeforeEachCallback.testAnnotationChecked);
+    }
+
+    @Test
+    @Order(2)
+    public void testBeforeClass() {
+        assertEquals(1, SimpleAnnotationCheckerBeforeClassCallback.count.get());
+    }
+
+    @Test
+    @QuarkusTestCallbacksTestCase.TestAnnotation
+    @Order(3)
+    public void testInfoTestCase(TestInfo testInfo) throws NoSuchMethodException {
+        assertEquals(testInfo.getTestClass().get(), QuarkusTestCallbacksITCase.class);
+        Method testMethod = testInfo.getTestMethod().get();
+        assertEquals(testMethod, QuarkusTestCallbacksITCase.class.getDeclaredMethod("testInfoTestCase", TestInfo.class));
+        assertEquals(1, testMethod.getAnnotationsByType(QuarkusTestCallbacksTestCase.TestAnnotation.class).length);
+        assertEquals(QuarkusTestCallbacksITCase.class, testInfo.getTestClass().get());
+    }
+
+    @Test
+    @Order(4)
+    public void testCallbackContextIsNotFailed() {
+        assertFalse(TestContextCheckerBeforeEachCallback.CONTEXT.getTestStatus().isTestFailed());
+        // To force the exception in the before each handler.
+        throwsCustomException = true;
+    }
+
+    @Test
+    @Order(5)
+    public void testCallbackContextIsFailed() {
+        assertTrue(TestContextCheckerBeforeEachCallback.CONTEXT.getTestStatus().isTestFailed());
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestCallbacksTestCase.java
@@ -119,7 +119,7 @@ public class QuarkusTestCallbacksTestCase {
     public @interface TestAnnotation {
     }
 
-    private static boolean isCustomException(Throwable ex) {
+    public static boolean isCustomException(Throwable ex) {
         try {
             return ex.getClass().getClassLoader().loadClass(CustomException.class.getName()).isInstance(ex);
         } catch (ClassNotFoundException e) {

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedITCase.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/QuarkusTestNestedITCase.java
@@ -1,0 +1,215 @@
+package io.quarkus.it.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * Tests {@link Nested} support of {@link QuarkusIntegrationTest}. Notes:
+ * <ul>
+ * <li>to avoid unexpected execution order, don't use surefire's {@code -Dtest=...}, use {@code -Dgroups=nested} instead</li>
+ * <li>order of nested test classes is reversed by JUnit (and there's no way to enforce a specific order)</li>
+ * </ul>
+ */
+@QuarkusIntegrationTest
+public class QuarkusTestNestedITCase {
+
+    private static final AtomicInteger COUNT_BEFORE_ALL = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_BEFORE_EACH = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_TEST = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_AFTER_EACH = new AtomicInteger(0);
+    private static final AtomicInteger COUNT_AFTER_ALL = new AtomicInteger(0);
+    private static final String EXPECTED_OUTER_VALUE = "set from outer";
+    private static final String EXPECTED_INNER_VALUE = "set from inner";
+    private static final String EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE = "set from second level first inner";
+    private static final String EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE = "set from second level second inner";
+
+    String outerValue;
+
+    @BeforeAll
+    static void beforeAll() {
+        COUNT_BEFORE_ALL.incrementAndGet();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        COUNT_BEFORE_EACH.incrementAndGet();
+        outerValue = EXPECTED_OUTER_VALUE;
+    }
+
+    @Test
+    void test() {
+        assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+        assertEquals(1, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(0, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+        assertEquals(0, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        assertEquals(0, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size(), "Found unexpected outer instances");
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class FirstNested {
+
+        String innerValue;
+
+        @BeforeEach
+        void beforeEach() {
+            COUNT_BEFORE_EACH.incrementAndGet();
+            innerValue = EXPECTED_INNER_VALUE;
+        }
+
+        @Test
+        @Order(1)
+        void testOne() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(7, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(2, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(5, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @Test
+        @Order(2)
+        void testTwo() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(9, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(3, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(7, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @Test
+        @Order(3)
+        void testOuterInstancesInBeforeEach() {
+            assertEquals(1, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size());
+        }
+
+        @Test
+        @Order(4)
+        void testOuterInstancesInAfterEach() {
+            assertEquals(1, TestContextCheckerAfterEachCallback.OUTER_INSTANCES.size());
+        }
+
+        @Test
+        void testInnerAndOuterValues() {
+            assertEquals(EXPECTED_INNER_VALUE, innerValue);
+            assertEquals(EXPECTED_OUTER_VALUE, outerValue);
+        }
+
+        @AfterEach
+        void afterEach() {
+            COUNT_AFTER_EACH.incrementAndGet();
+        }
+
+        @Nested
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+        class SecondLevelInnerNested {
+
+            private final AtomicInteger SECOND_LEVEL_COUNTER = new AtomicInteger(0);
+
+            String secondLevelInnerValue;
+
+            @BeforeEach
+            void beforeEach() {
+                SECOND_LEVEL_COUNTER.incrementAndGet();
+                secondLevelInnerValue = EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE;
+            }
+
+            @Test
+            @Order(1)
+            void testOne() {
+                assertEquals(1, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
+            }
+
+            @Test
+            @Order(2)
+            void testSecondLevelAndInnerAndOuterValues() {
+                assertEquals(2, SECOND_LEVEL_COUNTER.get(), "SECOND_LEVEL_COUNTER");
+                assertEquals(EXPECTED_INNER_VALUE, innerValue);
+                assertEquals(EXPECTED_OUTER_VALUE, outerValue);
+                assertEquals(EXPECTED_SECOND_LEVEL_FIRST_INNER_VALUE, secondLevelInnerValue);
+            }
+
+            @Test
+            @Order(3)
+            void testOuterInstancesInBeforeEach() {
+                assertEquals(2, TestContextCheckerBeforeEachCallback.OUTER_INSTANCES.size());
+            }
+
+            @Test
+            @Order(4)
+            void testOuterInstancesInAfterEach() {
+                assertEquals(2, TestContextCheckerAfterEachCallback.OUTER_INSTANCES.size());
+            }
+        }
+    }
+
+    @Nested
+    class SecondNested {
+
+        @BeforeEach
+        void beforeEach() {
+            COUNT_BEFORE_EACH.incrementAndGet();
+        }
+
+        @Test
+        void testOne() {
+            assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+            assertEquals(3, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+            assertEquals(1, COUNT_TEST.getAndIncrement(), "COUNT_TEST");
+            assertEquals(1, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+            assertEquals(0, COUNT_AFTER_ALL.get(), "COUNT_AFTER_ALL");
+        }
+
+        @AfterEach
+        void afterEach() {
+            COUNT_AFTER_EACH.incrementAndGet();
+        }
+
+        @Nested
+        class SecondLevelInnerNested {
+
+            String secondLevelInnerValue;
+
+            @BeforeEach
+            void beforeEach() {
+                secondLevelInnerValue = EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE;
+            }
+
+            @Test
+            void testSecondLevelAndInnerAndOuterValues() {
+                assertEquals(EXPECTED_OUTER_VALUE, outerValue);
+                assertEquals(EXPECTED_SECOND_LEVEL_SECOND_INNER_VALUE, secondLevelInnerValue);
+            }
+        }
+    }
+
+    @AfterEach
+    void afterEach() {
+        COUNT_AFTER_EACH.incrementAndGet();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        assertEquals(1, COUNT_BEFORE_ALL.get(), "COUNT_BEFORE_ALL");
+        assertEquals(23, COUNT_BEFORE_EACH.get(), "COUNT_BEFORE_EACH");
+        assertEquals(4, COUNT_TEST.get(), "COUNT_TEST");
+        assertEquals(23, COUNT_AFTER_EACH.get(), "COUNT_AFTER_EACH");
+        assertEquals(0, COUNT_AFTER_ALL.getAndIncrement(), "COUNT_AFTER_ALL");
+    }
+}

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleAnnotationCheckerBeforeClassCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/SimpleAnnotationCheckerBeforeClassCallback.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Assertions;
 
+import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback;
 
 public class SimpleAnnotationCheckerBeforeClassCallback implements QuarkusTestBeforeClassCallback {
@@ -12,10 +13,13 @@ public class SimpleAnnotationCheckerBeforeClassCallback implements QuarkusTestBe
 
     @Override
     public void beforeClass(Class<?> testClass) {
-        assertQuarkusClassLoader(Thread.currentThread().getContextClassLoader());
-        assertQuarkusClassLoader(testClass.getClassLoader());
+        if (testClass.isAnnotationPresent(QuarkusTest.class)) {
+            assertQuarkusClassLoader(Thread.currentThread().getContextClassLoader());
+            assertQuarkusClassLoader(testClass.getClassLoader());
+        }
+
         // make sure that this comes into play only for the test we care about
-        if (!testClass.getName().endsWith("QuarkusTestCallbacksTestCase")) {
+        if (!testClass.getName().startsWith("io.quarkus.it.main.QuarkusTestCallbacks")) {
             return;
         }
 

--- a/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
+++ b/integration-tests/main/src/test/java/io/quarkus/it/main/TestContextCheckerBeforeEachCallback.java
@@ -24,7 +24,7 @@ public class TestContextCheckerBeforeEachCallback implements QuarkusTestBeforeEa
         // make sure that this comes into play only for the test we care about
 
         Method testMethod = context.getTestMethod();
-        if (!testMethod.getDeclaringClass().getName().endsWith("QuarkusTestCallbacksTestCase")) {
+        if (!testMethod.getDeclaringClass().getName().startsWith("io.quarkus.it.main.QuarkusTestCallbacks")) {
             return;
         }
 

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractQuarkusTestWithContextExtension.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestWatcher;
 
-public class AbstractQuarkusTestWithContextExtension implements LifecycleMethodExecutionExceptionHandler, TestWatcher {
+public abstract class AbstractQuarkusTestWithContextExtension extends AbstractTestWithCallbacksExtension
+        implements LifecycleMethodExecutionExceptionHandler, TestWatcher {
     @Override
     public void handleAfterAllMethodExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
         markTestAsFailed(context, throwable);

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/AbstractTestWithCallbacksExtension.java
@@ -1,0 +1,160 @@
+package io.quarkus.test.junit;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback;
+import io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback;
+import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
+import io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback;
+import io.quarkus.test.junit.callback.QuarkusTestContext;
+import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+
+public abstract class AbstractTestWithCallbacksExtension {
+    private static List<Object> beforeClassCallbacks;
+    private static List<Object> afterConstructCallbacks;
+    private static List<Object> beforeEachCallbacks;
+    private static List<Object> beforeTestCallbacks;
+    private static List<Object> afterTestCallbacks;
+    private static List<Object> afterEachCallbacks;
+    private static List<Object> afterAllCallbacks;
+
+    protected boolean isBeforeTestCallbacksEmpty() {
+        return beforeTestCallbacks == null || beforeTestCallbacks.isEmpty();
+    }
+
+    protected void invokeBeforeTestExecutionCallbacks(QuarkusTestMethodContext quarkusTestMethodContext) throws Exception {
+        invokeBeforeTestExecutionCallbacks(QuarkusTestMethodContext.class, quarkusTestMethodContext);
+    }
+
+    protected void invokeBeforeTestExecutionCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(beforeTestCallbacks, "beforeTestExecution", clazz, classInstance);
+    }
+
+    protected boolean isAfterTestCallbacksEmpty() {
+        return afterTestCallbacks == null || afterTestCallbacks.isEmpty();
+    }
+
+    protected void invokeAfterTestExecutionCallbacks(QuarkusTestMethodContext quarkusTestMethodContext) throws Exception {
+        invokeAfterTestExecutionCallbacks(QuarkusTestMethodContext.class, quarkusTestMethodContext);
+    }
+
+    protected void invokeAfterTestExecutionCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(afterTestCallbacks, "afterTestExecution", clazz, classInstance);
+    }
+
+    protected void invokeBeforeClassCallbacks(Class<?> classInstance) throws Exception {
+        invokeBeforeClassCallbacks(Class.class, classInstance);
+    }
+
+    protected void invokeBeforeClassCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(beforeClassCallbacks, "beforeClass", clazz, classInstance);
+    }
+
+    protected void invokeAfterConstructCallbacks(Object testInstance) throws Exception {
+        invokeAfterConstructCallbacks(Object.class, testInstance);
+    }
+
+    protected void invokeAfterConstructCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(afterConstructCallbacks, "afterConstruct", clazz, classInstance);
+    }
+
+    protected boolean isBeforeEachCallbacksEmpty() {
+        return beforeEachCallbacks == null || beforeEachCallbacks.isEmpty();
+    }
+
+    protected void invokeBeforeEachCallbacks(QuarkusTestMethodContext quarkusTestMethodContext) throws Exception {
+        invokeBeforeEachCallbacks(QuarkusTestMethodContext.class, quarkusTestMethodContext);
+    }
+
+    protected void invokeBeforeEachCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(beforeEachCallbacks, "beforeEach", clazz, classInstance);
+    }
+
+    protected void invokeAfterEachCallbacks(QuarkusTestMethodContext testMethodContext) throws Exception {
+        invokeAfterEachCallbacks(QuarkusTestMethodContext.class, testMethodContext);
+    }
+
+    protected boolean isAfterAllCallbacksEmpty() {
+        return afterAllCallbacks == null || afterAllCallbacks.isEmpty();
+    }
+
+    protected void invokeAfterEachCallbacks(Class<?> clazz, Object classInstance) throws Exception {
+        invokeCallbacks(afterEachCallbacks, "afterEach", clazz, classInstance);
+    }
+
+    protected void invokeAfterAllCallbacks(QuarkusTestContext testContext) throws Exception {
+        invokeAfterAllCallbacks(QuarkusTestContext.class, testContext);
+    }
+
+    protected void invokeAfterAllCallbacks(Class<?> clazz, Object testContext) throws Exception {
+        invokeCallbacks(afterAllCallbacks, "afterAll", clazz, testContext);
+    }
+
+    protected void populateCallbacks(ClassLoader classLoader) throws ClassNotFoundException {
+        beforeClassCallbacks = new ArrayList<>();
+        afterConstructCallbacks = new ArrayList<>();
+        beforeEachCallbacks = new ArrayList<>();
+        beforeTestCallbacks = new ArrayList<>();
+        afterTestCallbacks = new ArrayList<>();
+        afterEachCallbacks = new ArrayList<>();
+        afterAllCallbacks = new ArrayList<>();
+
+        ServiceLoader<?> quarkusTestBeforeClassLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestBeforeClassCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestBeforeClassCallback : quarkusTestBeforeClassLoader) {
+            beforeClassCallbacks.add(quarkusTestBeforeClassCallback);
+        }
+        ServiceLoader<?> quarkusTestAfterConstructLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestAfterConstructCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestAfterConstructCallback : quarkusTestAfterConstructLoader) {
+            afterConstructCallbacks.add(quarkusTestAfterConstructCallback);
+        }
+        ServiceLoader<?> quarkusTestBeforeEachLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestBeforeEachCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestBeforeEachCallback : quarkusTestBeforeEachLoader) {
+            beforeEachCallbacks.add(quarkusTestBeforeEachCallback);
+        }
+        ServiceLoader<?> quarkusTestBeforeTestLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestBeforeTestExecutionCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestBeforeTestCallback : quarkusTestBeforeTestLoader) {
+            beforeTestCallbacks.add(quarkusTestBeforeTestCallback);
+        }
+        ServiceLoader<?> quarkusTestAfterTestLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestAfterTestExecutionCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestAfterTestCallback : quarkusTestAfterTestLoader) {
+            afterTestCallbacks.add(quarkusTestAfterTestCallback);
+        }
+        ServiceLoader<?> quarkusTestAfterEachLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestAfterEachCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestAfterEach : quarkusTestAfterEachLoader) {
+            afterEachCallbacks.add(quarkusTestAfterEach);
+        }
+        ServiceLoader<?> quarkusTestAfterAllLoader = ServiceLoader
+                .load(Class.forName(QuarkusTestAfterAllCallback.class.getName(), false, classLoader), classLoader);
+        for (Object quarkusTestAfterAll : quarkusTestAfterAllLoader) {
+            afterAllCallbacks.add(quarkusTestAfterAll);
+        }
+    }
+
+    private void invokeCallbacks(List<Object> callbacks, String methodName, Class<?> clazz, Object classInstance)
+            throws Exception {
+        if (callbacks == null || callbacks.isEmpty()) {
+            return;
+        }
+
+        try {
+            for (Object callback : callbacks) {
+                callback.getClass().getMethod(methodName, clazz)
+                        .invoke(callback, classInstance);
+            }
+        } catch (InvocationTargetException e) {
+            throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
+        }
+    }
+}

--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/QuarkusTestExtension.java
@@ -102,13 +102,6 @@ import io.quarkus.test.common.TestScopeManager;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.common.http.TestHTTPResourceManager;
 import io.quarkus.test.junit.buildchain.TestBuildChainCustomizerProducer;
-import io.quarkus.test.junit.callback.QuarkusTestAfterAllCallback;
-import io.quarkus.test.junit.callback.QuarkusTestAfterConstructCallback;
-import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
-import io.quarkus.test.junit.callback.QuarkusTestAfterTestExecutionCallback;
-import io.quarkus.test.junit.callback.QuarkusTestBeforeClassCallback;
-import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
-import io.quarkus.test.junit.callback.QuarkusTestBeforeTestExecutionCallback;
 import io.quarkus.test.junit.callback.QuarkusTestContext;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
 import io.quarkus.test.junit.internal.DeepClone;
@@ -134,13 +127,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
     private static Pattern clonePattern;
     private static Throwable firstException; //if this is set then it will be thrown from the very first test that is run, the rest are aborted
 
-    private static List<Object> beforeClassCallbacks;
-    private static List<Object> afterConstructCallbacks;
-    private static List<Object> beforeEachCallbacks;
-    private static List<Object> beforeTestCallbacks;
-    private static List<Object> afterTestCallbacks;
-    private static List<Object> afterEachCallbacks;
-    private static List<Object> afterAllCallbacks;
     private static Class<?> quarkusTestMethodContextClass;
     private static boolean hasPerTestResources;
     private static List<Function<Class<?>, String>> testHttpEndpointProviders;
@@ -254,6 +240,9 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             hasPerTestResources = (boolean) testResourceManager.getClass().getMethod("hasPerTestResources")
                     .invoke(testResourceManager);
 
+            // make sure that we start over every time we populate the callbacks
+            // otherwise previous runs of QuarkusTest (with different TestProfile values can leak into the new run)
+            quarkusTestMethodContextClass = null;
             populateCallbacks(startupAction.getClassLoader());
             populateTestMethodInvokers(startupAction.getClassLoader());
 
@@ -356,55 +345,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         deepClone = new SerializationWithXStreamFallbackDeepClone(startupAction.getClassLoader());
     }
 
-    private void populateCallbacks(ClassLoader classLoader) throws ClassNotFoundException {
-        // make sure that we start over every time we populate the callbacks
-        // otherwise previous runs of QuarkusTest (with different TestProfile values can leak into the new run)
-        quarkusTestMethodContextClass = null;
-        beforeClassCallbacks = new ArrayList<>();
-        afterConstructCallbacks = new ArrayList<>();
-        beforeEachCallbacks = new ArrayList<>();
-        beforeTestCallbacks = new ArrayList<>();
-        afterTestCallbacks = new ArrayList<>();
-        afterEachCallbacks = new ArrayList<>();
-        afterAllCallbacks = new ArrayList<>();
-
-        ServiceLoader<?> quarkusTestBeforeClassLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestBeforeClassCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestBeforeClassCallback : quarkusTestBeforeClassLoader) {
-            beforeClassCallbacks.add(quarkusTestBeforeClassCallback);
-        }
-        ServiceLoader<?> quarkusTestAfterConstructLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestAfterConstructCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestAfterConstructCallback : quarkusTestAfterConstructLoader) {
-            afterConstructCallbacks.add(quarkusTestAfterConstructCallback);
-        }
-        ServiceLoader<?> quarkusTestBeforeEachLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestBeforeEachCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestBeforeEachCallback : quarkusTestBeforeEachLoader) {
-            beforeEachCallbacks.add(quarkusTestBeforeEachCallback);
-        }
-        ServiceLoader<?> quarkusTestBeforeTestLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestBeforeTestExecutionCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestBeforeTestCallback : quarkusTestBeforeTestLoader) {
-            beforeTestCallbacks.add(quarkusTestBeforeTestCallback);
-        }
-        ServiceLoader<?> quarkusTestAfterTestLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestAfterTestExecutionCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestAfterTestCallback : quarkusTestAfterTestLoader) {
-            afterTestCallbacks.add(quarkusTestAfterTestCallback);
-        }
-        ServiceLoader<?> quarkusTestAfterEachLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestAfterEachCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestAfterEach : quarkusTestAfterEachLoader) {
-            afterEachCallbacks.add(quarkusTestAfterEach);
-        }
-        ServiceLoader<?> quarkusTestAfterAllLoader = ServiceLoader
-                .load(Class.forName(QuarkusTestAfterAllCallback.class.getName(), false, classLoader), classLoader);
-        for (Object quarkusTestAfterAll : quarkusTestAfterAllLoader) {
-            afterAllCallbacks.add(quarkusTestAfterAll);
-        }
-    }
-
     private void populateTestMethodInvokers(ClassLoader quarkusClassLoader) {
         testMethodInvokers = new ArrayList<>();
         try {
@@ -420,19 +360,14 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
     @Override
     public void beforeTestExecution(ExtensionContext context) throws Exception {
-        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || beforeTestCallbacks.isEmpty()) {
+        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || isBeforeTestCallbacksEmpty()) {
             return;
         }
         if (!failedBoot) {
             ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
             try {
-                for (Object beforeTestCallback : beforeTestCallbacks) {
-                    Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
-                    beforeTestCallback.getClass().getMethod("beforeTestExecution", tuple.getKey())
-                            .invoke(beforeTestCallback, tuple.getValue());
-                }
-            } catch (InvocationTargetException e) {
-                throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
+                Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
+                invokeBeforeTestExecutionCallbacks(tuple.getKey(), tuple.getValue());
             } finally {
                 setCCL(original);
             }
@@ -452,11 +387,8 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
             try {
                 pushMockContext();
-                for (Object beforeEachCallback : beforeEachCallbacks) {
-                    Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
-                    beforeEachCallback.getClass().getMethod("beforeEach", tuple.getKey())
-                            .invoke(beforeEachCallback, tuple.getValue());
-                }
+                Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
+                invokeBeforeEachCallbacks(tuple.getKey(), tuple.getValue());
                 String endpointPath = getEndpointPath(context, testHttpEndpointProviders);
                 if (runningQuarkusApplication != null) {
                     boolean secure = false;
@@ -470,8 +402,6 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                     runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
                             .getDeclaredMethod("setup", boolean.class).invoke(null, false);
                 }
-            } catch (InvocationTargetException e) {
-                throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
             } finally {
                 setCCL(original);
             }
@@ -548,19 +478,14 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
     @Override
     public void afterTestExecution(ExtensionContext context) throws Exception {
-        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || afterTestCallbacks.isEmpty()) {
+        if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || isAfterTestCallbacksEmpty()) {
             return;
         }
         if (!failedBoot) {
             ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
             try {
-                for (Object afterTestCallback : afterTestCallbacks) {
-                    Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
-                    afterTestCallback.getClass().getMethod("afterTestExecution", tuple.getKey())
-                            .invoke(afterTestCallback, tuple.getValue());
-                }
-            } catch (InvocationTargetException e) {
-                throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
+                Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
+                invokeAfterTestExecutionCallbacks(tuple.getKey(), tuple.getValue());
             } finally {
                 setCCL(original);
             }
@@ -577,17 +502,12 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
             popMockContext();
             ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
             try {
-                for (Object afterEachCallback : afterEachCallbacks) {
-                    Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
-                    afterEachCallback.getClass().getMethod("afterEach", tuple.getKey())
-                            .invoke(afterEachCallback, tuple.getValue());
-                }
+                Map.Entry<Class<?>, ?> tuple = createQuarkusTestMethodContextTuple(context);
+                invokeAfterEachCallbacks(tuple.getKey(), tuple.getValue());
                 runningQuarkusApplication.getClassLoader().loadClass(RestAssuredURLManager.class.getName())
                         .getDeclaredMethod("clearURL").invoke(null);
                 runningQuarkusApplication.getClassLoader().loadClass(TestScopeManager.class.getName())
                         .getDeclaredMethod("tearDown", boolean.class).invoke(null, false);
-            } catch (InvocationTargetException e) {
-                throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
             } finally {
                 setCCL(original);
             }
@@ -792,21 +712,14 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         if (runningQuarkusApplication != null) {
             try {
                 Thread.currentThread().setContextClassLoader(runningQuarkusApplication.getClassLoader());
-                for (Object beforeClassCallback : beforeClassCallbacks) {
-                    beforeClassCallback.getClass().getMethod("beforeClass", Class.class).invoke(beforeClassCallback,
-                            runningQuarkusApplication.getClassLoader().loadClass(requiredTestClass.getName()));
-                }
-            } catch (InvocationTargetException e) {
-                throw e.getCause();
+                invokeBeforeClassCallbacks(Class.class,
+                        runningQuarkusApplication.getClassLoader().loadClass(requiredTestClass.getName()));
             } finally {
                 Thread.currentThread().setContextClassLoader(old);
             }
         } else {
             // can this ever happen?
-            for (Object beforeClassCallback : beforeClassCallbacks) {
-                beforeClassCallback.getClass().getMethod("beforeClass", Class.class).invoke(beforeClassCallback,
-                        requiredTestClass);
-            }
+            invokeBeforeClassCallbacks(Class.class, requiredTestClass);
         }
 
         try {
@@ -860,15 +773,9 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
                 actualTestInstance = createActualTestInstance(actualTestClass, state);
             }
 
-            for (Object afterConstructCallback : afterConstructCallbacks) {
-                afterConstructCallback.getClass().getMethod("afterConstruct", Object.class).invoke(afterConstructCallback,
-                        actualTestInstance);
-            }
+            invokeAfterConstructCallbacks(Object.class, actualTestInstance);
             for (Object outerInstance : outerInstances) {
-                for (Object afterConstructCallback : afterConstructCallbacks) {
-                    afterConstructCallback.getClass().getMethod("afterConstruct", Object.class).invoke(afterConstructCallback,
-                            outerInstance);
-                }
+                invokeAfterConstructCallbacks(Object.class, outerInstance);
             }
         } catch (Exception e) {
             throw new TestInstantiationException("Failed to create test instance",
@@ -1179,7 +1086,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
         if (isNativeOrIntegrationTest(context.getRequiredTestClass()) || failedBoot) {
             return;
         }
-        if (afterAllCallbacks.isEmpty()) {
+        if (isAfterAllCallbacksEmpty()) {
             return;
         }
 
@@ -1191,12 +1098,7 @@ public class QuarkusTestExtension extends AbstractJvmQuarkusTestExtension
 
         ClassLoader original = setCCL(runningQuarkusApplication.getClassLoader());
         try {
-            for (Object afterAllCallback : afterAllCallbacks) {
-                afterAllCallback.getClass().getMethod("afterAll", quarkusTestContextClass)
-                        .invoke(afterAllCallback, quarkusTestContextInstance);
-            }
-        } catch (InvocationTargetException e) {
-            throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
+            invokeAfterAllCallbacks(quarkusTestContextClass, quarkusTestContextInstance);
         } finally {
             setCCL(original);
         }


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/28402

Note that I had to add two "expensive" tests to verify that this works fine for nested tests and the callback integration. 

At the moment, I only add support for `@QuarkusIntegrationTest`, but in the future, we could add support also for `@QuarkusMainIntegrationTest`.