### PR TITLE
Fix compatibility with Redis 5

### DIFF
--- a/extensions/redis-client/runtime/pom.xml
+++ b/extensions/redis-client/runtime/pom.xml
@@ -107,12 +107,18 @@
                     <name>test-containers</name>
                 </property>
             </activation>
+            <properties>
+                <redis.base.image>redis/redis-stack:7.0.2-RC2</redis.base.image>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
+                            <systemProperties>
+                                <redis.base.image>${redis.base.image}</redis.base.image>
+                            </systemProperties>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -123,6 +129,20 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>redis-5</id>
+            <properties>
+                <redis.base.image>redis:5</redis.base.image>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>redis-6</id>
+            <properties>
+                <redis.base.image>redis:6</redis.base.image>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BloomCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/BloomCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.bloom.BfReserveArgs;
 import io.quarkus.redis.datasource.bloom.BloomCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
+@RequiresCommand("bf.add")
 public class BloomCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CountMinCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CountMinCommandsTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.redis.datasource.countmin.CountMinCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
+@RequiresCommand("cms.query")
 public class CountMinCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CuckooCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/CuckooCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.cuckoo.CfReserveArgs;
 import io.quarkus.redis.datasource.cuckoo.CuckooCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
+@RequiresCommand("cf.add")
 public class CuckooCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/DatasourceTestBase.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/DatasourceTestBase.java
@@ -1,65 +1,27 @@
 package io.quarkus.redis.datasource;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.mutiny.core.Vertx;
-import io.vertx.mutiny.redis.client.Command;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
-import io.vertx.mutiny.redis.client.Request;
-import io.vertx.mutiny.redis.client.Response;
 
