### PR TITLE
Qute - fix type resolution for extension methods

### DIFF
--- a/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
+++ b/extensions/qute/deployment/src/main/java/io/quarkus/qute/deployment/MessageBundleProcessor.java
@@ -159,7 +159,7 @@ public class MessageBundleProcessor {
                     }
                     Map<String, ClassInfo> localeToInterface = new HashMap<>();
                     for (ClassInfo localizedInterface : localized) {
-                        String locale = localizedInterface.classAnnotation(Names.LOCALIZED).value().asString();
+                        String locale = localizedInterface.declaredAnnotation(Names.LOCALIZED).value().asString();
                         if (defaultLocale.equals(locale)) {
                             throw new MessageBundleException(
                                     String.format(
@@ -234,7 +234,7 @@ public class MessageBundleProcessor {
             beanRegistration.getContext().configure(bundleInterface.name()).addType(bundle.getDefaultBundleInterface().name())
                     // The default message bundle - add both @Default and @Localized
                     .addQualifier(DotNames.DEFAULT).addQualifier().annotation(Names.LOCALIZED)
-                    .addValue("value", getDefaultLocale(bundleInterface.classAnnotation(Names.BUNDLE), locales)).done()
+                    .addValue("value", getDefaultLocale(bundleInterface.declaredAnnotation(Names.BUNDLE), locales)).done()
                     .unremovable()
                     .scope(Singleton.class).creator(mc -> {
                         // Just create a new instance of the generated class
@@ -247,7 +247,7 @@ public class MessageBundleProcessor {
             for (ClassInfo localizedInterface : bundle.getLocalizedInterfaces().values()) {
                 beanRegistration.getContext().configure(localizedInterface.name())
                         .addType(bundle.getDefaultBundleInterface().name())
-                        .addQualifier(localizedInterface.classAnnotation(Names.LOCALIZED))
+                        .addQualifier(localizedInterface.declaredAnnotation(Names.LOCALIZED))
                         .unremovable()
                         .scope(Singleton.class).creator(mc -> {
                             // Just create a new instance of the generated class
@@ -770,8 +770,8 @@ public class MessageBundleProcessor {
         ClassInfo bundleInterface = bundleInterfaceWrapper.getClassInfo();
         LOGGER.debugf("Generate bundle implementation for %s", bundleInterface);
         AnnotationInstance bundleAnnotation = defaultBundleInterface != null
-                ? defaultBundleInterface.classAnnotation(Names.BUNDLE)
-                : bundleInterface.classAnnotation(Names.BUNDLE);
+                ? defaultBundleInterface.declaredAnnotation(Names.BUNDLE)
+                : bundleInterface.declaredAnnotation(Names.BUNDLE);
         AnnotationValue nameValue = bundleAnnotation.value();
         String bundleName = nameValue != null ? nameValue.asString() : MessageBundle.DEFAULT_NAME;
         AnnotationValue defaultKeyValue = bundleAnnotation.value(BUNDLE_DEFAULT_KEY);
@@ -864,7 +864,7 @@ public class MessageBundleProcessor {
             if (messageTemplate.contains("}")) {
                 if (defaultBundleInterface != null) {
                     if (locale == null) {
-                        AnnotationInstance localizedAnnotation = bundleInterface.classAnnotation(Names.LOCALIZED);
+                        AnnotationInstance localizedAnnotation = bundleInterface.declaredAnnotation(Names.LOCALIZED);
                         locale = localizedAnnotation.value().asString();
                     }
                     templateId = bundleName + "_" + locale + "_" + key;

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Item.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/Item.java
@@ -19,4 +19,8 @@ public class Item {
         return otherItems;
     }
 
+    public int getPrimitiveId() {
+        return 9;
+    }
+
 }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ItemWithName.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/ItemWithName.java
@@ -11,6 +11,10 @@ public class ItemWithName {
         return 2;
     }
 
+    public int getPrimitiveId() {
+        return getId() * -1;
+    }
+
     public Name getName() {
         return name;
     }

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionFailureTest.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OrOperatorTemplateExtensionFailureTest.java
@@ -23,6 +23,7 @@ public class OrOperatorTemplateExtensionFailureTest {
                                     "{@io.quarkus.qute.deployment.typesafe.Item item}\n" +
                                     "  {data:item.name.or(item2.name).pleaseMakeMyCaseUpper}\n" +
                                     "  {item.name.or(item2.name).pleaseMakeMyCaseUpper}\n" +
+                                    "  {item.getPrimitiveId().or(item2.getPrimitiveId()).missingMethod()}\n" +
                                     "{/for}\n"),
                             "templates/item.html"))
             .assertException(t -> {
@@ -42,6 +43,9 @@ public class OrOperatorTemplateExtensionFailureTest {
                 // validation failure in data namespace
                 assertTrue(te.getMessage().contains(
                         "{data:item.name.or(item2.name).pleaseMakeMyCaseUpper}: Property/method [pleaseMakeMyCaseUpper] not found on class [java.lang.String]"),
+                        te.getMessage());
+                assertTrue(te.getMessage().contains(
+                        "{item.getPrimitiveId().or(item2.getPrimitiveId()).missingMethod()}: Property/method [missingMethod()]"),
                         te.getMessage());
             });
 

--- a/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OtherItem.java
+++ b/extensions/qute/deployment/src/test/java/io/quarkus/qute/deployment/typesafe/OtherItem.java
@@ -3,9 +3,14 @@ package io.quarkus.qute.deployment.typesafe;
 public class OtherItem {
 
     static final int ID = 1;
+    static final int PRIMITIVE_ID = ID * -1;
 
     public Integer getId() {
         return ID;
+    }
+
+    public int getPrimitiveId() {
+        return PRIMITIVE_ID;
     }
 
 }


### PR DESCRIPTION
fixes failure in https://github.com/quarkiverse/quarkiverse/issues/74#issuecomment-1293678494 brought in by https://github.com/quarkusio/quarkus/pull/26826

When validating nested expression, we try to resolve type and it's possible we run into state where match class is null and match type is not. I mentioned it's not only case for extension methods as Renarde has Java member methods like 
```Java
public <T> T getError(String key) {
        return (T) values.get("error." + key);
}
```
This PR avoids NPE and improves handling of extension method type variables that "are" primitive types and caused the failure. Previously calls like `obj.getPrimitiveType().or(obj2.getPrimitiveType()).missingMethod` weren't validated, now they are. This behavior is closer to Java as primitive parameters passed as type variables are boxed (and it's better than what we had previously - `T`). Also it's not just an OR operator, user-defined extension methods should expect there boxed types rather than `T`.

I also mentioned there warnings logged _classAnnotation(org.jboss.jandex.DotName) in org.jboss.jandex.ClassInfo has been deprecated_, so now, `declaredAnnotation` is called instead of `classAnnotation`.