### PR TITLE
Update the classloading reference guide to mention fast-jar vs legacy-jar

### DIFF
--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -218,6 +218,9 @@
                         <parentFirstArtifact>au.com.dius.pact.core:matcher</parentFirstArtifact>
                         <parentFirstArtifact>au.com.dius.pact.consumer:junit5</parentFirstArtifact>
                         <parentFirstArtifact>au.com.dius.pact:consumer</parentFirstArtifact>
+
+                        <!-- Make use of byteman frictionless -->
+                        <parentFirstArtifact>org.jboss.byteman:byteman</parentFirstArtifact>
                     </parentFirstArtifacts>
                     <runnerParentFirstArtifacts>
                         <runnerParentFirstArtifact>org.graalvm.sdk:graal-sdk</runnerParentFirstArtifact>
@@ -235,6 +238,8 @@
                         <runnerParentFirstArtifact>io.smallrye.common:smallrye-common-io</runnerParentFirstArtifact>
                         <!-- QuarkusEntryPoint needs org-crac class definition -->
                         <runnerParentFirstArtifact>io.github.crac:org-crac</runnerParentFirstArtifact>
+                        <!-- Make use of byteman frictionless -->
+                        <runnerParentFirstArtifact>org.jboss.byteman:byteman</runnerParentFirstArtifact>
                     </runnerParentFirstArtifacts>
                     <excludedArtifacts>
                         <excludedArtifact>io.smallrye:smallrye-config</excludedArtifact>

--- a/docs/src/main/asciidoc/class-loading-reference.adoc
+++ b/docs/src/main/asciidoc/class-loading-reference.adoc
@@ -12,13 +12,19 @@ This document explains the Quarkus class loading architecture. It is intended fo
 authors and advanced users who want to understand exactly how Quarkus works.
 
 The Quarkus class loading architecture is slightly different depending on the mode that
-the application is run in. When running a production application everything is loaded
-in the system ClassLoader, so it is a completely flat class path. This also applies to
-native image mode which does not really support multiple ClassLoaders, and is based on
-a normal production Quarkus application.
+the application is run in.
+
+When running a production application using the `fast-jar` package type
+(which is the default), almost all dependencies are loaded via the `io.quarkus.bootstrap.runner.RunnerClassLoader`
+which indexes class at build time, while a small set of dependencies is loaded from the system ClassLoader.
+
+When running a production application using the `legacy-jar` package type everything is loaded
+in the system ClassLoader, so it is a completely flat classpath.
+
+The flat classpath strategy is also used for GraalVM native images, since GraalVM does not really support multiple ClassLoaders.
 
 For all other use cases (e.g. tests, dev mode, and building the application) Quarkus
-uses the class loading architecture outlined here.
+uses the class loading architecture outlined in following section.
 
 
 == Bootstrapping Quarkus


### PR DESCRIPTION
Also, make byteman parent-first to allow advanced users to use byteman frictionlessly.
 
Closes: #29043