### PR TITLE
Introduce proper method name for RegisteredComponentsBuildItem

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RegisteredComponentsBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/RegisteredComponentsBuildItem.java
@@ -27,8 +27,18 @@ abstract class RegisteredComponentsBuildItem extends SimpleBuildItem {
 
     /**
      * @return the registered beans
+     *
+     * @deprecated in favor of {@link #getBeans()}
      */
+    @Deprecated(forRemoval = true)
     public Collection<BeanInfo> geBeans() {
+        return beans;
+    }
+
+    /**
+     * @return the registered beans
+     */
+    public Collection<BeanInfo> getBeans() {
         return beans;
     }
 

--- a/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
+++ b/extensions/cache/deployment/src/main/java/io/quarkus/cache/deployment/CacheProcessor.java
@@ -212,7 +212,7 @@ class CacheProcessor {
     // Key generators must have a default constructor if they are not managed by Arc.
     private List<Throwable> validateKeyGeneratorsDefaultConstructor(CombinedIndexBuildItem combinedIndex,
             BeanDiscoveryFinishedBuildItem beanDiscoveryFinished, Set<DotName> keyGenerators) {
-        List<DotName> managedBeans = beanDiscoveryFinished.geBeans()
+        List<DotName> managedBeans = beanDiscoveryFinished.getBeans()
                 .stream()
                 .filter(BeanInfo::isClassBean)
                 .map(BeanInfo::getBeanClass)

--- a/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringProcessor.java
+++ b/extensions/smallrye-reactive-messaging/deployment/src/main/java/io/quarkus/smallrye/reactivemessaging/deployment/WiringProcessor.java
@@ -58,7 +58,7 @@ public class WiringProcessor {
     @BuildStep
     void discoverConnectors(BeanDiscoveryFinishedBuildItem beans, CombinedIndexBuildItem index,
             BuildProducer<ConnectorBuildItem> builder) {
-        beans.geBeans().stream()
+        beans.getBeans().stream()
                 .filter(bi -> bi.getQualifier(ReactiveMessagingDotNames.CONNECTOR).isPresent())
                 .forEach(bi -> {
                     if (isInboundConnector(bi.getImplClazz())) {


### PR DESCRIPTION
The old method still exists for compatibility reasons, but should be removed sometime in the future.