### PR TITLE
Prevent https://bugs.openjdk.org/browse/JDK-8180450 for RESTEasy Reactive code

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/test/java/io/quarkus/resteasy/reactive/runtime/mapping/RequestMapperTestCase.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/runtime/src/test/java/io/quarkus/resteasy/reactive/runtime/mapping/RequestMapperTestCase.java
@@ -1,7 +1,6 @@
 package io.quarkus.resteasy.reactive.runtime.mapping;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.jboss.resteasy.reactive.server.mapping.RequestMapper;
 import org.jboss.resteasy.reactive.server.mapping.URITemplate;
@@ -36,7 +35,7 @@ public class RequestMapperTestCase {
     }
 
     RequestMapper<String> mapper(String... vals) {
-        List<RequestMapper.RequestPath<String>> list = new ArrayList<>();
+        ArrayList<RequestMapper.RequestPath<String>> list = new ArrayList<>();
         for (String i : vals) {
             list.add(new RequestMapper.RequestPath<>(false, new URITemplate(i, false), i));
         }

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/Deployment.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
@@ -42,7 +43,7 @@ public class Deployment {
     private final ThreadSetupAction threadSetupAction;
     private final RequestContextFactory requestContextFactory;
     private final List<ServerRestHandler> preMatchHandlers;
-    private final List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
+    private final ArrayList<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
     private final List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers;
     private final RuntimeExceptionMapper exceptionMapper;
     private final boolean resumeOn404;
@@ -57,7 +58,7 @@ public class Deployment {
             ConfigurationImpl configuration, Supplier<Application> applicationSupplier,
             ThreadSetupAction threadSetupAction, RequestContextFactory requestContextFactory,
             List<ServerRestHandler> preMatchHandlers,
-            List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers,
+            ArrayList<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers,
             List<RuntimeConfigurableServerRestHandler> runtimeConfigurableServerRestHandlers,
             RuntimeExceptionMapper exceptionMapper,
             boolean resumeOn404,
@@ -138,7 +139,7 @@ public class Deployment {
         return preMatchHandlers;
     }
 
-    public List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> getClassMappers() {
+    public ArrayList<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> getClassMappers() {
         return classMappers;
     }
 

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeDeploymentManager.java
@@ -61,7 +61,7 @@ public class RuntimeDeploymentManager {
     private final ThreadSetupAction threadSetupAction;
     private final String rootPath;
 
-    private List<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
+    private ArrayList<RequestMapper.RequestPath<RestInitialHandler.InitialMatch>> classMappers;
 
     public RuntimeDeploymentManager(DeploymentInfo info,
             Supplier<Executor> executorSupplier,

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/startup/RuntimeMappingDeployment.java
@@ -22,7 +22,7 @@ class RuntimeMappingDeployment {
     private final SortedMap<URITemplate, List<RequestMapper.RequestPath<RuntimeResource>>> nullMethod;
 
     private String currentHttpMethod;
-    private List<RequestMapper.RequestPath<RuntimeResource>> currentMapperPerMethodTemplates;
+    private ArrayList<RequestMapper.RequestPath<RuntimeResource>> currentMapperPerMethodTemplates;
 
     private Map<String, RequestMapper<RuntimeResource>> classMapper;
     private int maxMethodTemplateNameCount = -1;

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceLocatorHandler.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/handlers/ResourceLocatorHandler.java
@@ -108,10 +108,10 @@ public class ResourceLocatorHandler implements ServerRestHandler {
         List<Map<String, RequestMapper<RuntimeResource>>> results = new ArrayList<>();
         Set<Class<?>> seen = new HashSet<>();
         findTargetRecursive(locatorClass, results, seen);
-        Map<String, List<RequestMapper.RequestPath<RuntimeResource>>> newMapper = new HashMap<>();
+        Map<String, ArrayList<RequestMapper.RequestPath<RuntimeResource>>> newMapper = new HashMap<>();
         for (Map<String, RequestMapper<RuntimeResource>> i : results) {
             for (Map.Entry<String, RequestMapper<RuntimeResource>> entry : i.entrySet()) {
-                List<RequestMapper.RequestPath<RuntimeResource>> list = newMapper.get(entry.getKey());
+                ArrayList<RequestMapper.RequestPath<RuntimeResource>> list = newMapper.get(entry.getKey());
                 if (list == null) {
                     newMapper.put(entry.getKey(), list = new ArrayList<>());
                 }
@@ -119,7 +119,7 @@ public class ResourceLocatorHandler implements ServerRestHandler {
             }
         }
         Map<String, RequestMapper<RuntimeResource>> finalResult = new HashMap<>();
-        for (Map.Entry<String, List<RequestMapper.RequestPath<RuntimeResource>>> i : newMapper.entrySet()) {
+        for (Map.Entry<String, ArrayList<RequestMapper.RequestPath<RuntimeResource>>> i : newMapper.entrySet()) {
             finalResult.put(i.getKey(), new RequestMapper<RuntimeResource>(i.getValue()));
         }
         //it does not matter if this is computed twice

--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/mapping/RequestMapper.java
@@ -14,18 +14,18 @@ public class RequestMapper<T> {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    private final PathMatcher<List<RequestPath<T>>> requestPaths;
-    private final PathMatcher.Builder<List<RequestPath<T>>> pathMatcherBuilder;
-    private final List<RequestPath<T>> templates;
+    private final PathMatcher<ArrayList<RequestPath<T>>> requestPaths;
+    private final PathMatcher.Builder<ArrayList<RequestPath<T>>> pathMatcherBuilder;
+    private final ArrayList<RequestPath<T>> templates;
     final int maxParams;
 
-    public RequestMapper(List<RequestPath<T>> templates) {
+    public RequestMapper(ArrayList<RequestPath<T>> templates) {
         pathMatcherBuilder = new PathMatcher.Builder<>();
         this.templates = templates;
         int max = 0;
-        Map<String, List<RequestPath<T>>> aggregates = new HashMap<>();
+        Map<String, ArrayList<RequestPath<T>>> aggregates = new HashMap<>();
         for (RequestPath<T> i : templates) {
-            List<RequestPath<T>> paths = aggregates.get(i.template.stem);
+            ArrayList<RequestPath<T>> paths = aggregates.get(i.template.stem);
             if (paths == null) {
                 aggregates.put(i.template.stem, paths = new ArrayList<>());
             }
@@ -47,19 +47,19 @@ public class RequestMapper<T> {
         });
     }
 
-    private void addPrefixPaths(String stem, List<RequestPath<T>> list) {
+    private void addPrefixPaths(String stem, ArrayList<RequestPath<T>> list) {
         pathMatcherBuilder.addPrefixPath(stem, list);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public RequestMatch<T> map(String path) {
         int pathLength = path.length();
-        PathMatcher.PathMatch<List<RequestPath<T>>> initialMatch = requestPaths.match(path);
+        PathMatcher.PathMatch<ArrayList<RequestPath<T>>> initialMatch = requestPaths.match(path);
         if (initialMatch.getValue() == null) {
             return null;
         }
 
-        List<RequestPath<T>> value = initialMatch.getValue();
+        ArrayList<RequestPath<T>> value = initialMatch.getValue();
         for (int index = 0; index < value.size(); index++) {
             RequestPath<T> potentialMatch = value.get(index);
             String[] params = (maxParams > 0) ? new String[maxParams] : EMPTY_STRING_ARRAY;
@@ -193,11 +193,11 @@ public class RequestMapper<T> {
         this.requestPaths.dump(0);
     }
 
-    public PathMatcher<List<RequestPath<T>>> getRequestPaths() {
+    public PathMatcher<ArrayList<RequestPath<T>>> getRequestPaths() {
         return requestPaths;
     }
 
-    public List<RequestPath<T>> getTemplates() {
+    public ArrayList<RequestPath<T>> getTemplates() {
         return templates;
     }
 }


### PR DESCRIPTION
The use of ArrayList (a concrete type) instead of List on some of hot path code can significantly cut down the type pollution for List