### PR TITLE
Qute - micro-optimizations

### DIFF
--- a/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
+++ b/extensions/qute/runtime/src/main/java/io/quarkus/qute/runtime/TemplateProducer.java
@@ -246,7 +246,7 @@ public class TemplateProducer {
                 if (!attributes.isEmpty()) {
                     attributes.forEach(instance::setAttribute);
                 }
-                if (!renderedActions.isEmpty()) {
+                if (renderedActions != null) {
                     renderedActions.forEach(instance::onRendered);
                 }
                 return instance;

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/EvaluatorImpl.java
@@ -1,6 +1,6 @@
 package io.quarkus.qute;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -19,33 +19,33 @@ import io.smallrye.mutiny.Uni;
 
 class EvaluatorImpl implements Evaluator {
 
-    private static final Logger LOGGER = Logger.getLogger(EvaluatorImpl.class);
+    private static final Logger LOG = Logger.getLogger(EvaluatorImpl.class);
 
     private final List<ValueResolver> resolvers;
-    private final Map<String, List<NamespaceResolver>> namespaceResolvers;
+    private final Map<String, NamespaceResolver[]> namespaceResolvers;
     private final boolean strictRendering;
     private final ErrorInitializer initializer;
 
     EvaluatorImpl(List<ValueResolver> valueResolvers, List<NamespaceResolver> namespaceResolvers, boolean strictRendering,
             ErrorInitializer errorInitializer) {
         this.resolvers = valueResolvers;
-        Map<String, List<NamespaceResolver>> namespaceResolversMap = new HashMap<>();
+        Map<String, NamespaceResolver[]> namespaceResolversMap = new HashMap<>();
         for (NamespaceResolver namespaceResolver : namespaceResolvers) {
-            List<NamespaceResolver> matching = namespaceResolversMap.get(namespaceResolver.getNamespace());
+            NamespaceResolver[] matching = namespaceResolversMap.get(namespaceResolver.getNamespace());
             if (matching == null) {
-                matching = new ArrayList<>();
-                namespaceResolversMap.put(namespaceResolver.getNamespace(), matching);
-            }
-            matching.add(namespaceResolver);
-        }
-        for (Entry<String, List<NamespaceResolver>> entry : namespaceResolversMap.entrySet()) {
-            List<NamespaceResolver> list = entry.getValue();
-            if (list.size() == 1) {
-                entry.setValue(Collections.singletonList(list.get(0)));
+                matching = new NamespaceResolver[] { namespaceResolver };
             } else {
+                int newLength = matching.length + 1;
+                matching = Arrays.copyOf(matching, newLength);
+                matching[newLength - 1] = namespaceResolver;
+            }
+            namespaceResolversMap.put(namespaceResolver.getNamespace(), matching);
+        }
+        for (Entry<String, NamespaceResolver[]> entry : namespaceResolversMap.entrySet()) {
+            NamespaceResolver[] matching = entry.getValue();
+            if (matching.length > 1) {
                 // Sort by priority - higher priority wins
-                list.sort(Comparator.comparingInt(WithPriority::getPriority).reversed());
-                entry.setValue(List.copyOf(list));
+                Arrays.sort(matching, Comparator.comparingInt(WithPriority::getPriority).reversed());
             }
         }
         this.namespaceResolvers = namespaceResolversMap;
@@ -55,10 +55,10 @@ class EvaluatorImpl implements Evaluator {
 
     @Override
     public CompletionStage<Object> evaluate(Expression expression, ResolutionContext resolutionContext) {
-        Iterator<Part> parts;
-        if (expression.hasNamespace()) {
-            parts = expression.getParts().iterator();
-            List<NamespaceResolver> matching = namespaceResolvers.get(expression.getNamespace());
+        if (expression.isLiteral()) {
+            return expression.asLiteral();
+        } else if (expression.hasNamespace()) {
+            NamespaceResolver[] matching = namespaceResolvers.get(expression.getNamespace());
             if (matching == null) {
                 return CompletedStage.failure(
                         initializer.error("No namespace resolver found for [{namespace}] in expression \\{{expression}\\}")
@@ -68,63 +68,61 @@ class EvaluatorImpl implements Evaluator {
                                 .origin(expression.getOrigin())
                                 .build());
             }
-            EvalContext context = new EvalContextImpl(false, null, resolutionContext, parts.next());
-            if (matching.size() == 1) {
+            List<Part> parts = expression.getParts();
+            Part part = parts.get(0);
+            EvalContext context = part.isVirtualMethod()
+                    ? new NamespaceMethodEvalContextImpl(resolutionContext, part, part.asVirtualMethod().getParameters())
+                    : new NamespaceEvalContextImpl(resolutionContext, part);
+            if (matching.length == 1) {
                 // Very often a single matching resolver will be found
-                return matching.get(0).resolve(context).thenCompose(r -> {
-                    if (parts.hasNext()) {
-                        return resolveReference(false, r, parts, resolutionContext, expression, 0);
-                    } else {
-                        return toCompletionStage(r);
-                    }
-                });
+                return matching[0].resolve(context).thenCompose(r -> (parts.size() > 1)
+                        ? resolveReference(false, r, parts, resolutionContext, expression, 1)
+                        : toCompletionStage(r));
             } else {
                 // Multiple namespace resolvers match
-                return resolveNamespace(context, resolutionContext, parts, matching.iterator(), expression);
+                return resolveNamespace(context, resolutionContext, parts, matching, 0, expression);
             }
         } else {
-            if (expression.isLiteral()) {
-                return expression.asLiteral();
-            } else {
-                parts = expression.getParts().iterator();
-                return resolveReference(true, resolutionContext.getData(), parts, resolutionContext, expression, 0);
-            }
+            return resolveReference(true, resolutionContext.getData(), expression.getParts(), resolutionContext, expression,
+                    0);
         }
     }
 
     private CompletionStage<Object> resolveNamespace(EvalContext context, ResolutionContext resolutionContext,
-            Iterator<Part> parts, Iterator<NamespaceResolver> resolvers, Expression expression) {
+            List<Part> parts, NamespaceResolver[] resolvers, int resolverIndex, Expression expression) {
         // Use the next matching namespace resolver
-        NamespaceResolver resolver = resolvers.next();
+        NamespaceResolver resolver = resolvers[resolverIndex];
         return resolver.resolve(context).thenCompose(r -> {
             if (Results.isNotFound(r)) {
                 // Result not found
-                if (resolvers.hasNext()) {
+                int nextIdx = resolverIndex + 1;
+                if (nextIdx < resolvers.length) {
                     // Try the next matching resolver
-                    return resolveNamespace(context, resolutionContext, parts, resolvers, expression);
+                    return resolveNamespace(context, resolutionContext, parts, resolvers, nextIdx, expression);
                 } else {
                     // No other matching namespace resolver exist
-                    if (parts.hasNext()) {
+                    if (parts.size() > 1) {
                         // Continue to the next part of the expression
-                        return resolveReference(false, r, parts, resolutionContext, expression, 0);
+                        return resolveReference(false, r, parts, resolutionContext, expression, 1);
                     } else if (strictRendering) {
                         throw propertyNotFound(r, expression);
                     }
                     return Results.notFound(context);
                 }
-            } else if (parts.hasNext()) {
-                return resolveReference(false, r, parts, resolutionContext, expression, 0);
+            } else if (parts.size() > 1) {
+                return resolveReference(false, r, parts, resolutionContext, expression, 1);
             } else {
                 return toCompletionStage(r);
             }
         });
     }
 
-    private CompletionStage<Object> resolveReference(boolean tryParent, Object ref, Iterator<Part> parts,
+    private CompletionStage<Object> resolveReference(boolean tryParent, Object ref, List<Part> parts,
             ResolutionContext resolutionContext, final Expression expression, int partIndex) {
-        Part part = parts.next();
-        EvalContextImpl evalContext = new EvalContextImpl(tryParent, ref, resolutionContext, part);
-        if (!parts.hasNext()) {
+        Part part = parts.get(partIndex);
+        EvalContextImpl evalContext = tryParent ? new EvalContextImpl(ref, resolutionContext, part)
+                : new TerminalEvalContextImpl(ref, resolutionContext, part);
+        if (partIndex + 1 >= parts.size()) {
             // The last part - no need to compose
             return resolve(evalContext, null, true, expression, true, partIndex);
         } else {
@@ -165,14 +163,14 @@ class EvaluatorImpl implements Evaluator {
         }
         if (applicableResolver == null) {
             ResolutionContext parent = evalContext.resolutionContext.getParent();
-            if (evalContext.tryParent && parent != null) {
+            if (parent != null && evalContext.tryParent()) {
                 // Continue with parent context
                 return resolve(
-                        new EvalContextImpl(true, parent.getData(), parent,
+                        new EvalContextImpl(parent.getData(), parent,
                                 evalContext.part),
                         null, false, expression, isLastPart, partIndex);
             }
-            LOGGER.tracef("Unable to resolve %s", evalContext);
+            LOG.tracef("Unable to resolve %s", evalContext);
             Object notFound;
             if (Results.isNotFound(evalContext.getBase())) {
                 // If the base is "not found" then just return it
@@ -259,17 +257,112 @@ class EvaluatorImpl implements Evaluator {
 
     }
 
+    static class NamespaceEvalContextImpl implements EvalContext {
+
+        final ResolutionContext resolutionContext;
+        final PartImpl part;
+        final String name;
+
+        NamespaceEvalContextImpl(ResolutionContext resolutionContext, Part part) {
+            this.resolutionContext = resolutionContext;
+            this.part = (PartImpl) part;
+            this.name = part.getName();
+        }
+
+        @Override
+        public Object getBase() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public List<Expression> getParams() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public CompletionStage<Object> evaluate(String value) {
+            return evaluate(ExpressionImpl.from(value));
+        }
+
+        @Override
+        public CompletionStage<Object> evaluate(Expression expression) {
+            return resolutionContext.evaluate(expression);
+        }
+
+        @Override
+        public Object getAttribute(String key) {
+            return resolutionContext.getAttribute(key);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("NamespaceEvalContextImpl [name=")
+                    .append(name).append("]");
+            return builder.toString();
+        }
+
+    }
+
+    static class NamespaceMethodEvalContextImpl extends NamespaceEvalContextImpl {
+
+        final List<Expression> params;
+
+        NamespaceMethodEvalContextImpl(ResolutionContext resolutionContext, Part part, List<Expression> params) {
+            super(resolutionContext, part);
+            this.params = params;
+        }
+
+        @Override
+        public List<Expression> getParams() {
+            return params;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("NamespaceMethodEvalContextImpl [name=")
+                    .append(name).append(", params=").append(params).append("]");
+            return builder.toString();
+        }
+
+    }
+
+    static class TerminalEvalContextImpl extends EvalContextImpl {
+
+        TerminalEvalContextImpl(Object base, ResolutionContext resolutionContext, Part part) {
+            super(base, resolutionContext, part);
+        }
+
+        @Override
+        boolean tryParent() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("TerminalEvalContextImpl [base=").append(base).append(", name=")
+                    .append(name).append(", params=").append(params).append("]");
+            return builder.toString();
+        }
+
+    }
+
     static class EvalContextImpl implements EvalContext {
 
-        final boolean tryParent;
         final Object base;
         final ResolutionContext resolutionContext;
         final PartImpl part;
         final List<Expression> params;
         final String name;
 
-        EvalContextImpl(boolean tryParent, Object base, ResolutionContext resolutionContext, Part part) {
-            this.tryParent = tryParent;
+        EvalContextImpl(Object base, ResolutionContext resolutionContext, Part part) {
             this.base = base;
             this.resolutionContext = resolutionContext;
             this.part = (PartImpl) part;
@@ -316,11 +409,15 @@ class EvaluatorImpl implements Evaluator {
             part.cachedResolver = valueResolver;
         }
 
+        boolean tryParent() {
+            return true;
+        }
+
         @Override
         public String toString() {
             StringBuilder builder = new StringBuilder();
-            builder.append("EvalContextImpl [tryParent=").append(tryParent).append(", base=").append(base).append(", name=")
-                    .append(getName()).append(", params=").append(getParams()).append("]");
+            builder.append("EvalContextImpl [base=").append(base).append(", name=")
+                    .append(name).append(", params=").append(params).append("]");
             return builder.toString();
         }
 

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/ExpressionImpl.java
@@ -61,6 +61,11 @@ final class ExpressionImpl implements Expression {
         this.origin = origin;
     }
 
+    @Override
+    public boolean hasNamespace() {
+        return namespace != null;
+    }
+
     public String getNamespace() {
         return namespace;
     }

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateImpl.java
@@ -235,7 +235,7 @@ class TemplateImpl implements Template {
                     } catch (Throwable e) {
                         result.completeExceptionally(e);
                     } finally {
-                        if (!renderedActions.isEmpty()) {
+                        if (renderedActions != null) {
                             for (Runnable action : renderedActions) {
                                 try {
                                     action.run();

--- a/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
+++ b/independent-projects/qute/core/src/main/java/io/quarkus/qute/TemplateInstanceBase.java
@@ -18,11 +18,10 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
     protected Object data;
     protected Map<String, Object> dataMap;
     protected final Map<String, Object> attributes;
-    protected final List<Runnable> renderedActions;
+    protected List<Runnable> renderedActions;
 
     public TemplateInstanceBase() {
         this.attributes = new HashMap<>();
-        this.renderedActions = new ArrayList<>();
     }
 
     @Override
@@ -56,21 +55,26 @@ public abstract class TemplateInstanceBase implements TemplateInstance {
 
     @Override
     public TemplateInstance onRendered(Runnable action) {
+        if (renderedActions == null) {
+            renderedActions = new ArrayList<>();
+        }
         renderedActions.add(action);
         return this;
     }
 
     @Override
     public long getTimeout() {
-        Object t = getAttribute(TemplateInstance.TIMEOUT);
-        if (t != null) {
-            if (t instanceof Long) {
-                return ((Long) t).longValue();
-            } else {
-                try {
-                    return Long.parseLong(t.toString());
-                } catch (NumberFormatException e) {
-                    LOG.warnf("Invalid timeout value set for " + toString() + ": " + t);
+        if (!attributes.isEmpty()) {
+            Object t = getAttribute(TemplateInstance.TIMEOUT);
+            if (t != null) {
+                if (t instanceof Long) {
+                    return ((Long) t).longValue();
+                } else {
+                    try {
+                        return Long.parseLong(t.toString());
+                    } catch (NumberFormatException e) {
+                        LOG.warnf("Invalid timeout value set for " + toString() + ": " + t);
+                    }
                 }
             }
         }

--- a/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
+++ b/independent-projects/qute/core/src/test/java/io/quarkus/qute/NamespaceResolversTest.java
@@ -31,9 +31,9 @@ public class NamespaceResolversTest {
 
     @Test
     public void testMultipleAndNotFound() {
-        // This one should we used first but returns NOT_FOUND and so the other resolver is used
         Engine engine = Engine.builder().addValueResolver(new ReflectionValueResolver())
                 .addNamespaceResolver(NamespaceResolver.builder("foo").resolve(e -> "foo1").build())
+                // This one should we used first but returns NOT_FOUND and so the other resolver is used
                 .addNamespaceResolver(NamespaceResolver.builder("foo").priority(50).resolve(Results.NotFound::from).build())
                 .build();
         assertEquals("FOO1", engine.parse("{foo:baz.toUpperCase}").render());


### PR DESCRIPTION
- Evaluator - we cannot reduce the allocations of EvalContext but we can try to reduce the size of allocated instances
- Evaluator - use array/index-based access instead of List/iterators for namespace resolvers and expression parts
- TemplateInstance - init renderedActions lazily