### PR TITLE
Docs update: document new generated extension metadata

### DIFF
--- a/docs/src/main/asciidoc/extension-metadata.adoc
+++ b/docs/src/main/asciidoc/extension-metadata.adoc
@@ -97,12 +97,15 @@ metadata:
 description: "A JAX-RS implementation utilizing build time processing and Vert.x.\
   \ This extension is not compatible with the quarkus-resteasy extension, or any of\
   \ the extensions that depend on it." <4>
+scm:
+  url: "https://github.com/quarkusio/quarkus" <5>
 ----
 
 <1> Quarkus version the extension was built with
 <2> https://quarkus.io/guides/capabilities[Capabilities] this extension provides
 <3> Direct dependencies on other extensions
 <4> Description that can be displayed to users. In this case, the description was copied from the `pom.xml` of the extension module but it could also be provided in the template file.
+<5> The source code repository of this extension. In GitHub Actions builds, it will be determined automatically. For other GitHub repositories, it can be controlled by setting a `GITHUB_REPOSITORY` environment variable.
 
 [[quarkus-extension-properties]]
 == META-INF/quarkus-extension.properties


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/28009 for context. I missed updating the docs in that PR, so updating now. 

I've updated the docs to reflect the current implementation and will continue to update as the implementation evolves.