### PR TITLE
Bump kafka-oauth-client from 0.10.0 to 0.11.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -201,7 +201,7 @@
         <aesh-readline.version>2.2</aesh-readline.version>
         <aesh.version>2.6</aesh.version>
         <!-- these two artifacts needs to be compatible together -->
-        <strimzi-oauth.version>0.10.0</strimzi-oauth.version>
+        <strimzi-oauth.version>0.11.0</strimzi-oauth.version>
         <strimzi-oauth.nimbus.version>9.25.6</strimzi-oauth.nimbus.version>
         <java-buildpack-client.version>0.0.6</java-buildpack-client.version>
         <org-crac.version>0.1.3</org-crac.version>


### PR DESCRIPTION
I checked the nimbus jose jwt version but this is [9.10](https://github.com/strimzi/strimzi-kafka-oauth/blob/release-0.11.x/pom.xml#L90) in kafka-oauth-client, whereas quarkus is already in [9.25.6](https://github.com/quarkusio/quarkus/blob/main/bom/application/pom.xml#L205). so I did not change it.
Thanks for the release @mstruk