### PR TITLE
Disable disk allocation in IT and remove prettyPeek()

### DIFF
--- a/integration-tests/logging-gelf/pom.xml
+++ b/integration-tests/logging-gelf/pom.xml
@@ -158,6 +158,11 @@
                                         <env>
                                             <discovery.type>single-node</discovery.type>
                                             <xpack.security.enabled>false</xpack.security.enabled>
+                                            <!--
+                                                Disable disk allocation decider as CI can be low on disk space and we
+                                                only create small indices.
+                                             -->
+                                            <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <log>

--- a/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
+++ b/integration-tests/logging-gelf/src/test/java/io/quarkus/logging/gelf/it/GelfLogHandlerTest.java
@@ -13,8 +13,9 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
 /**
- * This test is disabled by default as it needs a central log management system up and running to be able to be launched.
+ * This test needs a central log management system up and running to be able to be launched.
  * Check the README.md, it contains info of how to launch one prior to this test.
+ * In the CI, containers are launched via the docker-maven-plugin.
  *
  * This test is designed to be launched with ELK as the central management solution as the RestAssured assertion
  * check that a log events is received using the Elasticsearch search API. Launching the test with another solution will
@@ -36,7 +37,6 @@ public class GelfLogHandlerTest {
                             Response response = RestAssured.given()
                                     .when()
                                     .get("http://127.0.0.1:9200/_search?q=message")
-                                    .prettyPeek()
                                     .andReturn();
 
                             assertEquals(200, response.statusCode());


### PR DESCRIPTION
@gsmet This PR disable disk allocation decider based on disk usage, this is what caused CI to fails. I wonder if I should do the same for the other Elasticsearch ITs.

I also remove a prettyPeek that flood the log.