### PR TITLE
Update supported-by information for extension descriptors

### DIFF
--- a/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
+++ b/independent-projects/tools/devtools-common/src/main/java/io/quarkus/platform/catalog/processor/ExtensionProcessor.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.registry.catalog.Extension;
@@ -135,6 +136,31 @@ public final class ExtensionProcessor {
         if (getMetadataValue(extension, "status").isEmpty()) {
             extendedMetadata.put("status", "stable");
         }
+        @SuppressWarnings("unchecked")
+        final Collection<String> supporters = (Collection<String>) extendedMetadata.getOrDefault("supported-by",
+                new ArrayList<String>());
+        final Map<String, Object> supportStatuses = extendedMetadata.entrySet().stream()
+                .filter(e -> e.getKey().endsWith("-support"))
+                .collect(Collectors.toMap(
+                        k -> k.getKey(),
+                        v -> v.getValue()));
+
+        supportStatuses.entrySet().forEach((e) -> {
+            String supporter = e.getKey().replace("-support", "");
+
+            if (!supporters.contains(supporter)) {
+                supporters.add(supporter);
+            }
+        });
+        extendedMetadata.put("supported-by", supporters);
+
+        for (String s : supporters) {
+            if (!supportStatuses.keySet().contains(s + "-support")) {
+                supportStatuses.put(s + "-support", "stable");
+            }
+        }
+        extendedMetadata.putAll(supportStatuses);
+
         return extendedMetadata.entrySet().stream()
                 .map(e -> new AbstractMap.SimpleImmutableEntry<>(e.getKey(), (new MetadataValue(e.getValue()).asStringList())))
                 .filter(e -> !e.getValue().isEmpty())

--- a/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
+++ b/independent-projects/tools/devtools-common/src/test/java/io/quarkus/platform/catalog/processor/ExtensionProcessorTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.platform.catalog.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.registry.catalog.Extension;
+
+public class ExtensionProcessorTest {
+
+    @Test
+    public void testNoSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/resteasy-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertFalse(metadata.keySet().contains("supported-by"));
+        assertFalse(metadata.keySet().stream().anyMatch((k) -> k.endsWith("-support")));
+    }
+
+    @Test
+    public void testFullSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/rest-client-mutiny-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("xyz"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("techpreview", "deprecated"), metadata.get("xyz-support"));
+    }
+
+    @Test
+    public void testLegacySupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/agroal-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("redhat"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable"), metadata.get("redhat-support"));
+    }
+
+    @Test
+    public void testComplexSupportData() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/datasource-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("Red Hat", "xyz"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable", "awesome"), metadata.get("Red Hat-support"));
+        assertEquals(Arrays.asList("none"), metadata.get("xyz-support"));
+    }
+
+    @Test
+    public void testSupporterWithoutStatus() throws Exception {
+        Extension extension = Extension
+                .fromFile(Path.of(ExtensionProcessorTest.class.getResource("/flyway-extension.yaml").toURI()));
+        Map<String, Collection<String>> metadata = ExtensionProcessor.getSyntheticMetadata(extension);
+
+        assertEquals(Arrays.asList("xyz", "abc"), metadata.get("supported-by"));
+        assertEquals(Arrays.asList("stable"), metadata.get("xyz-support"));
+        assertEquals(Arrays.asList("stable"), metadata.get("abc-support"));
+    }
+
+}

--- a/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/agroal-extension.yaml
@@ -1,0 +1,28 @@
+---
+name: "Agroal - Database connection pool"
+artifact: "io.quarkus:quarkus-agroal:999-SNAPSHOT"
+metadata:
+  keywords:
+  - "agroal"
+  - "database-connection-pool"
+  - "datasource"
+  - "jdbc"
+  guide: "https://quarkus.io/guides/datasource"
+  categories:
+  - "data"
+  status: "stable"
+  redhat-support: "stable"
+  config:
+  - "quarkus.datasource."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.agroal"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-datasource"
+  - "io.quarkus:quarkus-narayana-jta"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Pool JDBC database connections (included in Hibernate ORM)"

