### PR TITLE
Mark graal-sdk and svm dependencies as "provided"

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -4239,6 +4239,7 @@
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
                 <version>${graal-sdk.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -111,6 +111,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -76,6 +76,7 @@
         <dependency>
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>

--- a/extensions/elytron-security/runtime/pom.xml
+++ b/extensions/elytron-security/runtime/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>

--- a/extensions/grpc-common/runtime/pom.xml
+++ b/extensions/grpc-common/runtime/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
+++ b/extensions/hibernate-search-orm-elasticsearch/runtime/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/independent-projects/bootstrap/bom/pom.xml
+++ b/independent-projects/bootstrap/bom/pom.xml
@@ -399,6 +399,7 @@
                 <groupId>org.graalvm.sdk</groupId>
                 <artifactId>graal-sdk</artifactId>
                 <version>${graal-sdk.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
In preparation for https://github.com/oracle/graal/pull/5232

CI run: https://github.com/graalvm/mandrel/actions/runs/3268680646