### PR TITLE
Use non closeable output stream for writting the multipart entities

### DIFF
--- a/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/jsonb/src/main/java/org/jboss/resteasy/reactive/server/jsonb/JsonbMessageBodyWriter.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.jboss.resteasy.reactive.common.providers.serialisers.JsonMessageBodyWriterUtil;
+import org.jboss.resteasy.reactive.server.NoopCloseAndFlushOutputStream;
 import org.jboss.resteasy.reactive.server.StreamingOutputStream;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -50,41 +51,5 @@ public class JsonbMessageBodyWriter extends ServerMessageBodyWriter.AllWriteable
         }
         // we don't use try-with-resources because that results in writing to the http output without the exception mapping coming into play
         originalStream.close();
-    }
-
-    /**
-     * This class is needed because Yasson doesn't give us a way to control if the output stream is going to be closed or not
-     */
-    private static class NoopCloseAndFlushOutputStream extends OutputStream {
-        private final OutputStream delegate;
-
-        public NoopCloseAndFlushOutputStream(OutputStream delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void flush() {
-
-        }
-
-        @Override
-        public void close() {
-
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            delegate.write(b);
-        }
-
-        @Override
-        public void write(byte[] b) throws IOException {
-            delegate.write(b);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            delegate.write(b, off, len);
-        }
     }
 }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/NoopCloseAndFlushOutputStream.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/NoopCloseAndFlushOutputStream.java
@@ -1,0 +1,41 @@
+package org.jboss.resteasy.reactive.server;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This class is needed because some message writers don't give us a way to control if the output stream is going to be closed
+ * or not.
+ */
+public class NoopCloseAndFlushOutputStream extends OutputStream {
+    private final OutputStream delegate;
+
+    public NoopCloseAndFlushOutputStream(OutputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        delegate.write(b, off, len);
+    }
+}

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/multipart/MultipartMessageBodyWriter.java
@@ -1,6 +1,5 @@
 package org.jboss.resteasy.reactive.server.core.multipart;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,6 +23,7 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import org.jboss.resteasy.reactive.common.core.Serialisers;
 import org.jboss.resteasy.reactive.common.reflection.ReflectionBeanFactoryCreator;
 import org.jboss.resteasy.reactive.multipart.FileDownload;
+import org.jboss.resteasy.reactive.server.NoopCloseAndFlushOutputStream;
 import org.jboss.resteasy.reactive.server.core.CurrentRequestManager;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.core.ServerSerialisers;
@@ -184,11 +184,10 @@ public class MultipartMessageBodyWriter extends ServerMessageBodyWriter.AllWrite
         boolean wrote = false;
         for (MessageBodyWriter<Object> writer : writers) {
             if (writer.isWriteable(entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType)) {
-                try (ByteArrayOutputStream writerOutput = new ByteArrayOutputStream()) {
+                try (NoopCloseAndFlushOutputStream writerOutput = new NoopCloseAndFlushOutputStream(os)) {
                     // FIXME: spec doesn't really say what headers we should use here
                     writer.writeTo(entity, entityClass, entityType, Serialisers.NO_ANNOTATION, mediaType,
                             Serialisers.EMPTY_MULTI_MAP, writerOutput);
-                    writerOutput.writeTo(os);
                     wrote = true;
                 }
 


### PR DESCRIPTION
Before, we used a ByteArrayOutputStream because some message writers closed the original output stream when writing the entity (like JSON).  The problem is that this approach needs double space (keeping the data in the byte array output stream and then copying the data to the original output stream). 
With these changes, we are proxying the original output stream and preventing the message writers not to close the output stream (this was already being used in the JsonbMessageBodyWriter). 
Fix https://github.com/quarkusio/quarkus/issues/28920