### PR TITLE
Don't include GraalVM dependencies in lib directory

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/JarResultBuildStep.java
@@ -973,6 +973,14 @@ public class JarResultBuildStep {
 
             log.info("Building native image source jar: " + runnerJar);
 
+            // Remove svm and graal-sdk artifacts as they are provided by GraalVM itself
+            if (classLoadingConfig.removedArtifacts.isEmpty()) {
+                classLoadingConfig.removedArtifacts = Optional.of(new ArrayList<>(2));
+            }
+            List<String> removedArtifacts = classLoadingConfig.removedArtifacts.get();
+            removedArtifacts.add("org.graalvm.nativeimage:svm");
+            removedArtifacts.add("org.graalvm.sdk:graal-sdk");
+
             doLegacyThinJarGeneration(curateOutcomeBuildItem, outputTargetBuildItem, transformedClasses,
                     applicationArchivesBuildItem, applicationInfo, packageConfig, generatedResources, libDir, allClasses,
                     runnerZipFs, mainClassBuildItem, classLoadingConfig);


### PR DESCRIPTION
In preparation for oracle/graal#5232

Since GraalVM dependencies are provided by GraalVM itself there is no need to include them in the lib directory of thin jars or in uber jars.

Supersedes https://github.com/quarkusio/quarkus/pull/28647

CI run: https://github.com/graalvm/mandrel/actions/runs/3269063301