### PR TITLE
Reflectionless interceptors

### DIFF
--- a/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodReflectionlessTest.java
+++ b/extensions/arc/deployment/src/test/java/io/quarkus/arc/test/interceptor/staticmethods/InterceptedStaticMethodReflectionlessTest.java
@@ -1,0 +1,210 @@
+package io.quarkus.arc.test.interceptor.staticmethods;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.MethodInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opentest4j.AssertionFailedError;
+
+import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.Reflectionless;
+import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
+import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InterceptedStaticMethodReflectionlessTest {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(InterceptMe.class, Simple.class, AnotherSimple.class, SimpleInterceptor.class))
+            .addBuildChainCustomizer(buildCustomizer());
+
+    static Consumer<BuildChainBuilder> buildCustomizer() {
+        return new Consumer<BuildChainBuilder>() {
+            @Override
+            public void accept(BuildChainBuilder builder) {
+                builder.addBuildStep(new BuildStep() {
+                    @Override
+                    public void execute(BuildContext context) {
+                        context.produce(new AnnotationsTransformerBuildItem(new AnnotationsTransformer() {
+                            @Override
+                            public boolean appliesTo(Kind kind) {
+                                return Kind.METHOD == kind;
+                            }
+
+                            @Override
+                            public void transform(TransformationContext context) {
+                                MethodInfo method = context.getTarget().asMethod();
+                                if (method.declaringClass().name().toString().endsWith("AnotherSimple")) {
+                                    context.transform().add(InterceptMe.class).done();
+                                }
+                            }
+
+                        }));
+                    }
+                }).produces(AnnotationsTransformerBuildItem.class).build();
+            }
+        };
+    }
+
+    @Test
+    public void testInterceptor() {
+        assertEquals("OK:PONG", Simple.ping("pong"));
+        assertNotNull(SimpleInterceptor.method);
+        assertFalse(SimpleInterceptor.method.isConstructor());
+        assertTrue(SimpleInterceptor.method.isStatic());
+        assertEquals("ping", SimpleInterceptor.method.getName());
+        assertEquals(Simple.class, SimpleInterceptor.method.getDeclaringClass());
+        assertEquals(1, SimpleInterceptor.method.getParameterTypes().length);
+        assertEquals(String.class, SimpleInterceptor.method.getParameterTypes()[0]);
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(InterceptMe.class));
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(InterceptMe.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("foo", SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertEquals(2, SimpleInterceptor.method.getAnnotations().length);
+
+        Simple.pong();
+        assertNotNull(SimpleInterceptor.method);
+        assertFalse(SimpleInterceptor.method.isConstructor());
+        assertTrue(SimpleInterceptor.method.isStatic());
+        assertEquals("pong", SimpleInterceptor.method.getName());
+        assertEquals(Simple.class, SimpleInterceptor.method.getDeclaringClass());
+        assertEquals(0, SimpleInterceptor.method.getParameterTypes().length);
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(InterceptMe.class));
+        assertFalse(SimpleInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(InterceptMe.class));
+        assertNull(SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals(1, SimpleInterceptor.method.getAnnotations().length);
+
+        assertEquals(42.0, Simple.testDouble(2.0, "foo", 5, null));
+        assertEquals(1, SimpleInterceptor.VOID_INTERCEPTIONS.get());
+        assertNotNull(SimpleInterceptor.method);
+        assertFalse(SimpleInterceptor.method.isConstructor());
+        assertTrue(SimpleInterceptor.method.isStatic());
+        assertEquals("testDouble", SimpleInterceptor.method.getName());
+        assertEquals(Simple.class, SimpleInterceptor.method.getDeclaringClass());
+        assertEquals(4, SimpleInterceptor.method.getParameterTypes().length);
+        assertEquals(double.class, SimpleInterceptor.method.getParameterTypes()[0]);
+        assertEquals(String.class, SimpleInterceptor.method.getParameterTypes()[1]);
+        assertEquals(int.class, SimpleInterceptor.method.getParameterTypes()[2]);
+        assertEquals(Simple.class, SimpleInterceptor.method.getParameterTypes()[3]);
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(InterceptMe.class));
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(InterceptMe.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("bar", SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertEquals(2, SimpleInterceptor.method.getAnnotations().length);
+
+        assertEquals("OK:PONG", AnotherSimple.ping("pong"));
+        assertNotNull(SimpleInterceptor.method);
+        assertFalse(SimpleInterceptor.method.isConstructor());
+        assertTrue(SimpleInterceptor.method.isStatic());
+        assertEquals("ping", SimpleInterceptor.method.getName());
+        assertEquals(AnotherSimple.class, SimpleInterceptor.method.getDeclaringClass());
+        assertEquals(1, SimpleInterceptor.method.getParameterTypes().length);
+        assertEquals(String.class, SimpleInterceptor.method.getParameterTypes()[0]);
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(InterceptMe.class));
+        assertTrue(SimpleInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(InterceptMe.class));
+        assertNotNull(SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("baz", SimpleInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertEquals(2, SimpleInterceptor.method.getAnnotations().length);
+    }
+
+    public static class Simple {
+        @InterceptMe
+        @MySimpleAnnotation("foo")
+        public static String ping(String val) {
+            return val.toUpperCase();
+        }
+
+        @InterceptMe
+        static void pong() {
+        }
+
+        @InterceptMe
+        @MySimpleAnnotation("bar")
+        protected static Double testDouble(double val, String str, int num, Simple parent) {
+            return val;
+        }
+    }
+
+    public static class AnotherSimple {
+        // @InterceptMe is added by the transformer
+        @MySimpleAnnotation("baz")
+        public static String ping(String val) {
+            return val.toUpperCase();
+        }
+    }
+
+    @Priority(1)
+    @Interceptor
+    @Reflectionless
+    @InterceptMe
+    static class SimpleInterceptor {
+        static final AtomicInteger VOID_INTERCEPTIONS = new AtomicInteger();
+
+        static MethodMetadata method;
+
+        @AroundInvoke
+        Object aroundInvoke(ArcInvocationContext ctx) throws Exception {
+            if (!ctx.getMethodMetadata().isStatic()) {
+                throw new AssertionFailedError("Not a static method!");
+            }
+            assertNull(ctx.getTarget());
+            assertNull(ctx.getMethod());
+            assertNotNull(ctx.getMethodMetadata());
+            method = ctx.getMethodMetadata();
+
+            Object ret = ctx.proceed();
+            if (ret != null) {
+                if (ret instanceof String) {
+                    return "OK:" + ctx.proceed();
+                } else if (ret instanceof Double) {
+                    return 42.0;
+                } else {
+                    throw new AssertionFailedError("Unsupported return type: " + ret.getClass());
+                }
+            } else {
+                VOID_INTERCEPTIONS.incrementAndGet();
+                return ret;
+            }
+        }
+    }
+
+    @InterceptorBinding
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @interface InterceptMe {
+    }
+
+    @Target({ TYPE, METHOD })
+    @Retention(RUNTIME)
+    @interface MySimpleAnnotation {
+        String value();
+    }
+}

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerCountedInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/MicrometerCountedInterceptor.java
@@ -1,6 +1,5 @@
 package io.quarkus.micrometer.runtime;
 
-import java.lang.reflect.Method;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 
@@ -13,6 +12,8 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.Reflectionless;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.tuples.Functions;
 
@@ -24,6 +25,7 @@ import io.smallrye.mutiny.tuples.Functions;
  * @see Counted
  */
 @Interceptor
+@Reflectionless
 @MicrometerCounted
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 10)
 public class MicrometerCountedInterceptor {
@@ -60,7 +62,7 @@ public class MicrometerCountedInterceptor {
         if (counted == null) {
             return context.proceed();
         }
-        Method method = context.getMethod();
+        MethodMetadata method = context.getMethodMetadata();
         Tags commonTags = getCommonTags(method.getDeclaringClass().getName(), method.getName());
 
         Class<?> returnType = method.getReturnType();

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/ConcurrentGaugeInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/ConcurrentGaugeInterceptor.java
@@ -9,9 +9,11 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.Reflectionless;
 
 @ConcurrentGauge
 @Interceptor
+@Reflectionless
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 10)
 class ConcurrentGaugeInterceptor {
 
@@ -24,12 +26,12 @@ class ConcurrentGaugeInterceptor {
 
     @AroundConstruct
     Object cGaugeConstructor(ArcInvocationContext context) throws Exception {
-        return cGauge(context, context.getConstructor().getDeclaringClass().getSimpleName());
+        return cGauge(context, context.getMethodMetadata().getDeclaringClass().getSimpleName());
     }
 
     @AroundInvoke
     Object cGaugeMethod(ArcInvocationContext context) throws Exception {
-        return cGauge(context, context.getMethod().getName());
+        return cGauge(context, context.getMethodMetadata().getName());
     }
 
     Object cGauge(ArcInvocationContext context, String methodName) throws Exception {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/CountedInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/CountedInterceptor.java
@@ -9,10 +9,12 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.Reflectionless;
 
 @SuppressWarnings("unused")
 @Counted
 @Interceptor
+@Reflectionless
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 10)
 class CountedInterceptor {
 
@@ -25,12 +27,12 @@ class CountedInterceptor {
 
     @AroundConstruct
     Object countedConstructor(ArcInvocationContext context) throws Exception {
-        return increment(context, context.getConstructor().getDeclaringClass().getSimpleName());
+        return increment(context, context.getMethodMetadata().getDeclaringClass().getSimpleName());
     }
 
     @AroundInvoke
     Object countedMethod(ArcInvocationContext context) throws Exception {
-        return increment(context, context.getMethod().getName());
+        return increment(context, context.getMethodMetadata().getName());
     }
 
     Object increment(ArcInvocationContext context, String methodName) throws Exception {

--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/TimedInterceptor.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/mpmetrics/TimedInterceptor.java
@@ -10,10 +10,12 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.Reflectionless;
 
 @SuppressWarnings("unused")
 @Timed
 @Interceptor
+@Reflectionless
 @Priority(Interceptor.Priority.LIBRARY_BEFORE + 10)
 class TimedInterceptor {
 
@@ -26,12 +28,12 @@ class TimedInterceptor {
 
     @AroundConstruct
     Object timedConstructor(ArcInvocationContext context) throws Exception {
-        return time(context, context.getConstructor().getDeclaringClass().getSimpleName());
+        return time(context, context.getMethodMetadata().getDeclaringClass().getSimpleName());
     }
 
     @AroundInvoke
     Object timedMethod(ArcInvocationContext context) throws Exception {
-        return time(context, context.getMethod().getName());
+        return time(context, context.getMethodMetadata().getName());
     }
 
     Object time(ArcInvocationContext context, String methodName) throws Exception {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanInfo.java
@@ -835,6 +835,14 @@ public class BeanInfo implements InjectionTargetInfo {
             return interceptors.isEmpty();
         }
 
+        boolean isReflectionless() {
+            for (InterceptorInfo interceptor : interceptors) {
+                if (!interceptor.isReflectionless()) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     static class DecorationInfo {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DecoratorGenerator.java
@@ -43,11 +43,13 @@ public class DecoratorGenerator extends BeanGenerator {
     protected static final String FIELD_NAME_DELEGATE_TYPE = "delegateType";
     static final String ABSTRACT_IMPL_SUFFIX = "_Impl";
 
-    public DecoratorGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
+    public DecoratorGenerator(AnnotationLiteralProcessor annotationLiterals, MethodMetadataProcessor methodsMetadata,
+            Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses, Map<BeanInfo, String> beanToGeneratedName,
             Predicate<DotName> injectionPointAnnotationsPredicate) {
-        super(annotationLiterals, applicationClassPredicate, privateMembers, generateSources, reflectionRegistration,
+        super(annotationLiterals, methodsMetadata, applicationClassPredicate, privateMembers, generateSources,
+                reflectionRegistration,
                 existingClasses, beanToGeneratedName, injectionPointAnnotationsPredicate, Collections.emptyList());
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/DotNames.java
@@ -60,6 +60,7 @@ import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.NoClassInterceptors;
+import io.quarkus.arc.Reflectionless;
 import io.quarkus.arc.Unremovable;
 import io.quarkus.arc.VetoedProducer;
 import io.quarkus.arc.impl.ComputingCache;
@@ -133,6 +134,7 @@ public final class DotNames {
     public static final DotName NO_CLASS_INTERCEPTORS = create(NoClassInterceptors.class);
     public static final DotName DEPRECATED = create(Deprecated.class);
     public static final DotName KOTLIN_METADATA_ANNOTATION = create("kotlin.Metadata");
+    public static final DotName REFLECTIONLESS = create(Reflectionless.class);
 
     public static final DotName BOOLEAN = create(Boolean.class);
     public static final DotName BYTE = create(Byte.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/FieldDescriptors.java
@@ -1,5 +1,6 @@
 package io.quarkus.arc.processor;
 
+import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import io.quarkus.arc.impl.AnnotationLiterals;
@@ -35,6 +36,9 @@ final class FieldDescriptors {
             "EMPTY_STRING_ARRAY", String[].class);
     static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
             "EMPTY_CLASS_ARRAY", Class[].class);
+
+    static final FieldDescriptor ANNOTATION_LITERALS_EMPTY_ANNOTATION_ARRAY = FieldDescriptor.of(AnnotationLiterals.class,
+            "EMPTY_ANNOTATION_ARRAY", Annotation[].class);
 
     private FieldDescriptors() {
     }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorGenerator.java
@@ -46,11 +46,13 @@ public class InterceptorGenerator extends BeanGenerator {
 
     protected static final String FIELD_NAME_BINDINGS = "bindings";
 
-    public InterceptorGenerator(AnnotationLiteralProcessor annotationLiterals, Predicate<DotName> applicationClassPredicate,
+    public InterceptorGenerator(AnnotationLiteralProcessor annotationLiterals, MethodMetadataProcessor methodsMetadata,
+            Predicate<DotName> applicationClassPredicate,
             PrivateMembersCollector privateMembers, boolean generateSources, ReflectionRegistration reflectionRegistration,
             Set<String> existingClasses, Map<BeanInfo, String> beanToGeneratedName,
             Predicate<DotName> injectionPointAnnotationsPredicate) {
-        super(annotationLiterals, applicationClassPredicate, privateMembers, generateSources, reflectionRegistration,
+        super(annotationLiterals, methodsMetadata, applicationClassPredicate, privateMembers, generateSources,
+                reflectionRegistration,
                 existingClasses, beanToGeneratedName, injectionPointAnnotationsPredicate, Collections.emptyList());
     }
 

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/InterceptorInfo.java
@@ -30,6 +30,8 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
 
     private final Set<AnnotationInstance> bindings;
 
+    private final boolean reflectionless;
+
     private final MethodInfo aroundInvoke;
 
     private final MethodInfo aroundConstruct;
@@ -39,11 +41,12 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
     private final MethodInfo preDestroy;
 
     InterceptorInfo(AnnotationTarget target, BeanDeployment beanDeployment, Set<AnnotationInstance> bindings,
-            List<Injection> injections, int priority) {
+            List<Injection> injections, int priority, boolean reflectionless) {
         super(target, beanDeployment, BuiltinScope.DEPENDENT.getInfo(),
                 Collections.singleton(Type.create(target.asClass().name(), Kind.CLASS)), new HashSet<>(), injections,
                 null, null, false, Collections.emptyList(), null, false, null, priority);
         this.bindings = bindings;
+        this.reflectionless = reflectionless;
         List<MethodInfo> aroundInvokes = new ArrayList<>();
         List<MethodInfo> aroundConstructs = new ArrayList<>();
         List<MethodInfo> postConstructs = new ArrayList<>();
@@ -102,6 +105,10 @@ public class InterceptorInfo extends BeanInfo implements Comparable<InterceptorI
 
     public Set<AnnotationInstance> getBindings() {
         return bindings;
+    }
+
+    public boolean isReflectionless() {
+        return reflectionless;
     }
 
     public MethodInfo getAroundInvoke() {

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Interceptors.java
@@ -51,10 +51,12 @@ final class Interceptors {
                     "It will be assigned a default priority value of 0.");
             priority = 0;
         }
+        boolean reflectionless = store.hasAnnotation(interceptorClass, DotNames.REFLECTIONLESS);
         return new InterceptorInfo(interceptorClass, beanDeployment,
                 bindings.size() == 1 ? Collections.singleton(bindings.iterator().next())
                         : Collections.unmodifiableSet(bindings),
-                Injection.forBean(interceptorClass, null, beanDeployment, transformer), priority);
+                Injection.forBean(interceptorClass, null, beanDeployment, transformer), priority,
+                reflectionless);
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodDescriptors.java
@@ -1,10 +1,13 @@
 package io.quarkus.arc.processor;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +31,7 @@ import io.quarkus.arc.InjectableBean.Kind;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.InjectableInterceptor;
 import io.quarkus.arc.InjectableReferenceProvider;
+import io.quarkus.arc.MethodMetadata;
 import io.quarkus.arc.impl.ClientProxies;
 import io.quarkus.arc.impl.CreationalContextImpl;
 import io.quarkus.arc.impl.DecoratorDelegateProvider;
@@ -69,10 +73,27 @@ public final class MethodDescriptors {
             InjectableReferenceProvider.class,
             CreationalContext.class);
 
+    public static final MethodDescriptor ANNOTATION_TYPE = MethodDescriptor.ofMethod(Annotation.class, "annotationType",
+            Class.class);
+
+    public static final MethodDescriptor ARRAYS_COPY_OF = MethodDescriptor.ofMethod(Arrays.class, "copyOf", Object[].class,
+            Object[].class, int.class);
+
+    public static final MethodDescriptor MAP_OF_ENTRIES = MethodDescriptor.ofMethod(Map.class, "ofEntries", Map.class,
+            Map.Entry[].class);
+
+    public static final MethodDescriptor MAP_ENTRY = MethodDescriptor.ofMethod(Map.class, "entry", Map.Entry.class,
+            Object.class, Object.class);
+
+    public static final MethodDescriptor MAP_CONTAINS_KEY = MethodDescriptor.ofMethod(Map.class, "containsKey", boolean.class,
+            Object.class);
+
     public static final MethodDescriptor MAP_GET = MethodDescriptor.ofMethod(Map.class, "get", Object.class, Object.class);
 
     public static final MethodDescriptor MAP_PUT = MethodDescriptor.ofMethod(Map.class, "put", Object.class, Object.class,
             Object.class);
+
+    public static final MethodDescriptor MAP_VALUES = MethodDescriptor.ofMethod(Map.class, "values", Collection.class);
 
     public static final MethodDescriptor INJECTABLE_REF_PROVIDER_GET = MethodDescriptor.ofMethod(
             InjectableReferenceProvider.class,
@@ -84,6 +105,9 @@ public final class MethodDescriptors {
     public static final MethodDescriptor LIST_ADD = MethodDescriptor.ofMethod(List.class, "add", boolean.class, Object.class);
 
     public static final MethodDescriptor LIST_GET = MethodDescriptor.ofMethod(List.class, "get", Object.class, int.class);
+
+    public static final MethodDescriptor COLLECTION_TO_ARRAY = MethodDescriptor.ofMethod(Collection.class, "toArray",
+            Object[].class, Object[].class);
 
     public static final MethodDescriptor OBJECT_EQUALS = MethodDescriptor.ofMethod(Object.class, "equals", boolean.class,
             Object.class);
@@ -164,13 +188,13 @@ public final class MethodDescriptors {
     public static final MethodDescriptor INVOCATION_CONTEXTS_PERFORM_AROUND_INVOKE = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "performAroundInvoke",
-            Object.class, Object.class, Method.class, Function.class, Object[].class, List.class,
+            Object.class, Object.class, Method.class, MethodMetadata.class, Function.class, Object[].class, List.class,
             Set.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_AROUND_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
             "aroundConstruct",
-            InvocationContext.class, Constructor.class, List.class, Supplier.class, Set.class);
+            InvocationContext.class, Constructor.class, MethodMetadata.class, List.class, Supplier.class, Set.class);
 
     public static final MethodDescriptor INVOCATION_CONTEXTS_POST_CONSTRUCT = MethodDescriptor.ofMethod(
             InvocationContexts.class,
@@ -230,7 +254,7 @@ public final class MethodDescriptors {
 
     public static final MethodDescriptor INTERCEPTED_METHOD_METADATA_CONSTRUCTOR = MethodDescriptor.ofConstructor(
             InterceptedMethodMetadata.class,
-            List.class, Method.class, Set.class);
+            List.class, Method.class, MethodMetadata.class, Set.class);
 
     public static final MethodDescriptor CREATIONAL_CTX_HAS_DEPENDENT_INSTANCES = MethodDescriptor.ofMethod(
             CreationalContextImpl.class,
@@ -243,8 +267,9 @@ public final class MethodDescriptors {
             ClassLoader.class);
 
     public static final MethodDescriptor CL_FOR_NAME = MethodDescriptor.ofMethod(Class.class, "forName", Class.class,
-            String.class,
-            boolean.class, ClassLoader.class);
+            String.class, boolean.class, ClassLoader.class);
+
+    public static final MethodDescriptor CLASS_GET_NAME = MethodDescriptor.ofMethod(Class.class, "getName", String.class);
 
     public static final MethodDescriptor REMOVED_BEAN_IMPL = MethodDescriptor.ofConstructor(RemovedBeanImpl.class, Kind.class,
             String.class, Set.class, Set.class);

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodMetadataGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodMetadataGenerator.java
@@ -1,0 +1,534 @@
+package io.quarkus.arc.processor;
+
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.ParameterMetadata;
+import io.quarkus.arc.impl.ComputingCache;
+import io.quarkus.arc.processor.MethodMetadataProcessor.MethodMetadataImplClass;
+import io.quarkus.arc.processor.MethodMetadataProcessor.MethodMetadataShape;
+import io.quarkus.arc.processor.MethodMetadataProcessor.ParameterMetadataImplClass;
+import io.quarkus.arc.processor.ResourceOutput.Resource;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.ClassOutput;
+import io.quarkus.gizmo.FieldCreator;
+import io.quarkus.gizmo.FieldDescriptor;
+import io.quarkus.gizmo.Gizmo;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+/**
+ * This is an internal companion of {@link MethodMetadataProcessor} that handles generating
+ * {@code MethodMetadata} and {@code ParameterMetadata} implementations.
+ * <p>
+ * See {@link #generate(ComputingCache, ComputingCache, Set) generate()} for more info.
+ */
+public class MethodMetadataGenerator extends AbstractGenerator {
+    static final int UNFOLD_ARRAYS_THRESHOLD = 4; // value found empirically
+
+    MethodMetadataGenerator(boolean generateSources) {
+        super(generateSources);
+    }
+
+    /**
+     * Creator of a {@link MethodMetadataProcessor} must call this method at an appropriate point
+     * in time and write the result to an appropriate output. If not, the bytecode sequences generated
+     * using the {@code MethodMetadataProcessor} will refer to non-existing classes.
+     *
+     * @param existingClasses names of classes that already exist and should not be generated again
+     * @return the generated classes, never {@code null}
+     */
+    Collection<Resource> generate(ComputingCache<MethodMetadataShape, MethodMetadataImplClass> methodsToGenerate,
+            ComputingCache<MethodMetadataProcessor.ParameterMetadataShape, ParameterMetadataImplClass> parametersToGenerate,
+            Set<String> existingClasses) {
+        List<Resource> resources = new ArrayList<>();
+        methodsToGenerate.forEachExistingValue(clazz -> {
+            ResourceClassOutput classOutput = new ResourceClassOutput(clazz.isApplicationClass, generateSources);
+            createMethodMetadataClass(classOutput, clazz, existingClasses);
+            resources.addAll(classOutput.getResources());
+        });
+        parametersToGenerate.forEachExistingValue(clazz -> {
+            ResourceClassOutput classOutput = new ResourceClassOutput(clazz.isApplicationClass, generateSources);
+            createParameterMetadataClass(classOutput, clazz, existingClasses);
+            resources.addAll(classOutput.getResources());
+        });
+        return resources;
+    }
+
+    /**
+     * Creator of a {@link MethodMetadataProcessor} must call this method at an appropriate point
+     * in time and write the result to an appropriate output. If not, the bytecode sequences generated
+     * using the {@code MethodMetadataProcessor} will refer to non-existing classes.
+     *
+     * @param existingClasses names of classes that already exist and should not be generated again
+     * @return the generated classes, never {@code null}
+     */
+    Collection<Future<Collection<Resource>>> generate(
+            ComputingCache<MethodMetadataShape, MethodMetadataImplClass> methodsToGenerate,
+            ComputingCache<MethodMetadataProcessor.ParameterMetadataShape, ParameterMetadataImplClass> parametersToGenerate,
+            Set<String> existingClasses, ExecutorService executor) {
+        List<Future<Collection<Resource>>> futures = new ArrayList<>();
+        methodsToGenerate.forEachExistingValue(clazz -> {
+            futures.add(executor.submit(() -> {
+                ResourceClassOutput classOutput = new ResourceClassOutput(clazz.isApplicationClass, generateSources);
+                createMethodMetadataClass(classOutput, clazz, existingClasses);
+                return classOutput.getResources();
+            }));
+        });
+        parametersToGenerate.forEachExistingValue(clazz -> {
+            futures.add(executor.submit(() -> {
+                ResourceClassOutput classOutput = new ResourceClassOutput(clazz.isApplicationClass, generateSources);
+                createParameterMetadataClass(classOutput, clazz, existingClasses);
+                return classOutput.getResources();
+            }));
+        });
+        return futures;
+    }
+
+    /**
+     * Based on given {@code methodMetadataClass} data, generates a {@code MethodMetadata} implementation
+     * into the given {@code classOutput}. Does nothing if {@code existingClasses} indicates that the class
+     * to be generated already exists.
+     *
+     * @param classOutput the output to which the class is written
+     * @param methodMetadataClass data about the {@code MethodMetadata} class to be generated
+     * @param existingClasses set of existing classes that shouldn't be generated again
+     */
+    private void createMethodMetadataClass(ClassOutput classOutput, MethodMetadataImplClass methodMetadataClass,
+            Set<String> existingClasses) {
+
+        String generatedClassName = methodMetadataClass.generatedClassName.replace('.', '/');
+        if (existingClasses.contains(generatedClassName)) {
+            return;
+        }
+
+        try (ClassCreator clazz = ClassCreator.builder()
+                .classOutput(classOutput)
+                .className(generatedClassName)
+                .interfaces(MethodMetadata.class)
+                .setFinal(true)
+                .build()) {
+
+            // boolean isConstructor;
+            FieldCreator isConstructorField = clazz.getFieldCreator("isConstructor", boolean.class);
+            isConstructorField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // boolean isStatic;
+            FieldCreator isStaticField = clazz.getFieldCreator("isStatic", boolean.class);
+            isStaticField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // String name;
+            FieldCreator nameField = clazz.getFieldCreator("name", String.class);
+            nameField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // int modifiers;
+            FieldCreator modifiersField = clazz.getFieldCreator("modifiers", int.class);
+            modifiersField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // Class declaringClass;
+            FieldCreator declaringClassField = clazz.getFieldCreator("declaringClass", Class.class);
+            declaringClassField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // Class returnType;
+            FieldCreator returnTypeField = clazz.getFieldCreator("returnType", Class.class);
+            returnTypeField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // ParameterMetadata parameterN;
+            // or
+            // ParameterMetadata[] parameters;
+            int parametersCount = methodMetadataClass.shape.parametersCount;
+            List<FieldCreator> unfoldedParameters = new ArrayList<>(parametersCount);
+            FieldCreator parametersArray = null;
+            if (methodMetadataClass.parametersUnfolded) {
+                for (int i = 0; i < parametersCount; i++) {
+                    FieldCreator parameter = clazz.getFieldCreator("parameter" + i, ParameterMetadata.class);
+                    parameter.setModifiers(ACC_PRIVATE | ACC_FINAL);
+                    unfoldedParameters.add(parameter);
+                }
+            } else {
+                parametersArray = clazz.getFieldCreator("parameters", ParameterMetadata[].class);
+                parametersArray.setModifiers(ACC_PRIVATE | ACC_FINAL);
+            }
+
+            int annotationsCount = methodMetadataClass.shape.annotationsCount;
+            AnnotationFields annotationFields = generateAnnotationFields(clazz, annotationsCount);
+
+            // constructor
+            MethodCreator constructor = clazz.getMethodCreator(Methods.INIT, void.class,
+                    (Object[]) methodMetadataClass.constructorParameterTypes());
+            constructor.invokeSpecialMethod(MethodDescriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
+            constructor.writeInstanceField(isConstructorField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(0));
+            constructor.writeInstanceField(isStaticField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(1));
+            constructor.writeInstanceField(nameField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(2));
+            constructor.writeInstanceField(modifiersField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(3));
+            constructor.writeInstanceField(declaringClassField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(4));
+            constructor.writeInstanceField(returnTypeField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(5));
+            if (methodMetadataClass.parametersUnfolded) {
+                for (int i = 0; i < parametersCount; i++) {
+                    constructor.writeInstanceField(unfoldedParameters.get(i).getFieldDescriptor(), constructor.getThis(),
+                            constructor.getMethodParam(6 + i));
+                }
+            } else {
+                constructor.writeInstanceField(parametersArray.getFieldDescriptor(), constructor.getThis(),
+                        constructor.getMethodParam(6));
+            }
+            if (methodMetadataClass.annotationsUnfolded) {
+                for (int i = 0; i < annotationsCount; i++) {
+                    constructor.writeInstanceField(annotationFields.unfolded.get(i).getFieldDescriptor(), constructor.getThis(),
+                            constructor.getMethodParam(6 + methodMetadataClass.parametersSlots + i));
+                }
+            } else {
+                constructor.writeInstanceField(annotationFields.map.getFieldDescriptor(), constructor.getThis(),
+                        constructor.getMethodParam(6 + methodMetadataClass.parametersSlots));
+            }
+            constructor.returnValue(null);
+
+            // boolean isConstructor();
+            MethodCreator isConstructor = clazz.getMethodCreator("isConstructor", boolean.class);
+            isConstructor.returnValue(
+                    isConstructor.readInstanceField(isConstructorField.getFieldDescriptor(), isConstructor.getThis()));
+
+            // boolean isStatic();
+            MethodCreator isStatic = clazz.getMethodCreator("isStatic", boolean.class);
+            isStatic.returnValue(isStatic.readInstanceField(isStaticField.getFieldDescriptor(), isStatic.getThis()));
+
+            // String getName();
+            MethodCreator getName = clazz.getMethodCreator("getName", String.class);
+            getName.returnValue(getName.readInstanceField(nameField.getFieldDescriptor(), getName.getThis()));
+
+            // int getModifiers();
+            MethodCreator getModifiers = clazz.getMethodCreator("getModifiers", int.class);
+            getModifiers
+                    .returnValue(getModifiers.readInstanceField(modifiersField.getFieldDescriptor(), getModifiers.getThis()));
+
+            // Class<?> getDeclaringClass();
+            MethodCreator getDeclaringClass = clazz.getMethodCreator("getDeclaringClass", Class.class);
+            getDeclaringClass.returnValue(
+                    getDeclaringClass.readInstanceField(declaringClassField.getFieldDescriptor(), getDeclaringClass.getThis()));
+
+            // Class<?> getReturnType();
+            MethodCreator getReturnType = clazz.getMethodCreator("getReturnType", Class.class);
+            getReturnType.returnValue(
+                    getReturnType.readInstanceField(returnTypeField.getFieldDescriptor(), getReturnType.getThis()));
+
+            // int getParameterCount();
+            MethodCreator getParameterCount = clazz.getMethodCreator("getParameterCount", int.class);
+            getParameterCount.returnValue(getParameterCount.load(parametersCount));
+
+            // Class<?>[] getParameterTypes();
+            MethodCreator getParameterTypes = clazz.getMethodCreator("getParameterTypes", Class[].class);
+            if (parametersCount == 0) {
+                ResultHandle emptyArray = getParameterTypes.readStaticField(
+                        FieldDescriptors.ANNOTATION_LITERALS_EMPTY_CLASS_ARRAY);
+                getParameterTypes.returnValue(emptyArray);
+            } else if (methodMetadataClass.parametersUnfolded) {
+                ResultHandle array = getParameterTypes.newArray(Class.class, parametersCount);
+                for (int i = 0; i < unfoldedParameters.size(); i++) {
+                    ResultHandle parameter = getParameterTypes.readInstanceField(
+                            unfoldedParameters.get(i).getFieldDescriptor(), getParameterTypes.getThis());
+                    ResultHandle parameterType = getParameterTypes.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(ParameterMetadata.class, "getType", Class.class),
+                            parameter);
+                    getParameterTypes.writeArrayValue(array, i, parameterType);
+                }
+                getParameterTypes.returnValue(array);
+            } else {
+                ResultHandle localArray = getParameterTypes.readInstanceField(parametersArray.getFieldDescriptor(),
+                        getParameterTypes.getThis());
+                ResultHandle array = getParameterTypes.newArray(Class.class, parametersCount);
+                for (int i = 0; i < parametersCount; i++) {
+                    ResultHandle parameter = getParameterTypes.readArrayValue(localArray, i);
+                    ResultHandle parameterType = getParameterTypes.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(ParameterMetadata.class, "getType", Class.class),
+                            parameter);
+                    getParameterTypes.writeArrayValue(array, i, parameterType);
+                }
+                getParameterTypes.returnValue(array);
+            }
+
+            // ParameterMetadata[] getParameters();
+            MethodCreator getParameters = clazz.getMethodCreator("getParameters", ParameterMetadata[].class);
+            if (parametersCount == 0) {
+                ResultHandle emptyArray = getParameters.readStaticField(
+                        FieldDescriptor.of(ParameterMetadata.class, "EMPTY_ARRAY", ParameterMetadata[].class));
+                getParameters.returnValue(emptyArray);
+            } else if (methodMetadataClass.parametersUnfolded) {
+                ResultHandle array = getParameters.newArray(ParameterMetadata.class, parametersCount);
+                for (int i = 0; i < unfoldedParameters.size(); i++) {
+                    ResultHandle parameter = getParameters.readInstanceField(
+                            unfoldedParameters.get(i).getFieldDescriptor(), getParameters.getThis());
+                    getParameters.writeArrayValue(array, i, parameter);
+                }
+                getParameters.returnValue(array);
+            } else {
+                ResultHandle localArray = getParameters.readInstanceField(parametersArray.getFieldDescriptor(),
+                        getParameters.getThis());
+                ResultHandle clone = getParameters.invokeVirtualMethod(
+                        MethodDescriptor.ofMethod(Annotation[].class, "clone", Annotation[].class), localArray);
+                getParameters.returnValue(clone);
+            }
+
+            generateAnnotationMethods(clazz, annotationFields);
+
+            // String toString();
+            MethodCreator toString = clazz.getMethodCreator("toString", String.class);
+            ResultHandle declaringClass = toString.readInstanceField(declaringClassField.getFieldDescriptor(),
+                    toString.getThis());
+            ResultHandle declaringClassName = toString.invokeVirtualMethod(MethodDescriptors.CLASS_GET_NAME, declaringClass);
+            ResultHandle returnType = toString.readInstanceField(returnTypeField.getFieldDescriptor(), toString.getThis());
+            ResultHandle returnTypeName = toString.invokeVirtualMethod(MethodDescriptors.CLASS_GET_NAME, returnType);
+            ResultHandle name = toString.readInstanceField(nameField.getFieldDescriptor(), toString.getThis());
+            Gizmo.StringBuilderGenerator str = Gizmo.newStringBuilder(toString);
+            str.append(returnTypeName)
+                    .append(' ')
+                    .append(declaringClassName)
+                    .append('.')
+                    .append(name)
+                    .append('(');
+            if (methodMetadataClass.parametersUnfolded) {
+                for (int i = 0; i < unfoldedParameters.size(); i++) {
+                    if (i > 0) {
+                        str.append(", ");
+                    }
+
+                    ResultHandle parameter = toString.readInstanceField(
+                            unfoldedParameters.get(i).getFieldDescriptor(), toString.getThis());
+                    ResultHandle parameterType = toString.invokeInterfaceMethod(
+                            MethodDescriptor.ofMethod(ParameterMetadata.class, "getType", Class.class),
+                            parameter);
+                    ResultHandle parameterTypeName = toString.invokeVirtualMethod(MethodDescriptors.CLASS_GET_NAME,
+                            parameterType);
+                    str.append(parameterTypeName);
+                }
+            } else {
+                ResultHandle localArray = toString.readInstanceField(parametersArray.getFieldDescriptor(),
+                        toString.getThis());
+                for (int i = 0; i < parametersCount; i++) {
+                    if (i > 0) {
+                        str.append(", ");
+                    }
+
+                    ResultHandle parameter = toString.readArrayValue(localArray, i);
+                    ResultHandle parameterType = toString.invokeVirtualMethod(
+                            MethodDescriptor.ofMethod(ParameterMetadata.class, "getType", Class.class),
+                            parameter);
+                    ResultHandle parameterTypeName = toString.invokeVirtualMethod(MethodDescriptors.CLASS_GET_NAME,
+                            parameterType);
+                    str.append(parameterTypeName);
+                }
+            }
+            str.append(')');
+            toString.returnValue(str.callToString());
+
+            Gizmo.generateEqualsAndHashCode(clazz, clazz.getExistingFields());
+        }
+    }
+
+    /**
+     * Based on given {@code parameterMetadataClass} data, generates a {@code ParameterMetadata} implementation
+     * into the given {@code classOutput}. Does nothing if {@code existingClasses} indicates that the class
+     * to be generated already exists.
+     *
+     * @param classOutput the output to which the class is written
+     * @param parameterMetadataClass data about the {@code ParameterMetadata} class to be generated
+     * @param existingClasses set of existing classes that shouldn't be generated again
+     */
+    private void createParameterMetadataClass(ClassOutput classOutput, ParameterMetadataImplClass parameterMetadataClass,
+            Set<String> existingClasses) {
+
+        String generatedClassName = parameterMetadataClass.generatedClassName.replace('.', '/');
+        if (existingClasses.contains(generatedClassName)) {
+            return;
+        }
+
+        try (ClassCreator clazz = ClassCreator.builder()
+                .classOutput(classOutput)
+                .className(generatedClassName)
+                .interfaces(ParameterMetadata.class)
+                .setFinal(true)
+                .build()) {
+
+            // String name;
+            FieldCreator nameField = clazz.getFieldCreator("name", String.class);
+            nameField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            // Class type;
+            FieldCreator typeField = clazz.getFieldCreator("type", Class.class);
+            typeField.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            int annotationsCount = parameterMetadataClass.shape.annotationsCount;
+            AnnotationFields annotationFields = generateAnnotationFields(clazz, annotationsCount);
+
+            // constructor
+            MethodCreator constructor = clazz.getMethodCreator(Methods.INIT, void.class,
+                    (Object[]) parameterMetadataClass.constructorParameterTypes());
+            constructor.invokeSpecialMethod(MethodDescriptors.OBJECT_CONSTRUCTOR, constructor.getThis());
+            constructor.writeInstanceField(nameField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(0));
+            constructor.writeInstanceField(typeField.getFieldDescriptor(), constructor.getThis(),
+                    constructor.getMethodParam(1));
+            if (parameterMetadataClass.annotationsUnfolded) {
+                for (int i = 0; i < annotationsCount; i++) {
+                    constructor.writeInstanceField(annotationFields.unfolded.get(i).getFieldDescriptor(),
+                            constructor.getThis(), constructor.getMethodParam(2 + i));
+                }
+            } else {
+                constructor.writeInstanceField(annotationFields.map.getFieldDescriptor(),
+                        constructor.getThis(), constructor.getMethodParam(2));
+            }
+            constructor.returnValue(null);
+
+            // String getName();
+            MethodCreator getName = clazz.getMethodCreator("getName", String.class);
+            getName.returnValue(getName.readInstanceField(nameField.getFieldDescriptor(), getName.getThis()));
+
+            // Class<?> getType();
+            MethodCreator getType = clazz.getMethodCreator("getType", Class.class);
+            getType.returnValue(getType.readInstanceField(typeField.getFieldDescriptor(), getType.getThis()));
+
+            generateAnnotationMethods(clazz, annotationFields);
+
+            // String toString();
+            MethodCreator toString = clazz.getMethodCreator("toString", String.class);
+            ResultHandle type = toString.readInstanceField(typeField.getFieldDescriptor(), toString.getThis());
+            ResultHandle typeName = toString.invokeVirtualMethod(MethodDescriptors.CLASS_GET_NAME, type);
+            ResultHandle name = toString.readInstanceField(nameField.getFieldDescriptor(), toString.getThis());
+            Gizmo.StringBuilderGenerator str = Gizmo.newStringBuilder(toString);
+            str.append(typeName).append(' ').append(name);
+            toString.returnValue(str.callToString());
+
+            Gizmo.generateEqualsAndHashCode(clazz, clazz.getExistingFields());
+        }
+    }
+
+    private static class AnnotationFields {
+        final List<FieldCreator> unfolded;
+        final FieldCreator map;
+
+        AnnotationFields(List<FieldCreator> unfolded, FieldCreator map) {
+            this.unfolded = unfolded;
+            this.map = map;
+        }
+
+        boolean isEmpty() {
+            return unfolded == null && map == null;
+        }
+    }
+
+    private static AnnotationFields generateAnnotationFields(ClassCreator clazz, int annotationsCount) {
+        // Annotation annotationN;
+        // or
+        // Map<Class<? extend Annotation>, Annotation> annotations;
+        if (annotationsCount == 0) {
+            return new AnnotationFields(null, null);
+        } else if (annotationsCount <= UNFOLD_ARRAYS_THRESHOLD) {
+            List<FieldCreator> unfoldedAnnotations = new ArrayList<>(annotationsCount);
+            for (int i = 0; i < annotationsCount; i++) {
+                FieldCreator annotation = clazz.getFieldCreator("annotation" + i, Annotation.class);
+                annotation.setModifiers(ACC_PRIVATE | ACC_FINAL);
+                unfoldedAnnotations.add(annotation);
+            }
+
+            return new AnnotationFields(unfoldedAnnotations, null);
+        } else {
+            FieldCreator annotationsArray = clazz.getFieldCreator("annotations", Map.class);
+            annotationsArray.setModifiers(ACC_PRIVATE | ACC_FINAL);
+
+            return new AnnotationFields(null, annotationsArray);
+        }
+    }
+
+    private static void generateAnnotationMethods(ClassCreator clazz, AnnotationFields annotationFields) {
+        // boolean isAnnotationPresent(Class<? extends Annotation> annotationClass)
+        MethodCreator isAnnotationPresent = clazz.getMethodCreator("isAnnotationPresent", boolean.class, Class.class);
+        if (annotationFields.isEmpty()) {
+            isAnnotationPresent.returnValue(isAnnotationPresent.load(false));
+        } else if (annotationFields.unfolded != null) {
+            ResultHandle param = isAnnotationPresent.getMethodParam(0);
+            for (FieldCreator annotationField : annotationFields.unfolded) {
+                ResultHandle annotation = isAnnotationPresent.readInstanceField(annotationField.getFieldDescriptor(),
+                        isAnnotationPresent.getThis());
+                ResultHandle annotationType = isAnnotationPresent.invokeInterfaceMethod(
+                        MethodDescriptors.ANNOTATION_TYPE, annotation);
+                ResultHandle equals = isAnnotationPresent.invokeVirtualMethod(MethodDescriptors.OBJECT_EQUALS,
+                        annotationType, param);
+                BytecodeCreator ifTrue = isAnnotationPresent.ifTrue(equals).trueBranch();
+                ifTrue.returnValue(ifTrue.load(true));
+            }
+            isAnnotationPresent.returnValue(isAnnotationPresent.load(false));
+        } else {
+            ResultHandle param = isAnnotationPresent.getMethodParam(0);
+            ResultHandle localMap = isAnnotationPresent.readInstanceField(annotationFields.map.getFieldDescriptor(),
+                    isAnnotationPresent.getThis());
+            ResultHandle result = isAnnotationPresent.invokeInterfaceMethod(MethodDescriptors.MAP_CONTAINS_KEY, localMap,
+                    param);
+            isAnnotationPresent.returnValue(result);
+        }
+
+        // <T extends Annotation> T getAnnotation(Class<T> annotationClass);
+        MethodCreator getAnnotation = clazz.getMethodCreator("getAnnotation", Annotation.class, Class.class);
+        if (annotationFields.isEmpty()) {
+            getAnnotation.returnValue(getAnnotation.loadNull());
+        } else if (annotationFields.unfolded != null) {
+            ResultHandle param = getAnnotation.getMethodParam(0);
+            for (FieldCreator annotationField : annotationFields.unfolded) {
+                ResultHandle annotation = getAnnotation.readInstanceField(annotationField.getFieldDescriptor(),
+                        getAnnotation.getThis());
+                ResultHandle annotationType = getAnnotation.invokeInterfaceMethod(MethodDescriptors.ANNOTATION_TYPE,
+                        annotation);
+                ResultHandle equals = getAnnotation.invokeVirtualMethod(MethodDescriptors.OBJECT_EQUALS, annotationType, param);
+                getAnnotation.ifTrue(equals).trueBranch().returnValue(annotation);
+            }
+            getAnnotation.returnValue(getAnnotation.loadNull());
+        } else {
+            ResultHandle param = getAnnotation.getMethodParam(0);
+            ResultHandle localMap = getAnnotation.readInstanceField(annotationFields.map.getFieldDescriptor(),
+                    getAnnotation.getThis());
+            ResultHandle result = getAnnotation.invokeInterfaceMethod(MethodDescriptors.MAP_GET, localMap, param);
+            getAnnotation.returnValue(result);
+        }
+
+        // Annotation[] getAnnotations();
+        MethodCreator getAnnotations = clazz.getMethodCreator("getAnnotations", Annotation[].class);
+        if (annotationFields.isEmpty()) {
+            ResultHandle emptyArray = getAnnotations.readStaticField(
+                    FieldDescriptors.ANNOTATION_LITERALS_EMPTY_ANNOTATION_ARRAY);
+            getAnnotations.returnValue(emptyArray);
+        } else if (annotationFields.unfolded != null) {
+            ResultHandle array = getAnnotations.newArray(Annotation.class, annotationFields.unfolded.size());
+            for (int i = 0; i < annotationFields.unfolded.size(); i++) {
+                ResultHandle annotationHandle = getAnnotations.readInstanceField(
+                        annotationFields.unfolded.get(i).getFieldDescriptor(), getAnnotations.getThis());
+                getAnnotations.writeArrayValue(array, i, annotationHandle);
+            }
+            getAnnotations.returnValue(array);
+        } else {
+            ResultHandle localMap = getAnnotations.readInstanceField(annotationFields.map.getFieldDescriptor(),
+                    getAnnotations.getThis());
+            ResultHandle values = getAnnotations.invokeInterfaceMethod(MethodDescriptors.MAP_VALUES, localMap);
+            ResultHandle emptyArray = getAnnotations
+                    .readStaticField(FieldDescriptors.ANNOTATION_LITERALS_EMPTY_ANNOTATION_ARRAY);
+            ResultHandle result = getAnnotations.invokeInterfaceMethod(MethodDescriptors.COLLECTION_TO_ARRAY, values,
+                    emptyArray);
+            getAnnotations.returnValue(result);
+        }
+    }
+}

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodMetadataProcessor.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/MethodMetadataProcessor.java
@@ -1,0 +1,321 @@
+package io.quarkus.arc.processor;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.ParameterMetadata;
+import io.quarkus.arc.impl.ComputingCache;
+import io.quarkus.gizmo.BytecodeCreator;
+import io.quarkus.gizmo.MethodDescriptor;
+import io.quarkus.gizmo.ResultHandle;
+
+/**
+ * Handles generating bytecode for {@link MethodMetadata} and {@link ParameterMetadata} implementations.
+ * The {@link #createMethodMetadata(BytecodeCreator, MethodInfo) createMethodMetadata()} method can be used
+ * to generate a bytecode sequence for instantiating a {@code MethodMetadata} for given method. That
+ * bytecode sequence necessarily also instantiates {@code ParameterMetadata} for all parameters.
+ * <p>
+ * Behind the scenes, for each {@code MethodMetadata} and {@code ParameterMetadata} instance, their classes
+ * are also generated. The generated classes are shared. That is, one class is generated for each shape
+ * of method (that is, number of parameters and number of annotations) and for each shape of parameter
+ * (that is, number of annotations).
+ * <p>
+ * This construct is thread-safe.
+ */
+public class MethodMetadataProcessor {
+    private final ComputingCache<MethodMetadataShape, MethodMetadataImplClass> methodsToGenerate;
+    private final ComputingCache<ParameterMetadataShape, ParameterMetadataImplClass> parametersToGenerate;
+
+    private final IndexView beanArchiveIndex;
+    private final AnnotationLiteralProcessor annotationLiterals;
+    private final AnnotationStore annotationStore;
+
+    MethodMetadataProcessor(IndexView beanArchiveIndex, AnnotationLiteralProcessor annotationLiterals,
+            AnnotationStore annotationStore, Predicate<DotName> applicationClassPredicate) {
+        this.methodsToGenerate = new ComputingCache<>(key -> {
+            String generatedClassName = generateMethodMetadataClassName(key);
+            return new MethodMetadataImplClass(key, generatedClassName,
+                    applicationClassPredicate.test(DotName.createSimple(generatedClassName)));
+        });
+        this.parametersToGenerate = new ComputingCache<>(key -> {
+            String generatedClassName = generateParameterMetadataClassName(key);
+            return new ParameterMetadataImplClass(key, generatedClassName,
+                    applicationClassPredicate.test(DotName.createSimple(generatedClassName)));
+        });
+
+        this.beanArchiveIndex = beanArchiveIndex;
+        this.annotationLiterals = annotationLiterals;
+        this.annotationStore = annotationStore;
+    }
+
+    boolean hasClassesToGenerate() {
+        return !methodsToGenerate.isEmpty() || !parametersToGenerate.isEmpty();
+    }
+
+    ComputingCache<MethodMetadataShape, MethodMetadataImplClass> getMethodsToGenerate() {
+        return methodsToGenerate;
+    }
+
+    ComputingCache<ParameterMetadataShape, ParameterMetadataImplClass> getParametersToGenerate() {
+        return parametersToGenerate;
+    }
+
+    /**
+     * Generates a bytecode sequence to obtain an instance of {@link MethodMetadata} that represents
+     * given {@code method}. For that purpose, a class implementing {@code MethodMetadata} is generated.
+     *
+     * @param bytecode will receive the bytecode sequence for obtaining the {@code MethodMetadata} object
+     *        as a sequence of {@link BytecodeCreator} method calls
+     * @param method method for which a {@code MethodMetadata} class should be generated
+     * @return a handle to the {@code MethodMetadata} object
+     */
+    public ResultHandle createMethodMetadata(BytecodeCreator bytecode, MethodInfo method) {
+        Objects.requireNonNull(method);
+
+        List<AnnotationInstance> annotations = annotationStore.getAnnotations(method)
+                .stream()
+                .filter(it -> it.target().kind() == AnnotationTarget.Kind.METHOD)
+                .collect(Collectors.toList());
+        int annotationsCount = annotations.size();
+        int parametersCount = method.parametersCount();
+        MethodMetadataShape shape = new MethodMetadataShape(parametersCount, annotationsCount);
+        MethodMetadataImplClass methodMetadataClass = methodsToGenerate.getValue(shape);
+
+        Class<?>[] constructorParameterTypes = methodMetadataClass.constructorParameterTypes();
+
+        ResultHandle[] constructorArguments = new ResultHandle[6 + methodMetadataClass.parametersSlots
+                + methodMetadataClass.annotationsSlots];
+        constructorArguments[0] = bytecode.load(Methods.INIT.equals(method.name()));
+        constructorArguments[1] = bytecode.load(Modifier.isStatic(method.flags()));
+        constructorArguments[2] = bytecode.load(Methods.INIT.equals(method.name())
+                ? method.declaringClass().name().toString()
+                : method.name());
+        constructorArguments[3] = bytecode.load((int) method.flags());
+        constructorArguments[4] = bytecode.loadClass(method.declaringClass());
+        constructorArguments[5] = bytecode.loadClass(Methods.INIT.equals(method.name())
+                ? method.declaringClass().name().toString()
+                : method.returnType().name().toString());
+        if (methodMetadataClass.parametersUnfolded) {
+            for (int i = 0; i < parametersCount; i++) {
+                constructorArguments[6 + i] = createParameterMetadata(bytecode, method.parameters().get(i));
+            }
+        } else {
+            ResultHandle array = bytecode.newArray(ParameterMetadata.class, parametersCount);
+            for (int i = 0; i < parametersCount; i++) {
+                ResultHandle parameterMetadata = createParameterMetadata(bytecode, method.parameters().get(i));
+                bytecode.writeArrayValue(array, i, parameterMetadata);
+            }
+            constructorArguments[6] = array;
+        }
+        if (methodMetadataClass.annotationsUnfolded) {
+            for (int i = 0; i < annotationsCount; i++) {
+                AnnotationInstance annotation = annotations.get(i);
+                ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotation.name());
+                constructorArguments[6 + methodMetadataClass.parametersSlots + i] = annotationLiterals.create(bytecode,
+                        annotationClass, annotation);
+            }
+        } else {
+            ResultHandle array = bytecode.newArray(Map.Entry.class, annotationsCount);
+            for (int i = 0; i < annotationsCount; i++) {
+                AnnotationInstance annotation = annotations.get(i);
+                ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotation.name());
+                ResultHandle annotationClassHandle = bytecode.loadClass(annotationClass);
+                ResultHandle annotationHandle = annotationLiterals.create(bytecode, annotationClass, annotation);
+                ResultHandle entry = bytecode.invokeStaticInterfaceMethod(MethodDescriptors.MAP_ENTRY, annotationClassHandle,
+                        annotationHandle);
+                bytecode.writeArrayValue(array, i, entry);
+            }
+            constructorArguments[6 + methodMetadataClass.parametersSlots] = bytecode
+                    .invokeStaticInterfaceMethod(MethodDescriptors.MAP_OF_ENTRIES, array);
+        }
+
+        return bytecode.newInstance(
+                MethodDescriptor.ofConstructor(methodMetadataClass.generatedClassName, (Object[]) constructorParameterTypes),
+                constructorArguments);
+    }
+
+    /**
+     * Generates a bytecode sequence to obtain an instance of {@link ParameterMetadata} that represents
+     * given {@code parameter}. For that purpose, a class implementing {@code ParameterMetadata} is generated.
+     *
+     * @param bytecode will receive the bytecode sequence for obtaining the {@code ParameterMetadata} object
+     *        as a sequence of {@link BytecodeCreator} method calls
+     * @param parameter method parameter for which a {@code ParameterMetadata} class should be generated
+     * @return a handle to the {@code ParameterMetadata} object
+     */
+    private ResultHandle createParameterMetadata(BytecodeCreator bytecode, MethodParameterInfo parameter) {
+        Objects.requireNonNull(parameter);
+
+        List<AnnotationInstance> annotations = annotationStore.getAnnotations(parameter.method())
+                .stream()
+                .filter(it -> it.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER
+                        && it.target().asMethodParameter().position() == parameter.position())
+                .collect(Collectors.toList());
+        int annotationsCount = annotations.size();
+        ParameterMetadataShape shape = new ParameterMetadataShape(annotationsCount);
+        ParameterMetadataImplClass parameterMetadataClass = parametersToGenerate.getValue(shape);
+
+        Class<?>[] constructorParameterTypes = parameterMetadataClass.constructorParameterTypes();
+
+        String parameterName = parameter.name();
+        if (parameterName == null) {
+            parameterName = "arg" + parameter.position();
+        }
+
+        ResultHandle[] constructorArguments = new ResultHandle[2 + parameterMetadataClass.annotationsSlots];
+        constructorArguments[0] = bytecode.load(parameterName);
+        constructorArguments[1] = bytecode.loadClass(parameter.type().name().toString());
+        if (parameterMetadataClass.annotationsUnfolded) {
+            for (int i = 0; i < annotationsCount; i++) {
+                AnnotationInstance annotation = annotations.get(i);
+                ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotation.name());
+                constructorArguments[2 + i] = annotationLiterals.create(bytecode, annotationClass, annotation);
+            }
+        } else {
+            ResultHandle array = bytecode.newArray(Map.Entry.class, annotationsCount);
+            for (int i = 0; i < annotationsCount; i++) {
+                AnnotationInstance annotation = annotations.get(i);
+                ClassInfo annotationClass = beanArchiveIndex.getClassByName(annotation.name());
+                ResultHandle annotationClassHandle = bytecode.loadClass(annotationClass);
+                ResultHandle annotationHandle = annotationLiterals.create(bytecode, annotationClass, annotation);
+                ResultHandle entry = bytecode.invokeStaticInterfaceMethod(MethodDescriptors.MAP_ENTRY, annotationClassHandle,
+                        annotationHandle);
+                bytecode.writeArrayValue(array, i, entry);
+            }
+            constructorArguments[2] = bytecode.invokeStaticInterfaceMethod(MethodDescriptors.MAP_OF_ENTRIES, array);
+        }
+
+        return bytecode.newInstance(
+                MethodDescriptor.ofConstructor(parameterMetadataClass.generatedClassName, (Object[]) constructorParameterTypes),
+                constructorArguments);
+    }
+
+    private static String generateMethodMetadataClassName(MethodMetadataShape shape) {
+        return AbstractGenerator.DEFAULT_PACKAGE + ".MethodMetadataImpl"
+                + "_p" + shape.parametersCount
+                + "_a" + shape.annotationsCount;
+    }
+
+    private static String generateParameterMetadataClassName(ParameterMetadataShape shape) {
+        return AbstractGenerator.DEFAULT_PACKAGE + ".ParameterMetadataImpl"
+                + "_a" + shape.annotationsCount;
+    }
+
+    static class MethodMetadataShape {
+        final int parametersCount;
+
+        final int annotationsCount;
+
+        MethodMetadataShape(int parametersCount, int annotationsCount) {
+            this.annotationsCount = annotationsCount;
+            this.parametersCount = parametersCount;
+        }
+    }
+
+    static class MethodMetadataImplClass {
+        final MethodMetadataShape shape;
+
+        final String generatedClassName;
+
+        final boolean isApplicationClass;
+
+        final boolean parametersUnfolded;
+        final int parametersSlots;
+
+        final boolean annotationsUnfolded;
+        final int annotationsSlots;
+
+        MethodMetadataImplClass(MethodMetadataShape shape, String generatedClassName, boolean isApplicationClass) {
+            this.shape = shape;
+            this.generatedClassName = generatedClassName;
+            this.isApplicationClass = isApplicationClass;
+
+            this.parametersUnfolded = shape.parametersCount <= MethodMetadataGenerator.UNFOLD_ARRAYS_THRESHOLD;
+            this.parametersSlots = parametersUnfolded ? shape.parametersCount : 1;
+
+            this.annotationsUnfolded = shape.annotationsCount <= MethodMetadataGenerator.UNFOLD_ARRAYS_THRESHOLD;
+            this.annotationsSlots = annotationsUnfolded ? shape.annotationsCount : 1;
+        }
+
+        Class<?>[] constructorParameterTypes() {
+            Class<?>[] result = new Class[6 + parametersSlots + annotationsSlots];
+            result[0] = boolean.class; // isConstructor
+            result[1] = boolean.class; // isStatic
+            result[2] = String.class; // name
+            result[3] = int.class; // modifiers
+            result[4] = Class.class; // declaringClass
+            result[5] = Class.class; // returnType
+            if (parametersUnfolded) {
+                for (int i = 0; i < shape.parametersCount; i++) {
+                    result[6 + i] = ParameterMetadata.class;
+                }
+            } else {
+                result[6] = ParameterMetadata[].class;
+            }
+            if (annotationsUnfolded) {
+                for (int i = 0; i < shape.annotationsCount; i++) {
+                    result[6 + parametersSlots + i] = Annotation.class;
+                }
+            } else {
+                result[6 + parametersSlots] = Map.class;
+            }
+            return result;
+        }
+    }
+
+    static class ParameterMetadataShape {
+        final int annotationsCount;
+
+        ParameterMetadataShape(int annotationsCount) {
+            this.annotationsCount = annotationsCount;
+        }
+    }
+
+    static class ParameterMetadataImplClass {
+        final ParameterMetadataShape shape;
+
+        final String generatedClassName;
+
+        final boolean isApplicationClass;
+
+        final boolean annotationsUnfolded;
+        final int annotationsSlots;
+
+        ParameterMetadataImplClass(ParameterMetadataShape shape, String generatedClassName, boolean isApplicationClass) {
+            this.shape = shape;
+            this.generatedClassName = generatedClassName;
+            this.isApplicationClass = isApplicationClass;
+
+            this.annotationsUnfolded = shape.annotationsCount <= MethodMetadataGenerator.UNFOLD_ARRAYS_THRESHOLD;
+            this.annotationsSlots = annotationsUnfolded ? shape.annotationsCount : 1;
+        }
+
+        Class<?>[] constructorParameterTypes() {
+            Class<?>[] result = new Class[2 + annotationsSlots];
+            result[0] = String.class; // name
+            result[1] = Class.class; // type
+            if (annotationsUnfolded) {
+                for (int i = 0; i < shape.annotationsCount; i++) {
+                    result[2 + i] = Annotation.class;
+                }
+            } else {
+                result[2] = Map.class;
+            }
+            return result;
+        }
+    }
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ArcInvocationContext.java
@@ -38,6 +38,17 @@ public interface ArcInvocationContext extends InvocationContext {
     <T extends Annotation> List<T> findIterceptorBindings(Class<T> annotationType);
 
     /**
+     * Returns a {@link MethodMetadata} representation of the intercepted method or constructor.
+     * This is similar to {@link #getMethod()} or {@link #getConstructor()}, except the implementation
+     * doesn't use reflection.
+     * <p>
+     * Returns {@code null} for {@code @PostConstruct} and {@code @PreDestroy} lifecycle callbacks.
+     *
+     * @return {@link MethodMetadata} representation of the intercepted method or constructor
+     */
+    MethodMetadata getMethodMetadata();
+
+    /**
      *
      * @param context
      * @param annotationType

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/MethodMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/MethodMetadata.java
@@ -1,0 +1,30 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.Annotation;
+
+// TODO documentation
+public interface MethodMetadata {
+    boolean isConstructor();
+
+    boolean isStatic();
+
+    String getName();
+
+    int getModifiers();
+
+    Class<?> getDeclaringClass();
+
+    Class<?> getReturnType();
+
+    int getParameterCount();
+
+    Class<?>[] getParameterTypes();
+
+    ParameterMetadata[] getParameters();
+
+    boolean isAnnotationPresent(Class<? extends Annotation> annotationClass);
+
+    <T extends Annotation> T getAnnotation(Class<T> annotationClass);
+
+    Annotation[] getAnnotations();
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ParameterMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/ParameterMetadata.java
@@ -1,0 +1,18 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.Annotation;
+
+// TODO documentation
+public interface ParameterMetadata {
+    ParameterMetadata[] EMPTY_ARRAY = new ParameterMetadata[0];
+
+    String getName();
+
+    Class<?> getType();
+
+    boolean isAnnotationPresent(Class<? extends Annotation> annotationClass);
+
+    <T extends Annotation> T getAnnotation(Class<T> annotationClass);
+
+    Annotation[] getAnnotations();
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflectionless.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/Reflectionless.java
@@ -1,0 +1,26 @@
+package io.quarkus.arc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InvocationContext;
+
+/**
+ * Marks an interceptor (a class annotated {@code @Interceptor}) as <em>reflectionless</em>.
+ * If all interceptors that apply to some method or constructor are reflectionless,
+ * the {@link InvocationContext#getMethod()} and {@link InvocationContext#getConstructor()} methods
+ * will always return {@code null}. That method will not be registered for reflection when
+ * compiling to a native image.
+ * <p>
+ * Some information about the intercepted method or constructor can be obtained more cheaply
+ * using {@link ArcInvocationContext#getMethodMetadata()}.
+ * <p>
+ * This annotation only makes sense for {@code @AroundInvoke} and {@code @AroundConstruct} interceptors.
+ * It doesn't affect {@code @PostConstruct} and {@code @PreDestroy} lifecycle callbacks.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Reflectionless {
+}

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AbstractInvocationContext.java
@@ -11,13 +11,16 @@ import java.util.Objects;
 import java.util.Set;
 
 import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.MethodMetadata;
 
 abstract class AbstractInvocationContext implements ArcInvocationContext {
 
     private static final Object[] EMPTY_PARAMS = new Object[0];
 
+    // TODO collapse `method` and `constructor` into a single field of type `Executable` to save space?
     protected final Method method;
     protected final Constructor<?> constructor;
+    protected final MethodMetadata methodMetadata;
     protected final Set<Annotation> interceptorBindings;
     protected final List<InterceptorInvocation> chain;
     protected Object target;
@@ -25,12 +28,13 @@ abstract class AbstractInvocationContext implements ArcInvocationContext {
     protected ContextDataMap contextData;
 
     protected AbstractInvocationContext(Object target, Method method,
-            Constructor<?> constructor,
+            Constructor<?> constructor, MethodMetadata methodMetadata,
             Object[] parameters, ContextDataMap contextData,
             Set<Annotation> interceptorBindings, List<InterceptorInvocation> chain) {
         this.target = target;
         this.method = method;
         this.constructor = constructor;
+        this.methodMetadata = methodMetadata;
         this.parameters = parameters != null ? parameters : EMPTY_PARAMS;
         this.contextData = contextData != null ? contextData : new ContextDataMap(interceptorBindings);
         this.interceptorBindings = interceptorBindings;
@@ -88,7 +92,7 @@ abstract class AbstractInvocationContext implements ArcInvocationContext {
 
     protected void validateParameters(Object[] params) {
         int newParametersCount = Objects.requireNonNull(params).length;
-        Class<?>[] parameterTypes = method.getParameterTypes();
+        Class<?>[] parameterTypes = methodMetadata.getParameterTypes();
         if (parameterTypes.length != newParametersCount) {
             throw new IllegalArgumentException(
                     "Wrong number of parameters - method has " + Arrays.toString(parameterTypes) + ", attempting to set "
@@ -123,4 +127,8 @@ abstract class AbstractInvocationContext implements ArcInvocationContext {
         return constructor;
     }
 
+    @Override
+    public MethodMetadata getMethodMetadata() {
+        return methodMetadata;
+    }
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AnnotationLiterals.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.impl;
 
+import java.lang.annotation.Annotation;
+
 public final class AnnotationLiterals {
 
     public static final boolean[] EMPTY_BOOLEAN_ARRAY = new boolean[0];
@@ -13,6 +15,8 @@ public final class AnnotationLiterals {
 
     public static final String[] EMPTY_STRING_ARRAY = new String[0];
     public static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
+
+    public static final Annotation[] EMPTY_ANNOTATION_ARRAY = new Annotation[0];
 
     private AnnotationLiterals() {
     }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundConstructInvocationContext.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import io.quarkus.arc.MethodMetadata;
+
 /**
  * An InvocationContext implementation used for AroundConstruct callbacks.
  */
@@ -13,9 +15,10 @@ class AroundConstructInvocationContext extends LifecycleCallbackInvocationContex
 
     private final Supplier<Object> aroundConstructForward;
 
-    AroundConstructInvocationContext(Constructor<?> constructor, Set<Annotation> interceptorBindings,
+    AroundConstructInvocationContext(Constructor<?> constructor, MethodMetadata methodMetadata,
+            Set<Annotation> interceptorBindings,
             List<InterceptorInvocation> chain, Supplier<Object> aroundConstructForward) {
-        super(null, constructor, interceptorBindings, chain);
+        super(null, constructor, methodMetadata, interceptorBindings, chain);
         this.aroundConstructForward = aroundConstructForward;
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/AroundInvokeInvocationContext.java
@@ -9,6 +9,8 @@ import java.util.function.Function;
 
 import javax.interceptor.InvocationContext;
 
+import io.quarkus.arc.MethodMetadata;
+
 /**
  * Special type of InvocationContext for AroundInvoke interceptors.
  * <p>
@@ -25,20 +27,20 @@ class AroundInvokeInvocationContext extends AbstractInvocationContext {
     private final int position;
     private final Function<InvocationContext, Object> aroundInvokeForward;
 
-    AroundInvokeInvocationContext(Object target, Method method, Object[] parameters,
+    AroundInvokeInvocationContext(Object target, Method method, MethodMetadata methodMetadata, Object[] parameters,
             ContextDataMap contextData, Set<Annotation> interceptorBindings, int position,
             List<InterceptorInvocation> chain, Function<InvocationContext, Object> aroundInvokeForward) {
-        super(target, method, null, parameters, contextData, interceptorBindings, chain);
+        super(target, method, null, methodMetadata, parameters, contextData, interceptorBindings, chain);
         this.position = position;
         this.aroundInvokeForward = aroundInvokeForward;
     }
 
-    static Object perform(Object target, Method method,
+    static Object perform(Object target, Method method, MethodMetadata methodMetadata,
             Function<InvocationContext, Object> aroundInvokeForward, Object[] parameters,
             List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) throws Exception {
 
-        return chain.get(0).invoke(new AroundInvokeInvocationContext(target, method,
+        return chain.get(0).invoke(new AroundInvokeInvocationContext(target, method, methodMetadata,
                 parameters, null, interceptorBindings, 1, chain, aroundInvokeForward));
     }
 
@@ -48,7 +50,8 @@ class AroundInvokeInvocationContext extends AbstractInvocationContext {
             if (position < chain.size()) {
                 // Invoke the next interceptor in the chain
                 return chain.get(position).invoke(new AroundInvokeInvocationContext(target, method,
-                        parameters, contextData, interceptorBindings, position + 1, chain, aroundInvokeForward));
+                        methodMetadata, parameters, contextData, interceptorBindings, position + 1, chain,
+                        aroundInvokeForward));
             } else {
                 // Invoke the target method
                 return aroundInvokeForward.apply(this);

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedMethodMetadata.java
@@ -5,15 +5,20 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.arc.MethodMetadata;
+
 public class InterceptedMethodMetadata {
 
     public final List<InterceptorInvocation> chain;
     public final Method method;
+    public final MethodMetadata methodMetadata;
     public final Set<Annotation> bindings;
 
-    public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, Set<Annotation> bindings) {
+    public InterceptedMethodMetadata(List<InterceptorInvocation> chain, Method method, MethodMetadata methodMetadata,
+            Set<Annotation> bindings) {
         this.chain = chain;
         this.method = method;
+        this.methodMetadata = methodMetadata;
         this.bindings = bindings;
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InterceptedStaticMethods.java
@@ -22,8 +22,8 @@ public final class InterceptedStaticMethods {
         if (method == null) {
             throw new IllegalArgumentException("Intercepted method metadata not found for key: " + key);
         }
-        return InvocationContexts.performAroundInvoke(null, method.metadata.method, method.forward, args, method.metadata.chain,
-                method.metadata.bindings);
+        return InvocationContexts.performAroundInvoke(null, method.metadata.method, method.metadata.methodMetadata,
+                method.forward, args, method.metadata.chain, method.metadata.bindings);
     }
 
     public static final class InterceptedStaticMethod {

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/InvocationContexts.java
@@ -10,6 +10,8 @@ import java.util.function.Supplier;
 
 import javax.interceptor.InvocationContext;
 
+import io.quarkus.arc.MethodMetadata;
+
 public final class InvocationContexts {
 
     private InvocationContexts() {
@@ -19,6 +21,7 @@ public final class InvocationContexts {
      *
      * @param target
      * @param method
+     * @param methodMetadata
      * @param aroundInvokeForward
      * @param args
      * @param chain
@@ -26,11 +29,12 @@ public final class InvocationContexts {
      * @return the return value
      * @throws Exception
      */
-    public static Object performAroundInvoke(Object target, Method method,
+    public static Object performAroundInvoke(Object target, Method method, MethodMetadata methodMetadata,
             Function<InvocationContext, Object> aroundInvokeForward, Object[] args,
             List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) throws Exception {
-        return AroundInvokeInvocationContext.perform(target, method, aroundInvokeForward, args, chain, interceptorBindings);
+        return AroundInvokeInvocationContext.perform(target, method, methodMetadata, aroundInvokeForward, args, chain,
+                interceptorBindings);
     }
 
     /**
@@ -42,7 +46,7 @@ public final class InvocationContexts {
      */
     public static InvocationContext postConstruct(Object target, List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
+        return new LifecycleCallbackInvocationContext(target, null, null, interceptorBindings, chain);
     }
 
     /**
@@ -54,21 +58,24 @@ public final class InvocationContexts {
      */
     public static InvocationContext preDestroy(Object target, List<InterceptorInvocation> chain,
             Set<Annotation> interceptorBindings) {
-        return new LifecycleCallbackInvocationContext(target, null, interceptorBindings, chain);
+        return new LifecycleCallbackInvocationContext(target, null, null, interceptorBindings, chain);
     }
 
     /**
      *
-     * @param target
+     * @param constructor
+     * @param methodMetadata
      * @param chain
+     * @param aroundConstructForward
      * @param interceptorBindings
      * @return a new {@link javax.interceptor.AroundConstruct} invocation context
      */
-    public static InvocationContext aroundConstruct(Constructor<?> constructor,
+    public static InvocationContext aroundConstruct(Constructor<?> constructor, MethodMetadata methodMetadata,
             List<InterceptorInvocation> chain,
             Supplier<Object> aroundConstructForward,
             Set<Annotation> interceptorBindings) {
-        return new AroundConstructInvocationContext(constructor, interceptorBindings, chain, aroundConstructForward);
+        return new AroundConstructInvocationContext(constructor, methodMetadata, interceptorBindings, chain,
+                aroundConstructForward);
     }
 
 }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LifecycleCallbackInvocationContext.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/LifecycleCallbackInvocationContext.java
@@ -6,6 +6,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Set;
 
+import io.quarkus.arc.MethodMetadata;
+
 /**
  * A simple InvocationContext implementation used for PostConstruct and PreDestroy callbacks.
  * <p>
@@ -15,9 +17,9 @@ class LifecycleCallbackInvocationContext extends AbstractInvocationContext {
 
     private int position = 0;
 
-    LifecycleCallbackInvocationContext(Object target, Constructor<?> constructor, Set<Annotation> interceptorBindings,
-            List<InterceptorInvocation> chain) {
-        super(target, null, constructor, null, null, interceptorBindings, chain);
+    LifecycleCallbackInvocationContext(Object target, Constructor<?> constructor, MethodMetadata methodMetadata,
+            Set<Annotation> interceptorBindings, List<InterceptorInvocation> chain) {
+        super(target, null, constructor, methodMetadata, null, null, interceptorBindings, chain);
     }
 
     @Override

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/reflectionless/AroundConstructReflectionlessInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/reflectionless/AroundConstructReflectionlessInterceptorTest.java
@@ -1,0 +1,114 @@
+package io.quarkus.arc.test.interceptors.reflectionless;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.inject.Singleton;
+import javax.interceptor.AroundConstruct;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.Reflectionless;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundConstructReflectionlessInterceptorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyInterceptorBinding.class, MyInterceptor.class, MyBean.class,
+            MyDependency.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        MyBean bean = arc.instance(MyBean.class).get();
+        assertNotNull(bean);
+
+        assertNotNull(MyInterceptor.method);
+        assertTrue(MyInterceptor.method.isConstructor());
+        assertFalse(MyInterceptor.method.isStatic());
+        assertEquals(MyBean.class.getName(), MyInterceptor.method.getName());
+        assertEquals(MyBean.class, MyInterceptor.method.getDeclaringClass());
+        assertEquals(1, MyInterceptor.method.getParameterCount());
+        assertEquals(1, MyInterceptor.method.getParameterTypes().length);
+        assertEquals(MyDependency.class, MyInterceptor.method.getParameterTypes()[0]);
+        assertEquals(1, MyInterceptor.method.getParameters().length);
+        assertEquals(MyDependency.class, MyInterceptor.method.getParameters()[0].getType());
+        assertEquals("dependency", MyInterceptor.method.getParameters()[0].getName());
+        assertEquals(1, MyInterceptor.method.getParameters()[0].getAnnotations().length);
+        assertTrue(MyInterceptor.method.getParameters()[0].isAnnotationPresent(MySimpleAnnotation.class));
+        assertFalse(MyInterceptor.method.getParameters()[0].isAnnotationPresent(Override.class));
+        assertNotNull(MyInterceptor.method.getParameters()[0].getAnnotation(MySimpleAnnotation.class));
+        assertEquals("quux", MyInterceptor.method.getParameters()[0].getAnnotation(MySimpleAnnotation.class).value());
+        assertNull(MyInterceptor.method.getParameters()[0].getAnnotation(Override.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MyInterceptorBinding.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(Override.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MyInterceptorBinding.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("foobar", MyInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertNull(MyInterceptor.method.getAnnotation(Override.class));
+        assertEquals(2, MyInterceptor.method.getAnnotations().length);
+    }
+
+    @Target({ TYPE, METHOD, CONSTRUCTOR })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @Target({ TYPE, METHOD, CONSTRUCTOR, PARAMETER })
+    @Retention(RUNTIME)
+    @interface MySimpleAnnotation {
+        String value();
+    }
+
+    @MyInterceptorBinding
+    @Priority(1)
+    @Interceptor
+    @Reflectionless
+    static class MyInterceptor {
+        static MethodMetadata method;
+
+        @AroundConstruct
+        Object aroundConstruct(ArcInvocationContext ctx) throws Exception {
+            assertNull(ctx.getMethod());
+            assertNotNull(ctx.getMethodMetadata());
+            method = ctx.getMethodMetadata();
+
+            return ctx.proceed();
+        }
+    }
+
+    @Singleton
+    static class MyBean {
+        @MyInterceptorBinding
+        @MySimpleAnnotation("foobar")
+        public MyBean(@MySimpleAnnotation("quux") MyDependency dependency) {
+        }
+    }
+
+    @Dependent
+    static class MyDependency {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/reflectionless/AroundInvokeReflectionlessInterceptorTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/interceptors/reflectionless/AroundInvokeReflectionlessInterceptorTest.java
@@ -1,0 +1,215 @@
+package io.quarkus.arc.test.interceptors.reflectionless;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Priority;
+import javax.inject.Singleton;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.ArcInvocationContext;
+import io.quarkus.arc.MethodMetadata;
+import io.quarkus.arc.Reflectionless;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class AroundInvokeReflectionlessInterceptorTest {
+    @RegisterExtension
+    public ArcTestContainer container = new ArcTestContainer(MyInterceptorBinding.class, MyInterceptor.class, MyBean.class);
+
+    @Test
+    public void test() {
+        ArcContainer arc = Arc.container();
+        MyBean bean = arc.instance(MyBean.class).get();
+
+        assertEquals(42, bean.primitive());
+        assertNotNull(MyInterceptor.method);
+        assertFalse(MyInterceptor.method.isConstructor());
+        assertFalse(MyInterceptor.method.isStatic());
+        assertEquals("primitive", MyInterceptor.method.getName());
+        assertEquals(MyBean.class, MyInterceptor.method.getDeclaringClass());
+        assertEquals(0, MyInterceptor.method.getParameterCount());
+        assertEquals(0, MyInterceptor.method.getParameters().length);
+        assertEquals(0, MyInterceptor.method.getParameterTypes().length);
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyInterceptorBinding.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyFirstAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MySecondAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MyInterceptorBinding.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("foo", MyInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertNull(MyInterceptor.method.getAnnotation(MyFirstAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MySecondAnnotation.class));
+        assertEquals(1, MyInterceptor.method.getAnnotations().length);
+
+        assertEquals("hello", bean.clazz());
+        assertNotNull(MyInterceptor.method);
+        assertFalse(MyInterceptor.method.isConstructor());
+        assertFalse(MyInterceptor.method.isStatic());
+        assertEquals("clazz", MyInterceptor.method.getName());
+        assertEquals(MyBean.class, MyInterceptor.method.getDeclaringClass());
+        assertEquals(0, MyInterceptor.method.getParameterCount());
+        assertEquals(0, MyInterceptor.method.getParameters().length);
+        assertEquals(0, MyInterceptor.method.getParameterTypes().length);
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyInterceptorBinding.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MyFirstAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MySecondAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MyInterceptorBinding.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("bar", MyInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertNotNull(MyInterceptor.method.getAnnotation(MyFirstAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MySecondAnnotation.class));
+        assertEquals(2, MyInterceptor.method.getAnnotations().length);
+
+        assertEquals(Collections.emptyList(), bean.parameterized(null, 0));
+        assertNotNull(MyInterceptor.method);
+        assertFalse(MyInterceptor.method.isConstructor());
+        assertFalse(MyInterceptor.method.isStatic());
+        assertEquals("parameterized", MyInterceptor.method.getName());
+        assertEquals(MyBean.class, MyInterceptor.method.getDeclaringClass());
+        assertEquals(2, MyInterceptor.method.getParameterCount());
+        assertEquals(2, MyInterceptor.method.getParameterTypes().length);
+        assertEquals(List.class, MyInterceptor.method.getParameterTypes()[0]);
+        assertEquals(int.class, MyInterceptor.method.getParameterTypes()[1]);
+        assertEquals(2, MyInterceptor.method.getParameters().length);
+        assertEquals(List.class, MyInterceptor.method.getParameters()[0].getType());
+        assertEquals("param1", MyInterceptor.method.getParameters()[0].getName());
+        assertEquals(0, MyInterceptor.method.getParameters()[0].getAnnotations().length);
+        assertEquals(int.class, MyInterceptor.method.getParameters()[1].getType());
+        assertEquals("param2", MyInterceptor.method.getParameters()[1].getName());
+        assertEquals(0, MyInterceptor.method.getParameters()[1].getAnnotations().length);
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyInterceptorBinding.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MyFirstAnnotation.class));
+        assertTrue(MyInterceptor.method.isAnnotationPresent(MySecondAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MyInterceptorBinding.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertEquals("baz", MyInterceptor.method.getAnnotation(MySimpleAnnotation.class).value());
+        assertNotNull(MyInterceptor.method.getAnnotation(MyFirstAnnotation.class));
+        assertNotNull(MyInterceptor.method.getAnnotation(MySecondAnnotation.class));
+        assertEquals(3, MyInterceptor.method.getAnnotations().length);
+
+        assertArrayEquals(new String[0], bean.array("", new String[0]));
+        assertNotNull(MyInterceptor.method);
+        assertFalse(MyInterceptor.method.isConstructor());
+        assertFalse(MyInterceptor.method.isStatic());
+        assertEquals("array", MyInterceptor.method.getName());
+        assertEquals(MyBean.class, MyInterceptor.method.getDeclaringClass());
+        assertEquals(2, MyInterceptor.method.getParameterCount());
+        assertEquals(2, MyInterceptor.method.getParameterTypes().length);
+        assertEquals(CharSequence.class, MyInterceptor.method.getParameterTypes()[0]);
+        assertEquals(CharSequence[].class, MyInterceptor.method.getParameterTypes()[1]);
+        assertEquals(2, MyInterceptor.method.getParameters().length);
+        assertEquals(CharSequence.class, MyInterceptor.method.getParameters()[0].getType());
+        assertEquals("typeVar", MyInterceptor.method.getParameters()[0].getName());
+        assertEquals(1, MyInterceptor.method.getParameters()[0].getAnnotations().length);
+        assertTrue(MyInterceptor.method.getParameters()[0].isAnnotationPresent(MyFirstAnnotation.class));
+        assertFalse(MyInterceptor.method.getParameters()[0].isAnnotationPresent(MySecondAnnotation.class));
+        assertNotNull(MyInterceptor.method.getParameters()[0].getAnnotation(MyFirstAnnotation.class));
+        assertNull(MyInterceptor.method.getParameters()[0].getAnnotation(MySecondAnnotation.class));
+        assertEquals(CharSequence[].class, MyInterceptor.method.getParameters()[1].getType());
+        assertEquals("typeVarArray", MyInterceptor.method.getParameters()[1].getName());
+        assertEquals(1, MyInterceptor.method.getParameters()[1].getAnnotations().length);
+        assertFalse(MyInterceptor.method.getParameters()[1].isAnnotationPresent(MyFirstAnnotation.class));
+        assertTrue(MyInterceptor.method.getParameters()[1].isAnnotationPresent(MySecondAnnotation.class));
+        assertNull(MyInterceptor.method.getParameters()[1].getAnnotation(MyFirstAnnotation.class));
+        assertNotNull(MyInterceptor.method.getParameters()[1].getAnnotation(MySecondAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyInterceptorBinding.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MySimpleAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MyFirstAnnotation.class));
+        assertFalse(MyInterceptor.method.isAnnotationPresent(MySecondAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MyInterceptorBinding.class));
+        assertNull(MyInterceptor.method.getAnnotation(MySimpleAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MyFirstAnnotation.class));
+        assertNull(MyInterceptor.method.getAnnotation(MySecondAnnotation.class));
+        assertEquals(0, MyInterceptor.method.getAnnotations().length);
+    }
+
+    @Target({ TYPE, METHOD, CONSTRUCTOR })
+    @Retention(RUNTIME)
+    @Documented
+    @InterceptorBinding
+    @interface MyInterceptorBinding {
+    }
+
+    @Target({ TYPE, METHOD, CONSTRUCTOR })
+    @Retention(RUNTIME)
+    @interface MySimpleAnnotation {
+        String value();
+    }
+
+    @Target({ TYPE, METHOD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface MyFirstAnnotation {
+    }
+
+    @Target({ TYPE, METHOD, PARAMETER })
+    @Retention(RUNTIME)
+    @interface MySecondAnnotation {
+    }
+
+    @MyInterceptorBinding
+    @Priority(1)
+    @Interceptor
+    @Reflectionless
+    static class MyInterceptor {
+        static MethodMetadata method;
+
+        @AroundInvoke
+        Object aroundInvoke(ArcInvocationContext ctx) throws Exception {
+            assertNull(ctx.getMethod());
+            assertNotNull(ctx.getMethodMetadata());
+            method = ctx.getMethodMetadata();
+
+            return ctx.proceed();
+        }
+    }
+
+    @Singleton
+    @MyInterceptorBinding
+    static class MyBean {
+        @MySimpleAnnotation("foo")
+        int primitive() {
+            return 42;
+        }
+
+        @MySimpleAnnotation("bar")
+        @MyFirstAnnotation
+        String clazz() {
+            return "hello";
+        }
+
+        @MySimpleAnnotation("baz")
+        @MyFirstAnnotation
+        @MySecondAnnotation
+        List<String> parameterized(List<Integer> param1, int param2) {
+            return Collections.emptyList();
+        }
+
+        <T extends CharSequence> String[] array(@MyFirstAnnotation T typeVar, @MySecondAnnotation T[] typeVarArray) {
+            return new String[0];
+        }
+    }
+}


### PR DESCRIPTION
This is a result of my attempt to optimize reflection usage in interceptors by providing an reflectionless alternative to `InvocationContext.getMethod()` / `getConstructor()`. This has 2 parts:

1. The `ArcInvocationContext` gains a new method `getMethodMetadata()`, which provides an alternative to `getMethod()` / `getConstructor()` that doesn't rely on reflection. Instead, `getMethodMetadata()` returns a new type `MethodMetadata`. This interface has methods similar to `java.lang.reflect.Method`, except it is implemented by a class generated during build specifically for each shape of intercepted method/constructor. For methods with small number of parameters or annotations, which is the most common case, the generated class has unfolded fields for parameters/annotations, which allows faster access than a data structure that's used otherwise (array or `Map`).
2. If an interceptor doesn't use the reflective methods mentioned above, it may be annotated `@Reflectionless`. If all interceptors that apply to some method/constructor are reflectionless, the `InvocationContext` methods `getMethod()` / `getConstructor()` will always return `null` when that method/constructor is intercepted, and the method/constructor is not registered for reflection (unless it is registered elsewhere).

The first commit is the infrastructure work, while the second is an example usage.

I measured performance impact using the JMH benchmark from this branch: https://github.com/Ladicek/arc-benchmarks/commits/reflectionless-interception

I measured RSS impact using this one-off tool: https://github.com/Ladicek/arc-crazybeans

# Benchmarks

## Measuring

All measurements were done on my otherwise-idle desktop machine (running Ubuntu 22.04 with kernel Linux 5.15.0-48-generic; hardware-wise it's Ryzen 5950X with 64 GB of RAM) with the following tuning:

```bash
# select the "performance" CPU scaling governor
sudo cpupower frequency-set -g performance

# disable hyperthreading
echo off | sudo tee /sys/devices/system/cpu/smt/control

# disable turbo boost
echo 0 | sudo tee /sys/devices/system/cpu/cpufreq/boost
```

(I know more tuning could/should be done, but I'm no expert...)

## Performance

`main` branch (82700f1f75455655accb335df85ec8d9fc258807):

```
Benchmark                                                                                   Mode  Cnt     Score    Error  Units
MethodAccessingInterceptionBenchmark.baseline_noInterceptor                                thrpt   25  4705.716 ±  1.563  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithAnnotationProceed       thrpt   25   551.225 ±  6.987  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithAnnotationShortCircuit  thrpt   25   579.019 ±  1.642  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithoutAnnotation           thrpt   25  1507.696 ± 17.745  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithAnnotationProceed                       thrpt   25   555.301 ±  1.868  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithAnnotationShortCircuit                  thrpt   25   580.690 ±  0.990  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithoutAnnotation                           thrpt   25  1519.545 ±  3.584  ops/s
```

this branch (4901aa9fb0ff57f3d30a6a0d085856688b340bf2):

```
Benchmark                                                                                       Mode  Cnt     Score     Error  Units
MethodAccessingInterceptionBenchmark.baseline_noInterceptor                                    thrpt   25  4707.689 ±   7.359  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectionlessWithAnnotationProceed       thrpt   25   841.232 ±  74.327  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectionlessWithAnnotationShortCircuit  thrpt   25   701.871 ± 105.664  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectionlessWithoutAnnotation           thrpt   25  1187.663 ± 127.325  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithAnnotationProceed           thrpt   25   460.182 ±  42.987  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithAnnotationShortCircuit      thrpt   25   537.209 ±  14.170  ops/s
MethodAccessingInterceptionBenchmark.manyAnnotations_reflectiveWithoutAnnotation               thrpt   25  1466.451 ±  15.869  ops/s
MethodAccessingInterceptionBenchmark.reflectionlessWithAnnotationProceed                       thrpt   25  1474.928 ±   7.062  ops/s
MethodAccessingInterceptionBenchmark.reflectionlessWithAnnotationShortCircuit                  thrpt   25  1307.191 ±   5.210  ops/s
MethodAccessingInterceptionBenchmark.reflectionlessWithoutAnnotation                           thrpt   25  1684.818 ±   8.631  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithAnnotationProceed                           thrpt   25   492.082 ±  47.662  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithAnnotationShortCircuit                      thrpt   25   493.029 ±  66.189  ops/s
MethodAccessingInterceptionBenchmark.reflectiveWithoutAnnotation                               thrpt   25  1467.469 ±  17.414  ops/s
```

## JVM RSS

`main` branch (reflection only): 106114.640 ± 580.154 kB
this branch (with `@Reflectionless`, so `getMethod()` returns `null`): 106108.000 ± 557.197 kB
this branch (without `@Reflectionless`, both methods are usable): 101162.720 ± 537.588 kB

The last line is pretty weird, but I ran the measurements several times and it's always the same. I don't have an explanation. Perhaps my RSS measurement methodology is wrong.

## Native RSS (GraalVM 22.2.0 Java 11 CE)

`main` branch (reflection only): 34404.400 ± 83.102 kB
this branch (with `@Reflectionless`, so `getMethod()` returns `null`): 33771.400 ± 75.389 kB
this branch (without `@Reflectionless`, both methods are usable): 35129.720 ± 80.170 kB

## Native binary size (GraalVM 22.2.0 Java 11 CE)

`main` branch (reflection only): 36226480 B
this branch (with `@Reflectionless`, so `getMethod()` returns `null`): 37500336 B
this branch (without `@Reflectionless`, both methods are usable): 37918128 B

# Conclusion

I originally generated 1 `MethodMetadata` implementation for each intercepted method. This was basically a bag of constants, so performance was even better than what's shown above. I later found that this has a huge impact on JVM RSS (in the same settings as benchmarks above, JVM RSS was 40 or 50 MB higher with this change compared to `main`). Interestingly, native RSS seemingly wasn't impacted at all.

I then refactored the code to the present approach. Performance still improves considerably, as shown above.

However, the RSS and native binary size impact is minuscule, which is the exact opposite of what I hoped for. My personal conclusion is that while I learned a lot, it was a waste of time otherwise.

I'm submitting this PR, as a draft, for your own consideration, but since this incurs significant maintenance cost for negligible gain, I propose we just don't merge it.