### PR TITLE
Fix vertx otel sdk reload in devmode

### DIFF
--- a/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
+++ b/extensions/opentelemetry/deployment/src/main/java/io/quarkus/opentelemetry/deployment/tracing/instrumentation/InstrumentationProcessor.java
@@ -1,0 +1,115 @@
+package io.quarkus.opentelemetry.deployment.tracing.instrumentation;
+
+import static io.quarkus.bootstrap.classloading.QuarkusClassLoader.isClassPresentAtRuntime;
+import static javax.interceptor.Interceptor.Priority.LIBRARY_AFTER;
+
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.opentelemetry.deployment.tracing.TracerEnabled;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.InstrumentationRecorder;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.grpc.GrpcTracingClientInterceptor;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.grpc.GrpcTracingServerInterceptor;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.reactivemessaging.ReactiveMessagingTracingDecorator;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.restclient.OpenTelemetryClientFilter;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.core.deployment.VertxOptionsConsumerBuildItem;
+import io.vertx.core.VertxOptions;
+
+@BuildSteps(onlyIf = TracerEnabled.class)
+public class InstrumentationProcessor {
+    static class MetricsExtensionAvailable implements BooleanSupplier {
+        private static final boolean IS_MICROMETER_EXTENSION_AVAILABLE = isClassPresentAtRuntime(
+                "io.quarkus.micrometer.runtime.binder.vertx.VertxHttpServerMetrics");
+
+        @Override
+        public boolean getAsBoolean() {
+            Config config = ConfigProvider.getConfig();
+            if (IS_MICROMETER_EXTENSION_AVAILABLE) {
+                if (config.getOptionalValue("quarkus.micrometer.enabled", Boolean.class).orElse(true)) {
+                    Optional<Boolean> httpServerEnabled = config
+                            .getOptionalValue("quarkus.micrometer.binder.http-server.enabled", Boolean.class);
+                    if (httpServerEnabled.isPresent()) {
+                        return httpServerEnabled.get();
+                    } else {
+                        return config.getOptionalValue("quarkus.micrometer.binder-enabled-default", Boolean.class).orElse(true);
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    static class GrpcExtensionAvailable implements BooleanSupplier {
+        private static final boolean IS_GRPC_EXTENSION_AVAILABLE = isClassPresentAtRuntime(
+                "io.quarkus.grpc.runtime.GrpcServerRecorder");
+
+        @Override
+        public boolean getAsBoolean() {
+            return IS_GRPC_EXTENSION_AVAILABLE;
+        }
+    }
+
+    @BuildStep(onlyIf = GrpcExtensionAvailable.class)
+    void grpcTracers(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(new AdditionalBeanBuildItem(GrpcTracingServerInterceptor.class));
+        additionalBeans.produce(new AdditionalBeanBuildItem(GrpcTracingClientInterceptor.class));
+    }
+
+    @BuildStep
+    void registerRestClientClassicProvider(
+            Capabilities capabilities,
+            BuildProducer<AdditionalIndexedClassesBuildItem> additionalIndexed,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        if (capabilities.isPresent(Capability.REST_CLIENT) && capabilities.isMissing(Capability.REST_CLIENT_REACTIVE)) {
+            additionalIndexed.produce(new AdditionalIndexedClassesBuildItem(OpenTelemetryClientFilter.class.getName()));
+            additionalBeans.produce(new AdditionalBeanBuildItem(OpenTelemetryClientFilter.class));
+        }
+    }
+
+    @BuildStep
+    void registerReactiveMessagingMessageDecorator(
+            Capabilities capabilities,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        if (capabilities.isPresent(Capability.SMALLRYE_REACTIVE_MESSAGING)) {
+            additionalBeans.produce(new AdditionalBeanBuildItem(ReactiveMessagingTracingDecorator.class));
+        }
+    }
+
+    @BuildStep(onlyIfNot = MetricsExtensionAvailable.class)
+    @Record(ExecutionTime.STATIC_INIT)
+    VertxOptionsConsumerBuildItem vertxTracingMetricsOptions(InstrumentationRecorder recorder) {
+        return new VertxOptionsConsumerBuildItem(recorder.getVertxTracingMetricsOptions(), LIBRARY_AFTER + 1);
+    }
+
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    VertxOptionsConsumerBuildItem vertxTracingOptions(InstrumentationRecorder recorder,
+            LaunchModeBuildItem launchMode) {
+        Consumer<VertxOptions> vertxTracingOptions;
+        if (launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT) {
+            // tracers are set in the OpenTelemetryProcessor
+            vertxTracingOptions = recorder.getVertxTracingOptionsDevMode();
+        } else {
+            vertxTracingOptions = recorder.getVertxTracingOptionsProd(recorder.createTracers());
+        }
+        return new VertxOptionsConsumerBuildItem(
+                vertxTracingOptions,
+                LIBRARY_AFTER);
+    }
+
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OpenTelemetryConfig.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/OpenTelemetryConfig.java
@@ -27,6 +27,8 @@ public final class OpenTelemetryConfig {
     @ConfigItem(defaultValue = "tracecontext,baggage")
     public List<String> propagators;
 
-    /** Build / static runtime config for tracer */
+    /**
+     * Build / static runtime config for tracer
+     */
     public TracerConfig tracer;
 }

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/TracerRecorder.java
@@ -2,7 +2,6 @@ package io.quarkus.opentelemetry.runtime.tracing;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
@@ -21,31 +20,12 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import io.quarkus.arc.Arc;
 import io.quarkus.opentelemetry.runtime.config.TracerRuntimeConfig;
-import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxMetricsFactory;
-import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracingFactory;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.core.tracing.TracingOptions;
 
 @Recorder
 public class TracerRecorder {
-    /* STATIC INIT */
-    public Consumer<VertxOptions> getVertxTracingOptions() {
-        TracingOptions tracingOptions = new TracingOptions()
-                .setFactory(new OpenTelemetryVertxTracingFactory());
-        return vertxOptions -> vertxOptions.setTracingOptions(tracingOptions);
-    }
-
-    public Consumer<VertxOptions> getVertxTracingMetricsOptions() {
-        MetricsOptions metricsOptions = new MetricsOptions()
-                .setEnabled(true)
-                .setFactory(new OpenTelemetryVertxMetricsFactory());
-        return vertxOptions -> vertxOptions.setMetricsOptions(metricsOptions);
-    }
-
     /* STATIC INIT */
     public RuntimeValue<SdkTracerProvider> createTracerProvider(
             String quarkusVersion,

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/InstrumentationRecorder.java
@@ -1,0 +1,66 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.EventBusInstrumenterVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.HttpInstrumenterVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.InstrumenterVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxMetricsFactory;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracer;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracingDevModeFactory;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.OpenTelemetryVertxTracingFactory;
+import io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx.SqlClientInstrumenterVertxTracer;
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.tracing.TracingOptions;
+
+@Recorder
+public class InstrumentationRecorder {
+
+    public static final OpenTelemetryVertxTracingDevModeFactory FACTORY = new OpenTelemetryVertxTracingDevModeFactory();
+
+    /* RUNTIME INIT */
+    public RuntimeValue<OpenTelemetryVertxTracer> createTracers() {
+        OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+        List<InstrumenterVertxTracer<?, ?>> instrumenterVertxTracers = new ArrayList<>();
+        instrumenterVertxTracers.add(new HttpInstrumenterVertxTracer(openTelemetry));
+        instrumenterVertxTracers.add(new EventBusInstrumenterVertxTracer(openTelemetry));
+        // TODO - Selectively register this in the recorder if the SQL Client is available.
+        instrumenterVertxTracers.add(new SqlClientInstrumenterVertxTracer(openTelemetry));
+        return new RuntimeValue<>(new OpenTelemetryVertxTracer(instrumenterVertxTracers));
+    }
+
+    /* RUNTIME INIT */
+    public Consumer<VertxOptions> getVertxTracingOptionsProd(
+            RuntimeValue<OpenTelemetryVertxTracer> tracer) {
+        TracingOptions tracingOptions = new TracingOptions()
+                .setFactory(new OpenTelemetryVertxTracingFactory(tracer.getValue()));
+        return vertxOptions -> vertxOptions.setTracingOptions(tracingOptions);
+    }
+
+    /* RUNTIME INIT */
+    public Consumer<VertxOptions> getVertxTracingOptionsDevMode() {
+        TracingOptions tracingOptions = new TracingOptions()
+                .setFactory(FACTORY);
+        return vertxOptions -> vertxOptions.setTracingOptions(tracingOptions);
+    }
+
+    /* RUNTIME INIT */
+    public void setTracerDevMode(RuntimeValue<OpenTelemetryVertxTracer> tracer) {
+        FACTORY.getVertxTracerDelegator().setDelegate(tracer.getValue());
+    }
+
+    /* RUNTIME INIT */
+    public Consumer<VertxOptions> getVertxTracingMetricsOptions() {
+        MetricsOptions metricsOptions = new MetricsOptions()
+                .setEnabled(true)
+                .setFactory(new OpenTelemetryVertxMetricsFactory());
+        return vertxOptions -> vertxOptions.setMetricsOptions(metricsOptions);
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java
@@ -44,7 +44,7 @@ import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.spi.tracing.TagExtractor;
 
-class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<HttpRequest, HttpResponse> {
+public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<HttpRequest, HttpResponse> {
     private final Instrumenter<HttpRequest, HttpResponse> serverInstrumenter;
     private final Instrumenter<HttpRequest, HttpResponse> clientInstrumenter;
 

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/InstrumenterVertxTracer.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/InstrumenterVertxTracer.java
@@ -17,7 +17,7 @@ import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
 @SuppressWarnings("unchecked")
-interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOperation, SpanOperation> {
+public interface InstrumenterVertxTracer<REQ, RESP> extends VertxTracer<SpanOperation, SpanOperation> {
     @Override
     default <R> SpanOperation receiveRequest(
             // The Vert.x context passed to use is already duplicated.

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxTracingDevModeFactory.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxTracingDevModeFactory.java
@@ -1,0 +1,84 @@
+package io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx;
+
+import java.util.function.BiConsumer;
+
+import io.vertx.core.Context;
+import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingOptions;
+import io.vertx.core.tracing.TracingPolicy;
+
+public class OpenTelemetryVertxTracingDevModeFactory implements VertxTracerFactory {
+    private final Delegator vertxTracerDelegator = new Delegator();
+
+    public OpenTelemetryVertxTracingDevModeFactory() {
+    }
+
+    public Delegator getVertxTracerDelegator() {
+        return vertxTracerDelegator;
+    }
+
+    @Override
+    public VertxTracer<?, ?> tracer(final TracingOptions options) {
+        return vertxTracerDelegator;
+    }
+
+    public static class Delegator implements VertxTracer {
+        private VertxTracer delegate;
+
+        public VertxTracer getDelegate() {
+            return delegate;
+        }
+
+        public Delegator setDelegate(final VertxTracer delegate) {
+            this.delegate = delegate;
+            return this;
+        }
+
+        @Override
+        public Object receiveRequest(
+                final Context context,
+                final SpanKind kind,
+                final TracingPolicy policy,
+                final Object request,
+                final String operation,
+                final Iterable headers,
+                final TagExtractor tagExtractor) {
+            return delegate.receiveRequest(context, kind, policy, request, operation, headers, tagExtractor);
+        }
+
+        @Override
+        public void sendResponse(
+                final Context context,
+                final Object response,
+                final Object payload,
+                final Throwable failure,
+                final TagExtractor tagExtractor) {
+            delegate.sendResponse(context, response, payload, failure, tagExtractor);
+        }
+
+        @Override
+        public Object sendRequest(
+                final Context context,
+                final SpanKind kind,
+                final TracingPolicy policy,
+                final Object request,
+                final String operation,
+                final BiConsumer headers,
+                final TagExtractor tagExtractor) {
+            return delegate.sendRequest(context, kind, policy, request, operation, headers, tagExtractor);
+        }
+
+        @Override
+        public void receiveResponse(
+                final Context context,
+                final Object response,
+                final Object payload,
+                final Throwable failure,
+                final TagExtractor tagExtractor) {
+            delegate.receiveResponse(context, response, payload, failure, tagExtractor);
+        }
+    }
+}

--- a/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxTracingFactory.java
+++ b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/OpenTelemetryVertxTracingFactory.java
@@ -1,23 +1,18 @@
 package io.quarkus.opentelemetry.runtime.tracing.intrumentation.vertx;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.OpenTelemetry;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
 
 public class OpenTelemetryVertxTracingFactory implements VertxTracerFactory {
+    private final OpenTelemetryVertxTracer openTelemetryVertxTracer;
+
+    public OpenTelemetryVertxTracingFactory(OpenTelemetryVertxTracer openTelemetryVertxTracer) {
+        this.openTelemetryVertxTracer = openTelemetryVertxTracer;
+    }
+
     @Override
     public VertxTracer<?, ?> tracer(final TracingOptions options) {
-        OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
-        List<InstrumenterVertxTracer<?, ?>> instrumenterVertxTracers = new ArrayList<>();
-        instrumenterVertxTracers.add(new HttpInstrumenterVertxTracer(openTelemetry));
-        instrumenterVertxTracers.add(new EventBusInstrumenterVertxTracer(openTelemetry));
-        // TODO - Selectively register this in the recorder if the SQL Client is available.
-        instrumenterVertxTracers.add(new SqlClientInstrumenterVertxTracer(openTelemetry));
-        return new OpenTelemetryVertxTracer(instrumenterVertxTracers);
+        return openTelemetryVertxTracer;
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/quarkusio/quarkus/issues/29645

Part of #26444
Currently OTel will not live reload, working only on first start. 

This PR includes: 
* Centralise instrumentation related classes in the Instrumentation processor and recorder.
* Create an OpenTelemetryWapper that will detect when the global OTel SDK has changed in development mode.

---------

Caveat: 
* On REST requests, the first instrumentation call after reload doesn't send span because OTEL is reloaded after the return of the call. The REST call starts with the old OTel SDK object in the vertx instrumentation and ends with the new one. 