### PR TITLE
Don't use `--add-modules` with GraalVM < 22.0.0.2

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -870,7 +870,8 @@ public class NativeImageBuildStep {
                         }
                     }
                 }
-                if (enableModules != null && enableModules.size() > 0) {
+                if (!graalVMVersion.isOlderThan(GraalVM.Version.VERSION_22_0_0_2)
+                        && enableModules != null && enableModules.size() > 0) {
                     String modules = enableModules.stream().map(NativeImageEnableModule::getModuleName).distinct().sorted()
                             .collect(Collectors.joining(","));
                     nativeImageArgs.add("--add-modules=" + modules);


### PR DESCRIPTION
Support for `--add-modules` was added in 22.0.0.2
https://github.com/oracle/graal/commit/f7b98697f1506ddb4cd317aa2b1b57748d03d986

Fixes #28475