### PR TITLE
Native TS, Enables WebJarResourceIT.java

### DIFF
--- a/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceIT.java
+++ b/integration-tests/webjars-locator/src/test/java/io/quarkus/it/webjar/locator/WebJarResourceIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.it.webjar.locator;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @QuarkusIntegrationTest
-@Disabled("https://github.com/quarkusio/quarkus/issues/22718")
 public class WebJarResourceIT extends WebJarResourceTest {
 }


### PR DESCRIPTION
See #22718 #22719

I don't think this should be disabled any more. I have failed to reproduce it with Quarkus 2.13.2.Final, both RHEL 8 and CentOS 8, both local Mandrel, Docker driven builder image and Podman driven builder image. Used Mandrel versions:

* native-image 23.0.0-devc32df52b0da Mandrel Distribution (Java Version 17.0.5-beta+7-202210062307)
* 22.3.0.0-1b2 Mandrel Distribution (Java Version 17.0.4.1+1-LTS)

The test seems to be passing just fine in ~45 runs.

If it fails somewhere and becomes labeled as
https://github.com/quarkusio/quarkus/labels/triage%2Fflaky-test we will debug it.