### PR TITLE
Updating smallrye-graphql-client to 1.8.2 adding configuration parameter `init-payload`

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -44,7 +44,7 @@
         <smallrye-health.version>3.3.0</smallrye-health.version>
         <smallrye-metrics.version>3.0.5</smallrye-metrics.version>
         <smallrye-open-api.version>2.3.1</smallrye-open-api.version>
-        <smallrye-graphql.version>1.8.1</smallrye-graphql.version>
+        <smallrye-graphql.version>1.8.2</smallrye-graphql.version>
         <smallrye-opentracing.version>2.1.1</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>5.5.0</smallrye-fault-tolerance.version>
         <smallrye-jwt.version>3.5.4</smallrye-jwt.version>

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfig.java
@@ -114,4 +114,9 @@ public class GraphQLClientConfig {
     @ConfigItem
     public OptionalInt maxRedirects;
 
+    /**
+     * Additional payload sent on websocket initialization.
+     */
+    @ConfigItem(name = "init-payload")
+    public Map<String, String> initPayload;
 }

--- a/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfigurationMergerBean.java
+++ b/extensions/smallrye-graphql-client/runtime/src/main/java/io/quarkus/smallrye/graphql/client/runtime/GraphQLClientConfigurationMergerBean.java
@@ -1,7 +1,9 @@
 package io.quarkus.smallrye.graphql.client.runtime;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -94,6 +96,8 @@ public class GraphQLClientConfigurationMergerBean {
     private GraphQLClientConfiguration toSmallRyeNativeConfiguration(GraphQLClientConfig quarkusConfig) {
         GraphQLClientConfiguration transformed = new GraphQLClientConfiguration();
         transformed.setHeaders(quarkusConfig.headers);
+        transformed.setInitPayload(Optional.ofNullable(quarkusConfig.initPayload)
+                .map(m -> new HashMap<String, Object>(m)).orElse(null));
         quarkusConfig.url.ifPresent(transformed::setUrl);
         transformed.setWebsocketSubprotocols(quarkusConfig.subprotocols.orElse(new ArrayList<>()));
         quarkusConfig.keyStore.ifPresent(transformed::setKeyStore);

--- a/jakarta/rewrite.yml
+++ b/jakarta/rewrite.yml
@@ -569,7 +569,7 @@ recipeList:
       newValue: 6.0.0-RC4
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-graphql.version
-      newValue: 2.0.0.RC10
+      newValue: 2.0.0.RC12
   - org.openrewrite.maven.ChangePropertyValue:
       key: smallrye-health.version
       newValue: 4.0.0


### PR DESCRIPTION
Updating smallrye-graphql-client to 1.8.2 adding configuration parameter
```
quarkus.smallrye-graphql-client."my-client".init-payload.token=${token}
```

The smallrye PR
https://github.com/smallrye/smallrye-graphql/pull/1590

Signed-off-by: Max Gabrielsson <max.gabrielsson@gmail.com>