### PR TITLE
Prevent possible NPE when building violations report

### DIFF
--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationExceptionMapper.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/jaxrs/ResteasyReactiveViolationExceptionMapper.java
@@ -19,7 +19,9 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.jboss.resteasy.reactive.common.util.ServerMediaType;
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 
 @Provider
 public class ResteasyReactiveViolationExceptionMapper implements ExceptionMapper<ValidationException> {
@@ -75,8 +77,7 @@ public class ResteasyReactiveViolationExceptionMapper implements ExceptionMapper
         // Check standard media types.
         MediaType mediaType = ValidatorMediaTypeUtil.getAcceptMediaType(
                 rrContext.getHttpHeaders().getAcceptableMediaTypes(),
-                rrContext.getTarget() != null ? Arrays.asList(rrContext.getTarget().getProduces().getSortedMediaTypes())
-                        : SUPPORTED_MEDIA_TYPES);
+                serverMediaTypes(rrContext));
         if (mediaType == null) {
             mediaType = MediaType.APPLICATION_JSON_TYPE;
         }
@@ -89,6 +90,17 @@ public class ResteasyReactiveViolationExceptionMapper implements ExceptionMapper
         builder.type(mediaType);
 
         return builder.build();
+    }
+
+    private List<MediaType> serverMediaTypes(ResteasyReactiveRequestContext context) {
+        if (context.getTarget() == null) {
+            return SUPPORTED_MEDIA_TYPES;
+        }
+        ServerMediaType serverMediaType = context.getTarget().getProduces();
+        if (serverMediaType == null) {
+            return SUPPORTED_MEDIA_TYPES;
+        }
+        return Arrays.asList(serverMediaType.getSortedMediaTypes());
     }
 
 }

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/main/java/io/quarkus/it/hibernate/validator/HibernateValidatorTestResource.java
@@ -19,6 +19,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.hibernate.validator.constraints.Length;
 import org.jboss.resteasy.reactive.RestPath;
@@ -86,6 +87,12 @@ public class HibernateValidatorTestResource {
     @Path("/no-produces/{id}/")
     public String testRestEndPointWithNoProduces(@Digits(integer = 5, fraction = 0) @RestPath("id") String id) {
         return id;
+    }
+
+    @GET
+    @Path("/no-produces-with-response/{id}/")
+    public Response testRestEndPointWithNoProducesUsingResponse(@Digits(integer = 5, fraction = 0) @RestPath("id") String id) {
+        return Response.ok(id).build();
     }
 
     @GET

--- a/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
+++ b/integration-tests/hibernate-validator-resteasy-reactive/src/test/java/io/quarkus/it/hibernate/validator/HibernateValidatorFunctionalityTest.java
@@ -170,6 +170,15 @@ public class HibernateValidatorFunctionalityTest {
     }
 
     @Test
+    public void testNoProducesWithResponse() {
+        RestAssured.given()
+                .get("/hibernate-validator/test/no-produces-with-response/plop/")
+                .then()
+                .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+                .body(containsString("numeric value out of bounds"));
+    }
+
+    @Test
     public void testRestEndPointReturnValueValidation() {
         // https://github.com/quarkusio/quarkus/issues/9174
         // Constraint validation exceptions thrown by Resteasy and related to return values


### PR DESCRIPTION
The NPE could happen when Response was used as a return type and no `@Produces` annotation was present.

Fixes: https://github.com/quarkusio/quarkus-workshops/issues/183