### PR TITLE
Remove use/mention of 'compile quarkus:dev'

### DIFF
--- a/docs/src/main/asciidoc/building-my-first-extension.adoc
+++ b/docs/src/main/asciidoc/building-my-first-extension.adoc
@@ -800,7 +800,7 @@ You can launch your application with the following command line:
 
 [source,bash]
 ----
-mvnDebug clean compile quarkus:dev
+mvnDebug quarkus:dev
 ----
 
 By default, Maven will wait for a connection on `localhost:8000`.
@@ -865,20 +865,12 @@ Run the application and notice the `Installed Features` list contains the `greet
 
 [source,shell,subs=attributes+]
 ----
-$ mvn clean compile quarkus:dev
+$ mvn quarkus:dev
 [INFO] Scanning for projects...
 [INFO]
 [INFO] -----------------------< org.acme:greeting-app >------------------------
 [INFO] Building greeting-app 1.0.0-SNAPSHOT
 [INFO] --------------------------------[ jar ]---------------------------------
-[INFO]
-[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ greeting-app ---
-[INFO]
-[INFO] --- quarkus-maven-plugin:{quarkus-version}:generate-code (default) @ greeting-app ---
-[INFO]
-[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ greeting-app ---
-[INFO] Using 'UTF-8' encoding to copy filtered resources.
-[INFO] Copying 1 resource
 [INFO]
 [INFO] --- maven-compiler-plugin:3.13.0:compile (default-compile) @ greeting-app ---
 [INFO] Nothing to compile - all classes are up to date
@@ -889,9 +881,9 @@ __  ____  __  _____   ___  __ ____  ______
  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/
  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/
-2021-01-27 10:28:07,240 INFO  [io.quarkus] (Quarkus Main Thread) greeting-app 1.0.0-SNAPSHOT on JVM (powered by Quarkus {quarkus-version}) started in 0.531s. Listening on: http://localhost:8080
-2021-01-27 10:28:07,242 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2021-01-27 10:28:07,243 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, greeting-extension, servlet]
+2022-11-20 04:25:36,885 INFO  [io.quarkus] (Quarkus Main Thread) greeting-app 1.0.0-SNAPSHOT on JVM (powered by Quarkus {quarkus-version}) started in 4.591s. Listening on: http://localhost:8080
+2022-11-20 04:25:36,911 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
+2022-11-20 04:25:36,913 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, greetin-extension, resteasy-reactive, smallrye-context-propagation, vertx]
 ----
 
 From an extension developer standpoint the Maven publication strategy is very handy and fast but Quarkus wants to go one step further by also ensuring a reliability of the ecosystem for the people who will use the extensions.

--- a/docs/src/main/asciidoc/cdi-reference.adoc
+++ b/docs/src/main/asciidoc/cdi-reference.adoc
@@ -455,7 +455,7 @@ Unused interceptors and decorators are not associated with any bean.
 
 [TIP]
 ====
-When using the dev mode (running `./mvnw clean compile quarkus:dev`), you can see more information about which beans are being removed:
+When using the dev mode (running `./mvnw quarkus:dev`), you can see more information about which beans are being removed:
 
 1. In the console - just enable the DEBUG level in your `application.properties`, i.e. `quarkus.log.category."io.quarkus.arc.processor".level=DEBUG`
 2. In the relevant Dev UI page

--- a/docs/src/main/asciidoc/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka-streams.adoc
@@ -22,7 +22,7 @@ It is recommended, that you have read the link:{quickstarts-tree-url}/kafka-quic
 
 [NOTE]
 ====
-The Quarkus extension for Kafka Streams allows for very fast turnaround times during development by supporting the Quarkus Dev Mode (e.g. via `./mvnw compile quarkus:dev`).
+The Quarkus extension for Kafka Streams allows for very fast turnaround times during development by supporting the Quarkus Dev Mode (e.g. via `./mvnw quarkus:dev`).
 After changing the code of your Kafka Streams topology, the application will automatically be reloaded when the next input message arrives.
 
 A recommended development set-up is to have some producer which creates test messages on the processed topic(s) in fixed intervals, e.g. every second and observe the streaming application's output topic(s) using a tool such as `kafkacat`.

--- a/docs/src/main/asciidoc/openapi-swaggerui.adoc
+++ b/docs/src/main/asciidoc/openapi-swaggerui.adoc
@@ -524,7 +524,7 @@ Now, we are ready to run our application:
 
 [source,bash]
 ----
-./mvnw compile quarkus:dev
+./mvnw quarkus:dev
 ----
 
 You can check the Swagger UI path in your application's log:

--- a/docs/src/main/asciidoc/security-jwt.adoc
+++ b/docs/src/main/asciidoc/security-jwt.adoc
@@ -251,7 +251,7 @@ public class TokenSecuredResource {
 they have either a "User" or "Admin" role assigned.
 <4> Here we build the reply the same way as in the `hello` method but also add a value of the JWT `birthdate` claim by directly calling the injected `JsonWebToken`.
 
-After you make this addition to your `TokenSecuredResource`, rerun the `./mvnw compile quarkus:dev` command, and then try `curl -v http://127.0.0.1:8080/secured/roles-allowed; echo` to attempt to access the new endpoint.
+After you make this addition to your `TokenSecuredResource`, rerun the `./mvnw quarkus:dev` command, and then try `curl -v http://127.0.0.1:8080/secured/roles-allowed; echo` to attempt to access the new endpoint.
 
 Your output should be as follows:
 

