### PR TITLE
Give a DuplicatedContextTest a bit more time

### DIFF
--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/DuplicatedContextTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/DuplicatedContextTest.java
@@ -131,7 +131,7 @@ public class DuplicatedContextTest {
 
         Uni.join().all(unis).andFailFast()
                 .runSubscriptionOn(Infrastructure.getDefaultExecutor())
-                .await().atMost(Duration.ofSeconds(30));
+                .await().atMost(Duration.ofSeconds(60));
 
     }
 


### PR DESCRIPTION
The test is stable on Linux but is not on Windows, which is notoriously slower. So trying to give it a bit more time.