### PR TITLE
Allow disabling Jackson ObjectMapper WRITE_DURATIONS_AS_TIMESTAMPS

### DIFF
--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonWriteDurationsAsTimestampsDisabledTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonWriteDurationsAsTimestampsDisabledTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonWriteDurationsAsTimestampsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-write-durations-as-timestamps-disabled.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testDurationWrittenAsIso8601() throws JsonProcessingException {
+        Pojo pojo = new Pojo();
+        pojo.duration = Duration.ofMillis(65542516);
+
+        assertThat(objectMapper.writeValueAsString(pojo)).isEqualTo("{\"duration\":\"PT18H12M22.516S\"}");
+    }
+
+    public static class Pojo {
+
+        public Duration duration;
+    }
+}

--- a/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonWriteDurationsAsTimestampsEnabledTest.java
+++ b/extensions/jackson/deployment/src/test/java/io/quarkus/jackson/deployment/JacksonWriteDurationsAsTimestampsEnabledTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.jackson.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class JacksonWriteDurationsAsTimestampsEnabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withConfigurationResource("application-write-durations-as-timestamps-enabled.properties");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testDurationWrittenAsTimestamp() throws JsonProcessingException {
+        Pojo pojo = new Pojo();
+        pojo.duration = Duration.ofMillis(65542516);
+
+        assertThat(objectMapper.writeValueAsString(pojo)).isEqualTo("{\"duration\":65542.516000000}");
+    }
+
+    public static class Pojo {
+
+        public Duration duration;
+    }
+}

--- a/extensions/jackson/deployment/src/test/resources/application-write-durations-as-timestamps-disabled.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-write-durations-as-timestamps-disabled.properties
@@ -1,0 +1,1 @@
+quarkus.jackson.write-durations-as-timestamps=false

--- a/extensions/jackson/deployment/src/test/resources/application-write-durations-as-timestamps-enabled.properties
+++ b/extensions/jackson/deployment/src/test/resources/application-write-durations-as-timestamps-enabled.properties
@@ -1,0 +1,1 @@
+quarkus.jackson.write-durations-as-timestamps=true

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/JacksonBuildTimeConfig.java
@@ -29,9 +29,18 @@ public class JacksonBuildTimeConfig {
 
     /**
      * If enabled, Jackson will serialize dates as numeric value(s).
+     * When disabled, they are serialized in ISO 8601 format.
      */
     @ConfigItem(defaultValue = "false")
     public boolean writeDatesAsTimestamps;
+
+    /**
+     * If enabled, Jackson will serialize durations as numeric value(s).
+     * When disabled, they are serialized in ISO 8601 format.
+     * This is enabled by default to match the default Jackson behavior.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean writeDurationsAsTimestamps;
 
     /**
      * If enabled, Jackson will ignore case during Enum deserialization.

--- a/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
+++ b/extensions/jackson/runtime/src/main/java/io/quarkus/jackson/runtime/ObjectMapperProducer.java
@@ -41,6 +41,10 @@ public class ObjectMapperProducer {
             // this feature is enabled by default, so we disable it
             objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         }
+        if (!jacksonBuildTimeConfig.writeDurationsAsTimestamps) {
+            // this feature is enabled by default, so we disable it
+            objectMapper.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
+        }
         if (jacksonBuildTimeConfig.acceptCaseInsensitiveEnums) {
             objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         }


### PR DESCRIPTION
Fixes #28605