### PR TITLE
Generate the attributes.adoc file during the build

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-registry-client</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -77,7 +76,6 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>${asciidoctorj.version}</version>
         </dependency>
 
         <!-- Minimal test dependencies for consistent build order -->
@@ -2805,6 +2803,37 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/asciidoc/sources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/asciidoc</directory>
+                                    <filtering>false</filtering>
+                                    <excludes>
+                                        <exclude>**/attributes.adoc</exclude>
+                                    </excludes>
+                                </resource>
+                                <resource>
+                                    <directory>src/main/asciidoc</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/attributes.adoc</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <configuration>
@@ -2876,7 +2905,7 @@
                             <arguments>
                                 <argument>${code-example-dir}</argument>
                                 <argument>${project.basedir}/..</argument>
-                                <argument>${project.basedir}/src/main/asciidoc</argument>
+                                <argument>${project.basedir}/target/asciidoc/sources</argument>
                             </arguments>
                             <environmentVariables>
                                 <MAVEN_CMD_LINE_ARGS>${env.MAVEN_CMD_LINE_ARGS}</MAVEN_CMD_LINE_ARGS>
@@ -2893,7 +2922,7 @@
                             <skip>${skipDocs}</skip>
                             <mainClass>io.quarkus.docs.generation.YamlMetadataGenerator</mainClass>
                             <arguments>
-                                <argument>${project.basedir}/src/main/asciidoc</argument>
+                                <argument>${project.basedir}/target/asciidoc/sources</argument>
                                 <argument>${project.basedir}/target</argument>
                             </arguments>
                             <environmentVariables>
@@ -2906,7 +2935,6 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${asciidoctor-maven-plugin.version}</version>
                 <configuration>
                     <skip>${skipDocs}</skip>
                     <enableVerbose>true</enableVerbose>
@@ -2915,7 +2943,7 @@
                           <severity>WARN</severity>
                         </failIf>
                     </logHandler>
-                    <sourceDirectory>src/main/asciidoc</sourceDirectory>
+                    <sourceDirectory>target/asciidoc/sources</sourceDirectory>
                     <preserveDirectories>true</preserveDirectories>
                     <attributes>
                         <generated-dir>${project.basedir}/../target/asciidoc/generated</generated-dir>
@@ -2929,81 +2957,11 @@
                         <docinfo1>true</docinfo1>
                         <!-- avoid content security policy violations -->
                         <skip-front-matter>true</skip-front-matter>
