### PR TITLE
Fix logging with panache in interfaces

### DIFF
--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingBean.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingBean.java
@@ -4,7 +4,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
 
 @Singleton
-public class LoggingBean {
+public class LoggingBean implements LoggingInterface {
     // not final to prevent constant inlining
     private static String msg = "Heya!";
 
@@ -18,6 +18,8 @@ public class LoggingBean {
     }
 
     public void doSomething() {
+        inheritedMethod("abc");
+
         if (Log.isDebugEnabled()) {
             Log.debug("starting massive computation");
         }

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingInterface.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingInterface.java
@@ -1,0 +1,9 @@
+package io.quarkus.logging;
+
+public interface LoggingInterface {
+    default void inheritedMethod(String param) {
+        if (Log.isInfoEnabled()) {
+            Log.infof("Default method from interface: %s", param);
+        }
+    }
+}

--- a/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
+++ b/integration-tests/logging-panache/src/test/java/io/quarkus/logging/LoggingWithPanacheTest.java
@@ -17,8 +17,8 @@ import io.quarkus.test.QuarkusUnitTest;
 public class LoggingWithPanacheTest {
     @RegisterExtension
     static final QuarkusUnitTest test = new QuarkusUnitTest()
-            .withApplicationRoot((jar) -> jar
-                    .addClasses(LoggingBean.class, LoggingEntity.class, NoStackTraceTestException.class))
+            .withApplicationRoot((jar) -> jar.addClasses(LoggingBean.class, LoggingInterface.class, LoggingEntity.class,
+                    NoStackTraceTestException.class))
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.logging\".min-level", "TRACE")
             .overrideConfigKey("quarkus.log.category.\"io.quarkus.logging\".level", "TRACE")
             .setLogRecordPredicate(record -> record.getLoggerName().startsWith("io.quarkus.logging.Logging"))
@@ -29,6 +29,7 @@ public class LoggingWithPanacheTest {
                 assertThat(lines).containsExactly(
                         "[INFO] Heya!",
                         "[TRACE] LoggingBean created",
+                        "[INFO] Default method from interface: abc",
                         "[DEBUG] starting massive computation",
                         "[DEBUG] one: 42",
                         "[TRACE] two: 42 | 13",


### PR DESCRIPTION
The logging transformation used to add a `private static final` field to each transformed class. This is invalid in case the transformed class is in fact an interface, because the JVMS requires interface fields to always be `public static final`.

With this commit, the logging transformation still adds `private` fields to regular classes, but when the transformed class is an interface, the generated field is `public`. This is not very nice, but working code trumps aesthetically pleasing code.

Fixes #29072