### PR TITLE
H2 reflection extensions via GraalVM Feature

### DIFF
--- a/extensions/jdbc/jdbc-h2/deployment/src/main/java/io/quarkus/jdbc/h2/deployment/H2JDBCReflections.java
+++ b/extensions/jdbc/jdbc-h2/deployment/src/main/java/io/quarkus/jdbc/h2/deployment/H2JDBCReflections.java
@@ -1,8 +1,25 @@
 package io.quarkus.jdbc.h2.deployment;
 
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.h2.mvstore.type.DataType;
+import org.h2.mvstore.type.StatefulDataType;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.NativeImageFeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
+import io.quarkus.jdbc.h2.runtime.H2Reflections;
 
 /**
  * Registers the {@code org.h2.Driver} so that it can be loaded
@@ -19,6 +36,51 @@ public final class H2JDBCReflections {
         //We register it for the sake of people not using Agroal.
         final String driverName = "org.h2.Driver";
         reflectiveClass.produce(new ReflectiveClassBuildItem(false, false, driverName));
+    }
+
+    @BuildStep
+    NativeImageFeatureBuildItem enableH2Feature() {
+        return new NativeImageFeatureBuildItem("io.quarkus.jdbc.h2.runtime.H2Reflections");
+    }
+
+    /**
+     * We need to index the H2 database core jar so to include custom extension types it's
+     * loading via reflection.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    IndexDependencyBuildItem indexH2Library() {
+        return new IndexDependencyBuildItem("com.h2database", "h2");
+    }
+
+    /**
+     * All implementors of {@link StatefulDataType.Factory} might get loaded reflectively.
+     * While we could hardcode the list included in H2, we prefer looking them up via Jandex
+     * so to also load custom implementations optionally provided by user code.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    GeneratedResourceBuildItem listStatefulDataTypeFactories(CombinedIndexBuildItem index) {
+        return generateListBy(H2Reflections.REZ_NAME_STATEFUL_DATATYPES, index,
+                i -> i.getAllKnownImplementors(StatefulDataType.Factory.class).stream());
+    }
+
+    /**
+     * All implementors of {@link DataType} which have an INSTANCE field
+     * need this field to be accessible via reflection.
+     * While we could hardcode the list included in H2, we prefer looking them up via Jandex
+     * so to also load custom implementations optionally provided by user code.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    GeneratedResourceBuildItem listBasicDataTypes(CombinedIndexBuildItem index) {
+        return generateListBy(H2Reflections.REZ_NAME_DATA_TYPE_SINGLETONS, index,
+                i -> i.getAllKnownImplementors(DataType.class)
+                        .stream().filter(classInfo -> classInfo.field("INSTANCE") != null));
+    }
+
+    private static GeneratedResourceBuildItem generateListBy(String resourceName, CombinedIndexBuildItem index,
+            Function<IndexView, Stream<ClassInfo>> selection) {
+        String classNames = selection.apply(index.getIndex()).map(ClassInfo::name).map(DotName::toString).sorted()
+                .collect(Collectors.joining("\n"));
+        return new GeneratedResourceBuildItem(resourceName, classNames.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2Reflections.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/H2Reflections.java
@@ -1,0 +1,73 @@
+package io.quarkus.jdbc.h2.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Scanner;
+import java.util.function.BiConsumer;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+/**
+ * Custom GraalVM feature to automatically register DataType and StatefulDataType
+ * implementors for reflective access.
+ * These are identified using Jandex, looking both into the H2 core jar and in
+ * user's indexed code.
+ */
+public final class H2Reflections implements Feature {
+
+    public static final String REZ_NAME_DATA_TYPE_SINGLETONS = "h2BasicDataTypeSingletons.classlist";
+    public static final String REZ_NAME_STATEFUL_DATATYPES = "h2StatefulDataType.classlist";
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        Class<?> metaType = access.findClassByName("org.h2.mvstore.type.MetaType");
+        access.registerReachabilityHandler(this::metaTypeReachable, metaType);
+    }
+
+    private void metaTypeReachable(DuringAnalysisAccess access) {
+        //Register some common metatypes - these are dynamically loaded depending on the data content.
+        register(REZ_NAME_DATA_TYPE_SINGLETONS, this::registerSingletonAccess, access);
+        //Now register implementors of org.h2.mvstore.type.StatefulDataType.Factory
+        register(REZ_NAME_STATEFUL_DATATYPES, this::registerForReflection, access);
+    }
+
+    void register(final String resourceName, BiConsumer<String, DuringAnalysisAccess> action, DuringAnalysisAccess access) {
+        try (InputStream resource = access.getApplicationClassLoader().getResourceAsStream(resourceName)) {
+            Scanner s = new Scanner(resource);
+            while (s.hasNext()) {
+                final String className = s.next();
+                action.accept(className, access);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void registerSingletonAccess(String className, DuringAnalysisAccess access) {
+        try {
+            final Field instance = access.findClassByName(className)
+                    .getDeclaredField("INSTANCE");
+            RuntimeReflection.register(instance);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void registerForReflection(
+            String className,
+            DuringAnalysisAccess duringAnalysisAccess) {
+        final Class<?> aClass = duringAnalysisAccess.findClassByName(className);
+        final Constructor<?>[] z = aClass.getDeclaredConstructors();
+        RuntimeReflection.register(aClass);
+        RuntimeReflection.register(z);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Support for H2 Database's extended data types";
+    }
+
+}

--- a/integration-tests/jpa-h2-embedded/src/main/resources/application.properties
+++ b/integration-tests/jpa-h2-embedded/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000
+#Test with H2 writing to actual disk, as it provides a superset coverage over testing in memory:
+quarkus.datasource.jdbc.url=jdbc:h2:./target/h2.db
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.datasource.jdbc.max-size=2


### PR DESCRIPTION
This is a follow up on #28409 , improving on missing reflective registrations which I hadn't initially spotted.

It's using a new pattern; wondering if we could use a general purpose helper to register reflection in this way: some of the input is dynamic, but I'm also registering them conditionally based on reachability.
Previously we had only examples of conditional registrations having a static list; or dynamically registered reflections - but not conditional.

Essentially this is what I do:

during the augmentation phase the dynamic types that need registration are being identified, and stored in text files which are included as resources. I need two different resources, for two different lists which need to be processed separately.
During native-image processing a custom GraalVM Feature loads these resources, and combines them with reachability information.

It's quite simple, but there's a fair bit of cerimony as we don't support this with existing APIs.