### PR TITLE
Do not check if debug port can be used in DEV mode on restart

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java
@@ -494,6 +494,10 @@ public abstract class QuarkusDevModeLauncher {
         return args;
     }
 
+    public Boolean getDebugPortOk() {
+        return debugPortOk;
+    }
+
     protected abstract boolean isDebugEnabled();
 
     protected void debug(Object msg, Object... args) {

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -447,7 +447,7 @@ public class DevMojo extends AbstractMojo {
                         try {
                             triggerCompile(false, false);
                             triggerCompile(true, false);
-                            newRunner = new DevModeRunner();
+                            newRunner = new DevModeRunner(runner.launcher.getDebugPortOk());
                         } catch (Exception e) {
                             getLog().info("Could not load changed pom.xml file, changes not applied", e);
                             continue;
@@ -907,7 +907,11 @@ public class DevMojo extends AbstractMojo {
         private Process process;
 
         private DevModeRunner() throws Exception {
-            launcher = newLauncher();
+            launcher = newLauncher(null);
+        }
+
+        private DevModeRunner(Boolean debugPortOk) throws Exception {
+            launcher = newLauncher(debugPortOk);
         }
 
         Collection<Path> pomFiles() {
@@ -961,7 +965,7 @@ public class DevMojo extends AbstractMojo {
         }
     }
 
-    private QuarkusDevModeLauncher newLauncher() throws Exception {
+    private QuarkusDevModeLauncher newLauncher(Boolean debugPortOk) throws Exception {
         String java = null;
         // See if a toolchain is configured
         if (toolchainManager != null) {
@@ -980,6 +984,7 @@ public class DevMojo extends AbstractMojo {
                 .debug(debug)
                 .debugHost(debugHost)
                 .debugPort(debugPort)
+                .debugPortOk(debugPortOk)
                 .deleteDevJar(deleteDevJar);
 
         setJvmArgs(builder);


### PR DESCRIPTION
fixes: #28187

Sometimes when you add dependency in DEV mode, app is restarting, the runner is shut down by the hook and [firstStart](https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/dev/IsolatedDevModeMain.java#L79) is called, error is logged saying that port is in use; after restart, JVM won't listen for a socket connection on the port after restart. This happens because at the time we check if there is some service listening on the IP/port, the previous runner is still up. Under given circumstances, the order of things is as follow:

- trigger restart
- prepare new DEV mode launcher (where socket check takes place)
- close previous runner (vacate IP/port)
- start listening for transport dt_socket at address xy

and we know the port is going to be available. [There is already a comment](https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java#L379) in the code that is saying we should not check the port on restart, and that's what this PR does. I didn't manage to reproduce the issue with Gradle (it seemed to me like changes in `build.gradle` are not reflected at all, thus it could not happen).

I know there is a draft https://github.com/quarkusio/quarkus/pull/28256 from @sberyozkin, but I want respectfully propose this as I think waiting isn't right strategy (please see the order of things mentioned above).