### PR TITLE
Prevent NPE in setAllHeaders

### DIFF
--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/jaxrs/AbstractResponseBuilder.java
@@ -131,9 +131,11 @@ public abstract class AbstractResponseBuilder extends Response.ResponseBuilder {
     }
 
     public void setAllHeaders(MultivaluedMap<String, String> values) {
-        for (Map.Entry<String, List<String>> i : values.entrySet()) {
-            for (String v : i.getValue()) {
-                metadata.add(i.getKey(), v);
+        if (values != null) {
+            for (Map.Entry<String, List<String>> i : values.entrySet()) {
+                for (String v : i.getValue()) {
+                    metadata.add(i.getKey(), v);
+                }
             }
         }
     }


### PR DESCRIPTION
I didn't add any test to cover this change because it's easier to fix than to replicate the conditions to reproduce it in either the extension or an integration test.
Still, let me know if you want it to cover it and maybe I can add wiremock in the integration-tests/rest-client-reactive.  
Fix https://github.com/quarkusio/quarkus/issues/28922