### PR TITLE
Kubernetes: support for common resources

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1181,6 +1181,24 @@ The provided replicas <1>, labels <2> and environment variables <3>  were retain
 * When the name of the container does not match the application name (or the overridden name), container specific configuration will be ignored.
 ====
 
+=== Using common resources
+
+When generating the manifests for multiple deployment targets like Kubernetes, OpenShift or Knative, we can place the common resources in `src/main/kubernetes/common.yml`, so these resources will be integrated into the generated `kubernetes.json`/`kubernetes.yml`, and `openshift.json`/`openshift.yml` files (if you configure the Kubernetes and Openshift extensions at the same time).
+
+For example, we can write a ConfigMap resource only once in the file `src/main/kubernetes/common.yml`:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-configmap
+data:
+  hello: world
+----
+
+And this config map resource will be integrated into the generated `kubernetes.json`/`kubernetes.yml`, and `openshift.json`/`openshift.yml` files.
+
 == Service Binding [[service_binding]]
 
 Quarkus supports the link:https://github.com/servicebinding/spec[Service Binding Specification for Kubernetes] to bind services to applications.

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +63,7 @@ class KubernetesProcessor {
 
     private static final Logger log = Logger.getLogger(KubernetesProcessor.class);
 
+    private static final String COMMON = "common";
     private static final String OUTPUT_ARTIFACT_FORMAT = "%s%s.jar";
     public static final String DEFAULT_HASH_ALGORITHM = "SHA-256";
 
@@ -138,13 +140,16 @@ class KubernetesProcessor {
             Optional<Project> optionalProject = KubernetesCommonHelper.createProject(applicationInfo, customProjectRoot,
                     artifactPath);
             optionalProject.ifPresent(project -> {
-
+                Set<String> targets = new HashSet<>();
+                targets.add(COMMON);
+                targets.addAll(kubernetesDeploymentTargets.getEntriesSortedByPriority()
+                        .stream()
+                        .map(DeploymentTargetEntry::getName)
+                        .collect(Collectors.toSet()));
                 final Map<String, String> generatedResourcesMap;
                 final SessionWriter sessionWriter = new SimpleFileWriter(project, false);
                 final SessionReader sessionReader = new SimpleFileReader(
-                        project.getRoot().resolve("src").resolve("main").resolve("kubernetes"), kubernetesDeploymentTargets
-                                .getEntriesSortedByPriority().stream()
-                                .map(DeploymentTargetEntry::getName).collect(Collectors.toSet()));
+                        project.getRoot().resolve("src").resolve("main").resolve("kubernetes"), targets);
                 sessionWriter.setProject(project);
 
                 if (launchMode.getLaunchMode() != LaunchMode.NORMAL) {

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCommonResourcesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithCommonResourcesTest.java
@@ -1,0 +1,73 @@
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.Version;
+import io.quarkus.kubernetes.spi.CustomProjectRootBuildItem;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestBuildStep;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class OpenshiftWithCommonResourcesTest {
+
+    private static final String APP_NAME = "openshift-with-common-resources";
+    private static final String COMMON_CONFIGMAP_NAME = "common-configmap";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .addCustomResourceEntry(Path.of("src", "main", "kubernetes", "common.yml"),
+                    "manifests/" + APP_NAME + "/common.yml")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-openshift", Version.getVersion())))
+            .addBuildChainCustomizerEntries(
+                    new QuarkusProdModeTest.BuildChainCustomizerEntry(CustomProjectRootBuildItemProducerProdMode.class,
+                            Collections.singletonList(CustomProjectRootBuildItem.class), Collections.emptyList()));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("openshift.yml"))
+                .satisfies(p -> assertThat(p.toFile().listFiles()).hasSize(4));
+        assertThat(DeserializationUtil.deserializeAsList(kubernetesDir.resolve("openshift.yml")))
+                .filteredOn(h -> h instanceof ConfigMap)
+                .singleElement()
+                .isInstanceOfSatisfying(ConfigMap.class, c -> c.getMetadata().getName().equals(COMMON_CONFIGMAP_NAME));
+        assertThat(DeserializationUtil.deserializeAsList(kubernetesDir.resolve("kubernetes.yml")))
+                .filteredOn(h -> h instanceof ConfigMap)
+                .singleElement()
+                .isInstanceOfSatisfying(ConfigMap.class, c -> c.getMetadata().getName().equals(COMMON_CONFIGMAP_NAME));
+    }
+
+    public static class CustomProjectRootBuildItemProducerProdMode extends ProdModeTestBuildStep {
+
+        public CustomProjectRootBuildItemProducerProdMode(Map<String, Object> testContext) {
+            super(testContext);
+        }
+
+        @Override
+        public void execute(BuildContext context) {
+            context.produce(new CustomProjectRootBuildItem(
+                    (Path) getTestContext().get(QuarkusProdModeTest.BUILD_CONTEXT_CUSTOM_SOURCES_PATH_KEY)));
+        }
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/manifests/openshift-with-common-resources/common.yml
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/manifests/openshift-with-common-resources/common.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-configmap
+data:
+  hello: world


### PR DESCRIPTION
When generating the manifests for multiple deployment targets like Kubernetes, OpenShift or Knative, we can place the common resources in `src/main/kubernetes/common.yml`, so these resources will be integrated into the generated `kubernetes.json`/`kubernetes.yml`, and `openshift.json`/`openshift.yml` files (if you configure the Kubernetes and Openshift extensions at the same time).

For example, we can write a ConfigMap resource only once in the file `src/main/kubernetes/common.yml`:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-configmap
data:
  hello: world
```

And this config map resource will be integrated into the generated `kubernetes.json`/`kubernetes.yml`, and `openshift.json`/`openshift.yml` files.

Fix https://github.com/quarkusio/quarkus/issues/22290