### PR TITLE
Rest Data Panache: Correct Open API integration

### DIFF
--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.List;
 
 import org.hamcrest.Matchers;
@@ -25,6 +27,7 @@ import io.restassured.RestAssured;
 class OpenApiIntegrationTest {
 
     private static final String OPEN_API_PATH = "/q/openapi";
+    private static final String COLLECTIONS_SCHEMA_REF = "#/components/schemas/Collection";
 
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
@@ -36,7 +39,7 @@ class OpenApiIntegrationTest {
                     .addAsResource("application.properties")
                     .addAsResource("import.sql"))
             .setForcedDependencies(List.of(
-                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-jdbc-h2-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-resteasy-jsonb-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-security-deployment", Version.getVersion())))
@@ -51,14 +54,28 @@ class OpenApiIntegrationTest {
                 .body("info.title", Matchers.equalTo("quarkus-hibernate-orm-rest-data-panache-deployment API"))
                 .body("paths.'/collections'", Matchers.hasKey("get"))
                 .body("paths.'/collections'.get.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.get.responses.'200'.content.'application/json'.schema.type", is("array"))
+                .body("paths.'/collections'.get.responses.'200'.content.'application/json'.schema.items.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections'", Matchers.hasKey("post"))
                 .body("paths.'/collections'.post.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.post.requestBody.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
+                .body("paths.'/collections'.post.responses.'201'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections'.post.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'.get.responses.'200'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections/{id}'.get.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'.put.requestBody.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
+                .body("paths.'/collections/{id}'.put.responses.'201'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/collections/{id}'.delete.responses", Matchers.hasKey("204"))
                 .body("paths.'/collections/{id}'.delete.security[0].SecurityScheme", Matchers.hasItem("admin"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
                 .body("paths.'/empty-list-items'.get.tags", Matchers.hasItem("EmptyListItemsResource"))

--- a/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-reactive-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/reactive/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.hibernate.reactive.rest.data.panache.deployment.openapi;
 
+import static org.hamcrest.Matchers.is;
+
 import java.util.List;
 
 import org.hamcrest.Matchers;
@@ -25,6 +27,7 @@ import io.restassured.RestAssured;
 class OpenApiIntegrationTest {
 
     private static final String OPEN_API_PATH = "/q/openapi";
+    private static final String COLLECTIONS_SCHEMA_REF = "#/components/schemas/Collection";
 
     @RegisterExtension
     static final QuarkusProdModeTest TEST = new QuarkusProdModeTest()
@@ -36,7 +39,7 @@ class OpenApiIntegrationTest {
                     .addAsResource("application.properties")
                     .addAsResource("import.sql"))
             .setForcedDependencies(List.of(
-                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi", Version.getVersion()),
+                    Dependency.of("io.quarkus", "quarkus-smallrye-openapi-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-reactive-pg-client-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-resteasy-reactive-jsonb-deployment", Version.getVersion()),
                     Dependency.of("io.quarkus", "quarkus-security-deployment", Version.getVersion())))
@@ -51,14 +54,28 @@ class OpenApiIntegrationTest {
                 .body("info.title", Matchers.equalTo("quarkus-hibernate-reactive-rest-data-panache-deployment API"))
                 .body("paths.'/collections'", Matchers.hasKey("get"))
                 .body("paths.'/collections'.get.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.get.responses.'200'.content.'application/json'.schema.type", is("array"))
+                .body("paths.'/collections'.get.responses.'200'.content.'application/json'.schema.items.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections'", Matchers.hasKey("post"))
                 .body("paths.'/collections'.post.tags", Matchers.hasItem("CollectionsResource"))
+                .body("paths.'/collections'.post.requestBody.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
+                .body("paths.'/collections'.post.responses.'201'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections'.post.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("get"))
+                .body("paths.'/collections/{id}'.get.responses.'200'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections/{id}'.get.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("put"))
+                .body("paths.'/collections/{id}'.put.requestBody.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
+                .body("paths.'/collections/{id}'.put.responses.'201'.content.'application/json'.schema.$ref",
+                        is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("user"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
+                .body("paths.'/collections/{id}'.delete.responses", Matchers.hasKey("204"))
                 .body("paths.'/collections/{id}'.delete.security[0].SecurityScheme", Matchers.hasItem("admin"))
                 .body("paths.'/empty-list-items'", Matchers.hasKey("get"))
                 .body("paths.'/empty-list-items'.get.tags", Matchers.hasItem("EmptyListItemsResource"))

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -110,6 +110,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
         if (hasValidatorCapability()) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -80,6 +80,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), RESOURCE_METHOD_NAME));
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, Long.class, false);
         addSecurityAnnotations(methodCreator, resourceProperties);
         if (!isResteasyClassic()) {
             // We only add the Links annotation in Resteasy Reactive because Resteasy Classic ignores the REL parameter:

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -90,6 +90,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addDeleteAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.NO_CONTENT);
         addSecurityAnnotations(methodCreator, resourceProperties);
 
         ResultHandle resource = methodCreator.readInstanceField(resourceField, methodCreator.getThis());

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -91,6 +91,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));
         addGetAnnotation(methodCreator);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
 
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -143,6 +143,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
@@ -209,6 +210,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -143,6 +143,7 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations
         if (hasValidatorCapability()) {


### PR DESCRIPTION
This pull request fixes the following issues:
- Open API could not deduct the return type when using `Response.class` (in Rest Data Panache classic).  
- For Rest Data Panache reactive, the return object for the endpoint '/get' was wrongly saying that was a single entity when is an array of entities.  
- Finally, for the update and delete endpoints, the result status code was wrong (for update should be 201 and for delete 204). 

Fix https://github.com/quarkusio/quarkus/issues/28786