### PR TITLE
Fix RESTEasy Reactive Kotlin serialization extensions

### DIFF
--- a/devtools/bom-descriptor-json/pom.xml
+++ b/devtools/bom-descriptor-json/pom.xml
@@ -2204,6 +2204,19 @@
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-resteasy-reactive-links</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -2190,6 +2190,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization;
+package io.quarkus.resteasy.reactive.kotlin.serialization.common.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
@@ -7,6 +7,8 @@ import javax.inject.Singleton;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime.KotlinSerializationConfig;
+import io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime.KotlinSerializerRecorder;
 import kotlinx.serialization.json.Json;
 
 public class KotlinSerializationCommonProcessor {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/pom.xml
@@ -18,7 +18,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/pom.xml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/pom.xml
@@ -13,8 +13,32 @@
     <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
     <name>Quarkus - RESTEasy Reactive - Kotlin Serialization Common</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-serialization-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
@@ -90,25 +114,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kotlin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-serialization-json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
 </project>

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/JsonConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/JsonConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization;
+package io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime;
 
 import java.util.StringJoiner;
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/KotlinSerializationConfig.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/KotlinSerializationConfig.java
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization;
+package io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime;
 
 import java.util.StringJoiner;
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/KotlinSerializerRecorder.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/common/runtime/KotlinSerializerRecorder.kt
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization
+package io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime
 
 import io.quarkus.runtime.annotations.Recorder
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+name: "RESTEasy Reactive Kotlin Serialization Common"
+metadata:
+  keywords:
+  - "resteasy reactive"
+  - "kotlin"
+  - "serialization"
+  categories:
+  - "web"
+  status: "stable"
+  unlisted: true

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/test/java/io/quarkus/kotlin/serialization/JsonConfigTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/runtime/src/test/java/io/quarkus/kotlin/serialization/JsonConfigTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime.JsonConfig;
 import kotlinx.serialization.json.JsonConfiguration;
 
 public class JsonConfigTest {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/deployment/KotlinSerializationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/deployment/KotlinSerializationProcessor.java
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization.deployment;
+package io.quarkus.resteasy.reactive.kotlin.serialization.deployment;
 
 import static io.quarkus.deployment.Feature.RESTEASY_REACTIVE_KOTLIN_SERIALIZATION;
 import static io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem.json;
@@ -20,9 +20,9 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.kotlin.serialization.KotlinSerializationMessageBodyReader;
-import io.quarkus.kotlin.serialization.KotlinSerializationMessageBodyWriter;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
+import io.quarkus.resteasy.reactive.kotlin.serialization.runtime.KotlinSerializationMessageBodyReader;
+import io.quarkus.resteasy.reactive.kotlin.serialization.runtime.KotlinSerializationMessageBodyWriter;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterBuildItem;
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/runtime/KotlinSerializationMessageBodyReader.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/runtime/KotlinSerializationMessageBodyReader.kt
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization
+package io.quarkus.resteasy.reactive.kotlin.serialization.runtime
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/runtime/KotlinSerializationMessageBodyWriter.kt
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/runtime/src/main/kotlin/io/quarkus/resteasy/reactive/kotlin/serialization/runtime/KotlinSerializationMessageBodyWriter.kt
@@ -1,4 +1,4 @@
-package io.quarkus.kotlin.serialization
+package io.quarkus.resteasy.reactive.kotlin.serialization.runtime
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json


### PR DESCRIPTION
- Fix split packages and make sure they are more future-proof
- Fix extension metadata and Maven plugin for the Common extension

Originally reported here: https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/Kotlinx.2Eserialization.20missing.20in.20all.20configuration.20options.3F
Initial issue was that the Kotlin Serialization doc was not accessible anymore in the all-config page.

Creating as draft for now to get CI feedback.