### PR TITLE
Prevent possible NPE in OIDC BackChannelLogoutHandler

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -56,9 +56,12 @@ public class BackChannelLogoutHandler {
             LOG.debugf("Back channel logout request for the tenant %s received", oidcTenantConfig.getTenantId().get());
             final TenantConfigContext tenantContext = getTenantConfigContext(context);
             if (tenantContext == null) {
-                LOG.debugf(
+                LOG.errorf(
                         "Tenant configuration for the tenant %s is not available or does not match the backchannel logout path",
                         oidcTenantConfig.getTenantId().get());
+                context.response().setStatusCode(400);
+                context.response().end();
+                return;
             }
 
             if (OidcUtils.isFormUrlEncodedRequest(context)) {


### PR DESCRIPTION
As discovered by @pjgg,  OIDC `BackChannelLogoutHandler` can throw NPE if no tenant configuration matching the back channel logout request has been found. `BackChannelLogoutHandler` checks if the tenant context is null and logs a message but currently forgets end the request, leading to a later NPE where this context is accessed.
OIDC back channel logout spec requires `400` be returned if the logout request is invalid or has failed for whatever reasons, so 400 is returned in this case, https://openid.net/specs/openid-connect-backchannel-1_0.html#BCResponse