### PR TITLE
Add the ability for extensions to configure JAX-RS SubResources as beans

### DIFF
--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveCDIProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveCDIProcessor.java
@@ -25,6 +25,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.resteasy.reactive.common.deployment.ResourceScanningResultBuildItem;
 import io.quarkus.resteasy.reactive.server.runtime.QuarkusContextProducers;
+import io.quarkus.resteasy.reactive.server.spi.SubResourcesAsBeansBuildItem;
 import io.quarkus.resteasy.reactive.spi.DynamicFeatureBuildItem;
 import io.quarkus.resteasy.reactive.spi.JaxrsFeatureBuildItem;
 
@@ -50,6 +51,21 @@ public class ResteasyReactiveCDIProcessor {
         beanDefiningAnnotations
                 .produce(new BeanDefiningAnnotationBuildItem(ResteasyReactiveDotNames.PROVIDER,
                         BuiltinScope.SINGLETON.getName()));
+    }
+
+    @BuildStep
+    void subResourcesAsBeans(ResourceScanningResultBuildItem setupEndpointsResult,
+            List<SubResourcesAsBeansBuildItem> subResourcesAsBeans,
+            BuildProducer<AdditionalBeanBuildItem> producer) {
+        if (subResourcesAsBeans.isEmpty() || setupEndpointsResult.getResult().getPossibleSubResources().isEmpty()) {
+            return;
+        }
+
+        List<String> classNames = new ArrayList<>(setupEndpointsResult.getResult().getPossibleSubResources().size());
+        for (DotName subResourceClass : setupEndpointsResult.getResult().getPossibleSubResources().keySet()) {
+            classNames.add(subResourceClass.toString());
+        }
+        producer.produce(new AdditionalBeanBuildItem(classNames.toArray(new String[0])));
     }
 
     // when an interface is annotated with @Path and there is only one implementation of it that is not annotated with @Path,

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/SubResourcesAsBeansTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/SubResourcesAsBeansTest.java
@@ -1,0 +1,81 @@
+package io.quarkus.resteasy.reactive.server.test;
+
+import static io.restassured.RestAssured.get;
+
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.hamcrest.Matchers;
+import org.jboss.resteasy.reactive.RestPath;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.builder.BuildChainBuilder;
+import io.quarkus.builder.BuildContext;
+import io.quarkus.builder.BuildStep;
+import io.quarkus.resteasy.reactive.server.spi.SubResourcesAsBeansBuildItem;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SubResourcesAsBeansTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .addBuildChainCustomizer(new Consumer<>() {
+                @Override
+                public void accept(BuildChainBuilder buildChainBuilder) {
+                    buildChainBuilder.addBuildStep(new BuildStep() {
+                        @Override
+                        public void execute(BuildContext context) {
+                            context.produce(new SubResourcesAsBeansBuildItem());
+                        }
+                    }).produces(SubResourcesAsBeansBuildItem.class).build();
+                }
+            })
+            .withApplicationRoot((jar) -> jar.addClasses(RestResource.class, MiddleRestResource.class, RestSubResource.class));
+
+    @Test
+    public void testSubResource() {
+        get("/sub-resource/Bob/Builder")
+                .then()
+                .body(Matchers.equalTo("Bob Builder"))
+                .statusCode(200);
+    }
+
+    @Path("/")
+    public static class RestResource {
+
+        private final MiddleRestResource restSubResource;
+
+        public RestResource(MiddleRestResource restSubResource) {
+            this.restSubResource = restSubResource;
+        }
+
+        @Path("sub-resource/{first}")
+        public MiddleRestResource hello(String first) {
+            return restSubResource;
+        }
+    }
+
+    public static class MiddleRestResource {
+
+        @Inject
+        RestSubResource restSubResource;
+
+        @Path("{last}")
+        public RestSubResource hello() {
+            return restSubResource;
+        }
+    }
+
+    public static class RestSubResource {
+
+        @GET
+        public String hello(HttpHeaders headers, @RestPath String first, @RestPath String last) {
+            return first + " " + last;
+        }
+    }
+}

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/SubResourcesAsBeansBuildItem.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/spi-deployment/src/main/java/io/quarkus/resteasy/reactive/server/spi/SubResourcesAsBeansBuildItem.java
@@ -1,0 +1,9 @@
+package io.quarkus.resteasy.reactive.server.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+/**
+ * If an extension generates this, then Quarkus will make JAX-RS Resources beans as well
+ */
+public final class SubResourcesAsBeansBuildItem extends MultiBuildItem {
+}

--- a/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceClass.java
+++ b/independent-projects/resteasy-reactive/common/runtime/src/main/java/org/jboss/resteasy/reactive/common/model/ResourceClass.java
@@ -45,10 +45,6 @@ public class ResourceClass {
      */
     private Map<String, String> classLevelExceptionMappers = new HashMap<>();
 
-    public boolean isSubResource() {
-        return path == null;
-    }
-
     public String getClassName() {
         return className;
     }


### PR DESCRIPTION
This is needed by Keycloak to aid the migration to RESTEasy Reactive

cc @pedroigor 