### PR TITLE
Docs - reactive SQL clients also supports service binding

### DIFF
--- a/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
+++ b/docs/src/main/asciidoc/deploying-to-kubernetes.adoc
@@ -1320,6 +1320,12 @@ To enable Service Binding for supported extensions, add the `quarkus-kubernetes-
 
 * `quarkus-kafka-client`
 * `quarkus-smallrye-reactive-messaging-kafka`
+
+* `quarkus-reactive-db2-client`
+* `quarkus-reactive-mssql-client`
+* `quarkus-reactive-mysql-client`
+* `quarkus-reactive-oracle-client`
+* `quarkus-reactive-pg-client`
 ====
 
 


### PR DESCRIPTION
There was added service binding support for the Reactive SQL clients in Quarkus 2.10 and docs should mention them among classic ones: https://github.com/quarkusio/quarkus/pull/25657