### PR TITLE
Keycloak admin client classic - use default Quarkus Jackson serializers also in native mode

### DIFF
--- a/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
+++ b/extensions/keycloak-admin-client/deployment/src/main/java/io/quarkus/keycloak/adminclient/deployment/KeycloakAdminClientProcessor.java
@@ -16,8 +16,10 @@ import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.AdditionalApplicationArchiveMarkerBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 import io.quarkus.keycloak.admin.client.common.AutoCloseableDestroyer;
@@ -43,6 +45,13 @@ public class KeycloakAdminClientProcessor {
                 .constructors(true)
                 .methods(true)
                 .build();
+    }
+
+    @Record(ExecutionTime.STATIC_INIT)
+    @Produce(ServiceStartBuildItem.class)
+    @BuildStep
+    public void integrate(ResteasyKeycloakAdminClientRecorder recorder) {
+        recorder.setClientProvider();
     }
 
     @Record(ExecutionTime.RUNTIME_INIT)

--- a/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
+++ b/extensions/keycloak-admin-client/runtime/src/main/java/io/quarkus/keycloak/adminclient/ResteasyKeycloakAdminClientRecorder.java
@@ -4,8 +4,13 @@ import static io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfigU
 
 import java.util.function.Supplier;
 
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+
+import org.keycloak.admin.client.ClientBuilderWrapper;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.spi.ResteasyClientClassicProvider;
 
 import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig;
 import io.quarkus.runtime.RuntimeValue;
@@ -49,5 +54,16 @@ public class ResteasyKeycloakAdminClientRecorder {
                 return keycloakBuilder.build();
             }
         };
+    }
+
+    public void setClientProvider() {
+        Keycloak.setClientProvider(new ResteasyClientClassicProvider() {
+            @Override
+            public Client newRestEasyClient(Object customJacksonProvider, SSLContext sslContext, boolean disableTrustManager) {
+                // point here is to use default Quarkus providers rather than org.keycloak.admin.client.JacksonProvider
+                // as it doesn't work properly in native mode
+                return ClientBuilderWrapper.create(sslContext, disableTrustManager).build();
+            }
+        });
     }
 }


### PR DESCRIPTION
closes: #29035 

Currently behavior between `quarkus-keycloak-admin-client` and `quarkus-keycloak-admin-client-reactive` differs in native mode where the classic version does fail on uknown properties during JSON deserialization. The reason is that in native `com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider` is missing (so producing `ReflectiveClassBuildItem` would fix the issue) and thus, Quarkus `ObjectMapper` is not loaded as `QuarkusObjectMapperContextResolver` is never called (only in native). This PR prevents Keycloak from using it's own version of `ResteasyJackson2Provider` (`JacksonProvider`), therefore default Quarkus provider is used and Quarkus `ObjectMapper` is used. This is a native issue and we don't have suitable module so no automated tests.