### PR TITLE
Follow the new syntax for the configuration of the Quarkus GitHub Lottery

### DIFF
--- a/.github/quarkus-github-lottery.yml
+++ b/.github/quarkus-github-lottery.yml
@@ -3,18 +3,49 @@ notifications:
     repository: "quarkusio/quarkus-github-lottery-reports"
 buckets:
   triage:
-    needsTriageLabel: "triage/needs-triage"
-    notificationExpiration: P3D
-labels:
-  needsTriage: "triage/needs-triage"
+    label: "triage/needs-triage"
+    delay: PT0S
+    timeout: P3D
+  maintenance:
+    reproducer:
+      label: "needs-reproducer"
+      needed:
+        delay: P21D
+        timeout: P3D
+      provided:
+        delay: P7D
+        timeout: P3D
+    stale:
+      delay: P60D
+      timeout: P14D
 participants:
   - username: "yrodiere"
     timezone: "Europe/Paris"
-    days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
     triage:
+      days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
       maxIssues: 3
+    maintenance:
+      labels: ["area/hibernate-orm", "area/hibernate-search", "area/elasticsearch"]
+      days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+      reproducer:
+        needed:
+          maxIssues: 4
+        provided:
+          maxIssues: 2
+      stale:
+        maxIssues: 5
   - username: "gsmet"
     timezone: "Europe/Paris"
-    days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
     triage:
+      days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
       maxIssues: 3
+    maintenance:
+      labels: ["area/hibernate-validator", "area/jakarta"]
+      days: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+      reproducer:
+        needed:
+          maxIssues: 4
+        provided:
+          maxIssues: 2
+      stale:
+        maxIssues: 5


### PR DESCRIPTION
Creating as a draft PR because I haven't deployed the version of the lottery app that requires this syntax yet.

Documentation of the new syntax is coming in the next few days, for now I'm just trying to validate that it all works correctly.

@gsmet I registered you for maintenance notifications every day for `area/jakarta` and `area/hibernate-validator`. Let me know if you want me to change that, or feel free to suggest changes and I'll integrate them.