### PR TITLE
get method doesn't return the value in hash group code snippet in redis reference

### DIFF
--- a/docs/src/main/asciidoc/redis-reference.adoc
+++ b/docs/src/main/asciidoc/redis-reference.adoc
@@ -304,7 +304,7 @@ public class MyRedisService {
     }
 
     public Person get(String field) {
-        commands.hget(MY_KEY, field);  // <4>
+        return commands.hget(MY_KEY, field);  // <4>
     }
 }
 ----


### PR DESCRIPTION
get method doesn't return the value in hash group code snippet in redis reference
https://github.com/quarkusio/quarkusio.github.io/issues/1554