### PR TITLE
Tests - migrate 2 deprecated Smallrye JWT properties

### DIFF
--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookie.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookie.properties
@@ -1,7 +1,7 @@
 mp.jwt.verify.publickey.location=/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com
 smallrye.jwt.claims.groups=User
-smallrye.jwt.token.header=Cookie
-smallrye.jwt.token.cookie=cookie_a
+mp.jwt.token.header=Cookie
+mp.jwt.token.cookie=cookie_a
 smallrye.jwt.sign.key.location=/privateKey.pem
 quarkus.smallrye-jwt.enabled=true

--- a/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookieDev.properties
+++ b/extensions/smallrye-jwt/deployment/src/test/resources/applicationJwtCookieDev.properties
@@ -1,7 +1,7 @@
 #mp.jwt.verify.publickey.location=/publicKey.pem
 #mp.jwt.verify.issuer=https://server.example.com
 #smallrye.jwt.claims.groups=User
-#smallrye.jwt.token.header=Cookie
-#smallrye.jwt.token.cookie=cookie_a
+#mp.jwt.token.header=Cookie
+#mp.jwt.token.cookie=cookie_a
 #smallrye.jwt.sign.key.location=/privateKey.pem
 quarkus.smallrye-jwt.enabled=true


### PR DESCRIPTION
There is no test using non-deprecated properties. If we need to choose, `io.quarkus.jwt.test.JwtCookieDevModeTestCase`, `JwtCookieUnitTest` should prefer non-deprecated `header` and `cookie` properties.

`smallrye.jwt.token.header` property is deprecated and will be removed in a future version. Tests now use `mp.jwt.token.header` property. `smallrye.jwt.token.cookie` property is deprecated and will be removed in a future version. Tests now use `mp.jwt.token.cookie` property.