### PR TITLE
Upgrade to OTel 1.19.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -24,8 +24,8 @@
         <opentracing-jdbc.version>0.2.4</opentracing-jdbc.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <opentracing-mongo.version>0.1.5</opentracing-mongo.version>
-        <opentelemetry.version>1.18.0</opentelemetry.version>
-        <opentelemetry-alpha.version>1.18.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry.version>1.19.0</opentelemetry.version>
+        <opentelemetry-alpha.version>1.19.0-alpha</opentelemetry-alpha.version>
         <jaeger.version>1.8.1</jaeger.version>
         <quarkus-http.version>4.1.9</quarkus-http.version>
         <micrometer.version>1.9.5</micrometer.version><!-- keep in sync with hdrhistogram -->

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/RestClientOpenTelemetryTest.java
@@ -2,12 +2,13 @@ package io.quarkus.opentelemetry.deployment.instrumentation;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_HOST;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_PORT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -67,7 +68,8 @@ public class RestClientOpenTelemetryTest {
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello", server.getAttributes().get(HTTP_ROUTE));
-        assertEquals(uri.getHost() + ":" + uri.getPort(), server.getAttributes().get(HTTP_HOST));
+        assertEquals(uri.getHost(), server.getAttributes().get(NET_HOST_NAME));
+        assertEquals(uri.getPort(), server.getAttributes().get(NET_HOST_PORT));
         assertEquals(uri.getPath() + "hello", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
@@ -132,7 +134,8 @@ public class RestClientOpenTelemetryTest {
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/{path}", server.getAttributes().get(HTTP_ROUTE));
-        assertEquals(uri.getHost() + ":" + uri.getPort(), server.getAttributes().get(HTTP_HOST));
+        assertEquals(uri.getHost(), server.getAttributes().get(NET_HOST_NAME));
+        assertEquals(uri.getPort(), server.getAttributes().get(NET_HOST_PORT));
         assertEquals(uri.getPath() + "hello/another", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);

--- a/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
+++ b/extensions/opentelemetry/deployment/src/test/java/io/quarkus/opentelemetry/deployment/instrumentation/VertxClientOpenTelemetryTest.java
@@ -2,12 +2,13 @@ package io.quarkus.opentelemetry.deployment.instrumentation;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_HOST;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_PORT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,7 +73,8 @@ public class VertxClientOpenTelemetryTest {
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello", server.getAttributes().get(HTTP_ROUTE));
-        assertEquals(uri.getHost() + ":" + uri.getPort(), server.getAttributes().get(HTTP_HOST));
+        assertEquals(uri.getHost(), server.getAttributes().get(NET_HOST_NAME));
+        assertEquals(uri.getPort(), server.getAttributes().get(NET_HOST_PORT));
         assertEquals(uri.getPath() + "hello", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
@@ -104,7 +106,8 @@ public class VertxClientOpenTelemetryTest {
         assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
         assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
         assertEquals("/hello/:name", server.getAttributes().get(HTTP_ROUTE));
-        assertEquals(uri.getHost() + ":" + uri.getPort(), server.getAttributes().get(HTTP_HOST));
+        assertEquals(uri.getHost(), server.getAttributes().get(NET_HOST_NAME));
+        assertEquals(uri.getPort(), server.getAttributes().get(NET_HOST_PORT));
         assertEquals(uri.getPath() + "hello/naruto", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);

--- a/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
+++ b/integration-tests/opentelemetry-reactive-messaging/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTestCase.java
@@ -3,6 +3,7 @@ package io.quarkus.it.opentelemetry;
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URL;
 import java.time.Duration;
@@ -117,7 +118,8 @@ public class OpenTelemetryTestCase {
         Assertions.assertEquals("GET", spanData.get("attr_http.method"));
         Assertions.assertEquals("1.1", spanData.get("attr_http.flavor"));
         Assertions.assertEquals("/direct", spanData.get("attr_http.target"));
-        Assertions.assertEquals(url.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(url.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(url.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         Assertions.assertEquals("http", spanData.get("attr_http.scheme"));
         Assertions.assertEquals("200", spanData.get("attr_http.status_code"));
         Assertions.assertNotNull(spanData.get("attr_http.client_ip"));

--- a/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
+++ b/integration-tests/opentelemetry/src/test/java/io/quarkus/it/opentelemetry/OpenTelemetryTest.java
@@ -94,7 +94,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", spanData.get("attr_http.method"));
         assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/direct", spanData.get("attr_http.target"));
-        assertEquals(directUrl.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
@@ -128,7 +129,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", server.get("attr_http.method"));
         assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/nopath", server.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), server.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("/nopath", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
@@ -159,7 +161,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", clientServer.get("attr_http.method"));
         assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/", clientServer.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), clientServer.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", clientServer.get("attr_http.scheme"));
         assertNull(clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
@@ -195,7 +198,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", server.get("attr_http.method"));
         assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/slashpath", server.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), server.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("/slashpath", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
@@ -225,7 +229,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", clientServer.get("attr_http.method"));
         assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/", clientServer.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), clientServer.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", clientServer.get("attr_http.scheme"));
         assertNull(clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
@@ -261,7 +266,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", server.get("attr_http.method"));
         assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/chained", server.get("attr_http.target"));
-        assertEquals(chainedUrl.getAuthority(), server.get("attr_http.host"));
+        assertEquals(deepPathUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("200", server.get("attr_http.status_code"));
         assertNotNull(server.get("attr_http.client_ip"));
@@ -316,7 +322,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", spanData.get("attr_http.method"));
         assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/direct", spanData.get("attr_http.target"));
-        assertEquals(directUrl.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
@@ -351,7 +358,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", spanData.get("attr_http.method"));
         assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/deep/path", spanData.get("attr_http.target"));
-        assertEquals(deepPathUrl.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));
@@ -386,7 +394,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", spanData.get("attr_http.method"));
         assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/param/12345", spanData.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("/param/{paramId}", spanData.get("attr_http.route"));
         assertEquals("200", spanData.get("attr_http.status_code"));
@@ -420,7 +429,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", server.get("attr_http.method"));
         assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/client/ping/one", server.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), server.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("/client/ping/{message}", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
@@ -448,7 +458,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", clientServer.get("attr_http.method"));
         assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/client/pong/one", clientServer.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), clientServer.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", clientServer.get("attr_http.scheme"));
         assertEquals("/client/pong/{message}", clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
@@ -483,7 +494,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", server.get("attr_http.method"));
         assertEquals("1.1", server.get("attr_http.flavor"));
         assertEquals("/client/async-ping/one", server.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), server.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", server.get("attr_http.scheme"));
         assertEquals("/client/async-ping/{message}", server.get("attr_http.route"));
         assertEquals("200", server.get("attr_http.status_code"));
@@ -511,7 +523,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", clientServer.get("attr_http.method"));
         assertEquals("1.1", clientServer.get("attr_http.flavor"));
         assertEquals("/client/pong/one", clientServer.get("attr_http.target"));
-        assertEquals(pathParamUrl.getAuthority(), clientServer.get("attr_http.host"));
+        assertEquals(pathParamUrl.getHost(), server.get("attr_net.host.name"));
+        assertEquals(pathParamUrl.getPort(), Integer.valueOf((String) server.get("attr_net.host.port")));
         assertEquals("http", clientServer.get("attr_http.scheme"));
         assertEquals("/client/pong/{message}", clientServer.get("attr_http.route"));
         assertEquals("200", clientServer.get("attr_http.status_code"));
@@ -547,7 +560,8 @@ public class OpenTelemetryTest {
         assertEquals("GET", spanData.get("attr_http.method"));
         assertEquals("1.1", spanData.get("attr_http.flavor"));
         assertEquals("/template/path/something", spanData.get("attr_http.target"));
-        assertEquals(directUrl.getAuthority(), spanData.get("attr_http.host"));
+        assertEquals(deepPathUrl.getHost(), spanData.get("attr_net.host.name"));
+        assertEquals(deepPathUrl.getPort(), Integer.valueOf((String) spanData.get("attr_net.host.port")));
         assertEquals("http", spanData.get("attr_http.scheme"));
         assertEquals("200", spanData.get("attr_http.status_code"));
         assertNotNull(spanData.get("attr_http.client_ip"));


### PR DESCRIPTION
SemanticAttributes.HTTP_HOST was deprecated and replaced by, to maintain feature parity:
SemanticAttributes.NET_HOST_NAME;
SemanticAttributes.NET_HOST_PORT;