### PR TITLE
Funqy Knative Events - filter by attribute when trigger is function name

### DIFF
--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithAttributeFilter.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithAttributeFilter.java
@@ -12,6 +12,15 @@ import io.smallrye.mutiny.Uni;
 public class WithAttributeFilter {
 
     @Funq
+    @CloudEventMapping(attributes = { @EventAttribute(name = "source", value = "mytestvalue") })
+    public String listOfStrings(List<Identity> identityList) {
+        return identityList
+                .stream()
+                .map(Identity::getName)
+                .collect(Collectors.joining(":"));
+    }
+
+    @Funq
     @CloudEventMapping(trigger = "listOfStrings", attributes = { @EventAttribute(name = "source", value = "testvalue") })
     public String toCommaSeparated(List<Identity> identityList) {
         return identityList

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithAttributeFilterTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithAttributeFilterTest.java
@@ -16,6 +16,19 @@ public class WithAttributeFilterTest {
                     .addClasses(WithAttributeFilter.class, Identity.class));
 
     @Test
+    public void testTriggerAsFuncNameFilterMatch() {
+        RestAssured.given().contentType("application/json")
+                .body("[{\"name\": \"Bill\"}, {\"name\": \"Matej\"}]")
+                .header("ce-id", "42")
+                .header("ce-type", "listOfStrings")
+                .header("ce-source", "mytestvalue")
+                .header("ce-specversion", "1.0")
+                .post("/")
+                .then().statusCode(200)
+                .body(equalTo("\"Bill:Matej\""));
+    }
+
+    @Test
     public void testAttributeFilterMatch() {
         RestAssured.given().contentType("application/json")
                 .body("[{\"name\": \"Bill\"}, {\"name\": \"Matej\"}]")

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithConflictingAttributeFilterAndTriggerAsFuncName.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithConflictingAttributeFilterAndTriggerAsFuncName.java
@@ -1,0 +1,24 @@
+package io.quarkus.funqy.test;
+
+import java.util.List;
+
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+import io.quarkus.funqy.knative.events.EventAttribute;
+
+public class WithConflictingAttributeFilterAndTriggerAsFuncName {
+
+    @Funq
+    @CloudEventMapping
+    public String listOfStrings(List<Identity> identityList) {
+        return "";
+    }
+
+    @Funq
+    @CloudEventMapping(trigger = "listOfStrings", attributes = {
+            @EventAttribute(name = "source", value = "test") })
+    public String bar(List<Identity> identityList) {
+        return "";
+    }
+
+}

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithConflictingAttributeFilterAndTriggerAsFuncNameTest.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithConflictingAttributeFilterAndTriggerAsFuncNameTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 
-public class WithDuplicateAttributeFilterTest {
+public class WithConflictingAttributeFilterAndTriggerAsFuncNameTest {
 
     @RegisterExtension
     static QuarkusUnitTest test = new QuarkusUnitTest().assertException(t -> {
@@ -25,7 +25,7 @@ public class WithDuplicateAttributeFilterTest {
         assertTrue(found, "Build failed with wrong exception, expected IllegalStateException but got " + t);
     })
             .withApplicationRoot((jar) -> jar
-                    .addClasses(WithDuplicateAttributeFilter.class, Identity.class));
+                    .addClasses(WithConflictingAttributeFilterAndTriggerAsFuncName.class, Identity.class));
 
     @Test
     public void testAttributeFilterMatch() {
@@ -33,18 +33,6 @@ public class WithDuplicateAttributeFilterTest {
                 .body("[{\"name\": \"Bill\"}, {\"name\": \"Matej\"}]")
                 .header("ce-id", "42")
                 .header("ce-type", "listOfStrings")
-                .header("ce-source", "test")
-                .header("ce-specversion", "1.0")
-                .post("/")
-                .then().statusCode(404);
-    }
-
-    @Test
-    public void testAttributeFilterMatchAndTriggerAsFuncName() {
-        RestAssured.given().contentType("application/json")
-                .body("[{\"name\": \"Bill\"}, {\"name\": \"Matej\"}]")
-                .header("ce-id", "42")
-                .header("ce-type", "toDashSeparated")
                 .header("ce-source", "test")
                 .header("ce-specversion", "1.0")
                 .post("/")

--- a/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithDuplicateAttributeFilter.java
+++ b/extensions/funqy/funqy-knative-events/deployment/src/test/java/io/quarkus/funqy/test/WithDuplicateAttributeFilter.java
@@ -27,4 +27,22 @@ public class WithDuplicateAttributeFilter {
                 .collect(Collectors.joining(";"));
     }
 
+    @Funq
+    @CloudEventMapping(trigger = "toDashSeparated", attributes = { @EventAttribute(name = "source", value = "test") })
+    public String toDashSeparated(List<Identity> identityList) {
+        return identityList
+                .stream()
+                .map(Identity::getName)
+                .collect(Collectors.joining("-"));
+    }
+
+    @Funq
+    @CloudEventMapping(trigger = "toDashSeparated", attributes = { @EventAttribute(name = "source", value = "test") })
+    public String toColonSeparated(List<Identity> identityList) {
+        return identityList
+                .stream()
+                .map(Identity::getName)
+                .collect(Collectors.joining(":"));
+    }
+
 }

--- a/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
+++ b/extensions/funqy/funqy-knative-events/runtime/src/main/java/io/quarkus/funqy/runtime/bindings/knative/events/KnativeEventsBindingRecorder.java
@@ -74,8 +74,12 @@ public class KnativeEventsBindingRecorder {
             String trigger;
             CloudEventMapping annotation = method.getAnnotation(CloudEventMapping.class);
             final List<Predicate<CloudEvent>> filter;
-            if (annotation != null && !annotation.trigger().isEmpty()) {
-                trigger = annotation.trigger();
+            if (annotation != null) {
+                if (!annotation.trigger().isEmpty()) {
+                    trigger = annotation.trigger();
+                } else {
+                    trigger = invoker.getName();
+                }
                 filter = filter(invoker.getName(), annotation);
             } else {
                 trigger = invoker.getName();


### PR DESCRIPTION
fixes: #28493

Attributes filter will be applied whether I specify trigger via `io.quarkus.funqy.knative.events.CloudEventMapping#trigger` or function name.