### PR TITLE
Enable more config providers for code generators except those found in the root app module

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/CodeGenWatcher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/CodeGenWatcher.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.app.CuratedApplication;
@@ -33,13 +34,15 @@ class CodeGenWatcher {
             final Collection<FSWatchUtil.Watcher> watchers = new ArrayList<>(codeGens.size());
             final Properties properties = new Properties();
             properties.putAll(context.getBuildSystemProperties());
+            final Config config = CodeGenerator.getConfig(curatedApplication.getApplicationModel(), LaunchMode.DEVELOPMENT,
+                    properties, deploymentClassLoader);
             for (CodeGenData codeGen : codeGens) {
                 watchers.add(new FSWatchUtil.Watcher(codeGen.sourceDir, codeGen.provider.inputExtension(),
                         modifiedPaths -> {
                             try {
                                 CodeGenerator.trigger(deploymentClassLoader,
                                         codeGen,
-                                        curatedApplication.getApplicationModel(), properties, LaunchMode.DEVELOPMENT, false);
+                                        curatedApplication.getApplicationModel(), config, false);
                             } catch (Exception any) {
                                 log.warn("Code generation failed", any);
                             }

--- a/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -72,7 +72,7 @@ public class GenerateCodeMojo extends QuarkusBootstrapMojo {
             Thread.currentThread().setContextClassLoader(deploymentClassLoader);
 
             final Class<?> codeGenerator = deploymentClassLoader.loadClass("io.quarkus.deployment.CodeGenerator");
-            final Method initAndRun = codeGenerator.getMethod("initAndRun", ClassLoader.class, PathCollection.class,
+            final Method initAndRun = codeGenerator.getMethod("initAndRun", QuarkusClassLoader.class, PathCollection.class,
                     Path.class, Path.class,
                     Consumer.class, ApplicationModel.class, Properties.class, String.class,
                     boolean.class);

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -48,6 +48,15 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         return ((QuarkusClassLoader) ccl).getElementsWithResource(resourceName, localOnly);
     }
 
+    public List<ClassPathElement> getAllElements(boolean localOnly) {
+        List<ClassPathElement> ret = new ArrayList<>();
+        if (parent instanceof QuarkusClassLoader && !localOnly) {
+            ret.addAll(((QuarkusClassLoader) parent).getAllElements(localOnly));
+        }
+        ret.addAll(elements);
+        return ret;
+    }
+
     /**
      * Indicates if a given class is present at runtime.
      *


### PR DESCRIPTION
Currently the config passed to the code generators is missing a lot of config sources compared to the original config built for the application. This change enables most of them except config providers found in the root application module because those haven't been compiled yet when running in dev mode.
This change also makes sure the `Config` instance is created once for all the providers and source paths, instead of number of providers * number of source paths.

Fixes https://github.com/quarkiverse/quarkus-openapi-generator/issues/131

