### PR TITLE
Fix duplicated TOC in writing-extensions.adoc

### DIFF
--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -4,14 +4,13 @@ and pull requests should be submitted there:
 https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 ////
 = Writing Your Own Extension
+include::_attributes.adoc[]
 :categories: writing-extensions
 :summary: Quarkus extensions optimize your applications by pushing as much work as possible to the build operation. This guide explains the rationale of Quarkus extensions and guides you through authoring your own extensions.
 :numbered:
 :sectnums:
 :sectnumlevels: 4
 :toc:
-
-include::_attributes.adoc[]
 
 Quarkus extensions add a new developer focused behavior to the core offering, and consist of two distinct parts, buildtime augmentation and runtime container. The augmentation part is responsible for all metadata processing, such as reading annotations, XML descriptors etc. The output of this augmentation phase is recorded bytecode which is responsible for directly instantiating the relevant runtime services.
 


### PR DESCRIPTION
Don't ask me why, when having the _attributes.adoc below :toc:, we end up with a second TOC on the website.

Fixes #28747