### PR TITLE
Update Groovy to 4.0.5 in enforcer-rules

### DIFF
--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -104,9 +104,9 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>3.0.12</version>
+                        <version>4.0.5</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
We need Groovy to be compatible with 19-EA.

@geoand this is part of a branch where I worked on 19 ea support.