### PR TITLE
Use https instead of ssh so sync is possible to test/try without SSH …

### DIFF
--- a/docs/sync-web-site.sh
+++ b/docs/sync-web-site.sh
@@ -37,11 +37,7 @@ if [ -z $TARGET_DIR ]; then
   if [[ "$QUARKUS_WEB_SITE_PUSH" != "true" ]]; then
     GIT_OPTIONS="--depth=1"
   fi
-  if [ -n "${RELEASE_GITHUB_TOKEN}" ]; then
-    git clone -b develop --single-branch $GIT_OPTIONS https://github.com/quarkusio/quarkusio.github.io.git ${TARGET_DIR}
-  else
-    git clone -b develop --single-branch $GIT_OPTIONS git@github.com:quarkusio/quarkusio.github.io.git ${TARGET_DIR}
-  fi
+  git clone -b develop --single-branch $GIT_OPTIONS https://github.com/quarkusio/quarkusio.github.io.git ${TARGET_DIR}
 fi
 
 if [ $BRANCH == "main" ] && [ "$QUARKUS_RELEASE" == "true" ]; then


### PR DESCRIPTION
Currently when testing docs / website sync a `git@..` based URL is used requiring additional setup to test.

I'm not sure if there is some steps in release process that *requires* use of `git@..` - as far as I'm aware HTTPS allows for same setup of signing etc. at push time; its just that HTTPS more likely to work and first and foremost will work without extra setup for pulling.

Hence my suggestion to change it in this script.

