### PR TITLE
Let RESTEasy Reactive exception mappers handle authentication failure with disabled proactive security

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/FormAuthRedirectTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/FormAuthRedirectTestCase.java
@@ -1,0 +1,56 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+
+public class FormAuthRedirectTestCase {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.form.enabled=true\n"), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testFormAuthFailure() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .filter(new CookieFilter())
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "a d m i n")
+                .formParam("j_password", "wrongpassword")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(302)
+                .header("location", containsString("/error"))
+                .header("quarkus-credential", nullValue());
+    }
+
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/RouteBuildItem.java
@@ -146,6 +146,19 @@ public final class RouteBuildItem extends MultiBuildItem {
             return this;
         }
 
+        /**
+         * @param route A normalized path used to define a basic route
+         *        (e.g. use HttpRootPathBuildItem to construct/resolve the path value). This path this is also
+         *        used on the "Not Found" page in dev mode.
+         * @param order Priority ordering of the route
+         * @param routeCustomizer Route customizer.
+         */
+        public Builder orderedRoute(String route, Integer order, Consumer<Route> routeCustomizer) {
+            this.routeFunction = new BasicRoute(route, order, routeCustomizer);
+            this.notFoundPagePath = this.routePath = route;
+            return this;
+        }
+
         public Builder handler(Handler<RoutingContext> handler) {
             this.handler = handler;
             return this;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/RestInitialHandler.java
@@ -41,10 +41,18 @@ public class RestInitialHandler implements ServerRestHandler {
         this.requestContextFactory = deployment.getRequestContextFactory();
     }
 
-    public void beginProcessing(Object extenalHttpContext) {
-        ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, extenalHttpContext,
+    public void beginProcessing(Object externalHttpContext) {
+        ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, externalHttpContext,
                 requestContext,
                 initialChain, deployment.getAbortHandlerChain());
+        rq.run();
+    }
+
+    public void beginProcessing(Object externalHttpContext, Throwable throwable) {
+        ResteasyReactiveRequestContext rq = requestContextFactory.createContext(deployment, externalHttpContext,
+                requestContext,
+                initialChain, deployment.getAbortHandlerChain());
+        rq.handleException(throwable);
         rq.run();
     }
 

--- a/integration-tests/elytron-resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/elytron/AuthenticationFailedExceptionMapper.java
+++ b/integration-tests/elytron-resteasy-reactive/src/main/java/io/quarkus/it/resteasy/reactive/elytron/AuthenticationFailedExceptionMapper.java
@@ -1,0 +1,19 @@
+package io.quarkus.it.resteasy.reactive.elytron;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.quarkus.security.AuthenticationFailedException;
+
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class AuthenticationFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
+
+    @Override
+    public Response toResponse(AuthenticationFailedException exception) {
+        return Response.status(401).entity("customized").build();
+    }
+}

--- a/integration-tests/elytron-resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/elytron/ExceptionMapperTest.java
+++ b/integration-tests/elytron-resteasy-reactive/src/test/java/io/quarkus/it/resteasy/reactive/elytron/ExceptionMapperTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.it.resteasy.reactive.elytron;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@TestProfile(value = ExceptionMapperTest.ExceptionMapperTestProfile.class)
+@QuarkusTest
+public class ExceptionMapperTest {
+
+    @Test
+    public void testCustomExceptionMapper() {
+        given()
+                .when()
+                .auth().preemptive().basic("unknownUsername", "unknownPassword")
+                .get("/fruit/all-with-security")
+                .then()
+                .statusCode(401)
+                .body(Matchers.equalTo("customized"));
+    }
+
+    public static class ExceptionMapperTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http.auth.proactive", "false",
+                    "quarkus.http.auth.permission.default.paths", "/*",
+                    "quarkus.http.auth.permission.default.policy", "authenticated");
+        }
+    }
+
+}


### PR DESCRIPTION
fixes: #25732
fixes:  #22971
fixes: #26314 (for proactive=false)

There are situations (e.g. permissions check, see #22971) when authentication is performed before RESTEasy Reactive begin processing, thus simply removing default authentication failure handler won't do. Users expects that exceptions mappers are going to be invoked (which is not a case).

This PR provides it's own auth failure handler that fails the event and let RR abort handlers to deal with exceptions. It intentionally handles only `proactive=false` scenarios (still, it fixes linked issues). It's necessary to differ between situations when RR begun procession (then we shouldn't fail event as it would be handled by both failure handlers and abort handlers) and didn't begin processing. I added `ExceptionMapperTest`, IT version can't be added as it requires disabled proactive security (build time property, so test profile won't do), we don't have suitable module for this.