### PR TITLE
Use failure handlers for security exceptions before JAX-RS chain starts

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication.adoc
@@ -124,7 +124,38 @@ for the xref:reactive-routes.adoc[Reactive routes] if a route response is synchr
 
 === How to customize authentication exception responses
 
-By default, the authentication security constraints are enforced before the JAX-RS chain starts.
+By default, the authentication security constraints are enforced before the JAX-RS chain starts and only way to handle Quarkus Security authentication exceptions is to provide a failure handler like this one:
+
+[source,java]
+----
+package io.quarkus.it.keycloak;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class AuthenticationFailedExceptionHandler {
+
+    public void init(@Observes Router router) {
+        router.route().failureHandler(new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext event) {
+                if (event.failure() instanceof AuthenticationFailedException) {
+                    event.response().setStatusCode(401).end(CUSTOMIZED_RESPONSE);
+                } else {
+                    event.next();
+                }
+            }
+        });
+    }
+}
+----
+
 Disabling the proactive authentication effectively shifts this process to the moment when the JAX-RS chain starts running thus making it possible to use JAX-RS `ExceptionMapper` to capture Quarkus Security authentication exceptions such as `io.quarkus.security.AuthenticationFailedException`, for example:
 
 [source,java]

--- a/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
+++ b/extensions/reactive-routes/deployment/src/main/java/io/quarkus/vertx/web/deployment/ReactiveRoutesProcessor.java
@@ -268,6 +268,17 @@ class ReactiveRoutesProcessor {
     }
 
     @BuildStep
