### PR TITLE
Propagate the javax.annotation.security annotations in REST Data

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -322,6 +322,26 @@ Default is `false`.
 * `path` - operation path (this is appended to the resource base path). Default is an empty string.
 * `rolesAllowed` - List of the security roles permitted to access this operation. It needs a Quarkus security extension to be present, otherwise it will be ignored. Default is empty.
 
+== Securing endpoints
+
+REST Data with Panache will use the Security annotations within the package `javax.annotation.security` that are defined on your resource interfaces:
+
+[source,java]
+----
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.RolesAllowed;
+
+@DenyAll
+@ResourceProperties
+public interface PeopleResource extends PanacheEntityResource<Person, Long> {
+    @RolesAllowed("superuser")
+    boolean delete(Long id);
+}
+----
+
+Additionally, if you are only interested in specifying the roles that are allowed to use the resources, the `@ResourceProperties` and `@MethodProperties` annotations have the field `rolesAllowed` to list the security roles permitted to access the resource or operation.
+
 == Query parameters
 
 REST Data with Panache supports the following query parameters with the generated resources.

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -318,6 +318,11 @@ For more information, see the link:{vault-guide}[Quarkus and HashiCorp Vault] do
 If your Quarkus Security architecture includes RESTEasy Reactive and Jackson, Quarkus can limit the fields that are included in JSON serialization based on the configured security.
 For more information, see xref:resteasy-reactive.adoc#secure-serialization[Writing REST services with RESTEasy Reactive].
 
