### PR TITLE
Improve Kotlin Serialization for native mode

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization-common/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/common/deployment/KotlinSerializationCommonProcessor.java
@@ -2,16 +2,60 @@ package io.quarkus.resteasy.reactive.kotlin.serialization.common.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Singleton;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime.KotlinSerializationConfig;
 import io.quarkus.resteasy.reactive.kotlin.serialization.common.runtime.KotlinSerializerRecorder;
 import kotlinx.serialization.json.Json;
 
 public class KotlinSerializationCommonProcessor {
+
+    private static final DotName SERIALIZABLE = DotName.createSimple("kotlinx.serialization.Serializable");
+    private static final String COMPANION_FIELD_NAME = "Companion";
+    private static final String[] EMPTY_ARRAY = new String[0];
+
+    // Kotlin Serialization generates classes at compile time which need to be available via reflection
+    // for serialization to work properly
+    @BuildStep
+    public void registerReflection(CombinedIndexBuildItem index, BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        var serializableInstances = index.getIndex().getAnnotations(SERIALIZABLE);
+        if (serializableInstances.isEmpty()) {
+            return;
+        }
+
+        List<String> supportClassNames = new ArrayList<>(serializableInstances.size());
+        List<String> serializableClassNames = new ArrayList<>(serializableInstances.size());
+        for (AnnotationInstance instance : serializableInstances) {
+            if (instance.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            var targetClass = instance.target().asClass();
+            var targetClassName = targetClass.name();
+            serializableClassNames.add(targetClassName.toString());
+            FieldInfo field = targetClass.field(COMPANION_FIELD_NAME);
+            if (field != null) {
+                supportClassNames.add(field.type().name().toString());
+            }
+        }
+        // the companion classes need to be registered for reflection so Kotlin can construct them and invoke methods reflectively
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, supportClassNames.toArray(EMPTY_ARRAY)));
+        // the serializable classes need to be registered for reflection, so they can be constructed and also Kotlin can determine the companion field at runtime
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, true, serializableClassNames.toArray(EMPTY_ARRAY)));
+    }
 
     @BuildStep
     @Record(STATIC_INIT)

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/deployment/KotlinSerializationProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive-kotlin-serialization/deployment/src/main/java/io/quarkus/resteasy/reactive/kotlin/serialization/deployment/KotlinSerializationProcessor.java
@@ -3,23 +3,16 @@ package io.quarkus.resteasy.reactive.kotlin.serialization.deployment;
 import static io.quarkus.deployment.Feature.RESTEASY_REACTIVE_KOTLIN_SERIALIZATION;
 import static io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem.json;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.Priorities;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.MediaType;
 
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationTarget;
-import org.jboss.jandex.DotName;
-
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ServerDefaultProducesHandlerBuildItem;
 import io.quarkus.resteasy.reactive.kotlin.serialization.runtime.KotlinSerializationMessageBodyReader;
 import io.quarkus.resteasy.reactive.kotlin.serialization.runtime.KotlinSerializationMessageBodyWriter;
@@ -27,30 +20,6 @@ import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterBuildItem;
 
 public class KotlinSerializationProcessor {
-
-    private static final DotName SERIALIZABLE = DotName.createSimple("kotlinx.serialization.Serializable");
-    private static final String COMPANION_CLASS_SUFFIX = "$Companion";
-
-    // Kotlin Serialization generates classes at compile time which need to be available via reflection
-    // for serialization to work properly
-    @BuildStep
-    public void registerReflection(CombinedIndexBuildItem index, BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        var serializableInstances = index.getIndex().getAnnotations(SERIALIZABLE);
-        if (serializableInstances.isEmpty()) {
-            return;
-        }
-
-        List<String> supportClassNames = new ArrayList<>(2 * serializableInstances.size());
-        for (AnnotationInstance instance : serializableInstances) {
-            if (instance.target().kind() != AnnotationTarget.Kind.CLASS) {
-                continue;
-            }
-            var targetClass = instance.target().asClass().name();
-            String companionClassName = targetClass.toString() + COMPANION_CLASS_SUFFIX;
-            supportClassNames.add(companionClassName);
-        }
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, false, supportClassNames.toArray(new String[0])));
-    }
 
     @BuildStep
     public void additionalProviders(

--- a/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/GreetingResource.kt
+++ b/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/GreetingResource.kt
@@ -1,6 +1,7 @@
 package io.quarkus.it.kotser
 
 import io.quarkus.it.kotser.model.Person
+import io.quarkus.it.kotser.model.Person2
 import io.quarkus.runtime.annotations.RegisterForReflection
 import kotlinx.coroutines.flow.flowOf
 import java.lang.reflect.Method
@@ -25,6 +26,13 @@ class GreetingResource {
     @Produces(MediaType.APPLICATION_JSON)
     fun hello(): Person {
         return Person("Jim Halpert")
+    }
+
+    @Path("unknownType")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    fun helloUnknownType(): Response {
+        return Response.ok(Person2("Foo Bar")).build()
     }
 
     @Path("suspend")

--- a/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/model/Person2.kt
+++ b/integration-tests/kotlin-serialization/src/main/kotlin/io/quarkus/it/kotser/model/Person2.kt
@@ -3,7 +3,7 @@ package io.quarkus.it.kotser.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Person(var name: String, var defaulted: String = "hi there!") {
+data class Person2(var name: String, var defaulted: String = "hey") {
     override fun toString(): String {
         TODO("this shouldn't get called. a proper serialization should be invoked.")
     }

--- a/integration-tests/kotlin-serialization/src/test/kotlin/io/quarkus/it/kotser/ResourceTest.kt
+++ b/integration-tests/kotlin-serialization/src/test/kotlin/io/quarkus/it/kotser/ResourceTest.kt
@@ -33,6 +33,16 @@ open class ResourceTest {
     }
 
     @Test
+    fun testGetUnknownType() {
+        When {
+            get("/unknownType")
+        } Then {
+            statusCode(200)
+            body(`is`("""{"name":"Foo Bar","defaulted":"hey"}"""))
+        }
+    }
+
+    @Test
     fun testSuspendGet() {
         When {
             get("/suspend")


### PR DESCRIPTION
This PR makes a few changes:

* It moves the discovery of Kotlin `@Serializable` classes from the server module to the common module
* It enhances changes the companion class discovery mechanism to match what Kotlin does at runtime
* It enhances the reflection registration process to ensure that the metadata Kotlin needs at runtime
is actually included in the native binary

Fixes #28734