### PR TITLE
Bump gitflow-incremental-builder from 4.1.1 to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <gitflow-incremental-builder.version>4.1.1</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.2.0</gitflow-incremental-builder.version>
         <quarkus-platform-bom-plugin.version>0.0.51</quarkus-platform-bom-plugin.version>
 
         <skipDocs>false</skipDocs>


### PR DESCRIPTION
Dependabot keeps timing out, so I'm doing it myself.

Nothing special for Quarkus; https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/releases/tag/v4.2.0