### PR TITLE
Allow AuthorizationControllers to access request for their decision

### DIFF
--- a/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AuthorizationController.java
+++ b/extensions/security/runtime-spi/src/main/java/io/quarkus/security/spi/runtime/AuthorizationController.java
@@ -2,6 +2,8 @@ package io.quarkus.security.spi.runtime;
 
 import javax.inject.Singleton;
 
+import io.vertx.ext.web.RoutingContext;
+
 /**
  * controller that allows authorization to be disabled in tests.
  */
@@ -10,5 +12,10 @@ public class AuthorizationController {
 
     public boolean isAuthorizationEnabled() {
         return true;
+    }
+
+    /** Overwrite, if you require routingContext information on HttpAuthorizer#checkPermission processing */
+    public boolean isAuthorizationEnabled(RoutingContext routingContext) {
+        return isAuthorizationEnabled();
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -91,7 +91,7 @@ public class HttpAuthorizer {
      *
      */
     public void checkPermission(RoutingContext routingContext) {
-        if (!controller.isAuthorizationEnabled()) {
+        if (!controller.isAuthorizationEnabled(routingContext)) {
             routingContext.next();
             return;
         }


### PR DESCRIPTION
Explained in https://github.com/quarkusio/quarkus/issues/26724 - this will allow authorization controllers to use request information for their decision making.