### PR TITLE
Handle maintenance releases in release-cli.sh

### DIFF
--- a/devtools/cli/distribution/release-cli.sh
+++ b/devtools/cli/distribution/release-cli.sh
@@ -13,6 +13,13 @@ then
     exit 1
 fi
 
+MAINTENANCE="$3"
+if [ -z "$MAINTENANCE" ]
+then
+    echo "Must specify maintenance mode"
+    exit 1
+fi
+
 DIST_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 pushd ${DIST_DIR}
 
@@ -43,7 +50,10 @@ popd
 
 export JRELEASER_PROJECT_VERSION=${VERSION}
 export JRELEASER_BRANCH=${BRANCH}
-export JRELEASER_CHOCOLATEY_GITHUB_BRANCH=${BRANCH}
+if [ "$MAINTENANCE" == "true" ]; then
+    export JRELEASER_CHOCOLATEY_GITHUB_BRANCH=${BRANCH}
+    export JRELEASER_HOMEBREW_GITHUB_BRANCH=${BRANCH}
+fi
 
 jbang org.jreleaser:jreleaser:1.3.0 full-release \
   --git-root-search \


### PR DESCRIPTION
The goal of this change is to not push maintenance branches to the main branch of the Homebrew repository. I'm unsure this will work though as it doesn't seem to work for Chocolatey.