### PR TITLE
Bump smallrye-open-api from 2.3.0 to 2.3.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -43,7 +43,7 @@
         <smallrye-config.version>2.12.1</smallrye-config.version>
         <smallrye-health.version>3.3.0</smallrye-health.version>
         <smallrye-metrics.version>3.0.5</smallrye-metrics.version>
-        <smallrye-open-api.version>2.3.0</smallrye-open-api.version>
+        <smallrye-open-api.version>2.3.1</smallrye-open-api.version>
         <smallrye-graphql.version>1.8.1</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.5.0</smallrye-fault-tolerance.version>

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -610,7 +610,7 @@ recipeList:
       newValue: 4.0.0
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-open-api.version
-      newValue: 3.0.0
+      newValue: 3.0.1
   - org.openrewrite.maven.ChangePropertyValue:
       key: microprofile-opentracing-api.version
       newValue: 3.0


### PR DESCRIPTION
Includes Jakarta rewrite smallrye-open-api bump from 3.0.0 to 3.0.1

Fixes #27902

https://github.com/smallrye/smallrye-open-api/releases/tag/2.3.1
https://github.com/smallrye/smallrye-open-api/releases/tag/3.0.1