+@ExtendWith(RedisServerExtension.class)
 public class DatasourceTestBase {
 
     final String key = UUID.randomUUID().toString();
-
-    public static Vertx vertx;
-    public static Redis redis;
-    public static RedisAPI api;
-
-    static GenericContainer<?> server = new GenericContainer<>(
-            DockerImageName.parse(System.getProperty("redis.base.image", "redis/redis-stack:7.0.2-RC2")))
-            .withExposedPorts(6379);
+    static Redis redis;
+    static Vertx vertx;
+    static RedisAPI api;
 
     @BeforeAll
     static void init() {
-        vertx = Vertx.vertx();
-        server.start();
-        redis = Redis.createClient(vertx, "redis://" + server.getHost() + ":" + server.getFirstMappedPort());
-        // If you want to use a local redis: redis = Redis.createClient(vertx, "redis://localhost:" + 6379);
-        api = RedisAPI.api(redis);
-    }
-
-    @AfterAll
-    static void cleanup() {
-        redis.close();
-        server.close();
-        vertx.closeAndAwait();
-    }
-
-    public static List<String> getAvailableCommands() {
-        List<String> commands = new ArrayList<>();
-        Response list = redis.send(Request.cmd(Command.COMMAND)).await().indefinitely();
-        for (Response response : list) {
-            commands.add(response.get(0).toString());
-        }
-        return commands;
-
-    }
-
-    public static String getRedisVersion() {
-        String info = redis.send(Request.cmd(Command.INFO)).await().indefinitely().toString();
-        // Look for the redis_version line
-        return info.lines().filter(s -> s.startsWith("redis_version")).findAny()
-                .map(line -> line.split(":")[1])
-                .orElseThrow();
+        redis = RedisServerExtension.redis;
+        vertx = RedisServerExtension.vertx;
+        api = RedisServerExtension.api;
     }
 
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GeoCommandsTest.java
@@ -88,8 +88,13 @@ public class GeoCommandsTest extends DatasourceTestBase {
 
         added = geo.geoadd(key, GeoItem.of(Place.suze, SUZE_LONGITUDE, SUZE_LATITUDE));
         assertThat(added).isTrue();
+    }
 
-        added = geo.geoadd(key, GeoItem.of(new Place("foo", 1), CRUSSOL_LONGITUDE, CRUSSOL_LATITUDE), new GeoAddArgs().nx());
+    @Test
+    @RequiresRedis6OrHigher
+    void geoaddWithNx() {
+        boolean added = geo.geoadd(key, GeoItem.of(new Place("foo", 1), CRUSSOL_LONGITUDE, CRUSSOL_LATITUDE),
+                new GeoAddArgs().nx());
         assertThat(added).isTrue();
     }
 
@@ -106,6 +111,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void geoAddWithXXorCH() {
 
         boolean added = geo.geoadd(key, 44.9396, CRUSSOL_LATITUDE, Place.crussol, new GeoAddArgs().xx());
@@ -363,6 +369,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void georadiusbymemberStoreDistWithCountAndSort() {
         populate();
         String resultKey = key + "-2";
@@ -374,6 +381,19 @@ public class GeoCommandsTest extends DatasourceTestBase {
         List<ScoredValue<String>> dist = commands.zrangeWithScores(resultKey, 0, -1);
         assertThat(dist).hasSize(2);
         assertThat(dist.get(0).score()).isBetween(55d, 60d);
+    }
+
+    @Test
+    void georadiusbymemberStoreDistWithSort() {
+        populate();
+        String resultKey = key + "-2";
+        long result = geo.georadiusbymember(key, Place.crussol, 100, GeoUnit.KM,
+                new GeoRadiusStoreArgs<String>().descending().storeDistKey(resultKey));
+        assertThat(result).isEqualTo(3);
+
+        SortedSetCommands<String, String> commands = ds.sortedSet(String.class);
+        List<ScoredValue<String>> dist = commands.zrangeWithScores(resultKey, 0, -1);
+        assertThat(dist).hasSize(3);
     }
 
     @Test
@@ -442,6 +462,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void geosearchWithCountAndSort() {
         populate();
 
@@ -460,6 +481,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void geosearchWithArgs() {
         populate();
 
@@ -508,6 +530,7 @@ public class GeoCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void geosearchStoreWithCountAndSort() {
         populate();
         String resultKey = key + "-2";

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GraphCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/GraphCommandsTest.java
@@ -15,6 +15,7 @@ import io.quarkus.redis.datasource.graph.GraphQueryResponseItem;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.vertx.core.json.JsonObject;
 
+@RequiresCommand("graph.query")
 public class GraphCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/HashCommandsTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,6 +98,22 @@ public class HashCommandsTest extends DatasourceTestBase {
         assertThat(hash.hgetall("missing")).isEmpty();
     }
 
+    /**
+     * Reproducer for <a href="https://github.com/quarkusio/quarkus/issues/28837">#28837</a>.
+     */
+    @Test
+    public void hgetallUsingIntegers() {
+        var cmd = ds.hash(Integer.class);
+        String key = UUID.randomUUID().toString();
+        assertThat(cmd.hgetall(key).isEmpty()).isTrue();
+
+        cmd.hset(key, Map.of("a", 1, "b", 2, "c", 3));
+
+        Map<String, Integer> map = cmd.hgetall(key);
+
+        assertThat(map).hasSize(3);
+    }
+
     @Test
     void hincrby() {
         assertThat(hash.hincrby(key, "one", 1)).isEqualTo(1);
@@ -171,6 +188,7 @@ public class HashCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void hrandfield() {
         hash.hset(key, Map.of("one", Person.person1, "two", Person.person2, "three", Person.person3));
 
@@ -179,6 +197,7 @@ public class HashCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void hrandfieldWithValues() {
         Map<String, Person> map = Map.of("one", Person.person1, "two", Person.person2, "three", Person.person3);
         hash.hset(key, map);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/JsonCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/JsonCommandsTest.java
@@ -19,6 +19,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+@RequiresCommand("json.get")
 public class JsonCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/KeyCommandsTest.java
@@ -75,6 +75,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void copy() {
         values.set(key, Person.person7);
         assertThat(keys.copy(key, key + "2")).isTrue();
@@ -83,6 +84,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void copyWithReplace() {
         values.set(key, Person.person7);
         values.set(key + 2, Person.person1);
@@ -91,6 +93,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void copyWithDestinationDb() {
         ds.withConnection(connection -> {
             connection.value(String.class, Person.class).set(key, Person.person7);
@@ -398,6 +401,7 @@ public class KeyCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void scanWithType() {
         values.set("key1", Person.person7);
         ds.list(Person.class).lpush("key2", Person.person7);

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ListCommandTest.java
@@ -157,6 +157,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void lpopCount() {
         assertThat(lists.lpop(key, 1)).isEqualTo(List.of());
         lists.rpush(key, Person.person1, Person.person2);
@@ -164,6 +165,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void lpos() {
 
         lists.rpush(key, Person.person4, Person.person5, Person.person6, Person.person1, Person.person2, Person.person3,
@@ -259,6 +261,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void rpopCount() {
         assertThat(lists.rpop(key, 1)).isEqualTo(List.of());
         lists.rpush(key, Person.person1, Person.person2);
@@ -301,6 +304,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void lmove() {
         String list1 = key;
         String list2 = key + "-2";
@@ -313,6 +317,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void blmove() {
         String list1 = key;
         String list2 = key + "-2";
@@ -325,6 +330,7 @@ public class ListCommandTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void sort() {
         ListCommands<String, String> commands = ds.list(String.class, String.class);
         commands.rpush(key, "9", "5", "1", "3", "5", "8", "7", "6", "2", "4");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis6OrHigherCondition.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/Redis6OrHigherCondition.java
@@ -10,26 +10,26 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.AnnotationUtils;
 
-class Redis7OrHigherCondition implements ExecutionCondition {
+class Redis6OrHigherCondition implements ExecutionCondition {
 
-    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@RequiresRedis7OrHigher is not present");
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@RequiresRedis6OrHigher is not present");
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        Optional<RequiresRedis7OrHigher> optional = AnnotationUtils.findAnnotation(context.getElement(),
-                RequiresRedis7OrHigher.class);
+        Optional<RequiresRedis6OrHigher> optional = AnnotationUtils.findAnnotation(context.getElement(),
+                RequiresRedis6OrHigher.class);
 
         if (optional.isPresent()) {
             String version = RedisServerExtension.getRedisVersion();
 
-            return isRedis7orHigher(version) ? enabled("Redis " + version + " >= 7")
-                    : disabled("Disabled, Redis " + version + " < 7");
+            return isRedis6orHigher(version) ? enabled("Redis " + version + " >= 6")
+                    : disabled("Disabled, Redis " + version + " < 6");
         }
 
         return ENABLED_BY_DEFAULT;
     }
 
-    public static boolean isRedis7orHigher(String version) {
-        return Integer.parseInt(version.split("\\.")[0]) >= 7;
+    public static boolean isRedis6orHigher(String version) {
+        return Integer.parseInt(version.split("\\.")[0]) >= 6;
     }
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisCommandCondition.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisCommandCondition.java
@@ -22,7 +22,7 @@ class RedisCommandCondition implements ExecutionCondition {
 
         if (optional.isPresent()) {
             String[] cmd = optional.get().value();
-            List<String> commands = DatasourceTestBase.getAvailableCommands();
+            List<String> commands = RedisServerExtension.getAvailableCommands();
 
             for (String c : cmd) {
                 if (!commands.contains(c.toLowerCase())) {

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RedisServerExtension.java
@@ -1,0 +1,93 @@
+package io.quarkus.redis.datasource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.redis.client.Command;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.mutiny.redis.client.Request;
+import io.vertx.mutiny.redis.client.Response;
+
+@SuppressWarnings("resource")
+public class RedisServerExtension implements BeforeAllCallback, AfterAllCallback {
+
+    static GenericContainer<?> server = new GenericContainer<>(
+            DockerImageName.parse(System.getProperty("redis.base.image", "redis/redis-stack:7.0.2-RC2")))
+            .withExposedPorts(6379);
+    static Redis redis;
+    static RedisAPI api;
+    static Vertx vertx;
+
+    public static String getHost() {
+        return server.getHost();
+    }
+
+    public static Integer getFirstMappedPort() {
+        return server.getFirstMappedPort();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        init();
+    }
+
+    private static boolean init() {
+        if (!server.isRunning()) {
+            server.start();
+            vertx = Vertx.vertx();
+            redis = Redis.createClient(vertx,
+                    "redis://" + RedisServerExtension.getHost() + ":" + RedisServerExtension.getFirstMappedPort());
+            // If you want to use a local redis: redis = Redis.createClient(vertx, "redis://localhost:" + 6379);
+            api = RedisAPI.api(redis);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        cleanup();
+    }
+
+    private static void cleanup() {
+        redis.close();
+        vertx.closeAndAwait();
+        server.stop();
+    }
+
+    public static List<String> getAvailableCommands() {
+        boolean mustcleanup = init();
+        List<String> commands = new ArrayList<>();
+        Response list = redis.send(Request.cmd(Command.COMMAND)).await().indefinitely();
+        for (Response response : list) {
+            commands.add(response.get(0).toString());
+        }
+        if (mustcleanup) {
+            cleanup();
+        }
+        return commands;
+
+    }
+
+    public static String getRedisVersion() {
+        boolean mustcleanup = init();
+        String info = redis.send(Request.cmd(Command.INFO)).await().indefinitely().toString();
+        if (mustcleanup) {
+            cleanup();
+        }
+        // Look for the redis_version line
+        return info.lines().filter(s -> s.startsWith("redis_version")).findAny()
+                .map(line -> line.split(":")[1])
+                .orElseThrow();
+
+    }
+
+}

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis6OrHigher.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/RequiresRedis6OrHigher.java
@@ -8,11 +8,11 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@Target({ ElementType.METHOD, ElementType.TYPE })
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@ExtendWith(RedisCommandCondition.class)
-@interface RequiresCommand {
+@ExtendWith(Redis6OrHigherCondition.class)
+@interface RequiresRedis6OrHigher {
 
-    String[] value();
+    // Important the class must extend DatasourceTestBase.
 }

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SetCommandsTest.java
@@ -114,6 +114,7 @@ public class SetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void smismember() {
         assertThat(sets.smismember(key, person1)).isEqualTo(List.of(false));
         sets.sadd(key, person1);
@@ -309,6 +310,7 @@ public class SetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void sort() {
         SetCommands<String, String> commands = ds.set(String.class, String.class);
         commands.sadd(key, "9", "5", "1", "3", "5", "8", "7", "6", "2", "4");

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SortedSetCommandsTest.java
@@ -104,6 +104,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zaddch() {
         assertThat(setOfPlaces.zadd(key, 1.0, Place.crussol)).isTrue();
         assertThat(setOfPlaces.zadd(key, new ZAddArgs().ch().xx(), 2.0, Place.crussol)).isTrue();
@@ -114,6 +115,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zaddincr() {
         assertThat(setOfPlaces.zadd(key, 1.0, Place.crussol)).isTrue();
         assertThat(setOfPlaces.zaddincr(key, 2.0, Place.crussol)).isEqualTo(3.0);
@@ -138,6 +140,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zaddgt() {
         assertThat(setOfPlaces.zadd(key, 1.0, Place.crussol)).isTrue();
         // new score less than the current score
@@ -155,6 +158,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zaddlt() {
         assertThat(setOfPlaces.zadd(key, 2.0, Place.crussol)).isTrue();
         // new score greater than the current score
@@ -195,6 +199,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zdiff() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -213,6 +218,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zdiffstore() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -255,6 +261,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zinterstoreWithArgs() {
         setOfPlaces.zadd("zset1", Map.of(Place.crussol, 1.0, Place.grignan, 2.0));
         setOfPlaces.zadd("zset2", Map.of(Place.crussol, 2.0, Place.grignan, 3.0, Place.suze, 4.0));
@@ -301,6 +308,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrandmember() {
         setOfPlaces.zadd("zset", Map.of(Place.crussol, 2.0, Place.grignan, 3.0, Place.suze, 4.0));
         assertThat(setOfPlaces.zrandmember("zset")).isIn(Place.crussol, Place.grignan, Place.suze);
@@ -326,6 +334,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangebyscore() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
 
@@ -343,6 +352,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangebyscoreWithScores() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
 
@@ -366,6 +376,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangebyscoreWithScoresInfinity() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, Double.POSITIVE_INFINITY, Place.grignan, Double.NEGATIVE_INFINITY));
         assertThat(setOfPlaces.zrangebyscoreWithScores(key, new ScoreRange<>(null, null))).hasSize(2);
@@ -373,6 +384,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangestorebylex() {
         setOfStrings.zadd(key, Map.of("a", 1.0, "b", 2.0, "c", 3.0, "d", 4.0));
         assertThat(setOfStrings.zrangestorebylex("key1", key, new Range<>("b", "d"), new ZRangeArgs().limit(0, 4)))
@@ -384,6 +396,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangestorebyscore() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
         assertThat(setOfPlaces.zrangestorebyscore("key1", key, new ScoreRange<>(0.0, 2.0),
@@ -395,6 +408,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangestore() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
         assertThat(setOfPlaces.zrangestore("key1", key, 0, -1)).isEqualTo(4);
@@ -447,6 +461,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrange() {
         populate();
         assertThat(setOfPlaces.zrange(key, 0, -1, new ZRangeArgs().rev()))
@@ -454,6 +469,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangeWithScores() {
         populate();
         assertThat(setOfPlaces.zrangeWithScores(key, 0, -1, new ZRangeArgs().rev()))
@@ -462,6 +478,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangebylex() {
         populateManyStringEntries();
         assertThat(setOfStrings.zrangebylex(key, Range.unbounded(), new ZRangeArgs().rev())).hasSize(100);
@@ -474,6 +491,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangebyscore() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
         ZRangeArgs rev = new ZRangeArgs().rev();
@@ -492,6 +510,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangebyscoreWithScores() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
         ZRangeArgs rev = new ZRangeArgs().rev();
@@ -523,6 +542,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangestorebylex() {
         setOfStrings.zadd(key, Map.of("a", 1.0, "b", 2.0, "c", 3.0, "d", 4.0));
         assertThat(setOfStrings.zrangestorebylex("key1", key, new Range<>("c", "-"),
@@ -531,6 +551,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrevrangestorebyscore() {
         setOfPlaces.zadd(key, Map.of(Place.crussol, 1.0, Place.grignan, 2.0, Place.suze, 3.0, Place.adhemar, 4.0));
         assertThat(
@@ -728,6 +749,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     public void zmscore() {
         setOfPlaces.zadd("zset1", Map.of(Place.crussol, 1.0, Place.grignan, 2.0));
         assertThat(setOfPlaces.zmscore("zset1", Place.crussol, Place.suze, Place.grignan))
@@ -821,6 +843,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zrangebylex() {
         populateManyStringEntries();
 
@@ -836,6 +859,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zremrangebylex() {
         populateManyStringEntries();
         assertThat(setOfStrings.zremrangebylex(key, new Range<>("aaa", false, "zzz", true))).isEqualTo(100);
@@ -845,6 +869,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zunion() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -868,6 +893,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zinter() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -887,6 +913,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zinterWithScores() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -904,6 +931,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void zinterWithArgs() {
         String zset1 = "zset1";
         String zset2 = "zset2";
@@ -931,6 +959,7 @@ public class SortedSetCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void sort() {
         SortedSetCommands<String, String> commands = ds.sortedSet(String.class, String.class);
         commands.zadd(key, Map.of("9", 9.0, "1", 1.0, "3", 3.0, "5", 5.0,

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/StringCommandsTest.java
@@ -22,6 +22,7 @@ import io.quarkus.redis.datasource.string.StringCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
 @SuppressWarnings("deprecation")
+@RequiresRedis6OrHigher // The ValueCommandsTest verify the behavior with Redis 5
 public class StringCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TopKCommandsTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.redis.datasource.topk.TopKCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 
+@RequiresCommand("topk.add")
 public class TopKCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource ds;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBloomCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalBloomCommandsTest.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings("unchecked")
+@RequiresCommand("bf.add")
 public class TransactionalBloomCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCountMinCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCountMinCommandsTest.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings({ "unchecked", "ConstantConditions" })
+@RequiresCommand("cms.query")
 public class TransactionalCountMinCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCuckooCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalCuckooCommandsTest.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings("unchecked")
+@RequiresCommand("cf.add")
 public class TransactionalCuckooCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGeoCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGeoCommandsTest.java
@@ -20,6 +20,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalGeoCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGraphCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalGraphCommandsTest.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings("unchecked")
+@RequiresCommand("graph.query")
 public class TransactionalGraphCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHashCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHashCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalHashCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHyperLogLogCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalHyperLogLogCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalHyperLogLogCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalJsonCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalJsonCommandsTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+@RequiresCommand("json.get")
 public class TransactionalJsonCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalKeyTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalKeyTest.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalKeyTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalListCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalListCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalListCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSetCommandsTest.java
@@ -14,6 +14,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalSetCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSortedSetCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalSortedSetCommandsTest.java
@@ -17,6 +17,7 @@ import io.quarkus.redis.datasource.transactions.TransactionResult;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalSortedSetCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalStringCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalStringCommandsTest.java
@@ -16,6 +16,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings("deprecation")
+@RequiresRedis6OrHigher
 public class TransactionalStringCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTopKCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalTopKCommandsTest.java
@@ -18,6 +18,7 @@ import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
 @SuppressWarnings({ "unchecked", "ConstantConditions" })
+@RequiresCommand("topk.add")
 public class TransactionalTopKCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/TransactionalValueCommandsTest.java
@@ -15,6 +15,7 @@ import io.quarkus.redis.datasource.value.TransactionalValueCommands;
 import io.quarkus.redis.runtime.datasource.BlockingRedisDataSourceImpl;
 import io.quarkus.redis.runtime.datasource.ReactiveRedisDataSourceImpl;
 
+@RequiresRedis6OrHigher
 public class TransactionalValueCommandsTest extends DatasourceTestBase {
 
     private RedisDataSource blocking;

--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/ValueCommandsTest.java
@@ -68,6 +68,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void getdel() {
         values.set(key, value);
         assertThat(values.getdel(key)).isEqualTo(value);
@@ -75,6 +76,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void getex() {
         values.set(key, value);
         assertThat(values.getex(key, new GetExArgs().ex(Duration.ofSeconds(100)))).isEqualTo(value);
@@ -176,6 +178,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void setExAt() {
         KeyCommands<String> keys = ds.key(String.class);
 
@@ -187,6 +190,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis6OrHigher
     void setKeepTTL() {
         KeyCommands<String> keys = ds.key(String.class);
 
@@ -207,6 +211,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void setGet() {
         assertThat(values.setGet(key, value)).isNull();
         assertThat(values.setGet(key, "value2")).isEqualTo(value);
@@ -214,6 +219,7 @@ public class ValueCommandsTest extends DatasourceTestBase {
     }
 
     @Test
+    @RequiresRedis7OrHigher
     void setGetWithArgs() {
         KeyCommands<String> keys = ds.key(String.class);
 


### PR DESCRIPTION
The output format of a few commands has changed between Redis 5 and 6.
This PR allows us to verify the compatibility with Redis 5, 6, and 7.

Note that it's the best effort, and we do not intend full compatibility with Redis 5, only the main use cases. Typically, Redis Stack is only supported with Redis 7.

Fix #28837 
