### PR TITLE
Resolve gradle user home misconfiguration

### DIFF
--- a/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
+++ b/independent-projects/bootstrap/gradle-resolver/src/main/java/io/quarkus/bootstrap/resolver/QuarkusGradleModelFactory.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ModelBuilder;
 import org.gradle.tooling.ProjectConnection;
+import org.gradle.wrapper.GradleUserHomeLookup;
 
 import io.quarkus.bootstrap.model.ApplicationModel;
 
@@ -19,6 +20,7 @@ public class QuarkusGradleModelFactory {
     public static ApplicationModel create(File projectDir, String mode, List<String> jvmArgs, String... tasks) {
         try (ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(projectDir)
+                .useGradleUserHomeDir(GradleUserHomeLookup.gradleUserHome())
                 .connect()) {
             return connection.action(new QuarkusModelBuildAction(mode)).forTasks(tasks).addJvmArguments(jvmArgs).run();
         }
@@ -27,6 +29,7 @@ public class QuarkusGradleModelFactory {
     public static ApplicationModel createForTasks(File projectDir, String... tasks) {
         try (ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(projectDir)
+                .useGradleUserHomeDir(GradleUserHomeLookup.gradleUserHome())
                 .connect()) {
             final ModelBuilder<ApplicationModel> modelBuilder = connection.model(ApplicationModel.class);
             if (tasks.length != 0) {


### PR DESCRIPTION
Resolves issue: https://github.com/quarkusio/quarkus/issues/20928

Traditionally happens against a CI pipeline with a custom gradle user home.

The issue occurs when extensions such as `quarkus-jacoco` attempt to load an ApplicationModel and the project being used:  
- Contains a custom gradle user home that is not `~./gradle`
- The custom gradle user home contains custom `gradle.properties` (traditionally something like `repoUsername` and `repoPassword`) in order to resolve dependencies from a private repository.

As a result of the custom gradle.properties file missed, the user is presented with errors related to missing gradle properties or not being able to resolve dependencies.