+    @Record(value = ExecutionTime.STATIC_INIT)
+    public void replaceDefaultAuthFailureHandler(VertxWebRecorder recorder, Capabilities capabilities,
+            BuildProducer<FilterBuildItem> filterBuildItemBuildProducer) {
+        if (capabilities.isMissing(Capability.RESTEASY_REACTIVE)) {
+            // replace default auth failure handler added by vertx-http so that route failure handlers can customize response
+            filterBuildItemBuildProducer
+                    .produce(new FilterBuildItem(recorder.addAuthFailureHandler(), FilterBuildItem.AUTHENTICATION - 1));
+        }
+    }
+
+    @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void addAdditionalRoutes(
             VertxWebRecorder recorder,

--- a/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/failure/AuthCompletionExceptionHandlerTest.java
+++ b/extensions/reactive-routes/deployment/src/test/java/io/quarkus/vertx/web/failure/AuthCompletionExceptionHandlerTest.java
@@ -1,0 +1,71 @@
+package io.quarkus.vertx.web.failure;
+
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.vertx.core.http.HttpServerResponse;
+
+public class AuthCompletionExceptionHandlerTest {
+
+    private static final String AUTHENTICATION_COMPLETION_EX = "AuthenticationCompletionException";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class,
+                            CustomAuthCompletionExceptionHandler.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.form.enabled=true\n"), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testAuthCompletionExMapper() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .filter(new CookieFilter())
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "a d m i n")
+                .formParam("j_password", "a d m i n")
+                .cookie("quarkus-redirect-location", "https://quarkus.io/guides")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .body(Matchers.equalTo(AUTHENTICATION_COMPLETION_EX));
+    }
+
+    public static final class CustomAuthCompletionExceptionHandler {
+
+        @Route(type = Route.HandlerType.FAILURE)
+        void handle(AuthenticationCompletionException e, HttpServerResponse response) {
+            response.setStatusCode(UNAUTHORIZED.getStatusCode()).end(AUTHENTICATION_COMPLETION_EX);
+        }
+
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ProactiveAuthCompletionExceptionHandlerTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ProactiveAuthCompletionExceptionHandlerTest.java
@@ -1,0 +1,85 @@
+package io.quarkus.resteasy.test.security;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class ProactiveAuthCompletionExceptionHandlerTest {
+
+    private static final String AUTHENTICATION_COMPLETION_EX = "AuthenticationCompletionException";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class,
+                            CustomAuthCompletionExceptionHandler.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.form.enabled=true\n"), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testAuthCompletionExMapper() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .filter(new CookieFilter())
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "a d m i n")
+                .formParam("j_password", "a d m i n")
+                .cookie("quarkus-redirect-location", "https://quarkus.io/guides")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .body(Matchers.equalTo(AUTHENTICATION_COMPLETION_EX));
+    }
+
+    /**
+     * Use failure handler as when proactive security is enabled, JAX-RS exception mappers won't do.
+     */
+    @ApplicationScoped
+    public static final class CustomAuthCompletionExceptionHandler {
+
+        public void init(@Observes Router router) {
+            router.route().failureHandler(new Handler<RoutingContext>() {
+                @Override
+                public void handle(RoutingContext event) {
+                    if (event.failure() instanceof AuthenticationCompletionException) {
+                        event.response().setStatusCode(401).end(AUTHENTICATION_COMPLETION_EX);
+                    } else {
+                        event.next();
+                    }
+                }
+            });
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthCompletionExceptionHandlerTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthCompletionExceptionHandlerTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationCompletionException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.restassured.RestAssured;
+import io.restassured.filter.cookie.CookieFilter;
+import io.vertx.core.http.HttpServerResponse;
+
+public class ProactiveAuthCompletionExceptionHandlerTest {
+
+    private static final String AUTHENTICATION_COMPLETION_EX = "AuthenticationCompletionException";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class,
+                            CustomAuthCompletionExceptionHandler.class)
+                    .addAsResource(new StringAsset("quarkus.http.auth.form.enabled=true\n"), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testAuthCompletionExMapper() {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        RestAssured
+                .given()
+                .filter(new CookieFilter())
+                .redirects().follow(false)
+                .when()
+                .formParam("j_username", "a d m i n")
+                .formParam("j_password", "a d m i n")
+                .cookie("quarkus-redirect-location", "https://quarkus.io/guides")
+                .post("/j_security_check")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .body(Matchers.equalTo(AUTHENTICATION_COMPLETION_EX));
+    }
+
+    /**
+     * Use failure handler as when proactive security is enabled, JAX-RS exception mappers won't do.
+     */
+    public static final class CustomAuthCompletionExceptionHandler {
+
+        @Route(type = Route.HandlerType.FAILURE)
+        void handle(AuthenticationCompletionException e, HttpServerResponse response) {
+            response.setStatusCode(UNAUTHORIZED.getStatusCode()).end(AUTHENTICATION_COMPLETION_EX);
+        }
+
+    }
+
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/main/java/io/quarkus/resteasy/reactive/server/runtime/ResteasyReactiveRecorder.java
@@ -220,9 +220,17 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
                 route.failureHandler(new Handler<RoutingContext>() {
                     @Override
                     public void handle(RoutingContext event) {
-                        if (event.failure() instanceof AuthenticationFailedException
+
+                        // this condition prevent exception mappers from handling auth failure exceptions when proactive
+                        // security is enabled as for now, community decided that's expected behavior and only way for
+                        // users to handle the exceptions is to define their own failure handler as in Reactive Routes
+                        // more info here: https://github.com/quarkusio/quarkus/pull/28648#issuecomment-1287203946
+                        final boolean eventFailedByRESTEasyReactive = event
+                                .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER) instanceof FailingDefaultAuthFailureHandler;
+
+                        if (eventFailedByRESTEasyReactive && (event.failure() instanceof AuthenticationFailedException
                                 || event.failure() instanceof AuthenticationCompletionException
-                                || event.failure() instanceof AuthenticationRedirectException) {
+                                || event.failure() instanceof AuthenticationRedirectException)) {
                             restInitialHandler.beginProcessing(event, event.failure());
                         } else {
                             event.next();
@@ -334,7 +342,14 @@ public class ResteasyReactiveRecorder extends ResteasyReactiveCommonRecorder imp
 
         @Override
         public void accept(RoutingContext event, Throwable throwable) {
-            event.fail(throwable);
+            if (event.failed()) {
+                //auth failure handler should never get called from route failure handlers
+                //but if we get to this point bad things have happened,
+                //so it is better to send a response than to hang
+                event.end();
+            } else {
+                event.fail(throwable);
+            }
         }
     }
 

--- a/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionHandlerTest.java
+++ b/extensions/smallrye-jwt/deployment/src/test/java/io/quarkus/jwt/test/EnabledProactiveAuthFailedExceptionHandlerTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.jwt.test;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpServerResponse;
+
+public class EnabledProactiveAuthFailedExceptionHandlerTest {
+
+    private static final String CUSTOMIZED_RESPONSE = "AuthenticationFailedException";
+    protected static final Class<?>[] classes = { JsonValuejectionEndpoint.class, TokenUtils.class,
+            AuthFailedExceptionFailureHandler.class };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(classes)
+                    .addAsResource(new StringAsset("quarkus.http.auth.proactive=true\n"), "application.properties"));
+
+    @Test
+    public void testExMapperCustomizedResponse() {
+        RestAssured
+                .given()
+                .auth().oauth2("absolute-nonsense")
+                .get("/endp/verifyInjectedIssuer").then()
+                .statusCode(401)
+                .body(Matchers.equalTo(CUSTOMIZED_RESPONSE));
+    }
+
+    public static class AuthFailedExceptionFailureHandler {
+
+        @Route(type = Route.HandlerType.FAILURE)
+        void authFailedExHandler(AuthenticationFailedException e, HttpServerResponse response) {
+            response.setStatusCode(401).end(CUSTOMIZED_RESPONSE);
+        }
+
+    }
+}


### PR DESCRIPTION
fixes: #28489
fixes: #28488

Make it possible to customize response when Quarkus Security authentication exceptions are thrown before JAX-RS chain started. That is done by failing event when proactive security is enabled and ensuring default failure handler `QuarkusErrorHandler` sends response if it wasn't sent downstream. We should provide a way to customize response as users were asking for it and currently it's not possible f.e. when `smallrye-jwt` receives invalid token to customize response.