### PR TITLE
QuarkusClassLoader - properly guard against null value

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -361,7 +361,10 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         if (name.endsWith(".class") && !endsWithTrailingSlash) {
             ClassPathElement[] providers = state.loadableResources.get(name);
             if (providers != null) {
-                return providers[0].getResource(name).getUrl();
+                ClassPathResource resource = providers[0].getResource(name);
+                if (resource != null) {
+                    return resource.getUrl();
+                }
             }
         } else {
             for (ClassPathElement i : elements) {


### PR DESCRIPTION
Fixes #28461 

I am not familiar with `QuarkusClassLoader` at all, but according to javadoc, `ClassPathElement.getResource()` can return `null` and the code doesn't guard against that.