### PR TITLE
Don't attach an uber-jar without a classifier

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -153,8 +153,12 @@ public class BuildMojo extends QuarkusBootstrapMojo {
                         }
                     }
                     if (uberJarWithSuffix) {
-                        projectHelper.attachArtifact(mavenProject(), result.getJar().getPath().toFile(),
-                                result.getJar().getClassifier());
+                        if (result.getJar().getClassifier().isEmpty()) {
+                            original.setFile(result.getJar().getPath().toFile());
+                        } else {
+                            projectHelper.attachArtifact(mavenProject(), result.getJar().getPath().toFile(),
+                                    result.getJar().getClassifier());
+                        }
                     }
                 }
             } finally {


### PR DESCRIPTION
W/o this change if `quarkus.package.add-runner-suffix=false` add the `quarkus-maven-plugin` is configured with `finalName` matching the project's `artifactId` then `mvn install` will fail on attaching the uber-jar to the project.