### PR TITLE
Support setting the RolesAllowed in the Panache REST Data extension

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -310,6 +310,7 @@ public interface PeopleResource extends PanacheEntityResource<Person, Long> {
 
 * `exposed` - whether resource could be exposed. A global resource property that can be overridden for each method. Default is `true`.
 * `path` - resource base path. Default path is a hyphenated lowercase resource name without a suffix of `resource` or `controller`.
+* `rolesAllowed` - List of the security roles permitted to access the resources. It needs a Quarkus security extension to be present, otherwise it will be ignored. Default is empty.
 * `paged` - whether collection responses should be paged or not.
 First, last, previous and next page URIs are included in the response headers if they exist.
 Request page index and size are taken from the `page` and `size` query parameters that default to `0` and `20` respectively.
@@ -322,6 +323,7 @@ Default is `false`.
 
 * `exposed` - does not expose a particular HTTP verb when set to `false`. Default is `true`.
 * `path` - operation path (this is appended to the resource base path). Default is an empty string.
+* `rolesAllowed` - List of the security roles permitted to access this operation. It needs a Quarkus security extension to be present, otherwise it will be ignored. Default is empty.
 
 == Query parameters
 

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -38,7 +38,8 @@ class OpenApiIntegrationTest {
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
-                    Dependency.of("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion())))
+                    Dependency.of("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-security-deployment", Version.getVersion())))
             .setRun(true);
 
     @Test
@@ -52,9 +53,13 @@ class OpenApiIntegrationTest {
                 .body("paths.'/collections'.get.tags", Matchers.hasItem("CollectionsResource"))
                 .body("paths.'/collections'", Matchers.hasKey("post"))
                 .body("paths.'/collections'.post.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.post.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'.get.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/collections/{id}'.delete.security[0].SecurityScheme", Matchers.hasItem("admin"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
                 .body("paths.'/empty-list-items'.get.tags", Matchers.hasItem("EmptyListItemsResource"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("post"))

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
@@ -1,8 +1,11 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.repository;
 
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.rest.data.panache.MethodProperties;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections", rolesAllowed = "user")
 public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
+    @MethodProperties(rolesAllowed = "admin")
+    boolean delete(String name);
 }

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -38,7 +38,8 @@ class OpenApiIntegrationTest {
             .setForcedDependencies(List.of(
                     Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-reactive-pg-client-deployment", Version.getVersion()),
-                    Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion())))
+                    Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-security-deployment", Version.getVersion())))
             .setRun(true);
 
     @Test
@@ -52,9 +53,13 @@ class OpenApiIntegrationTest {
                 .body("paths.'/collections'.get.tags", Matchers.hasItem("CollectionsResource"))
                 .body("paths.'/collections'", Matchers.hasKey("post"))
                 .body("paths.'/collections'.post.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.post.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'.get.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/collections/{id}'.delete.security[0].SecurityScheme", Matchers.hasItem("admin"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
                 .body("paths.'/empty-list-items'.get.tags", Matchers.hasItem("EmptyListItemsResource"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("post"))

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/CollectionsResource.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/repository/CollectionsResource.java
@@ -1,8 +1,11 @@
 package io.quarkus.hibernate.reactive.rest.data.panache.deployment.repository;
 
 import io.quarkus.hibernate.reactive.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.rest.data.panache.MethodProperties;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections", rolesAllowed = "user")
 public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
+    @MethodProperties(rolesAllowed = "admin")
+    boolean delete(String name);
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -37,16 +37,16 @@ class JaxRsResourceImplementor {
 
     private final List<MethodImplementor> methodImplementors;
 
-    JaxRsResourceImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        this.methodImplementors = Arrays.asList(new GetMethodImplementor(isResteasyClassic, isReactivePanache),
-                new ListMethodImplementor(isResteasyClassic, isReactivePanache),
-                new CountMethodImplementor(isResteasyClassic, isReactivePanache),
-                new AddMethodImplementor(withValidation, isResteasyClassic, isReactivePanache),
-                new UpdateMethodImplementor(withValidation, isResteasyClassic, isReactivePanache),
-                new DeleteMethodImplementor(isResteasyClassic, isReactivePanache),
+    JaxRsResourceImplementor(Capabilities capabilities) {
+        this.methodImplementors = Arrays.asList(new GetMethodImplementor(capabilities),
+                new ListMethodImplementor(capabilities),
+                new CountMethodImplementor(capabilities),
+                new AddMethodImplementor(capabilities),
+                new UpdateMethodImplementor(capabilities),
+                new DeleteMethodImplementor(capabilities),
                 // The list hal endpoint needs to be added for both resteasy classic and resteasy reactive
                 // because the pagination links are programmatically added.
-                new ListHalMethodImplementor(isResteasyClassic, isReactivePanache));
+                new ListHalMethodImplementor(capabilities));
     }
 
     /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/RestDataProcessor.java
@@ -65,8 +65,7 @@ public class RestDataProcessor {
 
         ClassOutput classOutput = isResteasyClassic ? new GeneratedBeanGizmoAdaptor(resteasyClassicImplementationsProducer)
                 : new GeneratedJaxRsResourceGizmoAdaptor(resteasyReactiveImplementationsProducer);
-        JaxRsResourceImplementor jaxRsResourceImplementor = new JaxRsResourceImplementor(hasValidatorCapability(capabilities),
-                isResteasyClassic, isReactivePanache);
+        JaxRsResourceImplementor jaxRsResourceImplementor = new JaxRsResourceImplementor(capabilities);
         ResourcePropertiesProvider resourcePropertiesProvider = new ResourcePropertiesProvider(index.getIndex());
 
         for (RestDataResourceBuildItem resourceBuildItem : resourceBuildItems) {
@@ -98,10 +97,6 @@ public class RestDataProcessor {
             }
         }
         return resourcePropertiesProvider.getForInterface(resourceMetadata.getResourceInterface());
-    }
-
-    private boolean hasValidatorCapability(Capabilities capabilities) {
-        return capabilities.isPresent(Capability.HIBERNATE_VALIDATOR);
     }
 
     private boolean hasAnyJsonCapabilityForResteasyClassic(Capabilities capabilities) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -6,6 +6,7 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
@@ -28,11 +29,8 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "add";
 
-    private final boolean withValidation;
-
-    public AddMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
-        this.withValidation = withValidation;
+    public AddMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**
@@ -112,8 +110,9 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
-        if (withValidation) {
+        if (hasValidatorCapability()) {
             methodCreator.getParameterAnnotations(0).addAnnotation(Valid.class);
         }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -5,6 +5,7 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import javax.ws.rs.core.Response;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
@@ -27,8 +28,8 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "count";
 
-    public CountMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public CountMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**
@@ -79,6 +80,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), RESOURCE_METHOD_NAME));
+        addSecurityAnnotations(methodCreator, resourceProperties);
         if (!isResteasyClassic()) {
             // We only add the Links annotation in Resteasy Reactive because Resteasy Classic ignores the REL parameter:
             // it always uses "list" for GET methods, so it interferes with the list implementation.

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -5,6 +5,7 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import javax.ws.rs.core.Response;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -28,8 +29,8 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "remove";
 
-    public DeleteMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public DeleteMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**
@@ -89,6 +90,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addDeleteAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addSecurityAnnotations(methodCreator, resourceProperties);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());
         ResultHandle id = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -5,6 +5,7 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import javax.ws.rs.core.Response;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -28,8 +29,8 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
 
     private static final String REL = "self";
 
-    public GetMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public GetMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**
@@ -90,6 +91,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));
         addGetAnnotation(methodCreator);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
+        addSecurityAnnotations(methodCreator, resourceProperties);
 
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
 import io.quarkus.gizmo.MethodCreator;
@@ -41,8 +42,8 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
-    public ListMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public ListMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
 
         this.paginationImplementor = new PaginationImplementor();
     }
@@ -142,6 +143,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(1), "page");
@@ -207,6 +209,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 
         ResultHandle sortQuery = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Response;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.AssignableResultHandle;
 import io.quarkus.gizmo.BranchResult;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -41,11 +42,8 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
 
     private static final String EXCEPTION_MESSAGE = "Failed to update an entity";
 
-    private final boolean withValidation;
-
-    public UpdateMethodImplementor(boolean withValidation, boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
-        this.withValidation = withValidation;
+    public UpdateMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**
@@ -145,8 +143,9 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
-        if (withValidation) {
+        if (hasValidatorCapability()) {
             methodCreator.getParameterAnnotations(1).addAnnotation(Valid.class);
         }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/HalMethodImplementor.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -26,8 +27,8 @@ import io.quarkus.resteasy.reactive.links.runtime.hal.ResteasyReactiveHalService
  */
 abstract class HalMethodImplementor extends StandardMethodImplementor {
 
-    HalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    HalMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
     }
 
     /**

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.BytecodeCreator;
 import io.quarkus.gizmo.ClassCreator;
 import io.quarkus.gizmo.FieldDescriptor;
@@ -42,8 +43,8 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
 
     private final SortImplementor sortImplementor = new SortImplementor();
 
-    public ListHalMethodImplementor(boolean isResteasyClassic, boolean isReactivePanache) {
-        super(isResteasyClassic, isReactivePanache);
+    public ListHalMethodImplementor(Capabilities capabilities) {
+        super(capabilities);
         this.paginationImplementor = new PaginationImplementor();
     }
 
@@ -133,6 +134,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(1), "page");
@@ -207,6 +209,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 
         ResultHandle sortQuery = methodCreator.getMethodParam(0);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/MethodProperties.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/MethodProperties.java
@@ -6,9 +6,12 @@ public class MethodProperties {
 
     private final String path;
 
-    public MethodProperties(boolean exposed, String path) {
+    private final String[] rolesAllowed;
+
+    public MethodProperties(boolean exposed, String path, String[] rolesAllowed) {
         this.exposed = exposed;
         this.path = path;
+        this.rolesAllowed = rolesAllowed;
     }
 
     public boolean isExposed() {
@@ -17,5 +20,9 @@ public class MethodProperties {
 
     public String getPath() {
         return path;
+    }
+
+    public String[] getRolesAllowed() {
+        return rolesAllowed;
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
@@ -14,15 +14,18 @@ public class ResourceProperties {
 
     private final String halCollectionName;
 
+    private final String[] rolesAllowed;
+
     private final Map<String, MethodProperties> methodProperties;
 
     public ResourceProperties(boolean exposed, String path, boolean paged, boolean hal, String halCollectionName,
-            Map<String, MethodProperties> methodProperties) {
+            String[] rolesAllowed, Map<String, MethodProperties> methodProperties) {
         this.exposed = exposed;
         this.path = path;
         this.paged = paged;
         this.hal = hal;
         this.halCollectionName = halCollectionName;
+        this.rolesAllowed = rolesAllowed;
         this.methodProperties = methodProperties;
     }
 
@@ -67,5 +70,13 @@ public class ResourceProperties {
 
     public String getHalCollectionName() {
         return halCollectionName;
+    }
+
+    public String[] getRolesAllowed(String methodName) {
+        if (methodProperties.containsKey(methodName)) {
+            return methodProperties.get(methodName).getRolesAllowed();
+        }
+
+        return rolesAllowed;
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
@@ -41,6 +41,7 @@ public class ResourcePropertiesProvider {
                 isPaged(annotation),
                 isHal(annotation),
                 getHalCollectionName(annotation, resourceInterface),
+                getRolesAllowed(annotation),
                 methodProperties);
     }
 
@@ -74,7 +75,7 @@ public class ResourcePropertiesProvider {
     }
 
     private MethodProperties getMethodProperties(AnnotationInstance annotation) {
-        return new MethodProperties(isExposed(annotation), getPath(annotation));
+        return new MethodProperties(isExposed(annotation), getPath(annotation), getRolesAllowed(annotation));
     }
 
     private boolean isHal(AnnotationInstance annotation) {
@@ -114,5 +115,13 @@ public class ResourcePropertiesProvider {
             return annotation.value("halCollectionName").asString();
         }
         return ResourceName.fromClass(resourceInterface);
+    }
+
+    private String[] getRolesAllowed(AnnotationInstance annotation) {
+        if (annotation != null && annotation.value("rolesAllowed") != null) {
+            return annotation.value("rolesAllowed").asStringArray();
+        }
+
+        return new String[0];
     }
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/MethodProperties.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/MethodProperties.java
@@ -30,4 +30,11 @@ public @interface MethodProperties {
      * Default: ""
      */
     String path() default "";
+
+    /**
+     * List of the security roles permitted to access this operation.
+     * <p>
+     * Default: ""
+     */
+    String[] rolesAllowed() default {};
 }

--- a/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/runtime/src/main/java/io/quarkus/rest/data/panache/ResourceProperties.java
@@ -57,4 +57,11 @@ public @interface ResourceProperties {
      * Default: hyphenated resource name without a suffix. Ignored suffixes are `Controller` and `Resource`.
      */
     String halCollectionName() default "";
+
+    /**
+     * List of the security roles permitted to access the resources.
+     * <p>
+     * Default: ""
+     */
+    String[] rolesAllowed() default {};
 }

--- a/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/ResourcePropertiesProvider.java
+++ b/extensions/spring-data-rest/deployment/src/main/java/io/quarkus/spring/data/rest/deployment/ResourcePropertiesProvider.java
@@ -41,7 +41,7 @@ public abstract class ResourcePropertiesProvider {
         String halCollectionName = getHalCollectionName(annotation, ResourceName.fromClass(interfaceName));
 
         return new ResourceProperties(isExposed(annotation), resourcePath, paged, true, halCollectionName,
-                getMethodProperties(repositoryInterfaceName));
+                new String[0], getMethodProperties(repositoryInterfaceName));
     }
 
     private Map<String, MethodProperties> getMethodProperties(DotName interfaceName) {
@@ -56,7 +56,7 @@ public abstract class ResourcePropertiesProvider {
     }
 
     private MethodProperties getMethodProperties(AnnotationInstance annotation) {
-        return new MethodProperties(isExposed(annotation), getPath(annotation, ""));
+        return new MethodProperties(isExposed(annotation), getPath(annotation, ""), new String[0]);
     }
 
     private AnnotationInstance findClassAnnotation(DotName interfaceName) {


### PR DESCRIPTION
With these changes, we can specify the roles using the annotations `@ResourceProperties` at resource level, and `@MethodProperties` for method level. 
Example:
```java
@ResourceProperties(rolesAllowed = "user")
public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
    @MethodProperties(rolesAllowed = "admin")
    boolean delete(String name);
}
```

Fix https://github.com/quarkusio/quarkus/issues/28507