### PR TITLE
Fix access log handling for root and non-root paths

### DIFF
--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/VertxHttpProcessor.java
@@ -312,9 +312,8 @@ class VertxHttpProcessor {
                 defaultRoute.map(DefaultRouteBuildItem::getRoute).orElse(null),
                 listOfFilters, vertx.getVertx(), lrc, mainRouter, httpRouteRouter.getHttpRouter(),
                 httpRouteRouter.getMutinyRouter(), httpRouteRouter.getFrameworkRouter(),
-                nonApplicationRootPathBuildItem.isDedicatedRouterRequired(),
-                nonApplicationRootPathBuildItem.isAttachedToMainRouter(),
                 httpRootPathBuildItem.getRootPath(),
+                nonApplicationRootPathBuildItem.getNonApplicationRootPath(),
                 launchMode.getLaunchMode(),
                 !requireBodyHandlerBuildItems.isEmpty(), bodyHandler, gracefulShutdownFilter,
                 shutdownConfig, executorBuildItem.getExecutorProxy());


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/28577

Open question: Should we log 404s for "/" accesses if rootPath is moved to some subpath? With config

quarkus.http.root-path=/app

Should `GET /whatever` be logged? Currently, it is not.