### PR TITLE
Qute checked fragments - ignore literal expressions during validation

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/QuteProcessor.java
@@ -669,7 +669,10 @@ public class QuteProcessor {
             }
 
             for (Expression expression : validation.fragmentExpressions) {
-                // Note that we ignore expressions with no type info and expressions with a hint referencing an expression from inside the fragment
+                // Note that we ignore literals and expressions with no type info and expressions with a hint referencing an expression from inside the fragment
+                if (expression.isLiteral()) {
+                    continue;
+                }
                 if (expression.hasTypeInfo()) {
                     Info info = TypeInfos.create(expression, index, null).get(0);
                     if (info.isTypeInfo()) {

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/fragment/CheckedTemplateFragmentTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/fragment/CheckedTemplateFragmentTest.java
@@ -19,13 +19,15 @@ public class CheckedTemplateFragmentTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .withApplicationRoot(root -> root
                     .addClasses(Templates.class, Item.class)
-                    .addAsResource(new StringAsset("{#each items}{#fragment id='item'}{it.name}{/fragment}{/each}"),
+                    .addAsResource(new StringAsset(
+                            "{#each items}{#fragment id='item'}{it.name}{#if it.name.length > 5} is a long name{/if}{/fragment}{/each}"),
                             "templates/CheckedTemplateFragmentTest/items.html"));
 
     @Test
     public void testFragment() {
         assertEquals("Foo", Templates.items(null).getFragment("item").data("it", new Item("Foo")).render());
         assertEquals("Foo", Templates.items$item(new Item("Foo")).render());
+        assertEquals("FooAndBar is a long name", Templates.items$item(new Item("FooAndBar")).render());
     }
 
     @CheckedTemplate


### PR DESCRIPTION
- literals have type info as well