### PR TITLE
Allow assigning entities to the Hibernate Reactive PU explicitly

### DIFF
--- a/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
+++ b/extensions/hibernate-orm/deployment/src/main/java/io/quarkus/hibernate/orm/deployment/HibernateOrmProcessor.java
@@ -1230,7 +1230,7 @@ public final class HibernateOrmProcessor {
         }
     }
 
-    private static Map<String, Set<String>> getModelClassesAndPackagesPerPersistenceUnits(HibernateOrmConfig hibernateOrmConfig,
+    public static Map<String, Set<String>> getModelClassesAndPackagesPerPersistenceUnits(HibernateOrmConfig hibernateOrmConfig,
             JpaModelBuildItem jpaModel, IndexView index, boolean enableDefaultPersistenceUnit) {
         Map<String, Set<String>> modelClassesAndPackagesPerPersistenceUnits = new HashMap<>();
 

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageAnnotationTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageAnnotationTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+
+import javax.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.excludedpackage.ExcludedEntity;
+import io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.packageincludedthroughannotation.EntityIncludedThroughPackageAnnotation;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class SinglePersistenceUnitPackageAnnotationTest {
+
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(EntityIncludedThroughPackageAnnotation.class.getPackage().getName())
+                    .addPackage(ExcludedEntity.class.getPackage().getName()))
+            .withConfigurationResource("application.properties")
+            // Expect a warning on startup
+            .setLogRecordPredicate(
+                    record -> record.getMessage().contains("Could not find a suitable persistence unit for model classes"))
+            .assertLogRecords(records -> assertThat(records)
+                    .as("Warnings on startup")
+                    .hasSize(1)
+                    .element(0).satisfies(record -> {
+                        assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains(
+                                        io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.excludedpackage.ExcludedEntity.class
+                                                .getName());
+                    }));
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Test
+    @RunOnVertxContext
+    public void testIncluded(UniAsserter asserter) {
+        EntityIncludedThroughPackageAnnotation entity = new EntityIncludedThroughPackageAnnotation("default");
+        asserter.assertThat(
+                () -> persist(entity).chain(() -> find(EntityIncludedThroughPackageAnnotation.class, entity.id)),
+                retrievedEntity -> assertThat(retrievedEntity.name).isEqualTo(entity.name));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testExcluded(UniAsserter asserter) {
+        ExcludedEntity entity = new ExcludedEntity("gsmet");
+        asserter.assertFailedWith(() -> persist(entity), t -> {
+            assertThat(t).hasMessageContaining("Unknown entity");
+        });
+    }
+
+    private Uni<Void> persist(Object entity) {
+        return sessionFactory.withTransaction(s -> s.persist(entity));
+    }
+
+    private <T> Uni<T> find(Class<T> entityClass, Object id) {
+        return sessionFactory.withSession(s -> s.find(entityClass, id));
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageConfigurationTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/SinglePersistenceUnitPackageConfigurationTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+
+import javax.inject.Inject;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.excludedpackage.ExcludedEntity;
+import io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.packageincludedthroughconfig.EntityIncludedThroughPackageConfig;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.vertx.RunOnVertxContext;
+import io.quarkus.test.vertx.UniAsserter;
+import io.smallrye.mutiny.Uni;
+
+public class SinglePersistenceUnitPackageConfigurationTest {
+
+    private static final Formatter LOG_FORMATTER = new PatternFormatter("%s");
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addPackage(EntityIncludedThroughPackageConfig.class.getPackage().getName())
+                    .addPackage(ExcludedEntity.class.getPackage().getName()))
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.hibernate-orm.packages",
+                    EntityIncludedThroughPackageConfig.class.getPackage().getName())
+            // Expect a warning on startup
+            .setLogRecordPredicate(
+                    record -> record.getMessage().contains("Could not find a suitable persistence unit for model classes"))
+            .assertLogRecords(records -> assertThat(records)
+                    .as("Warnings on startup")
+                    .hasSize(1)
+                    .element(0).satisfies(record -> {
+                        assertThat(record.getLevel()).isEqualTo(Level.WARNING);
+                        assertThat(LOG_FORMATTER.formatMessage(record))
+                                .contains(ExcludedEntity.class.getName());
+                    }));
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Test
+    @RunOnVertxContext
+    public void testIncluded(UniAsserter asserter) {
+        EntityIncludedThroughPackageConfig entity = new EntityIncludedThroughPackageConfig("default");
+        asserter.assertThat(
+                () -> persist(entity).chain(() -> find(EntityIncludedThroughPackageConfig.class, entity.id)),
+                retrievedEntity -> assertThat(retrievedEntity.name).isEqualTo(entity.name));
+    }
+
+    @Test
+    @RunOnVertxContext
+    public void testExcluded(UniAsserter asserter) {
+        ExcludedEntity entity = new ExcludedEntity("gsmet");
+        asserter.assertFailedWith(() -> persist(entity), t -> {
+            assertThat(t).hasMessageContaining("Unknown entity");
+        });
+    }
+
+    private Uni<Void> persist(Object entity) {
+        return sessionFactory.withTransaction(s -> s.persist(entity));
+    }
+
+    private <T> Uni<T> find(Class<T> entityClass, Object id) {
+        return sessionFactory.withSession(s -> s.find(entityClass, id));
+    }
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/excludedpackage/ExcludedEntity.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/excludedpackage/ExcludedEntity.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.excludedpackage;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class ExcludedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "excludedSeq")
+    public long id;
+
+    public String name;
+
+    public ExcludedEntity() {
+    }
+
+    public ExcludedEntity(String name) {
+        this.name = name;
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughannotation/EntityIncludedThroughPackageAnnotation.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughannotation/EntityIncludedThroughPackageAnnotation.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.packageincludedthroughannotation;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class EntityIncludedThroughPackageAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "includedSeq")
+    public long id;
+
+    public String name;
+
+    public EntityIncludedThroughPackageAnnotation() {
+    }
+
+    public EntityIncludedThroughPackageAnnotation(String name) {
+        this.name = name;
+    }
+
+}

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughannotation/package-info.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughannotation/package-info.java
@@ -1,0 +1,4 @@
+@PersistenceUnit(PersistenceUnit.DEFAULT)
+package io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.packageincludedthroughannotation;
+
+import io.quarkus.hibernate.orm.PersistenceUnit;

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughconfig/EntityIncludedThroughPackageConfig.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/singlepersistenceunit/entityassignment/packageincludedthroughconfig/EntityIncludedThroughPackageConfig.java
@@ -1,0 +1,24 @@
+package io.quarkus.hibernate.reactive.singlepersistenceunit.entityassignment.packageincludedthroughconfig;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class EntityIncludedThroughPackageConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "includedSeq")
+    public long id;
+
+    public String name;
+
+    public EntityIncludedThroughPackageConfig() {
+    }
+
+    public EntityIncludedThroughPackageConfig(String name) {
+        this.name = name;
+    }
+
+}


### PR DESCRIPTION
Fixes #28576 

Note this does *not* address #21110: while we support assigning classes/packages to any PU, we still will only create one PU, the default one, and assigning a class/package to a non-default PU will result in a warning. Basically this is just (very) minimal support for assigning entities to the default PU explicitly, so that other entities can be ignored.

/cc @DavideD 