### PR TITLE
Add the mvnDebug run configuration for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target
 *.iml
 .idea
+!.idea/runConfigurations
 .settings
 .project
 .classpath

--- a/.idea/runConfigurations/mvnDebug.xml
+++ b/.idea/runConfigurations/mvnDebug.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mvnDebug" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="8000" />
+    <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="8000" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
Quarkus developers that have to debug the core code, often find themselves using `mvnDebug`, as it's a very way to debug any code launched (and not forked) by Maven. This change makes sure that when importing the project into IntelliJ a remote debug configuration matching the settings used by `mvnDebug` is automatically setup