### PR TITLE
Adds `DelayedAttributes#toString()` for debugging

### DIFF
--- a/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DelayedAttributes.java
+++ b/extensions/opentelemetry/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/DelayedAttributes.java
@@ -83,6 +83,15 @@ public class DelayedAttributes implements Attributes {
         return delegate.toBuilder();
     }
 
+    @Override
+    public String toString() {
+        if (delegate == null) {
+            logDelegateNotFound();
+            return "{}";
+        }
+        return delegate.toString();
+    }
+
     /**
      * If we haven't previously logged an error,
      * log an error about a missing {@code delegate} and set {@code warningLogged=true}


### PR DESCRIPTION
For test assertions on `SpanData` objects (e.g. via AssertJ assertions) it would be useful if `DelayedAttributes` would implement `toString()`.