### PR TITLE
Validate media types for sub resources in Resteasy Reactive

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SimpleQuarkusRestTestCase.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.emptyString;
 
 import java.util.function.Supplier;
 
+import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.http.Headers;
 
 public class SimpleQuarkusRestTestCase {
@@ -107,6 +109,12 @@ public class SimpleQuarkusRestTestCase {
                 .then().body(Matchers.equalTo("otherSub"));
         RestAssured.get("/simple/sub")
                 .then().body(Matchers.equalTo("sub"));
+
+        RestAssured.with()
+                .contentType(ContentType.JSON)
+                .body("{\"test\": true}")
+                .patch("/simple/sub/patch/text")
+                .then().statusCode(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SubResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/simple/SubResource.java
@@ -1,7 +1,10 @@
 package io.quarkus.resteasy.reactive.server.test.simple;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
 
 public class SubResource {
 
@@ -14,5 +17,12 @@ public class SubResource {
     @Path("otherSub")
     public String otherPath() {
         return "otherSub";
+    }
+
+    @Path("patch/text")
+    @PATCH
+    @Consumes(MediaType.TEXT_PLAIN)
+    public String patchWithTextPlain(String patch) {
+        return "test-value: " + patch;
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeResourceDeployment.java
@@ -312,8 +312,8 @@ public class RuntimeResourceDeployment {
                 // we only need to parse the signature and create generic type when the declared type differs from the type
                 genericType = TypeSignatureParser.parse(bodyParameter.signature);
             }
-            handlers.add(new RequestDeserializeHandler(typeClass, genericType,
-                    consumesMediaTypes.isEmpty() ? null : consumesMediaTypes.get(0), serialisers, bodyParameterIndex));
+            handlers.add(new RequestDeserializeHandler(typeClass, genericType, consumesMediaTypes, serialisers,
+                    bodyParameterIndex));
         }
 
         // given that we may inject form params in the endpoint we need to make sure we read the body before


### PR DESCRIPTION
At the moment, there are two places where resteasy reactive is verifying the media types: (1) at the handler `ClassRoutingHandler` only for the main resources (it's not invoked for sub-resources, and (2) at the handler `RequestDeserializeHandler` for the rest.  

The issue is that the verification at `RequestDeserializeHandler` takes the one from the user which might not be compatible with the one set by the user using the annotation `@Consumes`.  

Note that I tried to make this handler be invoked also for sub-resources but it caused more troubles and it would not fix the root cause of the issue that is the logic in the handler `RequestDeserializeHandler` is wrong.  

Fix https://github.com/quarkusio/quarkus/issues/28460