### PR TITLE
Upgrade Hibernate ORM to 5.6.14.Final and ByteBuddy to 1.12.18, add test for HHH-15634

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -88,7 +88,7 @@
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
-        <hibernate-orm.version>5.6.12.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
+        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
         <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.9.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -89,7 +89,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <classmate.version>1.5.1</classmate.version>
         <hibernate-orm.version>5.6.12.Final</hibernate-orm.version> <!-- When updating, align bytebuddy.version to Hibernate needs as well (just below): -->
-        <bytebuddy.version>1.12.9</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
+        <bytebuddy.version>1.12.18</bytebuddy.version> <!-- Version controlled by Hibernate ORM's needs -->
         <hibernate-reactive.version>1.1.9.Final</hibernate-reactive.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.7.Final</hibernate-search.version>

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/AbstractLazyBasicTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/AbstractLazyBasicTest.java
@@ -1,0 +1,200 @@
+package io.quarkus.hibernate.orm.lazyloading;
+
+import static io.quarkus.hibernate.orm.TransactionTestUtils.inTransaction;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.UserTransaction;
+
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractLazyBasicTest {
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserTransaction transaction;
+
+    private final AccessDelegate delegate;
+    private Long entityId;
+
+    public AbstractLazyBasicTest(AccessDelegate delegate) {
+        this.delegate = delegate;
+    }
+
+    @Test
+    public void update_all_nullToNonNull() {
+        initNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllProperties(em, entityId, "updated1", "updated2", "updated3");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "updated2", "updated3");
+        });
+    }
+
+    @Test
+    public void update_allLazy_nullToNonNull() {
+        initNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, "updated1", "updated2");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "updated1", "updated2");
+        });
+    }
+
+    @Test
+    public void update_oneEager_nullToNonNull() {
+        initNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, "updated1");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", null, null);
+        });
+    }
+
+    @Test
+    public void update_oneLazy_nullToNonNull() {
+        initNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, "updated2");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "updated2", null);
+        });
+    }
+
+    @Test
+    public void update_all_nonNullToNonNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllProperties(em, entityId, "updated1", "updated2", "updated3");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "updated2", "updated3");
+        });
+    }
+
+    @Test
+    public void update_allLazy_nonNullToNonNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, "updated1", "updated2");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "updated1", "updated2");
+        });
+    }
+
+    @Test
+    public void update_oneEager_nonNullToNonNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, "updated1");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "updated1", "initial2", "initial3");
+        });
+    }
+
+    @Test
+    public void update_oneLazy_nonNullToNonNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, "updated2");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "updated2", "initial3");
+        });
+    }
+
+    @Test
+    public void update_all_nonNullToNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllProperties(em, entityId, null, null, null);
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    @Test
+    public void update_allLazy_nonNullToNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateAllLazyProperties(em, entityId, null, null);
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", null, null);
+        });
+    }
+
+    @Test
+    public void update_oneEager_nonNullToNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneEagerProperty(em, entityId, null);
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, "initial2", "initial3");
+        });
+    }
+
+    @Test
+    public void update_oneLazy_nonNullToNull() {
+        initNonNull();
+        inTransaction(transaction, () -> {
+            delegate.updateOneLazyProperty(em, entityId, null);
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", null, "initial3");
+        });
+    }
+
+    private void initNull() {
+        inTransaction(transaction, () -> {
+            entityId = delegate.create(em, null, null, null);
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, null, null, null);
+        });
+    }
+
+    private void initNonNull() {
+        inTransaction(transaction, () -> {
+            entityId = delegate.create(em, "initial1", "initial2", "initial3");
+        });
+        inTransaction(transaction, () -> {
+            delegate.testLazyLoadingAndPersistedValues(em, entityId, "initial1", "initial2", "initial3");
+        });
+    }
+
+    /**
+     * An interface for delegate classes,
+     * classes whose bytecode is transformed by Quarkus to replace public field access with getter/setter access.
+     * <p>
+     * (Test bytecode was not transformed by Quarkus when using QuarkusUnitTest last time I checked).
+     */
+    interface AccessDelegate {
+
+        long create(EntityManager entityManager, String eagerProperty1, String lazyProperty1, String lazyProperty2);
+
+        void updateAllProperties(EntityManager entityManager, long entityId, String eagerProperty1, String lazyProperty1,
+                String lazyProperty2);
+
+        void updateAllLazyProperties(EntityManager entityManager, long entityId, String lazyProperty1, String lazyProperty2);
+
+        void updateOneEagerProperty(EntityManager entityManager, long entityId, String eagerProperty1);
+
+        void updateOneLazyProperty(EntityManager entityManager, long entityId, String lazyProperty1);
+
+        void testLazyLoadingAndPersistedValues(EntityManager entityManager, long entityId,
+                String expectedEagerProperty1,
+                String expectedLazyProperty1,
+                String expectedLazyProperty2);
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicDefaultGroupTest.java
@@ -1,0 +1,118 @@
+package io.quarkus.hibernate.orm.lazyloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LazyBasicDefaultGroupTest extends AbstractLazyBasicTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TransactionTestUtils.class)
+                    .addClass(MyEntity.class)
+                    .addClass(AccessDelegate.class)
+                    .addClass(AccessDelegateImpl.class))
+            .withConfigurationResource("application.properties");
+
+    public LazyBasicDefaultGroupTest() {
+        super(new AccessDelegateImpl());
+    }
+
+    @Entity(name = "MyEntity")
+    public static class MyEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        public Long id;
+
+        @Basic
+        public String eagerProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        public String lazyProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        public String lazyProperty2;
+    }
+
+    private static class AccessDelegateImpl implements AccessDelegate {
+
+        @Override
+        public long create(EntityManager entityManager, String eagerProperty1, String lazyProperty1, String lazyProperty2) {
+            MyEntity myEntity = new MyEntity();
+            myEntity.eagerProperty1 = eagerProperty1;
+            myEntity.lazyProperty1 = lazyProperty1;
+            myEntity.lazyProperty2 = lazyProperty2;
+            entityManager.persist(myEntity);
+            return myEntity.id;
+        }
+
+        @Override
+        public void updateAllProperties(EntityManager entityManager, long entityId, String eagerProperty1, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateAllLazyProperties(EntityManager entityManager, long entityId, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateOneEagerProperty(EntityManager entityManager, long entityId, String eagerProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+        }
+
+        @Override
+        public void updateOneLazyProperty(EntityManager entityManager, long entityId, String lazyProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+        }
+
+        @Override
+        public void testLazyLoadingAndPersistedValues(EntityManager entityManager, long entityId,
+                String expectedEagerProperty1,
+                String expectedLazyProperty1,
+                String expectedLazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            assertThat(entity).isNotNull();
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.eagerProperty1).isEqualTo(expectedEagerProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.lazyProperty1).isEqualTo(expectedLazyProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isTrue();
+
+            assertThat(entity.lazyProperty2).isEqualTo(expectedLazyProperty2);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isTrue();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicMultiNonDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicMultiNonDefaultGroupTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.hibernate.orm.lazyloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.LazyGroup;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LazyBasicMultiNonDefaultGroupTest extends AbstractLazyBasicTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TransactionTestUtils.class)
+                    .addClass(MyEntity.class)
+                    .addClass(AccessDelegate.class)
+                    .addClass(AccessDelegateImpl.class))
+            .withConfigurationResource("application.properties");
+
+    public LazyBasicMultiNonDefaultGroupTest() {
+        super(new AccessDelegateImpl());
+    }
+
+    @Entity(name = "MyEntity")
+    public static class MyEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        public Long id;
+
+        @Basic
+        public String eagerProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        @LazyGroup("myGroup1")
+        public String lazyProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        @LazyGroup("myGroup2")
+        public String lazyProperty2;
+    }
+
+    private static class AccessDelegateImpl implements AccessDelegate {
+
+        @Override
+        public long create(EntityManager entityManager, String eagerProperty1, String lazyProperty1, String lazyProperty2) {
+            MyEntity myEntity = new MyEntity();
+            myEntity.eagerProperty1 = eagerProperty1;
+            myEntity.lazyProperty1 = lazyProperty1;
+            myEntity.lazyProperty2 = lazyProperty2;
+            entityManager.persist(myEntity);
+            return myEntity.id;
+        }
+
+        @Override
+        public void updateAllProperties(EntityManager entityManager, long entityId, String eagerProperty1, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateAllLazyProperties(EntityManager entityManager, long entityId, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateOneEagerProperty(EntityManager entityManager, long entityId, String eagerProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+        }
+
+        @Override
+        public void updateOneLazyProperty(EntityManager entityManager, long entityId, String lazyProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+        }
+
+        @Override
+        public void testLazyLoadingAndPersistedValues(EntityManager entityManager, long entityId,
+                String expectedEagerProperty1,
+                String expectedLazyProperty1,
+                String expectedLazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            assertThat(entity).isNotNull();
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.eagerProperty1).isEqualTo(expectedEagerProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.lazyProperty1).isEqualTo(expectedLazyProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.lazyProperty2).isEqualTo(expectedLazyProperty2);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isTrue();
+        }
+    }
+}

--- a/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicNonDefaultGroupTest.java
+++ b/extensions/hibernate-orm/deployment/src/test/java/io/quarkus/hibernate/orm/lazyloading/LazyBasicNonDefaultGroupTest.java
@@ -1,0 +1,121 @@
+package io.quarkus.hibernate.orm.lazyloading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.LazyGroup;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.orm.TransactionTestUtils;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class LazyBasicNonDefaultGroupTest extends AbstractLazyBasicTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClass(TransactionTestUtils.class)
+                    .addClass(MyEntity.class)
+                    .addClass(AccessDelegate.class)
+                    .addClass(AccessDelegateImpl.class))
+            .withConfigurationResource("application.properties");
+
+    public LazyBasicNonDefaultGroupTest() {
+        super(new AccessDelegateImpl());
+    }
+
+    @Entity(name = "MyEntity")
+    public static class MyEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        public Long id;
+
+        @Basic
+        public String eagerProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        @LazyGroup("myGroup")
+        public String lazyProperty1;
+
+        @Basic(fetch = FetchType.LAZY)
+        @LazyGroup("myGroup")
+        public String lazyProperty2;
+    }
+
+    private static class AccessDelegateImpl implements AccessDelegate {
+
+        @Override
+        public long create(EntityManager entityManager, String eagerProperty1, String lazyProperty1, String lazyProperty2) {
+            MyEntity myEntity = new MyEntity();
+            myEntity.eagerProperty1 = eagerProperty1;
+            myEntity.lazyProperty1 = lazyProperty1;
+            myEntity.lazyProperty2 = lazyProperty2;
+            entityManager.persist(myEntity);
+            return myEntity.id;
+        }
+
+        @Override
+        public void updateAllProperties(EntityManager entityManager, long entityId, String eagerProperty1, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateAllLazyProperties(EntityManager entityManager, long entityId, String lazyProperty1,
+                String lazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+            entity.lazyProperty2 = lazyProperty2;
+        }
+
+        @Override
+        public void updateOneEagerProperty(EntityManager entityManager, long entityId, String eagerProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.eagerProperty1 = eagerProperty1;
+        }
+
+        @Override
+        public void updateOneLazyProperty(EntityManager entityManager, long entityId, String lazyProperty1) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            entity.lazyProperty1 = lazyProperty1;
+        }
+
+        @Override
+        public void testLazyLoadingAndPersistedValues(EntityManager entityManager, long entityId,
+                String expectedEagerProperty1,
+                String expectedLazyProperty1,
+                String expectedLazyProperty2) {
+            MyEntity entity = entityManager.find(MyEntity.class, entityId);
+            assertThat(entity).isNotNull();
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.eagerProperty1).isEqualTo(expectedEagerProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isFalse();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isFalse();
+
+            assertThat(entity.lazyProperty1).isEqualTo(expectedLazyProperty1);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isTrue();
+
+            assertThat(entity.lazyProperty2).isEqualTo(expectedLazyProperty2);
+            assertThat(Hibernate.isPropertyInitialized(entity, "eagerProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty1")).isTrue();
+            assertThat(Hibernate.isPropertyInitialized(entity, "lazyProperty2")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
cc @gsmet

Creating as draft because the tests will fail until [HHH-15634](https://hibernate.atlassian.net/browse/HHH-15634) gets fixed and we upgrade our Hibernate ORM dependency.

This will be useful to test the patch that @dreab8 is currently working on for Hibernate ORM.

To launch the test, build Quarkus, then run:

```
mvn clean test -pl extensions/hibernate-orm/deployment -Dtest='LazyBasic*'
```