### PR TITLE
Type Pollution Agent Hint: removing the chances to cast to HttpServerRequestInternal in the hot path

### DIFF
--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AbstractRequestWrapper.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/AbstractRequestWrapper.java
@@ -31,10 +31,10 @@ import io.vertx.core.net.SocketAddress;
 public abstract class AbstractRequestWrapper
         implements HttpServerRequest, HttpServerRequestInternal {
 
-    protected final HttpServerRequestInternal delegate;
+    protected final HttpServerRequest delegate;
 
     protected AbstractRequestWrapper(HttpServerRequest request) {
-        delegate = (HttpServerRequestInternal) request;
+        delegate = request;
     }
 
     @Override
@@ -322,12 +322,12 @@ public abstract class AbstractRequestWrapper
 
     @Override
     public Context context() {
-        return delegate.context();
+        return ((HttpServerRequestInternal) delegate).context();
     }
 
     @Override
     public Object metric() {
-        return delegate.metric();
+        return ((HttpServerRequestInternal) delegate).metric();
     }
 
     @Override


### PR DESCRIPTION
Type Pollution Agent reported 
```
7:	io.vertx.core.http.impl.Http1xServerRequest
Count:	180889096
Types:
	io.vertx.core.http.HttpServerRequest
	io.vertx.core.http.impl.HttpServerRequestInternal
Traces:
	io.quarkus.vertx.http.runtime.AbstractRequestWrapper.<init>(AbstractRequestWrapper.java:37)
		class: io.vertx.core.http.impl.HttpServerRequestInternal
		count: 89051841
	io.quarkus.vertx.http.runtime.VertxHttpRecorder$1.handle(VertxHttpRecorder.java:160)
		class: io.vertx.core.http.HttpServerRequest
		count: 59965200
	io.quarkus.vertx.http.runtime.VertxHttpRecorder$15.handle(VertxHttpRecorder.java:596)
		class: io.vertx.core.http.HttpServerRequest
		count: 31872055
```
while running Techempower with `quarkus-resteasy-reactive-hibernate` (see https://github.com/TechEmpower/FrameworkBenchmarks/tree/86387398727d67dc63b8f645f93dcadf1141bb71/frameworks/Java/quarkus/resteasy-reactive-hibernate).

I'm aware that's going to slightly change the semantic of failing fast in case the request isn't of the right type and that it could be a false positive, but still, getting rid of it is the easier way to prevent scalability issues due to https://bugs.openjdk.org/browse/JDK-8180450 to happen.