### PR TITLE
Bump Reactive Messaging version to 3.21.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -52,7 +52,7 @@
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.27.0</smallrye-mutiny-vertx-binding.version>
-        <smallrye-reactive-messaging.version>3.20.0</smallrye-reactive-messaging.version>
+        <smallrye-reactive-messaging.version>3.21.0</smallrye-reactive-messaging.version>
         <smallrye-stork.version>1.3.0</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -619,7 +619,7 @@ recipeList:
       newValue: 3.0.0-RC1
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-reactive-messaging.version
-      newValue: 4.0.0.RC3
+      newValue: 4.0.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-rest-client.version
       newValue: 3.0
@@ -671,7 +671,7 @@ recipeList:
       newValue: 3.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-reactive-messaging-tck.version
-      newValue: 3.0-RC2
+      newValue: 3.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-rest-client-tck.version
       newValue: 3.0


### PR DESCRIPTION
Change jakarta rewrite versions smallrye-reactive-messaging -> 4.0.0, microprofile reactive messaging -> 3.0.0

Closes #28420