### PR TITLE
RESTEasy Reactive: allow exception mappers to handle auth failure exceptions when proactive security is enabled

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveProcessor.java
@@ -186,7 +186,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.ForbiddenException;
-import io.quarkus.vertx.http.deployment.FilterBuildItem;
+import io.quarkus.vertx.http.deployment.DefaultAuthFailureHandlerBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.VertxHttpRecorder;
@@ -1168,9 +1168,9 @@ public class ResteasyReactiveProcessor {
 
     @BuildStep
     @Record(value = ExecutionTime.STATIC_INIT)
-    public FilterBuildItem addDefaultAuthFailureHandler(ResteasyReactiveRecorder recorder) {
+    public DefaultAuthFailureHandlerBuildItem addDefaultAuthFailureHandler(ResteasyReactiveRecorder recorder) {
         // replace default auth failure handler added by vertx-http so that our exception mappers can customize response
-        return new FilterBuildItem(recorder.defaultAuthFailureHandler(), FilterBuildItem.AUTHENTICATION - 1);
+        return new DefaultAuthFailureHandlerBuildItem(recorder.defaultAuthFailureHandler());
     }
 
     private void checkForDuplicateEndpoint(ResteasyReactiveConfig config, Map<String, List<EndpointConfig>> allMethods) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomAuthCompletionExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/CustomAuthCompletionExceptionMapperTest.java
@@ -1,0 +1,72 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+
+public class CustomAuthCompletionExceptionMapperTest {
+
+    private static final String AUTHENTICATION_COMPLETION_EX = "AuthenticationCompletionException";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class,
+                            CustomAuthCompletionExceptionMapper.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.form.enabled=true\n"), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testAuthCompletionExMapper() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .filter(new CookieFilter())
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "a d m i n")
+                .formParam("j_password", "a d m i n")
+                .cookie("quarkus-redirect-location", "https://quarkus.io/guides")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .body(Matchers.equalTo(AUTHENTICATION_COMPLETION_EX));
+    }
+
+    public static final class CustomAuthCompletionExceptionMapper {
+
+        @ServerExceptionMapper(AuthenticationCompletionException.class)
+        public Response authenticationCompletionExceptionMapper() {
+            return Response.status(UNAUTHORIZED).entity(AUTHENTICATION_COMPLETION_EX).build();
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -56,7 +56,6 @@ import io.quarkus.security.AuthenticationRedirectException;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
-import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
@@ -317,17 +316,8 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
         return new ServerSerialisers();
     }
 
-    public Handler<RoutingContext> defaultAuthFailureHandler() {
-        return new Handler<RoutingContext>() {
-            @Override
-            public void handle(RoutingContext event) {
-                if (event.get(QuarkusHttpUser.AUTH_FAILURE_HANDLER) instanceof DefaultAuthFailureHandler) {
-                    // fail event rather than end it, so it's handled by abort handlers (see #addFailureHandler method)
-                    event.put(QuarkusHttpUser.AUTH_FAILURE_HANDLER, new FailingDefaultAuthFailureHandler());
-                }
-                event.next();
-            }
-        };
+    public BiConsumer<RoutingContext, Throwable> defaultAuthFailureHandler() {
+        return new FailingDefaultAuthFailureHandler();
     }
 
     private static final class FailingDefaultAuthFailureHandler implements BiConsumer<RoutingContext, Throwable> {

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/AbstractAuthFailedExceptionMappingTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/AbstractAuthFailedExceptionMappingTest.java
@@ -1,0 +1,39 @@
+package io.quarkus.jwt.test;
+
+import javax.ws.rs.core.Response;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.restassured.RestAssured;
+import io.vertx.ext.web.RoutingContext;
+
+public abstract class AbstractAuthFailedExceptionMappingTest {
+
+    private static final String CUSTOMIZED_RESPONSE = "AuthenticationFailedException";
+    protected static final Class<?>[] classes = { JsonValuejectionEndpoint.class, TokenUtils.class,
+            AuthFailedExceptionMapper.class };
+
+    @Test
+    public void testExMapperCustomizedResponse() {
+        RestAssured
+                .given()
+                .auth().oauth2("absolute-nonsense")
+                .get("/endp/verifyInjectedIssuer").then()
+                .statusCode(401)
+                .body(Matchers.equalTo(CUSTOMIZED_RESPONSE));
+    }
+
+    public static class AuthFailedExceptionMapper {
+
+        @ServerExceptionMapper(value = AuthenticationFailedException.class)
+        public Response handle(RoutingContext routingContext) {
+            return Response
+                    .status(401)
+                    .entity(CUSTOMIZED_RESPONSE).build();
+        }
+
+    }
+}

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionMappingTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionMappingTest.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 
-public class DisabledProactiveAuthFailedExceptionMappingTest extends AbstractAuthFailedExceptionMappingTest {
+public class EnabledProactiveAuthFailedExceptionMappingTest extends AbstractAuthFailedExceptionMappingTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot((jar) -> jar
                     .addClasses(classes)
-                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=false\n"), "application.properties"));
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=true\n"), "application.properties"));
 
 }

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/DefaultAuthFailureHandlerBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/DefaultAuthFailureHandlerBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkus.vertx.http.deployment;
+
+import java.util.function.BiConsumer;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * This way, extensions may register their own default {@link QuarkusHttpUser#AUTH_FAILURE_HANDLER}.
+ * If proactive auth is used, this is the only one.
+ */
+public final class DefaultAuthFailureHandlerBuildItem extends SimpleBuildItem {
+    private final BiConsumer<RoutingContext, Throwable> defaultAuthFailureHandler;
+
+    public DefaultAuthFailureHandlerBuildItem(BiConsumer<RoutingContext, Throwable> defaultAuthFailureHandler) {
+        this.defaultAuthFailureHandler = defaultAuthFailureHandler;
+    }
+
+    public BiConsumer<RoutingContext, Throwable> getDefaultAuthFailureHandler() {
+        return defaultAuthFailureHandler;
+    }
+}


### PR DESCRIPTION
fixes: #28489

Allows RR exceptions mappers to handle these of `AuthenticationCompletionException`, `AuthenticationRedirectException` and `AuthenticationFailedException` that would otherwise be handled by default auth failure handler (and ended) when proactive security is enabled. User will be able to provide his own custom exception mappers. Arguably most important change is that extensions are now able to provide their auth failure handler when proactive security is enabled. Without this feature, #5751 and #28488 can't be fixed.