### PR TITLE
Render Java example properly in Security Getting Started docs

### DIFF
--- a/docs/src/main/asciidoc/security-getting-started.adoc
+++ b/docs/src/main/asciidoc/security-getting-started.adoc
@@ -133,6 +133,7 @@ public class AdminResource {
 ----
 * Finally, implement the `/api/users/me` endpoint. As you can see from the source code example below, we are trusting only users with the `user` role.
 We are also using `SecurityContext` to get access to the currently authenticated `Principal`, and we return the user name, all of which is loaded from the database.
++
 [source,java]
 ----
 package org.acme.security.jpa;


### PR DESCRIPTION
Fixes appearance of one Java example in [Security Getting Started](https://quarkus.io/guides/security-getting-started)
Before PR
![image](https://user-images.githubusercontent.com/43821672/197193525-6b700849-810a-479d-aca8-2a9bec2a7bab.png)

After PR
![image](https://user-images.githubusercontent.com/43821672/197193459-31a7ca4f-0b95-406d-88d0-403526ffbd6c.png)
