### PR TITLE
Bump kubernetes-client-bom from 6.1.1 to 6.2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -151,8 +151,8 @@
         <kotlin.version>1.7.20</kotlin.version>
         <kotlin.coroutine.version>1.6.4</kotlin.coroutine.version>
         <kotlin-serialization.version>1.4.1</kotlin-serialization.version>
-        <kubernetes-client.version>6.1.1</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
-        <dekorate.version>3.0.2</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
+        <kubernetes-client.version>6.2.0</kubernetes-client.version> <!-- Please check with Java Operator SDK team before updating -->
+        <dekorate.version>3.1.1</dekorate.version> <!-- Please check with Java Operator SDK team before updating -->
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <awaitility.version>4.2.0</awaitility.version>
         <jboss-logmanager.version>1.0.10</jboss-logmanager.version>

--- a/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
+++ b/extensions/openshift-client/deployment/src/main/java/io/quarkus/openshift/client/deployment/OpenShiftClientProcessor.java
@@ -2,18 +2,28 @@ package io.quarkus.openshift.client.deployment;
 
 import java.util.Collections;
 
+import org.jboss.jandex.DotName;
+
+import io.fabric8.kubernetes.client.extension.ExtensionAdapter;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.impl.NamespacedOpenShiftExtensionAdapter;
+import io.fabric8.openshift.client.impl.OpenShiftClientImpl;
+import io.fabric8.openshift.client.impl.OpenShiftExtensionAdapter;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.IgnoreSplitPackageBuildItem;
 import io.quarkus.deployment.Feature;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.it.openshift.client.runtime.OpenShiftClientProducer;
 
 public class OpenShiftClientProcessor {
 
     @BuildStep
-    public void process(BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemProducer) {
+    public void registerBeanProducers(BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemProducer) {
         // wire up the OpenShiftClient bean support
         additionalBeanBuildItemProducer.produce(AdditionalBeanBuildItem.unremovableOf(OpenShiftClientProducer.class));
     }
@@ -21,6 +31,39 @@ public class OpenShiftClientProcessor {
     @BuildStep
     public FeatureBuildItem feature() {
         return new FeatureBuildItem(Feature.OPENSHIFT_CLIENT);
+    }
+
+    @BuildStep
+    public void process(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses,
+            CombinedIndexBuildItem combinedIndexBuildItem,
+            BuildProducer<ServiceProviderBuildItem> serviceProviderProducer) {
+
+        final String[] deserializerClasses = combinedIndexBuildItem.getIndex()
+                .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonDeserializer"))
+                .stream()
+                .map(c -> c.name().toString())
+                .filter(s -> s.startsWith("io.fabric8.openshift"))
+                .toArray(String[]::new);
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, deserializerClasses));
+
+        final String[] serializerClasses = combinedIndexBuildItem.getIndex()
+                .getAllKnownSubclasses(DotName.createSimple("com.fasterxml.jackson.databind.JsonSerializer"))
+                .stream()
+                .map(c -> c.name().toString())
+                .filter(s -> s.startsWith("io.fabric8.openshift"))
+                .toArray(String[]::new);
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(true, false, serializerClasses));
+
+        reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, true, OpenShiftClientImpl.class.getName()));
+        reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, true, DefaultOpenShiftClient.class.getName()));
+
+        // Register the default OpenShift ExtensionAdapter implementations
+        serviceProviderProducer.produce(new ServiceProviderBuildItem(
+                ExtensionAdapter.class.getName(), OpenShiftExtensionAdapter.class.getName()));
+        serviceProviderProducer.produce(new ServiceProviderBuildItem(
+                ExtensionAdapter.class.getName(), NamespacedOpenShiftExtensionAdapter.class.getName()));
     }
 
     @BuildStep


### PR DESCRIPTION
Kubernetes Client 6.2.0 was just released: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.2.0

Just speeding up the dependabot process to see if CI reports any issue.

/cc @metacosm