### PR TITLE
Cleaning Deprecated JDK API from quarkus core

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/Quarkus.java
@@ -68,7 +68,7 @@ public class Quarkus {
             //we already have an application, run it directly
             Class<? extends Application> appClass = (Class<? extends Application>) Class.forName(Application.APP_CLASS_NAME,
                     false, Thread.currentThread().getContextClassLoader());
-            Application application = appClass.newInstance();
+            Application application = appClass.getDeclaredConstructor().newInstance();
             ApplicationLifecycleManager.run(application, quarkusApplication, exitHandler, args);
             return;
         } catch (ClassNotFoundException e) {

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DisabledSSLContext.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DisabledSSLContext.java
@@ -20,7 +20,7 @@ import javax.net.ssl.TrustManager;
 public class DisabledSSLContext extends SSLContext {
 
     public DisabledSSLContext() {
-        super(new DisabledSSLContextSpi(), new Provider("DISABLED", 1, "DISABLED") {
+        super(new DisabledSSLContextSpi(), new Provider("DISABLED", "1.0", "DISABLED") {
         }, "DISABLED");
     }
 


### PR DESCRIPTION
Replaced Class.newInstance() with Class.getDeclaredConstructor().newInstance() as recommended Replaced new Provider("DISABLED", 1, "DISABLED") with new Provider("DISABLED", "1.0", "DISABLED") as recommended