### PR TITLE
ArC dev mode - add info about direct dependencies into the json

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DependencyGraph.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/devconsole/DependencyGraph.java
@@ -3,6 +3,7 @@ package io.quarkus.arc.deployment.devconsole;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class DependencyGraph {
 
@@ -17,12 +18,16 @@ public class DependencyGraph {
     }
 
     DependencyGraph forLevel(int level) {
+        return filterLinks(link -> link.level <= level);
+    }
+
+    DependencyGraph filterLinks(Predicate<Link> predicate) {
         // Filter out links first
         Set<Link> newLinks = new HashSet<>();
         Set<DevBeanInfo> newNodes = new HashSet<>();
         Set<String> usedIds = new HashSet<>();
         for (Link link : links) {
-            if (link.level <= level) {
+            if (predicate.test(link)) {
                 newLinks.add(link);
                 usedIds.add(link.source);
                 usedIds.add(link.target);

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/ArcDevProcessor.java
@@ -11,6 +11,7 @@ import io.quarkus.arc.InjectableBean;
 import io.quarkus.arc.deployment.ArcConfig;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem;
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
+import io.quarkus.arc.deployment.devconsole.ArcDevConsoleProcessor;
 import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.BuildExtension;
 import io.quarkus.arc.processor.DecoratorInfo;
@@ -71,7 +72,7 @@ public class ArcDevProcessor {
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
                 .route(beansPath)
                 .displayOnNotFoundPage("Active CDI Beans")
-                .handler(recorder.createBeansHandler()).build());
+                .handler(recorder.createBeansHandler(ArcDevConsoleProcessor.BEAN_DEPENDENCIES)).build());
 
         routes.produce(nonApplicationRootPathBuildItem.routeBuilder()
                 .route(removedBeansPath)

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/devmode/Json.java
@@ -81,7 +81,7 @@ public final class Json {
 
     abstract static class JsonBuilder<T> {
 
-        protected boolean ignoreEmptyBuilders = false;
+        protected final boolean ignoreEmptyBuilders;
 
         /**
          *


### PR DESCRIPTION
- i.e. enhance the response of /q/arc/beans
- ideally, we should merge the ArC dev mode endpoints with the Dev UI; the problem is that ArC dev mode endpoints use the runtime data, namely generatedClass, which is currently not available in the Dev UI build steps; also ArC deployment module cannot depend on vertx so we cannot produce a custom DevConsoleRouteBuildItem there (see for example io.quarkus.vertx.http.deployment.devmode.ArcDevProcessor#eventsEndpoint)
- resolves #27851