### PR TITLE
Support a silent mode for JWTAuthMechanism

### DIFF
--- a/extensions/smallrye-jwt/deployment/pom.xml
+++ b/extensions/smallrye-jwt/deployment/pom.xml
@@ -29,7 +29,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonp-deployment</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-jwt</artifactId>
@@ -49,6 +48,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/SilentModeUnitTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/SilentModeUnitTest.java
@@ -1,0 +1,32 @@
+package io.quarkus.jwt.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class SilentModeUnitTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(DefaultGroupsEndpoint.class)
+                    .addAsResource("publicKey.pem")
+                    .addAsResource("applicationJwtFormAuth.properties", "application.properties"));
+
+    @Test
+    public void testFormChallengeWithoutAuthorizationHeader() {
+        RestAssured.given().redirects().follow(false)
+                .get("/endp/echo")
+                .then().assertThat().statusCode(302);
+    }
+
+    @Test
+    public void testJwtChallengeWithAuthorizationHeader() {
+        RestAssured.given().auth()
+                .oauth2("123")
+                .get("/endp/routingContext")
+                .then().assertThat().statusCode(401);
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtFormAuth.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtFormAuth.properties
@@ -1,0 +1,13 @@
+mp.jwt.verify.publickey.location=/publicKey.pem
+mp.jwt.verify.issuer=https://server.example.com
+quarkus.smallrye-jwt.enabled=true
+
+quarkus.smallrye-jwt.silent=true
+
+quarkus.http.auth.form.enabled=true
+quarkus.http.auth.form.login-page=login
+quarkus.http.auth.form.landing-page=landing
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.alice=alice
+quarkus.security.users.embedded.roles.alice=admin

--- a/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
+++ b/extensions/smallrye-jwt/runtime/src/main/java/io/quarkus/smallrye/jwt/runtime/auth/SmallRyeJwtConfig.java
@@ -13,4 +13,19 @@ public class SmallRyeJwtConfig {
      */
     @ConfigItem(defaultValue = "false")
     public boolean blockingAuthentication;
+
+    /**
+     * Always create HTTP 401 challenge, even for requests containing no authentication credentials.
+     *
+     * JWT authentication mechanism will return HTTP 401 when an authentication challenge is required.
+     * However if it is used alongside one of the interactive authentication mechanisms then returning HTTP 401
+     * to the users accessing the application from a browser may not be desired.
+     *
+     * If you prefer you can request that JWT authentication mechanism does not create a challenge in such cases
+     * by setting this property to 'true'.
+     *
+     */
+    @ConfigItem
+    public boolean silent;
+
 }


### PR DESCRIPTION
Related to #28247.

Hi @FroMage, IMHO this is the best we can do - `JWT` mechanism is not aware of other mechanisms, `Basic+Form` is a special combination, they are built in mechanisms, `vertx-http` knows if both are enabled or not; but also using a silent mode by default appears to be wrong as we can have a case where for example JWT is restricted to a specific path only - which JWT is not aware of - and then returning 302 would be wrong.

So the application which needs it will just enable a `silent` mode for JWT.

The only problem with this PR I just can't get the test passing, because `FormAuthenticationMechanism` (or some custom mechanism - I've tried) is not registered, for some reasons it just does not work in `smallrye-jwt/deployment` and creating a new integration test for it seems a bit too much. 

Can you please try this PR in Renarde ? If it works then I guess we can just commit the main source update only as the change is trivial