### PR TITLE
Disable test in CI/CD on Mac, because of failures on GitHub actions runner

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -292,7 +292,7 @@ jobs:
           fetch-depth: 0
       - name: Add quarkusio remote
         shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
+        run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
 
       - name: apt clean
         if: "!startsWith(matrix.java.os-name, 'windows') && !startsWith(matrix.java.os-name, 'macos')"
@@ -632,7 +632,7 @@ jobs:
           fetch-depth: 0
       - name: Add quarkusio remote
         shell: bash
-        run: git remote add quarkusio https://github.com/quarkusio/quarkus.git
+        run: git remote show quarkusio &> /dev/null || git remote add quarkusio https://github.com/quarkusio/quarkus.git
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Set up JDK 11

--- a/integration-tests/mongodb-devservices/pom.xml
+++ b/integration-tests/mongodb-devservices/pom.xml
@@ -139,6 +139,30 @@
                 </plugins>
             </build>
         </profile>
+            <!-- Disabled pending fix of #28779 -->
+            <profile>
+                <id>mac-m1</id>
+                <activation>
+                    <os>
+                        <family>mac</family>
+                        <arch>aarch64</arch>
+                    </os>
+                    <property>
+                        <name>env.GITHUB_ACTIONS</name>
+                        <value>true</value>
+                    </property>
+                </activation>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
See discussion in  #28779 

This is only a "putting our hands over our eyes and going lalala" workaround, but it should have some diagnostic value, and reduce noise in the builds.