### PR TITLE
Make quarkus.arc.context-propagation.enabled optional

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcContextPropagationConfig.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.deployment;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -7,10 +9,11 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class ArcContextPropagationConfig {
 
     /**
-     * If set to true and SmallRye Context Propagation extension is present then enable the context propagation for CDI
-     * contexts.
+     * Support for context propagation will be enabled if the {@code quarkus-smallrye-context-propagation} extension is present,
+     * and this value is {@code true}. If this value is unset then the support will be enabled unless the {@code quarkus-vertx}
+     * extension is present and the {@code io.quarkus.vertx.runtime.VertxCurrentContextFactory} is registered.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enabled;
+    @ConfigItem
+    public Optional<Boolean> enabled;
 
 }

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -834,8 +834,11 @@ public class ArcProcessor {
     }
 
     @BuildStep
-    void registerContextPropagation(ArcConfig config, BuildProducer<ThreadContextProviderBuildItem> threadContextProvider) {
-        if (config.contextPropagation.enabled) {
+    void registerContextPropagation(ArcConfig config, Capabilities capabilities,
+            Optional<CurrentContextFactoryBuildItem> currentContextFactory,
+            BuildProducer<ThreadContextProviderBuildItem> threadContextProvider) {
+        if (config.contextPropagation.enabled
+                .orElse(capabilities.isMissing(Capability.VERTX) || currentContextFactory.isEmpty())) {
             threadContextProvider.produce(new ThreadContextProviderBuildItem(ArcContextProvider.class));
         }
     }


### PR DESCRIPTION
- support for context propagation will be enabled if the quarkus-smallrye-context-propagation extension is present and the value is true
- if the value is unset then the support will be enabled unless the quarkus-vertx extension is present and the
io.quarkus.vertx.runtime.VertxCurrentContextFactory is registered

Note that support for context propagation is now enabled by default even if it's not needed when the `VertxCurrentContextFactory` is registered (it does not make use of threadlocals). As a result the `ArcContextProvider` is used and produces unnecessary overhead.