### PR TITLE
Avoid errors when using lambdaCapturingTypes with GraalVM < 22.1.0

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/annotations/RegisterForReflection.java
@@ -47,7 +47,8 @@ public @interface RegisterForReflection {
     boolean serialization() default false;
 
     /**
-     * The lambda capturing types performing serialization in the native image
+     * The lambda capturing types performing serialization in the native image. This parameter is only supported when
+     * using GraalVM / Mandrel >= 22.1.0
      */
     String[] lambdaCapturingTypes() default {};
 }


### PR DESCRIPTION
* Update javadoc to reflect that lambdaCapturingTypes are not supported when using GraalVM < 22.1.0
* Skip code registering lambda capturing classes when using GraalVM < 22.1.0

Closes #28530

Creating as draft and keeping as a fallback in case we need to maintain GraalVM 21.3 support in 2.13.