### PR TITLE
Throw an IllegalStateException with basic info about the provider that failed to provide a resource

### DIFF
--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/PathTreeClassPathElement.java
@@ -13,6 +13,7 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -180,6 +181,26 @@ public class PathTreeClassPathElement extends AbstractClassPathElement {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName()).append("[");
+        if (getDependencyKey() != null) {
+            sb.append(getDependencyKey().toGacString()).append(" ");
+        }
+        final Iterator<Path> i = pathTree.getRoots().iterator();
+        if (i.hasNext()) {
+            sb.append(i.next());
+            while (i.hasNext()) {
+                sb.append(",").append(i.next());
+            }
+        }
+        sb.append(" runtime=").append(isRuntime());
+        final Set<String> resources = this.resources;
+        sb.append(" resources=").append(resources == null ? "null" : resources.size());
+        return sb.append(']').toString();
     }
 
     private class Resource implements ClassPathResource {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/QuarkusClassLoader.java
@@ -361,7 +361,12 @@ public class QuarkusClassLoader extends ClassLoader implements Closeable {
         if (name.endsWith(".class") && !endsWithTrailingSlash) {
             ClassPathElement[] providers = state.loadableResources.get(name);
             if (providers != null) {
-                return providers[0].getResource(name).getUrl();
+                final ClassPathResource resource = providers[0].getResource(name);
+                if (resource == null) {
+                    throw new IllegalStateException(providers[0] + " from " + getName() + " (closed=" + this.isClosed()
+                            + ") was expected to provide " + name + " but failed");
+                }
+                return resource.getUrl();
             }
         } else {
             for (ClassPathElement i : elements) {


### PR DESCRIPTION
After chatting with @kdubb about https://github.com/quarkusio/quarkus/issues/28461 and difficulty to reproduce the issue, we thought it may be useful to have a bit more info about the state of the classloader and the classpath element that was expected to provide the resource when we run into this issue next time.