### PR TITLE
Bump liquibase.version from 4.16.1 to 4.17.1

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -159,7 +159,7 @@
         <jboss-logmanager.version>1.0.11</jboss-logmanager.version>
         <flyway.version>9.6.0</flyway.version>
         <yasson.version>1.0.11</yasson.version>
-        <liquibase.version>4.16.1</liquibase.version>
+        <liquibase.version>4.17.1</liquibase.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
         <mongo-client.version>4.7.2</mongo-client.version>

--- a/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
+++ b/extensions/liquibase-mongodb/deployment/src/main/java/io/quarkus/liquibase/mongodb/deployment/LiquibaseMongodbProcessor.java
@@ -91,6 +91,8 @@ class LiquibaseMongodbProcessor {
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
 
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(liquibase.diff.compare.CompareControl.class.getName()));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(
+                liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator.class.getName()));
 
         reflective.produce(new ReflectiveClassBuildItem(false, true, false,
                 liquibase.change.AbstractSQLChange.class.getName(),
@@ -115,7 +117,8 @@ class LiquibaseMongodbProcessor {
                 liquibase.sql.visitor.ReplaceSqlVisitor.class.getName(),
                 liquibase.sql.visitor.AppendSqlVisitor.class.getName(),
                 liquibase.sql.visitor.RegExpReplaceSqlVisitor.class.getName(),
-                liquibase.ext.mongodb.database.MongoClientDriver.class.getName()));
+                liquibase.ext.mongodb.database.MongoClientDriver.class.getName(),
+                liquibase.resource.PathHandlerFactory.class.getName()));
 
         reflective.produce(new ReflectiveClassBuildItem(false, false, true,
                 liquibase.change.ConstraintsConfig.class.getName()));

--- a/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
+++ b/extensions/liquibase/deployment/src/main/java/io/quarkus/liquibase/deployment/LiquibaseProcessor.java
@@ -111,6 +111,8 @@ class LiquibaseProcessor {
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundle) {
 
         runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(liquibase.diff.compare.CompareControl.class.getName()));
+        runtimeInitialized.produce(new RuntimeInitializedClassBuildItem(
+                liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator.class.getName()));
 
         reflective.produce(new ReflectiveClassBuildItem(false, true, false,
                 liquibase.change.AbstractSQLChange.class.getName(),
@@ -135,7 +137,8 @@ class LiquibaseProcessor {
                 liquibase.sql.visitor.PrependSqlVisitor.class.getName(),
                 liquibase.sql.visitor.ReplaceSqlVisitor.class.getName(),
                 liquibase.sql.visitor.AppendSqlVisitor.class.getName(),
-                liquibase.sql.visitor.RegExpReplaceSqlVisitor.class.getName()));
+                liquibase.sql.visitor.RegExpReplaceSqlVisitor.class.getName(),
+                liquibase.resource.PathHandlerFactory.class.getName()));
 
         reflective.produce(new ReflectiveClassBuildItem(false, false, true,
                 liquibase.change.ConstraintsConfig.class.getName()));


### PR DESCRIPTION
Bumps `liquibase.version` from 4.16.1 to 4.17.1.

Updates `liquibase-core` from 4.16.1 to 4.17.1
- [Release notes](https://github.com/liquibase/liquibase/releases)
- [Changelog](https://github.com/liquibase/liquibase/blob/master/changelog.txt)
- [Commits](https://github.com/liquibase/liquibase/compare/v4.16.1...v4.17.1)

Updates `liquibase-mongodb` from 4.16.1 to 4.17.1
- [Release notes](https://github.com/liquibase/liquibase-mongodb/releases)
- [Changelog](https://github.com/liquibase/liquibase-mongodb/blob/main/RELEASE.md)
- [Commits](https://github.com/liquibase/liquibase-mongodb/compare/liquibase-mongodb-4.16.1...liquibase-mongodb-4.17.1)

---
updated-dependencies:
- dependency-name: org.liquibase:liquibase-core dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.liquibase.ext:liquibase-mongodb dependency-type: direct:production update-type: version-update:semver-minor ...