### PR TITLE
Fix various issues in hibernate-reactive-panache-kotlin

### DIFF
--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
@@ -164,7 +164,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -194,6 +193,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jakarta/transform.sh
+++ b/jakarta/transform.sh
@@ -274,6 +274,7 @@ update_scope_in_test_properties "extensions/resteasy-reactive/rest-client-reacti
 update_scope_in_test_properties "extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/mp-classname-scope-test-application.properties"
 update_scope_in_test_properties "extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/resources/mp-global-scope-test-application.properties"
 transform_kotlin_module "extensions/panache/hibernate-orm-panache-kotlin"
+transform_kotlin_module "extensions/panache/hibernate-reactive-panache-kotlin"
 transform_kotlin_module "extensions/panache/mongodb-panache-kotlin"
 sed -i "s@javax/xml/bind/annotation/@jakarta/xml/bind/annotation/@g" ./extensions/panache/panache-common/deployment/src/main/java/io/quarkus/panache/common/deployment/PanacheConstants.java
 transform_kotlin_module "extensions/scheduler/kotlin"


### PR DESCRIPTION
javadoc:javadoc can't deal with Kotlin classes and it breaks the release build.