### PR TITLE
Improve the number of classes that are loaded by our AppCDS support

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSControlPointBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/builditem/AppCDSControlPointBuildItem.java
@@ -1,0 +1,11 @@
+package io.quarkus.deployment.pkg.builditem;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * If this build item is generated, then it means that there is a recorder step that can be used as a point at which
+ * the application loading during AppCDS generation can be stopped safely, therefore allowing Quarkus to not have to
+ * stop loading the application in the static init phase which is the default approach for AppCDS generation.
+ */
+public final class AppCDSControlPointBuildItem extends SimpleBuildItem {
+}

--- a/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/steps/MainClassBuildStep.java
@@ -70,6 +70,7 @@ import io.quarkus.runtime.Application;
 import io.quarkus.runtime.ApplicationLifecycleManager;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.NativeImageRuntimePropertiesRecorder;
+import io.quarkus.runtime.PreventFurtherStepsException;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.StartupContext;
@@ -276,6 +277,10 @@ public class MainClassBuildStep {
 
         tryBlock.invokeStaticMethod(
                 ofMethod(QuarkusConsole.class, "start", void.class));
+
+        CatchBlockCreator preventFurtherStepsBlock = tryBlock.addCatch(PreventFurtherStepsException.class);
+        preventFurtherStepsBlock.invokeVirtualMethod(ofMethod(StartupContext.class, "close", void.class), startupContext);
+
         cb = tryBlock.addCatch(Throwable.class);
 
         // an exception was thrown before logging was actually setup, we simply dump everything to the console

--- a/core/runtime/src/main/java/io/quarkus/runtime/PreventFurtherStepsException.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/PreventFurtherStepsException.java
@@ -1,0 +1,10 @@
+package io.quarkus.runtime;
+
+/**
+ * When this exception is thrown from a recorder method, then no other recorder steps
+ * will be executed.
+ * This is likely of very limited use, but it does allow us to boot the application up to a certain point
+ * for example in AppCDS generation.
+ */
+public final class PreventFurtherStepsException extends RuntimeException {
+}

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreBeanContainerBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/PreBeanContainerBuildItem.java
@@ -1,0 +1,22 @@
+package io.quarkus.arc.deployment;
+
+import io.quarkus.arc.runtime.BeanContainer;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * A build item that represents the fully initialized CDI bean container.
+ * This item is produced immediately before {@link BeanContainerBuildItem} in order to give recorders the chance to
+ * do something immediately before real recording steps come into play.
+ */
+public final class PreBeanContainerBuildItem extends SimpleBuildItem {
+
+    private final BeanContainer value;
+
+    public PreBeanContainerBuildItem(BeanContainer value) {
+        this.value = value;
+    }
+
+    public BeanContainer getValue() {
+        return value;
+    }
+}

--- a/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/appcds/AppCDSRecorder.java
+++ b/extensions/arc/runtime/src/main/java/io/quarkus/arc/runtime/appcds/AppCDSRecorder.java
@@ -1,0 +1,31 @@
+package io.quarkus.arc.runtime.appcds;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.runtime.PreventFurtherStepsException;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class AppCDSRecorder {
+
+    public void controlGenerationAndExit() {
+        if (Boolean.parseBoolean(System.getProperty("quarkus.appcds.generate", "false"))) {
+            CountDownLatch latch = new CountDownLatch(1);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    Quarkus.blockingExit();
+                    latch.countDown();
+                }
+            }).start();
+            try {
+                latch.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                System.err.println("Unable to properly shutdown Quarkus application when creating AppCDS");
+            }
+            throw new PreventFurtherStepsException();
+        }
+    }
+}


### PR DESCRIPTION
The way this is done is by picking a much later point in the startup process that is safe for the application to reach. This point is basically when Arc has created all its beans as frameworks commence their work after this point.