### PR TITLE
go-offline: initialize Maven artifact resolver with the current project dir

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GoOfflineMojo.java
@@ -102,6 +102,7 @@ public class GoOfflineMojo extends AbstractMojo {
     private MavenArtifactResolver getResolver() throws MojoExecutionException {
         try {
             return MavenArtifactResolver.builder()
+                    .setCurrentProject(project.getBasedir().toString())
                     .setRemoteRepositoryManager(remoteRepositoryManager)
                     .setRemoteRepositories(repos)
                     .setPreferPomsFromWorkspace(true)


### PR DESCRIPTION
Fix https://github.com/quarkusio/quarkus/issues/27615
