### PR TITLE
DRYness: consolidate duplicated code in extension build plugins

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/build.gradle
+++ b/devtools/gradle/gradle-extension-plugin/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation platform("io.quarkus:quarkus-bom:${version}")
     implementation project(":gradle-model")
     implementation "io.quarkus:quarkus-core-deployment"
+    implementation "io.quarkus:quarkus-devtools-common"
     implementation "io.quarkus:quarkus-bootstrap-gradle-resolver"
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"

--- a/devtools/gradle/gradle-extension-plugin/pom.xml
+++ b/devtools/gradle/gradle-extension-plugin/pom.xml
@@ -42,6 +42,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-devtools-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -39,6 +38,7 @@ import io.quarkus.bootstrap.BootstrapConstants;
 import io.quarkus.bootstrap.model.AppArtifactCoords;
 import io.quarkus.bootstrap.model.AppArtifactKey;
 import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.devtools.project.extensions.ScmInfoProvider;
 import io.quarkus.extension.gradle.QuarkusExtensionConfiguration;
 import io.quarkus.extension.gradle.dsl.Capability;
 import io.quarkus.extension.gradle.dsl.RemovedResource;
@@ -311,7 +311,7 @@ public class ExtensionDescriptorTask extends DefaultTask {
     }
 
     private void computeSourceLocation(ObjectNode extObject) {
-        Map<String, String> repo = getSourceRepo();
+        Map<String, String> repo = ScmInfoProvider.getSourceRepo();
         if (repo != null) {
             ObjectNode scm = extObject.putObject("scm");
             for (Map.Entry<String, String> e : repo.entrySet()) {
@@ -319,22 +319,6 @@ public class ExtensionDescriptorTask extends DefaultTask {
 
             }
         }
-    }
-
-    static Map<String, String> getSourceRepo() {
-        // We could try and parse the .git/config file, but that will be fragile
-        // Let's assume we only care about the repo for official-ish builds produced via github actions
-        String repo = System.getenv("GITHUB_REPOSITORY");
-        if (repo != null) {
-            Map info = new HashMap();
-            String qualifiedRepo = "https://github.com/" + repo;
-            // Don't try and guess where slashes will be, just deal with any double slashes by brute force
-            qualifiedRepo = qualifiedRepo.replace("github.com//", "github.com/");
-
-            info.put("url", qualifiedRepo);
-            return info;
-        }
-        return null;
     }
 
     private void computeQuarkusCoreVersion(ObjectNode extObject) {

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -187,7 +187,7 @@ public class ExtensionDescriptorTaskTest {
      * that is increasingly hard to do on Java 17+; see https://github.com/junit-pioneer/junit-pioneer/issues/509
      */
     @Test
-    public void shouldGenerateSourcePointer() throws IOException {
+    public void shouldGenerateScmInformation() throws IOException {
         TestUtils.writeFile(buildFile, TestUtils.getDefaultGradleBuildFileContent(true, Collections.emptyList(), ""));
         File metaInfDir = new File(testProjectDir, "src/main/resources/META-INF");
         metaInfDir.mkdirs();

--- a/independent-projects/extension-maven-plugin/pom.xml
+++ b/independent-projects/extension-maven-plugin/pom.xml
@@ -240,6 +240,17 @@
             <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devtools-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-devtools-codestarts</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
         </dependency>

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -68,6 +68,7 @@ import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
 import io.quarkus.bootstrap.util.DependencyUtils;
+import io.quarkus.devtools.project.extensions.ScmInfoProvider;
 import io.quarkus.fs.util.ZipUtils;
 import io.quarkus.maven.capabilities.CapabilitiesConfig;
 import io.quarkus.maven.capabilities.CapabilityConfig;
@@ -574,22 +575,6 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
         return originalArtifact.replace("${project.version}", projectVersion);
     }
 
-    static Map<String, String> getSourceRepo() {
-        // We could try and parse the .git/config file, but that will be fragile
-        // Let's assume we only care about the repo for official-ish builds produced via github actions
-        String repo = System.getenv("GITHUB_REPOSITORY");
-        if (repo != null) {
-            Map info = new HashMap();
-            String qualifiedRepo = "https://github.com/" + repo;
-            // Don't try and guess where slashes will be, just deal with any double slashes by brute force
-            qualifiedRepo = qualifiedRepo.replace("github.com//", "github.com/");
-
-            info.put("url", qualifiedRepo);
-            return info;
-        }
-        return null;
-    }
-
     private static JsonNode getJsonElement(ObjectNode extObject, String... elements) {
         JsonNode mvalue = extObject.get(elements[0]);
         int i = 1;
@@ -689,7 +674,7 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     }
 
     private void addSource(ObjectNode extObject) throws MojoExecutionException {
-        Map<String, String> repo = getSourceRepo();
+        Map<String, String> repo = ScmInfoProvider.getSourceRepo();
         if (repo != null) {
             ObjectNode scm = extObject.putObject("scm");
             for (Map.Entry<String, String> e : repo.entrySet()) {

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
@@ -1,7 +1,6 @@
 package io.quarkus.maven;
 
 import static io.quarkus.maven.ExtensionDescriptorMojo.getCodestartArtifact;
-import static io.quarkus.maven.ExtensionDescriptorMojo.getSourceRepo;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Map;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
@@ -104,7 +102,6 @@ class ExtensionDescriptorMojoTest extends AbstractMojoTestCase {
             // Lazily test that the scm is there but is an object
             assertYamlContainsObject(fileContents, "scm");
             assertYamlContains(fileContents, "url", "https://github.com/some/repo");
-
         }
 
     }
@@ -204,18 +201,6 @@ class ExtensionDescriptorMojoTest extends AbstractMojoTestCase {
                 getCodestartArtifact("io.quarkus:my-ext:codestarts:jar:1.0", "999-SN"));
         assertEquals("io.quarkus:my-ext:999-SN",
                 getCodestartArtifact("io.quarkus:my-ext:${project.version}", "999-SN"));
-    }
-
-    @Test
-    void testGetSourceControlCoordinates() {
-        // From maven this property should be set, running in an IDE it won't be unless specially configured
-        if (System.getenv("GITHUB_REPOSITORY") != null) {
-            Map repo = getSourceRepo();
-            assertNotNull(repo);
-            assertTrue(repo.get("url").toString().matches("https://github.com/some/repo"));
-        } else {
-            assertNull(getSourceRepo());
-        }
     }
 
     private ExtensionDescriptorMojo makeMojo(String dirName) throws Exception {

--- a/independent-projects/tools/devtools-common/pom.xml
+++ b/independent-projects/tools/devtools-common/pom.xml
@@ -125,6 +125,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <scope>test</scope>
+            <version>2.0.1</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ScmInfoProvider.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/devtools/project/extensions/ScmInfoProvider.java
@@ -1,0 +1,24 @@
+package io.quarkus.devtools.project.extensions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScmInfoProvider {
+
+    public static Map<String, String> getSourceRepo() {
+        // We could try and parse the .git/config file, but that will be fragile
+        // Let's assume we only care about the repo for official-ish builds produced via github actions
+        String repo = System.getenv("GITHUB_REPOSITORY");
+        if (repo != null) {
+            Map info = new HashMap();
+            String qualifiedRepo = "https://github.com/" + repo;
+            // Don't try and guess where slashes will be, just deal with any double slashes by brute force
+            qualifiedRepo = qualifiedRepo.replace("github.com//", "github.com/");
+
+            info.put("url", qualifiedRepo);
+            return info;
+        }
+        return null;
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/extensions/ScmInfoProviderTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/devtools/project/extensions/ScmInfoProviderTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.devtools.project.extensions;
+
+import static io.quarkus.devtools.project.extensions.ScmInfoProvider.getSourceRepo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(SystemStubsExtension.class)
+public class ScmInfoProviderTest {
+
+    @SystemStub
+    private EnvironmentVariables environment;
+
+    @BeforeEach
+    public void setUp() {
+        environment.set("GITHUB_REPOSITORY", null);
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoEnvironmentOrBuildConfigIsPresent() {
+        Map scm = getSourceRepo();
+        // We shouldn't throw an exception or get upset, we should just quietly return null
+        assertNull(scm);
+    }
+
+    @Test
+    void testGetSourceControlCoordinates() {
+        String repoName = "org/place";
+        environment.set("GITHUB_REPOSITORY", repoName);
+        Map repo = getSourceRepo();
+        assertNotNull(repo);
+        assertEquals(repo.get("url").toString(), "https://github.com/org/place");
+    }
+}


### PR DESCRIPTION
I've added a dependency on devtools-common from all of the extension build plugins, so that I can eliminate duplicated code I introduced in the last changeset.

The implementation and the test method are just copied across from the duplicated versions.