### PR TITLE
Clarify that both RESTEasy Classic and Reactive support locale resolution

### DIFF
--- a/docs/src/main/asciidoc/validation.adoc
+++ b/docs/src/main/asciidoc/validation.adoc
@@ -385,7 +385,8 @@ You can configure this behavior by adding the following configuration in your `a
 quarkus.default-locale=fr-FR
 ----
 
-If you are using RESTEasy Reactive, in the context of a JAX-RS endpoint, Hibernate Validator will automatically resolve the optimal locale to use from the `Accept-Language` HTTP header,
+If you are using RESTEasy (Classic or Reactive), in the context of a JAX-RS endpoint,
+Hibernate Validator will automatically resolve the optimal locale to use from the `Accept-Language` HTTP header,
 provided the supported locales have been properly specified in the `application.properties`:
 
 [source, properties]


### PR DESCRIPTION
As far as I can tell, the feature is not limited to RESTEasy Reactive: we have both `io.quarkus.hibernate.validator.runtime.locale.ResteasyClassicLocaleResolver` and `io.quarkus.hibernate.validator.runtime.locale.ResteasyReactiveLocaleResolver`.