### PR TITLE
ConfigUtil.argLineValue should handle values with spaces

### DIFF
--- a/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ConfigUtil.java
+++ b/test-framework/junit5/src/main/java/io/quarkus/test/junit/launcher/ConfigUtil.java
@@ -21,14 +21,18 @@ public final class ConfigUtil {
         if (strValue == null) {
             return Collections.emptyList();
         }
-        String[] parts = strValue.split("\\s+");
+        return splitArgs(strValue);
+    }
+
+    static List<String> splitArgs(String strValue) {
+        String[] parts = strValue.split("-");
         List<String> result = new ArrayList<>(parts.length);
         for (String s : parts) {
             String trimmed = s.trim();
             if (trimmed.isEmpty()) {
                 continue;
             }
-            result.add(trimmed);
+            result.add('-' + trimmed);
         }
         return result;
     }

--- a/test-framework/junit5/src/test/java/io/quarkus/test/junit/launcher/ConfigUtilTest.java
+++ b/test-framework/junit5/src/test/java/io/quarkus/test/junit/launcher/ConfigUtilTest.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.junit.launcher;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigUtilTest {
+
+    @Test
+    void splitArgs() {
+        assertEquals(
+                List.of("-Xms2G", "-Dprop=value", "-DdoubleQuoted=\"value1,    value2\"",
+                        "-DsingleQuoted='   value3,\t\nvalue4'"),
+                ConfigUtil.splitArgs(
+                        "-Xms2G -Dprop=value -DdoubleQuoted=\"value1,    value2\" -DsingleQuoted='   value3,\t\nvalue4'"));
+    }
+}


### PR DESCRIPTION
Passing ` quarkus.test.arg-line` currently won't work correctly if some values have spaces in them.