### PR TITLE
Disable Kubernetes Dev Services in Gradle tests

### DIFF
--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/application.properties
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-# Configuration file
-# key = value
+quarkus.kubernetes-client.devservices.enabled=false


### PR DESCRIPTION
These tests are executed in the Windows machine where there is no Docker instance running.  
Related to the changes in https://github.com/quarkusio/quarkus/pull/28305 
Related to CI failures like https://github.com/quarkusio/quarkus/runs/9165337690#user-content-test-failure-org.acme.applicationconfigresourcetest-1