### PR TITLE
Allow configuring Ingress rules

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -625,7 +625,7 @@ containers:
       memory: 64Mi
 ----
 
-=== Exposing with Secured Ingress
+=== Exposing your application in Kubernetes
 
 Kubernetes exposes applications using https://kubernetes.io/docs/concepts/services-networking/ingress[Ingress resources]. To generate the Ingress resource, just apply the following configuration:
 
@@ -661,7 +661,109 @@ spec:
             pathType: Prefix
 ----
 
-After deploying these resources to Kubernetes, the Ingress resource will allow unsecured connections to reach out your application. 
+After deploying these resources to Kubernetes, the Ingress resource will allow unsecured connections to reach out your application.
+
+==== Adding Ingress rules
+
+To customize the default `host` and `path` properties of the generated Ingress resources, you need to apply the following configuration:
+
+[source]
+----
+quarkus.kubernetes.ingress.expose=true
+# To change the Ingress host. By default, it's empty.
+quarkus.kubernetes.ingress.host=prod.svc.url
+# To change the Ingress path of the generated Ingress rule. By default, it's "/".
+quarkus.kubernetes.ports.http.path=/prod
+----
+
+This would generate the following Ingress resource:
+
+[source, yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-with-ingress
+    app.kubernetes.io/version: 0.1-SNAPSHOT
+  name: kubernetes-with-ingress
+spec:
+  rules:
+    - host: prod.svc.url
+      http:
+        paths:
+          - backend:
+              service:
+                name: kubernetes-with-ingress
+                port:
+                  name: http
+            path: /prod
+            pathType: Prefix
+----
+
+Additionally, you can also add new Ingress rules by adding the following configuration:
+
+[source]
+----
+# Example to add a new rule
+quarkus.kubernetes.ingress.rules.1.host=dev.svc.url
+quarkus.kubernetes.ingress.rules.1.path=/dev
+quarkus.kubernetes.ingress.rules.1.path-type=ImplementationSpecific
+# by default, path type is Prefix
+
+# Exmple to add a new rule that use another service binding
+quarkus.kubernetes.ingress.rules.2.host=alt.svc.url
+quarkus.kubernetes.ingress.rules.2.path=/ea
+quarkus.kubernetes.ingress.rules.2.service-name=updated-service
+quarkus.kubernetes.ingress.rules.2.service-port-name=tcpurl
+----
+
+This would generate the following Ingress resource:
+
+[source, yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-with-ingress
+    app.kubernetes.io/version: 0.1-SNAPSHOT
+  name: kubernetes-with-ingress
+spec:
+  rules:
+    - host: prod.svc.url
+      http:
+        paths:
+          - backend:
+              service:
+                name: kubernetes-with-ingress
+                port:
+                  name: http
+            path: /prod
+            pathType: Prefix
+    - host: dev.svc.url
+      http:
+        paths:
+          - backend:
+              service:
+                name: kubernetes-with-ingress
+                port:
+                  name: http
+            path: /dev
+            pathType: ImplementationSpecific
+    - host: alt.svc.url
+      http:
+        paths:
+          - backend:
+              service:
+                name: updated-service
+                port:
+                  name: tcpurl
+            path: /ea
+            pathType: Prefix
+----
+
+==== Securing the Ingress resource
 
 To secure the incoming connections, Kubernetes allows enabling https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[TLS] within the Ingress resource by specifying a Secret that contains a TLS private key and certificate. You can generate a secured Ingress resource by simply adding the "tls.secret-name" properties:
 

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeIngressRuleDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ChangeIngressRuleDecorator.java
@@ -1,0 +1,180 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.dekorate.kubernetes.config.IngressRule;
+import io.dekorate.kubernetes.config.Port;
+import io.dekorate.kubernetes.decorator.AddIngressRuleDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.utils.Strings;
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressServiceBackendBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpecBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.ServiceBackendPort;
+import io.fabric8.kubernetes.api.model.networking.v1.ServiceBackendPortBuilder;
+
+/**
+ * TODO: Workaround for https://github.com/quarkusio/quarkus/issues/28812
+ * We need to remove the duplicate paths of the generated Ingress. The following logic can be removed after
+ * bumping the next Dekorate version that includes the fix: https://github.com/dekorateio/dekorate/pull/1092.
+ */
+public class ChangeIngressRuleDecorator extends NamedResourceDecorator<IngressSpecBuilder> {
+
+    private static final String DEFAULT_PREFIX = "Prefix";
+
+    private final Optional<Port> defaultHostPort;
+    private final IngressRule rule;
+
+    public ChangeIngressRuleDecorator(String name, Optional<Port> defaultHostPort, IngressRule rule) {
+        super(name);
+        this.defaultHostPort = defaultHostPort;
+        this.rule = rule;
+    }
+
+    @Override
+    public void andThenVisit(IngressSpecBuilder spec, ObjectMeta meta) {
+        if (!spec.hasMatchingRule(existingRule -> Strings.equals(rule.getHost(), existingRule.getHost()))) {
+            spec.addNewRule()
+                    .withHost(rule.getHost())
+                    .withNewHttp()
+                    .addNewPath()
+                    .withPathType(pathType())
+                    .withPath(path())
+                    .withNewBackend()
+                    .withNewService()
+                    .withName(serviceName())
+                    .withPort(createPort(defaultHostPort))
+                    .endService()
+                    .endBackend()
+                    .endPath()
+                    .endHttp()
+                    .endRule();
+        } else {
+            spec.accept(new HostVisitor(defaultHostPort));
+        }
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { AddIngressRuleDecorator.class, RemoveDuplicateIngressRuleDecorator.class };
+    }
+
+    private String serviceName() {
+        return Strings.defaultIfEmpty(rule.getServiceName(), name);
+    }
+
+    private String path() {
+        return Strings.defaultIfEmpty(rule.getPath(), defaultHostPort.map(p -> p.getPath()).orElse("/"));
+    }
+
+    private String pathType() {
+        return Strings.defaultIfEmpty(rule.getPathType(), DEFAULT_PREFIX);
+    }
+
+    private ServiceBackendPort createPort(Optional<Port> defaultHostPort) {
+        ServiceBackendPortBuilder builder = new ServiceBackendPortBuilder();
+        if (Strings.isNotNullOrEmpty(rule.getServicePortName())) {
+            builder.withName(rule.getServicePortName());
+        } else if (rule.getServicePortNumber() != null && rule.getServicePortNumber() >= 0) {
+            builder.withNumber(rule.getServicePortNumber());
+        } else if (Strings.isNullOrEmpty(rule.getServiceName()) || Strings.equals(rule.getServiceName(), name)) {
+            // Trying to get the port from the service
+            Port servicePort = defaultHostPort
+                    .orElseThrow(() -> new RuntimeException(
+                            "Could not find any matching port to configure the Ingress Rule. Specify the "
+                                    + "service port using `kubernetes.ingress.service-port-name`"));
+            builder.withName(servicePort.getName());
+        } else {
+            throw new RuntimeException("The service port for '" + rule.getServiceName() + "' was not set. Specify one "
+                    + "using `kubernetes.ingress.service-port-name`");
+        }
+
+        return builder.build();
+    }
+
+    private class HostVisitor extends TypedVisitor<IngressRuleBuilder> {
+
+        private final Optional<Port> defaultHostPort;
+
+        public HostVisitor(Optional<Port> defaultHostPort) {
+            this.defaultHostPort = defaultHostPort;
+        }
+
+        @Override
+        public void visit(IngressRuleBuilder existingRule) {
+            if (Strings.equals(existingRule.getHost(), rule.getHost())) {
+                if (!existingRule.hasHttp()) {
+                    existingRule.withNewHttp()
+                            .addNewPath()
+                            .withPathType(pathType())
+                            .withPath(path())
+                            .withNewBackend()
+                            .withNewService()
+                            .withName(serviceName())
+                            .withPort(createPort(defaultHostPort))
+                            .endService()
+                            .endBackend()
+                            .endPath().endHttp();
+                } else if (existingRule.getHttp().getPaths().stream()
+                        .noneMatch(p -> Strings.equals(p.getPath(), path()) && Strings.equals(p.getPathType(), pathType()))) {
+                    existingRule.editHttp()
+                            .addNewPath()
+                            .withPathType(pathType())
+                            .withPath(path())
+                            .withNewBackend()
+                            .withNewService()
+                            .withName(serviceName())
+                            .withPort(createPort(defaultHostPort))
+                            .endService()
+                            .endBackend()
+                            .endPath().endHttp();
+                } else {
+                    existingRule.accept(new PathVisitor(defaultHostPort));
+                }
+            }
+        }
+    }
+
+    private class PathVisitor extends TypedVisitor<HTTPIngressPathBuilder> {
+
+        private final Optional<Port> defaultHostPort;
+
+        public PathVisitor(Optional<Port> defaultHostPort) {
+            this.defaultHostPort = defaultHostPort;
+        }
+
+        @Override
+        public void visit(HTTPIngressPathBuilder existingPath) {
+            if (Strings.equals(existingPath.getPath(), rule.getPath())) {
+                if (!existingPath.hasBackend()) {
+                    existingPath.withNewBackend()
+                            .withNewService()
+                            .withName(serviceName())
+                            .withPort(createPort(defaultHostPort))
+                            .endService()
+                            .endBackend();
+                } else {
+                    existingPath.accept(new ServiceVisitor(defaultHostPort));
+                }
+            }
+        }
+    }
+
+    private class ServiceVisitor extends TypedVisitor<IngressServiceBackendBuilder> {
+
+        private final Optional<Port> defaultHostPort;
+
+        public ServiceVisitor(Optional<Port> defaultHostPort) {
+            this.defaultHostPort = defaultHostPort;
+        }
+
+        @Override
+        public void visit(IngressServiceBackendBuilder service) {
+            service.withName(Strings.defaultIfEmpty(rule.getServiceName(), name)).withPort(createPort(defaultHostPort));
+        }
+    }
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressConfig.java
@@ -33,4 +33,10 @@ public class IngressConfig {
     @ConfigItem
     Map<String, IngressTlsConfig> tls;
 
+    /**
+     * Custom rules for the current ingress resource.
+     */
+    @ConfigItem
+    Map<String, IngressRuleConfig> rules;
+
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressRuleConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/IngressRuleConfig.java
@@ -1,0 +1,48 @@
+package io.quarkus.kubernetes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class IngressRuleConfig {
+
+    /**
+     * The host under which the rule is going to be used.
+     */
+    @ConfigItem
+    String host;
+
+    /**
+     * The path under which the rule is going to be used. Default is "/".
+     */
+    @ConfigItem(defaultValue = "/")
+    String path;
+
+    /**
+     * The path type strategy to use by the Ingress rule. Default is "Prefix".
+     */
+    @ConfigItem(defaultValue = "Prefix")
+    String pathType;
+
+    /**
+     * The service name to be used by this Ingress rule. Default is the generated service name of the application.
+     */
+    @ConfigItem
+    Optional<String> serviceName;
+
+    /**
+     * The service port name to be used by this Ingress rule. Default is the port name of the generated service of
+     * the application.
+     */
+    @ConfigItem
+    Optional<String> servicePortName;
+
+    /**
+     * The service port number to be used by this Ingress rule. This is only used when the servicePortName is not set.
+     */
+    @ConfigItem
+    Optional<Integer> servicePortNumber;
+
+}

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDuplicateIngressRuleDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDuplicateIngressRuleDecorator.java
@@ -1,0 +1,37 @@
+package io.quarkus.kubernetes.deployment;
+
+import io.dekorate.kubernetes.decorator.AddIngressRuleDecorator;
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpecBuilder;
+
+/**
+ * TODO: Workaround for https://github.com/quarkusio/quarkus/issues/28812
+ * We need to remove the duplicate paths of the generated Ingress. The following logic can be removed after
+ * bumping the next Dekorate version that includes the fix: https://github.com/dekorateio/dekorate/pull/1092.
+ */
+public class RemoveDuplicateIngressRuleDecorator extends NamedResourceDecorator<IngressSpecBuilder> {
+
+    public RemoveDuplicateIngressRuleDecorator(String name) {
+        super(name);
+    }
+
+    @Override
+    public void andThenVisit(IngressSpecBuilder spec, ObjectMeta meta) {
+        if (spec.hasRules()) {
+            spec.editMatchingRule(rule -> {
+                rule.editHttp()
+                        .removeMatchingFromPaths(path -> rule.getHttp().getPaths().stream()
+                                .filter(p -> p.hashCode() == path.hashCode()).count() > 1)
+                        .endHttp();
+                return true;
+            });
+        }
+    }
+
+    @Override
+    public Class<? extends Decorator>[] after() {
+        return new Class[] { AddIngressRuleDecorator.class };
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressRulesTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithIngressRulesTest.java
@@ -1,0 +1,95 @@
+
+package io.quarkus.it.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.quarkus.builder.Version;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KubernetesWithIngressRulesTest {
+
+    private static final String APP_NAME = "kubernetes-with-ingress-rules";
+    private static final String PROD_INGRESS_HOST = "prod.svc.url";
+    private static final String DEV_INGRESS_HOST = "dev.svc.url";
+    private static final String ALT_INGRESS_HOST = "alt.svc.url";
+    private static final String PREFIX = "Prefix";
+    private static final String HTTP = "http";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar.addClasses(GreetingResource.class))
+            .setApplicationName(APP_NAME)
+            .setApplicationVersion("0.1-SNAPSHOT")
+            .withConfigurationResource(APP_NAME + ".properties")
+            .setLogFileName("k8s.log")
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-kubernetes", Version.getVersion())));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void assertGeneratedResources() throws IOException {
+        final Path kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        assertThat(kubernetesDir)
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.json"))
+                .isDirectoryContaining(p -> p.getFileName().endsWith("kubernetes.yml"));
+        List<HasMetadata> list = DeserializationUtil
+                .deserializeAsList(kubernetesDir.resolve("kubernetes.yml"));
+        Ingress i = findFirst(list, Ingress.class).orElseThrow(() -> new IllegalStateException());
+        assertNotNull(i);
+        assertEquals(3, i.getSpec().getRules().size(), "There are more rules than expected");
+        assertTrue(i.getSpec().getRules().stream().anyMatch(this::generatedRuleWasUpdated));
+        assertTrue(i.getSpec().getRules().stream().anyMatch(this::newRuleWasAdded));
+        assertTrue(i.getSpec().getRules().stream().anyMatch(this::newRuleWasAddedWithCustomService));
+    }
+
+    private boolean newRuleWasAddedWithCustomService(IngressRule rule) {
+        return ALT_INGRESS_HOST.equals(rule.getHost())
+                && rule.getHttp().getPaths().size() == 1
+                && rule.getHttp().getPaths().stream().anyMatch(p -> p.getPath().equals("/ea")
+                        && p.getPathType().equals(PREFIX)
+                        && p.getBackend().getService().getName().equals("updated-service")
+                        && p.getBackend().getService().getPort().getName().equals("tcp"));
+    }
+
+    private boolean newRuleWasAdded(IngressRule rule) {
+        return DEV_INGRESS_HOST.equals(rule.getHost())
+                && rule.getHttp().getPaths().size() == 1
+                && rule.getHttp().getPaths().stream().anyMatch(p -> p.getPath().equals("/dev")
+                        && p.getPathType().equals("ImplementationSpecific")
+                        && p.getBackend().getService().getName().equals(APP_NAME)
+                        && p.getBackend().getService().getPort().getName().equals(HTTP));
+    }
+
+    private boolean generatedRuleWasUpdated(IngressRule rule) {
+        return PROD_INGRESS_HOST.equals(rule.getHost())
+                && rule.getHttp().getPaths().size() == 1
+                && rule.getHttp().getPaths().stream().anyMatch(p -> p.getPath().equals("/prod")
+                        && p.getPathType().equals(PREFIX)
+                        && p.getBackend().getService().getName().equals(APP_NAME)
+                        && p.getBackend().getService().getPort().getName().equals(HTTP));
+    }
+
+    <T extends HasMetadata> Optional<T> findFirst(List<HasMetadata> list, Class<T> t) {
+        return (Optional<T>) list.stream()
+                .filter(i -> t.isInstance(i))
+                .findFirst();
+    }
+}

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-rules.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/kubernetes-with-ingress-rules.properties
@@ -1,0 +1,19 @@
+quarkus.kubernetes.ingress.expose=true
+quarkus.kubernetes.ingress.host=prod.svc.url
+quarkus.kubernetes.ports.http.path=/prod
+
+# Case 1: Update existing rule
+quarkus.kubernetes.ingress.rules.0.host=prod.svc.url
+quarkus.kubernetes.ingress.rules.0.path=/prod
+
+# Case 2: Add a new rule
+quarkus.kubernetes.ingress.rules.1.host=dev.svc.url
+quarkus.kubernetes.ingress.rules.1.path=/dev
+quarkus.kubernetes.ingress.rules.1.path-type=ImplementationSpecific
+# by default, path type is Prefix
+
+# Case 2: Add a new rule using another service
+quarkus.kubernetes.ingress.rules.2.host=alt.svc.url
+quarkus.kubernetes.ingress.rules.2.path=/ea
+quarkus.kubernetes.ingress.rules.2.service-name=updated-service
+quarkus.kubernetes.ingress.rules.2.service-port-name=tcp


### PR DESCRIPTION
These changes also ensures that not duplicated ingress rules are generated.

#### Adding Ingress rules

To customize the default `host` and `path` properties of the generated Ingress resources, you need to apply the following configuration:

```
quarkus.kubernetes.ingress.expose=true
# To change the Ingress host. By default, it's empty.
quarkus.kubernetes.ingress.host=prod.svc.url
# To change the Ingress path of the generated Ingress rule. By default, it's "/".
quarkus.kubernetes.ports.http.path=/prod
```

This would generate the following Ingress resource:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app.kubernetes.io/name: kubernetes-with-ingress
    app.kubernetes.io/version: 0.1-SNAPSHOT
  name: kubernetes-with-ingress
spec:
  rules:
    - host: prod.svc.url
      http:
        paths:
          - backend:
              service:
                name: kubernetes-with-ingress
                port:
                  name: http
            path: /prod
            pathType: Prefix
```

Additionally, you can also add new Ingress rules by adding the following configuration:

```
# Example to add a new rule
quarkus.kubernetes.ingress.rules.1.host=dev.svc.url
quarkus.kubernetes.ingress.rules.1.path=/dev
quarkus.kubernetes.ingress.rules.1.path-type=ImplementationSpecific
# by default, path type is Prefix

# Exmple to add a new rule that use another service binding
quarkus.kubernetes.ingress.rules.2.host=alt.svc.url
quarkus.kubernetes.ingress.rules.2.path=/ea
quarkus.kubernetes.ingress.rules.2.service-name=updated-service
quarkus.kubernetes.ingress.rules.2.service-port-name=tcpurl
```

This would generate the following Ingress resource:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app.kubernetes.io/name: kubernetes-with-ingress
    app.kubernetes.io/version: 0.1-SNAPSHOT
  name: kubernetes-with-ingress
spec:
  rules:
    - host: prod.svc.url
      http:
        paths:
          - backend:
              service:
                name: kubernetes-with-ingress
                port:
                  name: http
            path: /prod
            pathType: Prefix
    - host: dev.svc.url
      http:
        paths:
          - backend:
              service:
                name: kubernetes-with-ingress
                port:
                  name: http
            path: /dev
            pathType: ImplementationSpecific
    - host: alt.svc.url
      http:
        paths:
          - backend:
              service:
                name: updated-service
                port:
                  name: tcpurl
            path: /ea
            pathType: Prefix
```

Fix https://github.com/quarkusio/quarkus/issues/28812 Fix https://github.com/quarkusio/quarkus/issues/26747