+== Secure auto-generated resources by REST Data with Panache
+
+If you're using the REST Data with Panache extension to auto-generate your resources, you can still use the Security annotations within the package `javax.annotation.security`. 
+For more information, see xref:rest-data-panache.adoc#securing-endpoints[Securing auto-generated resources].
+
 == National Vulnerability Database
 
 Most of the Quarkus tags are registered in the US link:https://nvd.nist.gov[National Vulnerability Database] (NVD) in Common Platform Enumeration (CPE) name format.

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/AbstractEntity.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/AbstractEntity.java
@@ -1,0 +1,17 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class AbstractEntity<IdType extends Number> {
+
+    @Id
+    @GeneratedValue
+    private IdType id;
+
+    public IdType getId() {
+        return id;
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/AbstractItem.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/AbstractItem.java
@@ -1,0 +1,25 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+@MappedSuperclass
+public abstract class AbstractItem<IdType extends Number> extends AbstractEntity<IdType> {
+
+    private String name;
+
+    @ManyToOne(optional = false)
+    @JsonProperty(access = Access.WRITE_ONLY)
+    private Collection collection;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/Collection.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/Collection.java
@@ -1,0 +1,45 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+@Entity
+public class Collection {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "collection")
+    private List<Item> items = new LinkedList<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Item> getItems() {
+        return items;
+    }
+
+    public void setItems(List<Item> items) {
+        this.items = items;
+    }
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/CollectionsRepository.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/CollectionsRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+
+@ApplicationScoped
+public class CollectionsRepository implements PanacheRepositoryBase<Collection, String> {
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/CollectionsResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.annotation.security.RolesAllowed;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections", rolesAllowed = "user")
+public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
+    @RolesAllowed("superuser")
+    Collection update(String id, Collection entity);
+
+    @MethodProperties(rolesAllowed = "admin")
+    boolean delete(String name);
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItem.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItem.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.persistence.Entity;
+
+@Entity
+public class EmptyListItem extends AbstractItem<Long> {
+
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItemsRepository.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItemsRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class EmptyListItemsRepository implements PanacheRepository<EmptyListItem> {
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItemsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/EmptyListItemsResource.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties(hal = true)
+public interface EmptyListItemsResource extends PanacheRepositoryResource<EmptyListItemsRepository, EmptyListItem, Long> {
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/Item.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/Item.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Item extends AbstractItem<Long> {
+
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/ItemsRepository.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/ItemsRepository.java
@@ -1,0 +1,9 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class ItemsRepository implements PanacheRepository<Item> {
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/ItemsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/ItemsResource.java
@@ -1,0 +1,8 @@
+package io.quarkus.hibernate.orm.rest.data.panache.deployment.openapi;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
+import io.quarkus.rest.data.panache.ResourceProperties;
+
+@ResourceProperties(hal = true)
+public interface ItemsResource extends PanacheRepositoryResource<ItemsRepository, Item, Long> {
+}

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/openapi/OpenApiIntegrationTest.java
@@ -9,17 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.builder.Version;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractEntity;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.AbstractItem;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.Collection;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.CollectionsRepository;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.CollectionsResource;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItem;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItemsRepository;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.EmptyListItemsResource;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.Item;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsRepository;
-import io.quarkus.hibernate.orm.rest.data.panache.deployment.repository.ItemsResource;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.test.QuarkusProdModeTest;
 import io.restassured.RestAssured;
@@ -73,7 +62,7 @@ class OpenApiIntegrationTest {
                         is(COLLECTIONS_SCHEMA_REF))
                 .body("paths.'/collections/{id}'.put.responses.'201'.content.'application/json'.schema.$ref",
                         is(COLLECTIONS_SCHEMA_REF))
-                .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("user"))
+                .body("paths.'/collections/{id}'.put.security[0].SecurityScheme", Matchers.hasItem("superuser"))
                 .body("paths.'/collections/{id}'", Matchers.hasKey("delete"))
                 .body("paths.'/collections/{id}'.delete.responses", Matchers.hasKey("204"))
                 .body("paths.'/collections/{id}'.delete.security[0].SecurityScheme", Matchers.hasItem("admin"))

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/repository/CollectionsResource.java
@@ -1,11 +1,8 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.repository;
 
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheRepositoryResource;
-import io.quarkus.rest.data.panache.MethodProperties;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
-@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections", rolesAllowed = "user")
+@ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
 public interface CollectionsResource extends PanacheRepositoryResource<CollectionsRepository, Collection, String> {
-    @MethodProperties(rolesAllowed = "admin")
-    boolean delete(String name);
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.Capabilities;
@@ -87,6 +88,11 @@ class JaxRsResourceImplementor {
         if (capabilities.isPresent(Capability.SMALLRYE_OPENAPI)) {
             String className = StringUtils.substringAfterLast(resourceMetadata.getResourceInterface(), ".");
             classCreator.addAnnotation(OPENAPI_TAG_ANNOTATION).add("name", className);
+        }
+        if (resourceProperties.getClassAnnotations() != null) {
+            for (AnnotationInstance classAnnotation : resourceProperties.getClassAnnotations()) {
+                classCreator.addAnnotation(classAnnotation);
+            }
         }
     }
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -106,6 +106,7 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
 
         // Add method annotations
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addPostAnnotation(methodCreator);
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/CountMethodImplementor.java
@@ -80,6 +80,7 @@ public final class CountMethodImplementor extends StandardMethodImplementor {
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), RESOURCE_METHOD_NAME));
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, Long.class, false);
         addSecurityAnnotations(methodCreator, resourceProperties);
         if (!isResteasyClassic()) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/DeleteMethodImplementor.java
@@ -90,6 +90,7 @@ public final class DeleteMethodImplementor extends StandardMethodImplementor {
         addDeleteAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.NO_CONTENT);
         addSecurityAnnotations(methodCreator, resourceProperties);
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/GetMethodImplementor.java
@@ -91,6 +91,7 @@ public final class GetMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_METHOD_NAME), "{id}"));
         addGetAnnotation(methodCreator);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/ListMethodImplementor.java
@@ -143,6 +143,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
@@ -210,6 +211,7 @@ public final class ListMethodImplementor extends StandardMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addProducesAnnotation(methodCreator, APPLICATION_JSON);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.OK, resourceMetadata.getEntityType(), true);
         addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/StandardMethodImplementor.java
@@ -1,5 +1,7 @@
 package io.quarkus.rest.data.panache.deployment.methods;
 
+import java.util.Collection;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -13,6 +15,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.logging.Logger;
 
 import io.quarkus.deployment.Capabilities;
@@ -152,6 +155,14 @@ public abstract class StandardMethodImplementor implements MethodImplementor {
 
     protected void addSortQueryParamValidatorAnnotation(AnnotatedElement element) {
         element.addAnnotation(SortQueryParamValidator.class);
+    }
+
+    protected void addMethodAnnotations(AnnotatedElement element, Collection<AnnotationInstance> methodAnnotations) {
+        if (methodAnnotations != null) {
+            for (AnnotationInstance methodAnnotation : methodAnnotations) {
+                element.addAnnotation(methodAnnotation);
+            }
+        }
     }
 
     protected void addSecurityAnnotations(AnnotatedElement element, ResourceProperties resourceProperties) {

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -143,6 +143,7 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_UPDATE_METHOD_NAME));
         addOpenApiResponseAnnotation(methodCreator, Response.Status.CREATED, resourceMetadata.getEntityType());
         addSecurityAnnotations(methodCreator, resourceProperties);
         // Add parameter annotations

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/hal/ListHalMethodImplementor.java
@@ -134,6 +134,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addSecurityAnnotations(methodCreator, resourceProperties);
         addSortQueryParamValidatorAnnotation(methodCreator);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
@@ -209,6 +210,7 @@ public final class ListHalMethodImplementor extends HalMethodImplementor {
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addGetAnnotation(methodCreator);
         addProducesAnnotation(methodCreator, APPLICATION_HAL_JSON);
+        addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addSecurityAnnotations(methodCreator, resourceProperties);
         addQueryParamAnnotation(methodCreator.getParameterAnnotations(0), "sort");
 

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/MethodProperties.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/MethodProperties.java
@@ -1,5 +1,9 @@
 package io.quarkus.rest.data.panache.deployment.properties;
 
+import java.util.Collection;
+
+import org.jboss.jandex.AnnotationInstance;
+
 public class MethodProperties {
 
     private final boolean exposed;
@@ -8,10 +12,14 @@ public class MethodProperties {
 
     private final String[] rolesAllowed;
 
-    public MethodProperties(boolean exposed, String path, String[] rolesAllowed) {
+    private final Collection<AnnotationInstance> methodAnnotations;
+
+    public MethodProperties(boolean exposed, String path, String[] rolesAllowed,
+            Collection<AnnotationInstance> methodAnnotations) {
         this.exposed = exposed;
         this.path = path;
         this.rolesAllowed = rolesAllowed;
+        this.methodAnnotations = methodAnnotations;
     }
 
     public boolean isExposed() {
@@ -24,5 +32,9 @@ public class MethodProperties {
 
     public String[] getRolesAllowed() {
         return rolesAllowed;
+    }
+
+    public Collection<AnnotationInstance> getMethodAnnotations() {
+        return methodAnnotations;
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourceProperties.java
@@ -1,6 +1,10 @@
 package io.quarkus.rest.data.panache.deployment.properties;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+
+import org.jboss.jandex.AnnotationInstance;
 
 public class ResourceProperties {
 
@@ -16,16 +20,20 @@ public class ResourceProperties {
 
     private final String[] rolesAllowed;
 
+    private final Collection<AnnotationInstance> classAnnotations;
+
     private final Map<String, MethodProperties> methodProperties;
 
     public ResourceProperties(boolean exposed, String path, boolean paged, boolean hal, String halCollectionName,
-            String[] rolesAllowed, Map<String, MethodProperties> methodProperties) {
+            String[] rolesAllowed, Collection<AnnotationInstance> classAnnotations,
+            Map<String, MethodProperties> methodProperties) {
         this.exposed = exposed;
         this.path = path;
         this.paged = paged;
         this.hal = hal;
         this.halCollectionName = halCollectionName;
         this.rolesAllowed = rolesAllowed;
+        this.classAnnotations = classAnnotations;
         this.methodProperties = methodProperties;
     }
 
@@ -78,5 +86,17 @@ public class ResourceProperties {
         }
 
         return rolesAllowed;
+    }
+
+    public Collection<AnnotationInstance> getClassAnnotations() {
+        return classAnnotations;
+    }
+
+    public Collection<AnnotationInstance> getMethodAnnotations(String methodName) {
+        if (methodProperties.containsKey(methodName)) {
+            return methodProperties.get(methodName).getMethodAnnotations();
+        }
+
+        return Collections.emptyList();
     }
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/properties/ResourcePropertiesProvider.java
@@ -1,7 +1,13 @@
 package io.quarkus.rest.data.panache.deployment.properties;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.security.RolesAllowed;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
@@ -19,6 +25,8 @@ public class ResourcePropertiesProvider {
     private static final DotName METHOD_PROPERTIES_ANNOTATION = DotName.createSimple(
             io.quarkus.rest.data.panache.MethodProperties.class.getName());
 
+    private static final List<String> ANNOTATIONS_TO_COPY = List.of(RolesAllowed.class.getPackageName());
+
     private final IndexView index;
 
     public ResourcePropertiesProvider(IndexView index) {
@@ -32,9 +40,6 @@ public class ResourcePropertiesProvider {
     public ResourceProperties getForInterface(String resourceInterface) {
         DotName resourceInterfaceName = DotName.createSimple(resourceInterface);
         AnnotationInstance annotation = findResourcePropertiesAnnotation(resourceInterfaceName);
-        Map<String, MethodProperties> methodProperties = new HashMap<>();
-        collectMethodProperties(resourceInterfaceName, methodProperties);
-
         return new ResourceProperties(
                 isExposed(annotation),
                 getPath(annotation, resourceInterface),
@@ -42,7 +47,28 @@ public class ResourcePropertiesProvider {
                 isHal(annotation),
                 getHalCollectionName(annotation, resourceInterface),
                 getRolesAllowed(annotation),
-                methodProperties);
+                collectAnnotationsToCopy(resourceInterfaceName),
+                collectMethodProperties(resourceInterfaceName));
+    }
+
+    private Collection<AnnotationInstance> collectAnnotationsToCopy(DotName className) {
+        Set<AnnotationInstance> annotations = new HashSet<>();
+        ClassInfo classInfo = index.getClassByName(className);
+        if (classInfo == null) {
+            return annotations;
+        }
+
+        for (AnnotationInstance annotation : classInfo.classAnnotations()) {
+            if (ANNOTATIONS_TO_COPY.stream().anyMatch(annotation.name().toString()::startsWith)) {
+                annotations.add(annotation);
+            }
+        }
+
+        if (classInfo.superName() != null) {
+            annotations.addAll(collectAnnotationsToCopy(classInfo.superName()));
+        }
+
+        return annotations;
     }
 
     private AnnotationInstance findResourcePropertiesAnnotation(DotName className) {
@@ -59,23 +85,36 @@ public class ResourcePropertiesProvider {
         return null;
     }
 
-    private void collectMethodProperties(DotName className, Map<String, MethodProperties> properties) {
+    private Map<String, MethodProperties> collectMethodProperties(DotName className) {
+        Map<String, MethodProperties> methodProperties = new HashMap<>();
         ClassInfo classInfo = index.getClassByName(className);
         if (classInfo == null) {
-            return;
+            return methodProperties;
         }
+
         for (MethodInfo method : classInfo.methods()) {
-            if (!properties.containsKey(method.name()) && method.hasAnnotation(METHOD_PROPERTIES_ANNOTATION)) {
-                properties.put(method.name(), getMethodProperties(method.annotation(METHOD_PROPERTIES_ANNOTATION)));
+            AnnotationInstance annotation = method.annotation(METHOD_PROPERTIES_ANNOTATION);
+            Set<AnnotationInstance> annotationsToCopy = new HashSet<>();
+            for (AnnotationInstance ann : method.annotations()) {
+                if (ANNOTATIONS_TO_COPY.stream().anyMatch(ann.name().toString()::startsWith)) {
+                    annotationsToCopy.add(ann);
+                }
+            }
+
+            if (!methodProperties.containsKey(method.name())
+                    && (annotation != null || !annotationsToCopy.isEmpty())) {
+                methodProperties.put(method.name(), getMethodProperties(annotation, annotationsToCopy));
             }
         }
         if (classInfo.superName() != null) {
-            collectMethodProperties(classInfo.superName(), properties);
+            methodProperties.putAll(collectMethodProperties(classInfo.superName()));
         }
+
+        return methodProperties;
     }
 
-    private MethodProperties getMethodProperties(AnnotationInstance annotation) {
-        return new MethodProperties(isExposed(annotation), getPath(annotation), getRolesAllowed(annotation));
+    private MethodProperties getMethodProperties(AnnotationInstance annotation, Set<AnnotationInstance> annotationsToCopy) {
+        return new MethodProperties(isExposed(annotation), getPath(annotation), getRolesAllowed(annotation), annotationsToCopy);
     }
 
     private boolean isHal(AnnotationInstance annotation) {


### PR DESCRIPTION
With these changes, the REST Data with Panache extension will propagate the Security annotations within the package `javax.annotation.security` that are defined on your resource interfaces:

```java
import javax.annotation.security.DenyAll;
import javax.annotation.security.RolesAllowed;

@DenyAll
@ResourceProperties
public interface PeopleResource extends PanacheEntityResource<Person, Long> {
    @RolesAllowed("superuser")
    boolean delete(Long id);
}
```

Additionally, if you are only interested in specifying the roles that are allowed to use the resources, the `@ResourceProperties` and `@MethodProperties` annotations have the field `rolesAllowed` to list the security roles permitted to access the resource or operation.

Fix https://github.com/quarkusio/quarkus/issues/28995