### PR TITLE
Rest-client-reactive support ClientRequestContext.[get|set]EntityStream()

### DIFF
--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientRequestContextImpl.java
@@ -3,6 +3,9 @@ package org.jboss.resteasy.reactive.client.impl;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -34,7 +37,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.client.spi.ResteasyReactiveClientRequestContext;
-import org.jboss.resteasy.reactive.common.NotImplementedYet;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.headers.HeaderUtil;
 import org.jboss.resteasy.reactive.common.jaxrs.ConfigurationImpl;
@@ -248,12 +250,24 @@ public class ClientRequestContextImpl implements ResteasyReactiveClientRequestCo
 
     @Override
     public OutputStream getEntityStream() {
-        throw new NotImplementedYet();
+        if (!hasEntity())
+            return null;
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+            objectOutputStream.writeObject(getEntity());
+            objectOutputStream.close();
+            return byteArrayOutputStream;
+
+        } catch (IOException exception) {
+            return null;
+            //FIXME: handle exception properly.
+        }
     }
 
     @Override
     public void setEntityStream(OutputStream outputStream) {
-        throw new NotImplementedYet();
+        restClientRequestContext.entityStream = outputStream;
     }
 
     @Override

--- a/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
+++ b/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/RestClientRequestContext.java
@@ -3,6 +3,7 @@ package org.jboss.resteasy.reactive.client.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -65,6 +66,7 @@ public class RestClientRequestContext extends AbstractResteasyReactiveContext<Re
     URI uri;
     // Changeable by the request filter
     Entity<?> entity;
+    OutputStream entityStream;
     GenericType<?> responseType;
     private boolean responseTypeSpecified;
     private final ClientImpl restClient;


### PR DESCRIPTION
The getter and setter of EntityStream is implemented by adding a new member in RestClientContext.I tried to reuse previous workarounds in implementing methods.
Please check my changes and verify due to I m first contributor in Quarkus. Thanks.

Fixes #25706