-
-                        <quarkus-version>${project.version}</quarkus-version>
-                        <surefire-version>${version.surefire.plugin}</surefire-version>
-                        <graalvm-version>${graal-sdk.version-for-documentation}</graalvm-version>
-                        <graalvm-flavor>${graal-sdk.version-for-documentation}-java11</graalvm-flavor>
-                        <mandrel-version>${mandrel.version-for-documentation}</mandrel-version>
-                        <mandrel-flavor>${mandrel.version-for-documentation}-java11</mandrel-flavor>
-                        <restassured-version>${rest-assured.version}</restassured-version>
-                        <maven-version>${proposed-maven-version}</maven-version>
-                        <gradle-version>${gradle-wrapper.version}</gradle-version>
-                        <elasticsearch-image>${elasticsearch.image}</elasticsearch-image>
-                        <logstash-image>${logstash.image}</logstash-image>
-                        <kibana-image>${kibana.image}</kibana-image>
-                        <keycloak-docker-image>${keycloak.docker.image}</keycloak-docker-image>
-
-                        <jandex-version>${jandex.version}</jandex-version>
-                        <jandex-gradle-plugin-version>${jandex-gradle-plugin.version}</jandex-gradle-plugin-version>
-                        <kotlin-version>${kotlin.version}</kotlin-version>
-
-                        <grpc-version>${grpc.version}</grpc-version>
-                        <protoc-version>${protoc.version}</protoc-version>
-                        <elasticsearch-version>${elasticsearch-server.version}</elasticsearch-version>
-                        <gcf-invoker-version>${gcf-invoker.version}</gcf-invoker-version>
-
-                        <!-- Project website home page -->
-                        <quarkus-home-url>${quarkus-home-url}</quarkus-home-url>
-                        <!-- Root URL of the GitHub organization -->
-                        <quarkus-org-url>https://github.com/quarkusio</quarkus-org-url>
-
-                        <!-- === Website URLs === -->
-                        <!-- This will probably go away once all the pages are integrated in the website but keep track of the links -->
-                        <quarkus-site-getting-started>${quarkus-home-url}/getting-started</quarkus-site-getting-started>
-                        <quarkus-site-extension-authors-guide>${quarkus-home-url}/documentation/extension-authors-guide</quarkus-site-extension-authors-guide>
-                        <quarkus-site-live-coding>${quarkus-home-url}/live-coding</quarkus-site-live-coding>
-
-                        <!-- === Communication === -->
-                        <quarkus-chat-url>https://quarkusio.zulipchat.com/#</quarkus-chat-url>
-                        <quarkus-mailing-list-subscription-email>quarkus-dev+subscribe@googlegroups.com</quarkus-mailing-list-subscription-email>
-                        <quarkus-mailing-list-index>https://groups.google.com/d/forum/quarkus-dev</quarkus-mailing-list-index>
-
-                        <!-- === Quarkus project settings === -->
-                        <!-- Quarkus repository base URL -->
-                        <quarkus-base-url>${quarkus-base-url}</quarkus-base-url>
-                        <!-- Quarkus repository URL to clone -->
-                        <quarkus-clone-url>${quarkus-base-url}.git</quarkus-clone-url>
-                        <!-- Quarkus URL to main source archive -->
-                        <quarkus-archive-url>${quarkus-base-url}/archive/main.zip</quarkus-archive-url>
-                        <!-- Quarkus URL to main blob source tree; used for referencing source files -->
-                        <quarkus-blob-url>${quarkus-base-url}/blob/main</quarkus-blob-url>
-                        <!-- Quarkus URL to main source tree root; used for referencing directories -->
-                        <quarkus-tree-url>${quarkus-base-url}/tree/main</quarkus-tree-url>
-                        <!-- Quarkus URL to issues -->
-                        <quarkus-issues-url>${quarkus-base-url}/issues</quarkus-issues-url>
-                        <quarkus-images-url>https://github.com/quarkusio/quarkus-images/tree</quarkus-images-url>
-
-                        <!-- === Quickstart settings === -->
-                        <!-- Quickstart repository base URL -->
-                        <quickstarts-base-url>${quickstarts-base-url}</quickstarts-base-url>
-                        <!-- Quickstart repository URL to clone -->
-                        <quickstarts-clone-url>${quickstarts-base-url}.git</quickstarts-clone-url>
-                        <!-- Quickstart URL to main source archive -->
-                        <quickstarts-archive-url>${quickstarts-base-url}/archive/main.zip</quickstarts-archive-url>
-                        <!-- Quickstart URL to main blob source tree; used for referencing source files -->
-                        <quickstarts-blob-url>${quickstarts-base-url}/blob/main</quickstarts-blob-url>
-                        <!-- Quickstart URL to main source tree root; used for referencing directories -->
-                        <quickstarts-tree-url>${quickstarts-base-url}/tree/main</quickstarts-tree-url>
-
-                        <!-- Quarkiverse documentation links -->
-                        <amazon-services-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html</amazon-services-guide>
-                        <config-consul-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html</config-consul-guide>
-                        <hibernate-search-orm-elasticsearch-aws-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html</hibernate-search-orm-elasticsearch-aws-guide>
-                        <neo4j-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html</neo4j-guide>
-                        <vault-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html</vault-guide>
-                        <vault-datasource-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html</vault-datasource-guide>
-                        <micrometer-registry-guide>https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/</micrometer-registry-guide>
+                        <!--
+                        Attributes are now maintained in:
+                        - src/main/asciidoc-filtered/attributes.adoc for attributes that are actually used in the doc content e.g. versions, urls.
+                        - src/main/asciidoc/attributes-local.adoc for technical attributes that have to be overridden in the website.
+                        -->
                     </attributes>
                 </configuration>
                 <executions>

--- a/docs/src/main/asciidoc/attributes-local.adoc
+++ b/docs/src/main/asciidoc/attributes-local.adoc
@@ -1,0 +1,13 @@
+// for rendering the final website the attributes are set in the appropriate
+// location based on source versions in https://github.com/quarkusio/quarkusio.github.io/
+// they are duplicated here to ease the preview when editing in the IDE
+:idprefix:
+:idseparator: -
+:icons: font
+:code-examples: ../../../../target/asciidoc/examples
+:doc-guides: ./
+:doc-examples: ./_examples
+:generated-dir: ../../../../target/asciidoc/generated
+:imagesdir: ./images
+:includes: ./includes
+:toc: preamble