--- a/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/datasource-extension.yaml
@@ -1,0 +1,23 @@
+---
+artifact: "io.quarkus:quarkus-datasource:999-SNAPSHOT"
+name: "Datasources"
+metadata:
+  keywords:
+  - "datasource"
+  guide: "https://quarkus.io/guides/datasource"
+  categories:
+  - "data"
+  status: "stable"
+  supported-by: 
+      - "Red Hat"
+  Red Hat-support:
+      - "stable"
+      - "awesome"
+  xyz-support:
+      - "none"
+  unlisted: true
+  built-with-quarkus-core: "999-SNAPSHOT"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+description: "Configure your datasources"

--- a/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/flyway-extension.yaml
@@ -1,0 +1,30 @@
+---
+artifact: "io.quarkus:quarkus-flyway:999-SNAPSHOT"
+name: "Flyway"
+metadata:
+  keywords:
+  - "flyway"
+  - "database"
+  - "data"
+  guide: "https://quarkus.io/guides/flyway"
+  categories:
+  - "data"
+  status: "stable"
+  supported-by: 
+  - "xyz"
+  - "abc"
+  config:
+  - "quarkus.flyway."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.flyway"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-agroal"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-datasource"
+  - "io.quarkus:quarkus-narayana-jta"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Handle your database schema migrations"

--- a/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/rest-client-mutiny-extension.yaml
@@ -1,0 +1,31 @@
+---
+artifact: "io.quarkus:quarkus-rest-client-mutiny:999-SNAPSHOT"
+name: "REST Client Classic Mutiny support"
+metadata:
+  keywords:
+  - "rest-client-mutiny"
+  - "rest-client"
+  - "web-client"
+  - "microprofile-rest-client"
+  - "mutiny"
+  categories:
+  - "web"
+  - "reactive"
+  status: "deprecated"
+  supported-by: 
+      - "xyz"
+  xyz-support:
+      - "techpreview"
+      - "deprecated"
+  built-with-quarkus-core: "999-SNAPSHOT"
+  extension-dependencies:
+  - "io.quarkus:quarkus-rest-client"
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-resteasy-common"
+  - "io.quarkus:quarkus-apache-httpclient"
+  - "io.quarkus:quarkus-rest-client-config"
+  - "io.quarkus:quarkus-resteasy-mutiny-common"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+description: "Enable Mutiny for the REST client"

--- a/independent-projects/tools/devtools-common/src/test/resources/resteasy-extension.yaml
+++ b/independent-projects/tools/devtools-common/src/test/resources/resteasy-extension.yaml
@@ -1,0 +1,39 @@
+---
+name: "RESTEasy Classic"
+artifact: "io.quarkus:quarkus-resteasy:999-SNAPSHOT"
+metadata:
+  short-name: "jax-rs"
+  keywords:
+  - "resteasy"
+  - "jaxrs"
+  - "web"
+  - "rest"
+  guide: "https://quarkus.io/guides/resteasy"
+  categories:
+  - "web"
+  status: "stable"
+  codestart:
+    name: "resteasy"
+    languages:
+    - "java"
+    - "kotlin"
+    - "scala"
+    artifact: "io.quarkus:quarkus-project-core-extension-codestarts::jar:999-SNAPSHOT"
+  config:
+  - "quarkus.resteasy."
+  built-with-quarkus-core: "999-SNAPSHOT"
+  capabilities:
+    provides:
+    - "io.quarkus.rest"
+    - "io.quarkus.resteasy"
+  extension-dependencies:
+  - "io.quarkus:quarkus-vertx-http"
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+  - "io.quarkus:quarkus-vertx"
+  - "io.quarkus:quarkus-netty"
+  - "io.quarkus:quarkus-resteasy-server-common"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-resteasy-common"
+description: "REST endpoint framework implementing JAX-RS and more"


### PR DESCRIPTION
In support of #8021, process the supported-by attribute to find a supporter name, then create or update an attribute with the supporter name and the suffix of `-support` to with the status(es) for the extension supporter.  If there is an existing tag ending with `-support`, a `supported-by` tag will be created updated for the supporter(s).

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>