### PR TITLE
Support synthetic fields to be linked by resteasy reactive links

### DIFF
--- a/docs/src/main/asciidoc/resteasy-reactive.adoc
+++ b/docs/src/main/asciidoc/resteasy-reactive.adoc
@@ -1382,7 +1382,30 @@ Link: <http://localhost:8080/records/1>; rel="update"
 Link: <http://localhost:8080/records/1>; rel="delete"
 ----
 
-Finally, when calling the delete resource, you should not see any web links as the method `delete` is not annotated with the `@InjectRestLinks` annotation.
+The `get`, `update`, and `delete` methods use the path param "id" and as the field "id" exists in the entity type "Record", the web link properly populates the value "1" in the returned links. In addition to this, we can also generate web links with path params that do not match with any field of the entity type. For example, the following method is using a path param "text" and the entity Record does not have any field named "text":
+
+[source,java]
+----
+@Path("/records")
+public class RecordsResource {
+
+    // ...
+
+    @GET
+    @Path("/search/{text}")
+    @RestLink(rel = "search records by free text")
+    @InjectRestLinks
+    public List<Record> search(@PathParam("text") String text) { <4>
+        // ...
+    }
+
+    // ...
+}
+----
+
+The generated web link for this resource is `Link: <http://localhost:8080/search/{text}>; rel="search records by free text"`.
+
+Finally, when calling the `delete` resource, you should not see any web links as the method `delete` is not annotated with the `@InjectRestLinks` annotation.
 
 ==== Programmatically access to the web links registry
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/main/java/io/quarkus/resteasy/reactive/links/deployment/LinksProcessor.java
@@ -176,18 +176,17 @@ final class LinksProcessor {
                                 index);
                         fieldInfo = byIdAnnotation.get();
                     }
-                    if (fieldInfo == null) {
-                        throw new RuntimeException(
-                                String.format("Class '%s' field '%s' was not found", className, parameterName));
-                    }
-                    GetterMetadata getterMetadata = new GetterMetadata(fieldInfo);
-                    if (!implementedGetters.contains(getterMetadata)) {
-                        implementGetterWithAccessor(classOutput, bytecodeTransformersProducer, getterMetadata);
-                        implementedGetters.add(getterMetadata);
-                    }
 
-                    getterAccessorsContainerRecorder.addAccessor(getterAccessorsContainer,
-                            entityType, getterMetadata.getFieldName(), getterMetadata.getGetterAccessorName());
+                    if (fieldInfo != null) {
+                        GetterMetadata getterMetadata = new GetterMetadata(fieldInfo);
+                        if (!implementedGetters.contains(getterMetadata)) {
+                            implementGetterWithAccessor(classOutput, bytecodeTransformersProducer, getterMetadata);
+                            implementedGetters.add(getterMetadata);
+                        }
+
+                        getterAccessorsContainerRecorder.addAccessor(getterAccessorsContainer,
+                                entityType, getterMetadata.getFieldName(), getterMetadata.getGetterAccessorName());
+                    }
                 }
             }
         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/RestLinksInjectionTest.java
@@ -37,7 +37,9 @@ public class RestLinksInjectionTest {
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
                 Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/1")).rel("self").build().toString(),
-                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString());
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString(),
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/slugOrId/{slugOrId}")).rel("get-by-slug-or-id")
+                        .build("{slugOrId}").toString());
 
         List<String> secondRecordLinks = when().get(recordsUrl + "/2")
                 .thenReturn()
@@ -50,7 +52,9 @@ public class RestLinksInjectionTest {
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/second"))
                         .rel("get-by-slug")
                         .build()
-                        .toString());
+                        .toString(),
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/slugOrId/{slugOrId}")).rel("get-by-slug-or-id")
+                        .build("{slugOrId}").toString());
     }
 
     @Test
@@ -63,7 +67,9 @@ public class RestLinksInjectionTest {
                 Link.fromUri(recordsUrl).rel("list").build().toString(),
                 Link.fromUri(recordsWithoutLinksUrl).rel("list-without-links").build().toString(),
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/1")).rel("self").build().toString(),
-                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString());
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/first")).rel("get-by-slug").build().toString(),
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/slugOrId/{slugOrId}")).rel("get-by-slug-or-id")
+                        .build("{slugOrId}").toString());
 
         List<String> secondRecordLinks = when().get(recordsUrl + "/second")
                 .thenReturn()
@@ -76,7 +82,9 @@ public class RestLinksInjectionTest {
                 Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/second"))
                         .rel("get-by-slug")
                         .build()
-                        .toString());
+                        .toString(),
+                Link.fromUriBuilder(UriBuilder.fromUri(recordsUrl).path("/slugOrId/{slugOrId}")).rel("get-by-slug-or-id")
+                        .build("{slugOrId}").toString());
     }
 
     @Test

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/deployment/src/test/java/io/quarkus/resteasy/reactive/links/deployment/TestResource.java
@@ -68,4 +68,16 @@ public class TestResource {
                 .findFirst()
                 .orElseThrow(NotFoundException::new);
     }
+
+    @GET
+    @Path("/slugOrId/{slugOrId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RestLink(rel = "get-by-slug-or-id")
+    public TestRecord getBySlugOrId(@PathParam("slugOrId") String slugOrId) {
+        return RECORDS.stream()
+                .filter(record -> record.getSlug().equals(slugOrId)
+                        || slugOrId.equalsIgnoreCase(String.valueOf(record.getId())))
+                .findFirst()
+                .orElseThrow(NotFoundException::new);
+    }
 }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-links/runtime/src/main/java/io/quarkus/resteasy/reactive/links/runtime/RestLinksProviderImpl.java
@@ -63,10 +63,11 @@ final class RestLinksProviderImpl implements RestLinksProvider {
         List<Object> values = new ArrayList<>(linkInfo.getPathParameters().size());
         for (String name : linkInfo.getPathParameters()) {
             GetterAccessor accessor = getterAccessorsContainer.get(linkInfo.getEntityType(), name);
-            if (accessor == null) {
-                throw new RuntimeException("Could not get '" + name + "' value");
+            if (accessor != null) {
+                values.add(accessor.get(instance));
+            } else {
+                values.add("{" + name + "}");
             }
-            values.add(accessor.get(instance));
         }
         return values.toArray();
     }


### PR DESCRIPTION
Synthetic fields are fields that are not part of the current entity to be linked, but still, we want these endpoints to be linked/exposed.

Before these changes, if we add a resource like the following one:

```java
@GET
@Path("/slugOrId/{slugOrId}")
@Produces(MediaType.APPLICATION_JSON)
@RestLink(rel = "get-by-slug-or-id")
public TestRecord getBySlugOrId(@PathParam("slugOrId") String slugOrId) {
    // ...
}
```

The path param `slugOrId` does not match with any field of the entity `TestRecord`, and because this resource is annotated with `RestLink`, it fails with a runtime exception saying that the field `slugOrId` was not found.

After these changes, we allow the resources that use non-existing fields as path params and still the link will be exposed as specified in the `RestLink` annotation.