### PR TITLE
Manage version for Apache Commons Text

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -187,6 +187,7 @@
         <picocli.version>4.6.3</picocli.version>
         <google-cloud-functions.version>1.0.4</google-cloud-functions.version>
         <commons-compress.version>1.21</commons-compress.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <gson.version>2.9.1</gson.version>
         <log4j2-jboss-logmanager.version>1.1.1.Final</log4j2-jboss-logmanager.version>
         <log4j2-api.version>2.19.0</log4j2-api.version>
@@ -3119,6 +3120,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
cc/ @gsmet & @yrodiere 

We need to manage org.apache.commons:commons-text to ensure consistent version, as it's being used by several components.

I've found at least these listing it as transitive dependency:
 - Liquibase
 - io.smallrye.reactive:smallrye-reactive-messaging-kafka-test-companion
 - net.sourceforge.htmlunit:htmlunit:jar
 - org.apache.activemq:artemis-server
 - io.quarkus:quarkus-avro-deployment