### PR TITLE
Apply polish to Mongo tracing code

### DIFF
--- a/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
+++ b/extensions/mongodb-client/deployment/src/main/java/io/quarkus/mongodb/deployment/MongoClientProcessor.java
@@ -67,12 +67,13 @@ import io.quarkus.mongodb.runtime.MongoServiceBindingConverter;
 import io.quarkus.mongodb.runtime.MongodbConfig;
 import io.quarkus.mongodb.runtime.dns.MongoDnsClient;
 import io.quarkus.mongodb.runtime.dns.MongoDnsClientProvider;
+import io.quarkus.mongodb.tracing.MongoTracingCommandListener;
 import io.quarkus.runtime.metrics.MetricsFactory;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 import io.quarkus.vertx.deployment.VertxBuildItem;
 
 public class MongoClientProcessor {
-    private static final String MONGODB_TRACING_COMMANDLISTENER_CLASSNAME = "io.quarkus.mongodb.tracing.MongoTracingCommandListener";
+    private static final String MONGODB_TRACING_COMMAND_LISTENER = MongoTracingCommandListener.class.getName();
     private static final DotName MONGO_CLIENT_ANNOTATION = DotName.createSimple(MongoClientName.class.getName());
 
     private static final DotName MONGO_CLIENT = DotName.createSimple(MongoClient.class.getName());
@@ -144,7 +145,7 @@ public class MongoClientProcessor {
                 .map(ci -> ci.name().toString())
                 .collect(Collectors.toList());
         if (buildTimeConfig.tracingEnabled && capabilities.isPresent(Capability.OPENTRACING)) {
-            names.add(MONGODB_TRACING_COMMANDLISTENER_CLASSNAME);
+            names.add(MONGODB_TRACING_COMMAND_LISTENER);
         }
         return new CommandListenerBuildItem(names);
     }

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -1,5 +1,7 @@
 package io.quarkus.mongodb.tracing;
 
+import org.jboss.logging.Logger;
+
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
@@ -7,8 +9,6 @@ import com.mongodb.event.CommandSucceededEvent;
 
 import io.opentracing.contrib.mongo.common.TracingCommandListener;
 import io.opentracing.util.GlobalTracer;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Command Listener for Mongo client delegated to {@link TracingCommandListener}.
@@ -16,7 +16,7 @@ import io.vertx.core.logging.LoggerFactory;
  */
 public class MongoTracingCommandListener implements CommandListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MongoTracingCommandListener.class);
+    private static final Logger LOGGER = Logger.getLogger(MongoTracingCommandListener.class);
 
     private TracingCommandListener delegate;
 

--- a/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
+++ b/extensions/mongodb-client/runtime/src/main/java/io/quarkus/mongodb/tracing/MongoTracingCommandListener.java
@@ -18,7 +18,7 @@ public class MongoTracingCommandListener implements CommandListener {
 
     private static final Logger LOGGER = Logger.getLogger(MongoTracingCommandListener.class);
 
-    private TracingCommandListener delegate;
+    private final TracingCommandListener delegate;
 
     public MongoTracingCommandListener() {
         this.delegate = new TracingCommandListener.Builder(GlobalTracer.get()).build();


### PR DESCRIPTION
Although the tracing code deals with deprecated OpenTracing integration, these changes took less than 5 minutes to make while looking into the root cause of https://github.com/quarkusio/quarkus/issues/28427, so there is no reason to not include them