### PR TITLE
Set logging manager for Gradle test task in codestart

### DIFF
--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle-kotlin-dsl/base/build-layout.include.qute
@@ -59,3 +59,7 @@ java {
     {/if}
 }
 {/}
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/gradle/base/build-layout.include.qute
@@ -55,3 +55,7 @@ java {
     {/if}
 }
 {/}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/build.gradle.kts
@@ -34,6 +34,7 @@ subprojects {
           dependsOn("cleanTest")
           useJUnitPlatform()
           setForkEvery(1)
+          systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
       }
     }
 

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/build.gradle
@@ -31,6 +31,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module-kts/build.gradle.kts
@@ -31,3 +31,7 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     options.compilerArgs.add("-parameters")
 }
+
+tasks.withType<Test> {
+    systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
+}

--- a/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/add-remove-extension-single-module/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
+++ b/integration-tests/gradle/src/main/resources/additional-source-sets/build.gradle
@@ -51,4 +51,9 @@ task functionalTest(type: Test, description: 'Functional tests', dependsOn: [pro
         showStandardStreams = true
     }
     systemProperty 'quarkus.http.host', 'localhost'
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
 }

--- a/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-multi-module/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/annotation-processor-simple-module/build.gradle
@@ -10,6 +10,7 @@ test {
     dependsOn 'cleanTest'
     useJUnitPlatform()
     forkEvery 1
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
 }
 
 repositories {

--- a/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-application-project/build.gradle
@@ -32,3 +32,7 @@ run {
         systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
     }
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/build.gradle
@@ -25,3 +25,7 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-native-module/build.gradle
@@ -34,3 +34,7 @@ quarkusBuild {
         additionalArgs= ["--verbose"]
     }
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/build.gradle
@@ -24,3 +24,7 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/build.gradle
@@ -23,4 +23,5 @@ subprojects{
           }
           mavenCentral()
      }
+
 }

--- a/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-kotlin-application-project/build.gradle
@@ -22,3 +22,7 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project-test-setup/build.gradle
@@ -27,6 +27,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/bean-in-testsources-project/build.gradle
@@ -44,3 +44,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/multi-module-project/build.gradle
@@ -15,6 +15,9 @@ subprojects {
         implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusPlatformVersion}")
     }
 
+    test {
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+    }
 }
 
 group 'org.acme'

--- a/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/builder/simple-module-project/build.gradle
@@ -23,3 +23,7 @@ version '1.0-SNAPSHOT'
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-dao/build.gradle
@@ -33,3 +33,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
+++ b/integration-tests/gradle/src/main/resources/composite-project-with-dependencies/gradle-rest/build.gradle
@@ -33,3 +33,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/conditional-test-project/build.gradle
@@ -12,3 +12,7 @@ repositories {
     }
     mavenCentral()
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/configuration-inheritance-project/build.gradle
@@ -26,3 +26,6 @@ dependencies {
     testImplementation 'org.apache.commons:commons-collections4::tests'
 }
 
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-config-java-module/build.gradle
@@ -41,3 +41,7 @@ quarkusBuild {
         attributes(['framework': 'quarkus'], 'org.acme')
     }
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-filesystem-provider/build.gradle
@@ -26,6 +26,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-java-native-sourceset-module/build.gradle
@@ -51,3 +51,7 @@ quarkusBuild {
         additionalArgs= ["--verbose"]
     }
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/custom-working-dir-app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/custom-working-dir-app/build.gradle
@@ -24,3 +24,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
 }
 
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dependency-constraints-project/build.gradle
@@ -26,3 +26,6 @@ dependencies {
     implementation 'javax.json.bind:javax.json.bind-api'
 }
 
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/dotenv-config-java-module/build.gradle
@@ -32,3 +32,7 @@ compileTestJava {
 quarkusDev {
     workingDir = System.getProperty("java.io.tmpdir")
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
+++ b/integration-tests/gradle/src/main/resources/extensions/simple-extension/build.gradle
@@ -10,4 +10,8 @@ subprojects {
         }
         mavenCentral()
     }
+
+    test {
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+    }
 }

--- a/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/grpc-multi-module-project/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
+++ b/integration-tests/gradle/src/main/resources/implementation-files/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {

--- a/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-bean-from-test-config/application/build.gradle
@@ -26,3 +26,7 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/it-test-basic-project/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/jandex-basic-multi-module-project/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {
@@ -40,4 +41,5 @@ subprojects {
 
         implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     }
+
 }

--- a/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
+++ b/integration-tests/gradle/src/main/resources/list-extension-single-module/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/app/build.gradle
@@ -25,3 +25,7 @@ compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-included-build/external-library/build.gradle
@@ -23,3 +23,7 @@ compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/build.gradle
@@ -12,3 +12,4 @@ repositories {
 
 group 'org.acme'
 version '1.0.0-SNAPSHOT'
+

--- a/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-named-injection/quarkus/build.gradle
@@ -34,3 +34,7 @@ compileTestJava {
 test {
     systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/build.gradle
@@ -29,3 +29,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/build.gradle
@@ -15,5 +15,7 @@ subprojects {
         }
         mavenCentral()
     }
+
+
 }
 

--- a/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
+++ b/integration-tests/gradle/src/main/resources/mutable-jar/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
+++ b/integration-tests/gradle/src/main/resources/quarkus-dev-dependency/build.gradle
@@ -35,3 +35,7 @@ run {
         systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
     }
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/spring-dependency-plugin-project/build.gradle
@@ -30,3 +30,7 @@ dependencies {
 compileJava {
     options.compilerArgs << '-parameters'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-in-build-steps/build.gradle
@@ -29,4 +29,8 @@ subprojects {
         }
         mavenCentral()
     }
+
+    test {
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+    }
 }

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/build.gradle
@@ -31,3 +31,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-fast-jar-format-works/build.gradle
@@ -28,3 +28,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-that-legacy-jar-format-works/build.gradle
@@ -28,3 +28,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
+++ b/integration-tests/gradle/src/main/resources/test-uber-jar-format-works/build.gradle
@@ -28,3 +28,7 @@ compileJava {
 compileTestJava {
     options.encoding = 'UTF-8'
 }
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/uber-jar-for-multi-module-project/build.gradle
@@ -24,6 +24,7 @@ subprojects {
         dependsOn 'cleanTest'
         useJUnitPlatform()
         forkEvery 1
+        systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
     }
 
     repositories {


### PR DESCRIPTION
As mentioned in the issus, this adds a configuration for system logging in codestart.

close #26138 