### PR TITLE
Demote the "test dir mapping" log message to debug

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/extension/QuarkusPluginExtension.java
@@ -77,7 +77,7 @@ public class QuarkusPluginExtension {
                             project.relativePath(outputDirectoryAsFile)))
                     .collect(Collectors.joining(","));
             task.environment(BootstrapConstants.TEST_TO_MAIN_MAPPINGS, fileList);
-            project.getLogger().lifecycle("test dir mapping - {}", fileList);
+            project.getLogger().debug("test dir mapping - {}", fileList);
 
             final String nativeRunner = task.getProject().getBuildDir().toPath().resolve(finalName() + "-runner")
                     .toAbsolutePath()


### PR DESCRIPTION
This log message of the gradle application plugin seems to be unnecessary and confusing to the ordinary plugin user (i.e. a developer building a Quarkus application with Gradle).