### PR TITLE
Apply additional JAX-RS security only for endpoints and not all resource methods

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/DenyAllJaxRsTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/DenyAllJaxRsTest.java
@@ -4,6 +4,11 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.emptyString;
 
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,7 +28,7 @@ public class DenyAllJaxRsTest {
                     .addClasses(PermitAllResource.class, UnsecuredResource.class,
                             TestIdentityProvider.class,
                             TestIdentityController.class,
-                            UnsecuredSubResource.class)
+                            UnsecuredSubResource.class, HelloResource.class)
                     .addAsResource(new StringAsset("quarkus.security.jaxrs.deny-unannotated-endpoints = true\n"),
                             "application.properties"));
 
@@ -82,6 +87,16 @@ public class DenyAllJaxRsTest {
         assertStatus(path, 200, 200);
     }
 
+    @Test
+    public void testNonEndpointMethodAreNotDenied() {
+        // ensure io.quarkus.resteasy.test.security.DenyAllJaxRsTest.HelloResource.getHello is not secured with DenyAllInterceptor
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("hello"));
+    }
+
     private void assertStatus(String path, int status, int anonStatus) {
         given().auth().preemptive()
                 .basic("admin", "admin").get(path)
@@ -94,6 +109,21 @@ public class DenyAllJaxRsTest {
         when().get(path)
                 .then()
                 .statusCode(anonStatus);
+
+    }
+
+    @Path("/hello")
+    public static class HelloResource {
+
+        @PermitAll
+        @GET
+        public String hello() {
+            return getHello();
+        }
+
+        public String getHello() {
+            return "hello";
+        }
 
     }
 

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DefaultRolesAllowedJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DefaultRolesAllowedJaxRsTest.java
@@ -3,6 +3,7 @@ package io.quarkus.resteasy.reactive.server.test.security;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ public class DefaultRolesAllowedJaxRsTest {
                     .addClasses(PermitAllResource.class, UnsecuredResource.class,
                             TestIdentityProvider.class,
                             TestIdentityController.class,
-                            UnsecuredSubResource.class)
+                            UnsecuredSubResource.class, HelloResource.class)
                     .addAsResource(new StringAsset("quarkus.security.jaxrs.default-roles-allowed=admin\n"),
                             "application.properties"));
 
@@ -75,6 +76,15 @@ public class DefaultRolesAllowedJaxRsTest {
     public void shouldAllowPermitAllClass() {
         String path = "/permitAll/sub/subMethod";
         assertStatus(path, 200, 200, 200);
+    }
+
+    @Test
+    public void testServerExceptionMapper() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("unauthorizedExceptionMapper"));
     }
 
     private void assertStatus(String path, int adminStatus, int userStatus, int anonStatus) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/DenyAllJaxRsTest.java
@@ -3,6 +3,7 @@ package io.quarkus.resteasy.reactive.server.test.security;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 
+import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ public class DenyAllJaxRsTest {
                     .addClasses(PermitAllResource.class, UnsecuredResource.class,
                             TestIdentityProvider.class,
                             TestIdentityController.class,
-                            UnsecuredSubResource.class)
+                            UnsecuredSubResource.class, HelloResource.class)
                     .addAsResource(new StringAsset("quarkus.security.jaxrs.deny-unannotated-endpoints = true\n"),
                             "application.properties"));
 
@@ -78,6 +79,15 @@ public class DenyAllJaxRsTest {
     public void shouldAllowPermitAllClass() {
         String path = "/permitAll/sub/subMethod";
         assertStatus(path, 200, 200);
+    }
+
+    @Test
+    public void testServerExceptionMapper() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(200)
+                .body(Matchers.equalTo("unauthorizedExceptionMapper"));
     }
 
     private void assertStatus(String path, int status, int anonStatus) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/HelloResource.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/HelloResource.java
@@ -1,0 +1,22 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+import io.quarkus.security.UnauthorizedException;
+
+@Path("/hello")
+public class HelloResource {
+    @GET
+    public String hello() {
+        return "hello";
+    }
+
+    @ServerExceptionMapper
+    public Response unauthorizedExceptionMapper(UnauthorizedException unauthorizedException) {
+        return Response.ok("unauthorizedExceptionMapper").build();
+    }
+}

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalDenyingUnannotatedTransformer.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalDenyingUnannotatedTransformer.java
@@ -1,5 +1,6 @@
 package io.quarkus.security.deployment;
 
+import static io.quarkus.security.deployment.SecurityProcessor.createMethodDescription;
 import static io.quarkus.security.deployment.SecurityTransformerUtils.DENY_ALL;
 
 import java.util.Collection;
