### PR TITLE
Do not set the Hibernate ORM dialect unnecessarily in docs/tests

### DIFF
--- a/docs/src/main/asciidoc/opentelemetry.adoc
+++ b/docs/src/main/asciidoc/opentelemetry.adoc
@@ -245,8 +245,6 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.url=jdbc:otel:postgresql://localhost:5432/mydatabase
 # use the 'OpenTelemetryDriver' instead of the one for your database
 quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
-# configure Hibernate ORM dialect
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
 ----
 
 == Additional configuration

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver-legacy-qualifiers/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 # Hibernate ORM settings 
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
+# Necessary because we're creating datasources dynamically,
+# which means the extension can't rely on a static datasource to guess the dialect
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 

--- a/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
+++ b/integration-tests/hibernate-orm-tenancy/connection-resolver/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 # Hibernate ORM settings 
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.multitenant=database
+# Necessary because we're creating datasources dynamically,
+# which means the extension can't rely on a static datasource to guess the dialect
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDB106Dialect
 quarkus.hibernate-orm.packages=io.quarkus.it.hibernate.multitenancy.fruit
 

--- a/integration-tests/jpa-mssql/src/main/resources/application.properties
+++ b/integration-tests/jpa-mssql/src/main/resources/application.properties
@@ -3,6 +3,5 @@ quarkus.datasource.username=sa
 quarkus.datasource.password=${mssqldb.sa-password}
 quarkus.datasource.jdbc.url=${mssqldb.url}
 quarkus.datasource.jdbc.max-size=8
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.SQLServer2012Dialect
 quarkus.hibernate-orm.database.generation=create
 quarkus.datasource.jdbc.additional-jdbc-properties.trustServerCertificate=true


### PR DESCRIPTION
Most of the time, Quarkus/Agroal is able to determine the dialect automatically.