### PR TITLE
Turn off monitoring of bean invocations and fired events by default

### DIFF
--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -1083,6 +1083,10 @@ In the development mode, two special endpoints are registered automatically to p
 
 NOTE: These endpoints are only available in the development mode, i.e. when you run your application via `mvn quarkus:dev` (or `./gradlew quarkusDev`).
 
+=== Monitoring Business Method Invocations and Events
+
+In the development mode, it is also possible to enable monitoring of business method invocations and fired events.
+Simply set the `quarkus.arc.dev-mode.monitoring-enabled` configuration property to `true` and explore the relevant Dev UI pages.
 
 [[arc-configuration-reference]]
 == ArC Configuration Reference

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcDevModeConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcDevModeConfig.java
@@ -9,7 +9,7 @@ public class ArcDevModeConfig {
     /**
      * If set to true then the container monitors business method invocations and fired events during the development mode.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public boolean monitoringEnabled;
 
 }

--- a/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleArcSmokeTest.java
+++ b/integration-tests/devmode/src/test/java/io/quarkus/test/devconsole/DevConsoleArcSmokeTest.java
@@ -5,6 +5,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Named;
 
 import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -20,7 +21,8 @@ public class DevConsoleArcSmokeTest {
     @RegisterExtension
     static final QuarkusDevModeTest test = new QuarkusDevModeTest()
             .withApplicationRoot((jar) -> jar
-                    .addClasses(Foo.class));
+                    .addClasses(Foo.class).addAsResource(new StringAsset("quarkus.arc.dev-mode.monitoring-enabled=true"),
+                            "application.properties"));
 
     @Test
     public void testPages() {


### PR DESCRIPTION
- this feature seems to cause more problems than benefits
- set quarkus.arc.dev-mode.monitoring-enabled=true to turn it on