@@ -9,24 +10,25 @@ import java.util.Set;
 import org.jboss.jandex.AnnotationTarget;
 
 import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.security.spi.runtime.MethodDescription;
 
 public class AdditionalDenyingUnannotatedTransformer implements AnnotationsTransformer {
 
-    private final Set<String> classNames;
+    private final Set<MethodDescription> methods;
 
-    public AdditionalDenyingUnannotatedTransformer(Collection<String> classNames) {
-        this.classNames = new HashSet<>(classNames);
+    public AdditionalDenyingUnannotatedTransformer(Collection<MethodDescription> methods) {
+        this.methods = new HashSet<>(methods);
     }
 
     @Override
     public boolean appliesTo(AnnotationTarget.Kind kind) {
-        return kind == org.jboss.jandex.AnnotationTarget.Kind.CLASS;
+        return kind == AnnotationTarget.Kind.METHOD;
     }
 
     @Override
     public void transform(TransformationContext context) {
-        String className = context.getTarget().asClass().name().toString();
-        if (classNames.contains(className)) {
+        MethodDescription methodDescription = createMethodDescription(context.getTarget().asMethod());
+        if (methods.contains(methodDescription)) {
             context.transform().add(DENY_ALL).done();
         }
     }

--- a/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalRolesAllowedTransformer.java
+++ b/extensions/security/deployment/src/main/java/io/quarkus/security/deployment/AdditionalRolesAllowedTransformer.java
@@ -1,5 +1,6 @@
 package io.quarkus.security.deployment;
 
+import static io.quarkus.security.deployment.SecurityProcessor.createMethodDescription;
 import static io.quarkus.security.deployment.SecurityTransformerUtils.ROLES_ALLOWED;
 
 import java.util.Collection;
@@ -11,27 +12,28 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
 
 import io.quarkus.arc.processor.AnnotationsTransformer;
+import io.quarkus.security.spi.runtime.MethodDescription;
 
 public class AdditionalRolesAllowedTransformer implements AnnotationsTransformer {
 
-    private final Set<String> classNames;
+    private final Set<MethodDescription> methods;
     private final AnnotationValue[] rolesAllowed;
 
-    public AdditionalRolesAllowedTransformer(Collection<String> classNames, List<String> rolesAllowed) {
-        this.classNames = new HashSet<>(classNames);
+    public AdditionalRolesAllowedTransformer(Collection<MethodDescription> methods, List<String> rolesAllowed) {
+        this.methods = new HashSet<>(methods);
         this.rolesAllowed = rolesAllowed.stream().map(s -> AnnotationValue.createStringValue("", s))
                 .toArray(AnnotationValue[]::new);
     }
 
     @Override
     public boolean appliesTo(AnnotationTarget.Kind kind) {
-        return kind == AnnotationTarget.Kind.CLASS;
+        return kind == AnnotationTarget.Kind.METHOD;
     }
 
     @Override
     public void transform(TransformationContext context) {
-        String className = context.getTarget().asClass().name().toString();
-        if (classNames.contains(className)) {
+        MethodDescription method = createMethodDescription(context.getTarget().asMethod());
+        if (methods.contains(method)) {
             context.transform().add(ROLES_ALLOWED, AnnotationValue.createArrayValue("value", rolesAllowed)).done();
         }
     }

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredClassesBuildItem.java
@@ -11,6 +11,8 @@ import io.quarkus.builder.item.MultiBuildItem;
 
 /**
  * Contains classes that need to have @DenyAll on all methods that don't have security annotations
+ *
+ * @deprecated use {@link AdditionalSecuredMethodsBuildItem}
  */
 public final class AdditionalSecuredClassesBuildItem extends MultiBuildItem {
 

--- a/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredMethodsBuildItem.java
+++ b/extensions/security/spi/src/main/java/io/quarkus/security/spi/AdditionalSecuredMethodsBuildItem.java
@@ -1,0 +1,31 @@
+package io.quarkus.security.spi;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.jandex.MethodInfo;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * Contains methods that need to have {@link javax.annotation.security.DenyAll} or
+ * {@link javax.annotation.security.RolesAllowed}.
+ */
+public final class AdditionalSecuredMethodsBuildItem extends MultiBuildItem {
+
+    public final Collection<MethodInfo> additionalSecuredMethods;
+    public final Optional<List<String>> rolesAllowed;
+
+    public AdditionalSecuredMethodsBuildItem(Collection<MethodInfo> additionalSecuredMethods) {
+        this.additionalSecuredMethods = Collections.unmodifiableCollection(additionalSecuredMethods);
+        rolesAllowed = Optional.empty();
+    }
+
+    public AdditionalSecuredMethodsBuildItem(Collection<MethodInfo> additionalSecuredMethods,
+            Optional<List<String>> rolesAllowed) {
+        this.additionalSecuredMethods = Collections.unmodifiableCollection(additionalSecuredMethods);
+        this.rolesAllowed = rolesAllowed;
+    }
+}


### PR DESCRIPTION
fixes: #28791

When using JAX-RS security configuration properties `quarkus.security.jaxrs.deny-unannotated-endpoints` and `quarkus.security.jaxrs.default-roles-allowed` all resource methods that can be intercepted (endpoints or not) are secured by security interceptors (e.g. `DenyAllInterceptor` and `RolesAllowedInterceptor`). This leads to unexpected behavior when non-endpoints are invoked in a fashion that can be intercepted, one example - add `@ServerExceptionMapper` to a resource (methods annotated with this annotation also expects to be in resource, see its Javadoc), this mapper method will be secured (and if it handles Unauthorized, it should lead to circular reference).

This PR secures endpoints rather than classes. To do that in RR, I had to extract logic behind endpoint selection (to keep the logic in one place).