### PR TITLE
Updated RunOptions.Semantic option

### DIFF
--- a/docs/src/main/asciidoc/transaction.adoc
+++ b/docs/src/main/asciidoc/transaction.adoc
@@ -189,7 +189,7 @@ public class TransactionExample {
                     }
                     return RunOptions.ExceptionResult.ROLLBACK;
                 })
-                .semantic(RunOptions.Semantic.SUSPEND_EXISTING), () -> {
+                .semantic(RunOptions.Semantic.REQUIRE_NEW), () -> {
             //do work
             return 0;
         });


### PR DESCRIPTION
Updated RunOptions.Semantic example, replaced `RunOptions.Semantic.SUSPEND_EXISTING` with `RunOptions.Semantic.REQUIRE_NEW`.

Existing usage example will by default throw an exception: **java.lang.IllegalStateException: Cannot specify both an exception handler and SUSPEND_EXISTING.**