--- a/docs/src/main/asciidoc/attributes.adoc
+++ b/docs/src/main/asciidoc/attributes.adoc
@@ -1,13 +1,52 @@
-// for rendering the final website the attributes are set in the appropriate
-// location based on source versions in https://github.com/quarkusio/quarkusio.github.io/
-// they are duplicated here to ease the preview when editing in the IDE
-:idprefix:
-:idseparator: -
-:icons: font
-:code-examples: ../../../../target/asciidoc/examples
-:doc-guides: ./
-:doc-examples: ./_examples
-:generated-dir: ../../../../target/asciidoc/generated
-:imagesdir: ./images
-:includes: ./includes
-:toc: preamble
+:project-name: Quarkus
+:quarkus-version: ${project.version}
+
+:maven-version: ${proposed-maven-version}
+:graalvm-version: ${graal-sdk.version-for-documentation}
+:graalvm-flavor: ${graal-sdk.version-for-documentation}-java11
+:mandrel-version: ${mandrel.version-for-documentation}
+:mandrel-flavor: ${mandrel.version-for-documentation}-java11
+:surefire-version: ${version.surefire.plugin}
+:gradle-version: ${gradle-wrapper.version}
+:elasticsearch-version: ${elasticsearch-server.version}
+:elasticsearch-image: ${elasticsearch.image}
+:logstash-image: ${logstash.image}
+:kibana-image: ${kibana.image}
+:keycloak-docker-image: ${keycloak.docker.image}
+:jandex-version: ${jandex.version}
+:jandex-gradle-plugin.version: ${jandex-gradle-plugin.version}
+:kotlin-version: ${kotlin.version}
+:grpc-version: ${grpc.version}
+:protoc-version: ${protoc.version}
+:gcf-invoker-version: ${gcf-invoker.version}
+
+:quarkus-home-url: ${quarkus-home-url}
+:quarkus-org-url: https://github.com/quarkusio
+:quarkus-site-getting-started: /get-started
+:quarkus-writing-extensions-guide: /guides/writing-extensions
+:quarkus-site-publications: /publications
+:quarkus-base-url: ${quarkus-base-url}
+:quarkus-clone-url: ${quarkus-base-url}.git
+:quarkus-archive-url: ${quarkus-base-url}/archive/main.zip
+:quarkus-blob-url: ${quarkus-base-url}/blob/main
+:quarkus-tree-url: ${quarkus-base-url}/tree/main
+:quarkus-issues-url: ${quarkus-base-url}/issues
+:quarkus-images-url: https://github.com/quarkusio/quarkus-images/tree
+:quarkus-chat-url: https://quarkusio.zulipchat.com
+:quarkus-mailing-list-subscription-email: quarkus-dev+subscribe@googlegroups.com
+:quarkus-mailing-list-index: https://groups.google.com/d/forum/quarkus-dev
+:quickstarts-base-url: ${quickstarts-base-url}
+:quickstarts-clone-url: ${quickstarts-base-url}.git
+:quickstarts-archive-url: ${quickstarts-base-url}/archive/main.zip
+:quickstarts-blob-url: ${quickstarts-base-url}/blob/main
+:quickstarts-tree-url: ${quickstarts-base-url}/tree/main
+
+:amazon-services-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-amazon-services/dev/index.html
+:config-consul-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-extensions/dev/consul.html
+:hibernate-search-orm-elasticsearch-aws-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-hibernate-search-extras/dev/index.html
+:neo4j-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-neo4j/dev/index.html
+:vault-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html
+:vault-datasource-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/vault-datasource.html
+:micrometer-registry-guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/index.html
+
+include::./attributes-local.adoc[]

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -298,7 +298,6 @@ The complete list of externalized variables for use is given in the following ta
 |Property Name|Value|Description
 |\{quarkus-version}|{quarkus-version}|The current version of the project.
 |\{quarkus-home-url}|{quarkus-home-url}| The location of the project home page.
-|\{quarkus-site-getting-started}|{quarkus-site-getting-started}| The location of the getting started page.
 
 |\{quarkus-org-url}|{quarkus-org-url}| The location of the project GitHub organization.
 |\{quarkus-base-url}|{quarkus-base-url}| Quarkus GitHub URL common base prefix.

--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -43,14 +43,14 @@ else
   TARGET_CONFIG=${TARGET_DIR}/_generated-config/${BRANCH}
 fi
 
-echo "Copying from src/main/asciidoc/* to $TARGET_GUIDES"
+echo "Copying from target/asciidoc/sources/* to $TARGET_GUIDES"
 rsync -vr --delete \
     --exclude='**/*.html' \
     --exclude='**/index.adoc' \
-    --exclude='**/attributes.adoc' \
+    --exclude='**/attributes-local.adoc' \
     --exclude='**/guides.md' \
     --exclude='**/_templates' \
-    src/main/asciidoc/* \
+    target/asciidoc/sources/* \
     $TARGET_GUIDES
 
 echo "\nCopying from ../target/asciidoc/generated/ to $TARGET_CONFIG"


### PR DESCRIPTION
Currently, we maintain a copy of the attributes.adoc in the website and we always get it wrong when we add a new attribute.

This way, attributes.adoc will come directly from the release and will be complete.
Attributes that can be overridden have been moved to attributes-local.adoc. attributes-local.adoc won't be overwritten when syncing.

@ebullient this should solve the problem of having to (badly) sync the attributes between the main repository and the website. The `attributes.adoc` file will now be generated and synced and I created a new `attributes-local.adoc` file that is not synced and can be overridden (typically for paths that are specific to the environment).