### PR TITLE
H2 embedded: disable support for compiling javascript/groovy triggers

### DIFF
--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/DeleteCompilers.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/DeleteCompilers.java
@@ -1,0 +1,32 @@
+package io.quarkus.jdbc.h2.runtime.graalvm;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@Delete
+@TargetClass(className = "org.h2.util.SourceCompiler$GroovyCompiler")
+final class DeleteGroovyCompiler {
+
+}
+
+@Delete
+@TargetClass(className = "org.h2.util.SourceCompiler$StringJavaFileObject")
+final class DeleteStringJavaFileObject {
+
+}
+
+@Delete
+@TargetClass(className = "org.h2.util.SourceCompiler$JavaClassObject")
+final class DeleteJavaClassObject {
+
+}
+
+@Delete
+@TargetClass(className = "org.h2.util.SourceCompiler$ClassFileManager")
+final class DeleteClassFileManager {
+
+}
+
+public final class DeleteCompilers {
+
+}

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/DisableSourceCompiler.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/DisableSourceCompiler.java
@@ -1,0 +1,50 @@
+package io.quarkus.jdbc.h2.runtime.graalvm;
+
+import java.lang.reflect.Method;
+
+import javax.script.CompiledScript;
+import javax.script.ScriptException;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@Substitute
+@TargetClass(className = "org.h2.util.SourceCompiler")
+public final class DisableSourceCompiler {
+
+    private static final String ERR = "It's not possible to compile H2 triggers when embedding the engine in GraalVM native images";
+
+    //Delete it all
+
+    @Substitute
+    public static boolean isJavaxScriptSource(String source) {
+        throw new UnsupportedOperationException(ERR);
+    }
+
+    @Substitute
+    public CompiledScript getCompiledScript(String packageAndClassName) throws ScriptException {
+        throw new UnsupportedOperationException(ERR);
+    }
+
+    @Substitute
+    public Class<?> getClass(String packageAndClassName)
+            throws ClassNotFoundException {
+        throw new UnsupportedOperationException(ERR);
+    }
+
+    @Substitute
+    public void setSource(String className, String source) {
+        //no-op
+    }
+
+    @Substitute
+    public void setJavaSystemCompiler(boolean enabled) {
+        //no-op
+    }
+
+    @Substitute
+    public Method getMethod(String className) {
+        throw new UnsupportedOperationException(ERR);
+    }
+
+}

--- a/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/NoCompiledTriggersSupport.java
+++ b/extensions/jdbc/jdbc-h2/runtime/src/main/java/io/quarkus/jdbc/h2/runtime/graalvm/NoCompiledTriggersSupport.java
@@ -1,0 +1,18 @@
+package io.quarkus.jdbc.h2.runtime.graalvm;
+
+import org.h2.engine.Database;
+import org.h2.util.SourceCompiler;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(Database.class)
+public final class NoCompiledTriggersSupport {
+
+    @Substitute
+    public SourceCompiler getCompiler() {
+        throw new UnsupportedOperationException(
+                "It's not possible to compile H2 triggers when embedding the engine in GraalVM native images");
+    }
+
+}


### PR DESCRIPTION
Not including aa test as I'm not sure how to trigger it - but this should fix a problem in the ecosystem CI:
 - https://github.com/quarkusio/quarkus/issues/9142

