### PR TITLE
Update to graalvm and mandrel 22.3.0 - 2.13

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -80,7 +80,7 @@
         <maven-toolchain.version>3.0-alpha-2</maven-toolchain.version>
         <plexus-utils.version>3.3.0</plexus-utils.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
-        <graal-sdk.version>22.2.0</graal-sdk.version>
+        <graal-sdk.version>22.3.0</graal-sdk.version>
         <graal-svm.version>${graal-sdk.version}</graal-svm.version>
         <gizmo.version>1.1.1.Final</gizmo.version>
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java
@@ -16,8 +16,8 @@ import io.quarkus.runtime.util.ContainerRuntimeUtil;
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public class NativeConfig {
 
-    public static final String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-native-image:22.2-java17";
-    public static final String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17";
+    public static final String DEFAULT_GRAALVM_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-native-image:22.3-java17";
+    public static final String DEFAULT_MANDREL_BUILDER_IMAGE = "quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17";
 
     /**
      * Comma-separated, additional arguments to pass to the build process.

--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/GraalVM.java
@@ -27,7 +27,7 @@ public final class GraalVM {
         public static final Version VERSION_22_2_0 = new Version("GraalVM 22.2.0", "22.2.0", Distribution.ORACLE);
 
         public static final Version MINIMUM = VERSION_22_2_0;
-        public static final Version CURRENT = VERSION_22_2_0;
+        public static final Version CURRENT = VERSION_22_3_0;
         public static final int UNDEFINED = -1;
 
         final String fullVersion;

--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/ConfigurationSubstitutions.java
@@ -2,8 +2,8 @@ package io.quarkus.runtime.graal;
 
 import org.eclipse.microprofile.config.Config;
 
+import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.AlwaysInline;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <!-- The Graal version we suggest using in documentation - as that's
            what we work with by self downloading it: -->
-        <graal-sdk.version-for-documentation>22.2</graal-sdk.version-for-documentation>
-        <mandrel.version-for-documentation>22.2</mandrel.version-for-documentation>
+        <graal-sdk.version-for-documentation>22.3</graal-sdk.version-for-documentation>
+        <mandrel.version-for-documentation>22.3</mandrel.version-for-documentation>
 
         <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
         <asciidoctorj-pdf.version>1.5.0-beta.8</asciidoctorj-pdf.version>

--- a/docs/src/main/asciidoc/building-native-image.adoc
+++ b/docs/src/main/asciidoc/building-native-image.adoc
@@ -653,10 +653,10 @@ Building fully statically linked binaries enables the usage of a https://hub.doc
 
 Sample multistage Dockerfile for building an image from `scratch`:
 
-[source, dockerfile]
+[source,dockerfile,subs=attributes+]
 ----
 ## Stage 1 : build with maven builder image with native capabilities
-FROM quay.io/quarkus/ubi-quarkus-native-image:22.0-java11 AS build
+FROM quay.io/quarkus/ubi-quarkus-native-image:{graalvm-flavor} AS build
 USER root
 RUN microdnf install make gcc
 COPY --chown=quarkus:quarkus mvnw /code/mvnw

--- a/docs/src/main/asciidoc/doc-reference.adoc
+++ b/docs/src/main/asciidoc/doc-reference.adoc
@@ -299,6 +299,6 @@ The complete list of externalized variables for use is given in the following ta
 |\{quickstarts-tree-url}|{quickstarts-tree-url}| Quickstarts URL to main source tree root; used for referencing directories.
 
 |\{graalvm-version}|{graalvm-version}| Recommended GraalVM version to use.
-|\{graalvm-flavor}|{graalvm-flavor}| The builder image tag of GraalVM to use e.g. `22.2-java17`. Use a `java17` version.
+|\{graalvm-flavor}|{graalvm-flavor}| The builder image tag of GraalVM to use e.g. `22.3-java17`. Use a `java17` version.
 |===
 

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/RemoteOnly.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graal/RemoteOnly.java
@@ -2,8 +2,8 @@ package io.quarkus.jdbc.h2.runtime.graal;
 
 import org.h2.engine.ConnectionInfo;
 
+import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.AlwaysInline;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 

--- a/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
+++ b/extensions/jdbc/jdbc-mssql/runtime/src/main/java/io/quarkus/jdbc/mssql/runtime/graal/com/microsoft/sqlserver/jdbc/SQLServerJDBCSubstitutions.java
@@ -8,7 +8,7 @@ import javax.net.ssl.KeyManager;
 
 import com.microsoft.sqlserver.jdbc.SQLServerException;
 import com.microsoft.sqlserver.jdbc.SQLServerStatement;
-import com.oracle.svm.core.annotate.AlwaysInline;
+import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;

--- a/independent-projects/bootstrap/pom.xml
+++ b/independent-projects/bootstrap/pom.xml
@@ -62,7 +62,7 @@
         <jboss-logmanager-embedded.version>1.0.10</jboss-logmanager-embedded.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
-        <graal-sdk.version>22.2.0</graal-sdk.version>
+        <graal-sdk.version>22.3.0</graal-sdk.version>
         <plexus-classworlds.version>2.6.0</plexus-classworlds.version> <!-- not actually used but ClassRealm class is referenced from the API used in BootstrapWagonConfigurator -->
         <smallrye-common.version>1.13.1</smallrye-common.version>
         <gradle-tooling.version>7.5.1</gradle-tooling.version>


### PR DESCRIPTION
- Update to GraalVM and Mandrel 22.3.0 images
- Use the GraalVM 22.3 AlwaysInline annotation