--- a/docs/src/main/asciidoc/writing-extensions.adoc
+++ b/docs/src/main/asciidoc/writing-extensions.adoc
@@ -2359,12 +2359,12 @@ as this will only increase the verbosity of logs in the particular test where th
 ==== Multi-module Maven Projects and the Development Mode
 
 It's not uncommon to develop an extension in a multi-module Maven project that also contains an "example" module.
-However, if you want to run the example in the development mode then the `-DnoDeps` system property must be used in order to exclude the local project dependencies.
-Otherwise, Quarkus attempts to monitor the extension classes and this may result in weird class loading issues.
+
+In multi-module Maven projects we recommend to have an explicit `compile` call to ensure compilation happens before the `quarkus:dev` goal is executed.
 
 [source,bash]
 ----
-./mvnw compile quarkus:dev -DnoDeps
+./mvnw compile quarkus:dev
 ----
 
 ==== Indexer does not include your external dependency

--- a/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/codestart.yml
+++ b/independent-projects/tools/base-codestarts/src/main/resources/codestarts/quarkus/buildtool/maven/codestart.yml
@@ -11,7 +11,7 @@ language:
         guide: https://quarkus.io/guides/maven-tooling
         guide-native: https://quarkus.io/guides/building-native-image
         cmd:
-          dev: compile quarkus:dev
+          dev: quarkus:dev
           package: package
           package-uber-jar: package -Dquarkus.package.jar.type=uber-jar
           package-legacy-jar: package -Dquarkus.package.jar.type=legacy-jar

--- a/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
+++ b/independent-projects/tools/devtools-testing/src/main/java/io/quarkus/devtools/testing/codestarts/QuarkusCodestartTest.java
@@ -227,7 +227,7 @@ public class QuarkusCodestartTest implements BeforeAllCallback, AfterAllCallback
      * Very usefull to check if a file contains a specific String:
      * <br>
      * Example:<br>
-     * codestartTest.assertThatGeneratedFile(JAVA, "README.md").satisfies(checkContains("./mvnw compile quarkus:dev
+     * codestartTest.assertThatGeneratedFile(JAVA, "README.md").satisfies(checkContains("./mvnw quarkus:dev
      * -Dquarkus.args='Quarky"));
      *
      * @param language the language

--- a/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
+++ b/independent-projects/tools/devtools-testing/src/test/resources/__snapshots__/QuarkusCodestartGenerationTest/generateDefault/README.md
@@ -9,7 +9,7 @@ If you want to learn more about Quarkus, please visit its website: <https://quar
 You can run your application in dev mode that enables live coding using:
 
 ```shell script
-mvn compile quarkus:dev
+mvn quarkus:dev
 ```
 
 > **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at <http://localhost:8080/q/dev/>.

--- a/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/PicocliCodestartTest.java
+++ b/integration-tests/devtools/src/test/java/io/quarkus/devtools/codestarts/quarkus/PicocliCodestartTest.java
@@ -31,7 +31,7 @@ public class PicocliCodestartTest {
         codestartTest.checkGeneratedSource("org.acme.GreetingCommand");
 
         codestartTest.assertThatGeneratedFile(JAVA, "README.md")
-                .satisfies(checkContains("./mvnw compile quarkus:dev -Dquarkus.args='Quarky"));
+                .satisfies(checkContains("./mvnw quarkus:dev -Dquarkus.args='Quarky"));
 
         codestartGradleTest.assertThatGeneratedFile(JAVA, "README.md")
                 .satisfies(checkContains("./gradlew quarkusDev --quarkus-args='Quarky'"));

--- a/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/elasticsearch-rest-client/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module-kts/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/add-extension-multi-module/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-composite-build-extension-project/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-library-module/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-java-platform-module/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/basic-multi-module-project/application/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/inject-quarkus-app-properties/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/kotlin-grpc-project/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-kotlin-project/web/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-module-parent-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/multi-source-project/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/gradle/src/main/resources/test-resources-vs-main-resources/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/kotlin/src/test/resources/projects/classic-kotlin/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/kotlin/src/test/resources/projects/kotlin-compiler-args/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-inst/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-build/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-build/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-generate/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-generate/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-no-undertow/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-no-undertow/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-noconfig/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-noconfig/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-remote-dev/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic-resource-filtering/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic-resource-filtering/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/classic/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/classic/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-file-deletion/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-file-deletion/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs-with-profile/src/main/resources-primary/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs-with-profile/src/main/resources-primary/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs/src/main/resources-primary/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/dev-mode-multiple-resource-dirs/src/main/resources-primary/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/ignore-entries-uber-jar/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-classpath/html/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-parent-dep/runner/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-revision-prop/html/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule-root-no-src/html/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/multimodule/html/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/project-with-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-expansion/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/property-overrides/runner/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/quarkus.package.output-directory/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rest-client-custom-headers-extension/runner/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/rr-with-json-logging/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/test-module-dependency/app/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/maven/src/test/resources-filtered/projects/uberjar-check/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>

--- a/integration-tests/scala/src/test/resources/projects/classic-scala/src/main/resources/META-INF/resources/index.html
+++ b/integration-tests/scala/src/test/resources/projects/classic-scala/src/main/resources/META-INF/resources/index.html
@@ -114,7 +114,7 @@
 
         <h2>What can I do from here?</h2>
 
-        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn compile quarkus:dev</code>.
+        <p>If not already done, run the application in <em>dev mode</em> using: <code>mvn quarkus:dev</code>.
         </p>
         <ul>
             <li>Add REST resources, Servlets, functions and other services in <code>src/main/java</code>.</li>


### PR DESCRIPTION
`compile quarkus:dev` was needed in pre 1.0 Quarkus - time to remove it as not needed.