### PR TITLE
Upgrade to Mutiny 1.8.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -138,7 +138,7 @@
         <brotli4j.version>1.8.0</brotli4j.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.5.0.Final</jboss-logging.version>
-        <mutiny.version>1.7.0</mutiny.version>
+        <mutiny.version>1.8.0</mutiny.version>
         <kafka3.version>3.3.1</kafka3.version>
         <lz4.version>1.8.0</lz4.version> <!-- dependency of the kafka-clients that could be overridden by other imported BOMs in the platform -->
         <snappy.version>1.1.8.4</snappy.version>

--- a/independent-projects/qute/pom.xml
+++ b/independent-projects/qute/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss-logging>3.5.0.Final</version.jboss-logging>
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
-        <version.smallrye-mutiny>1.7.0</version.smallrye-mutiny>
+        <version.smallrye-mutiny>1.8.0</version.smallrye-mutiny>
     </properties>
 
     <modules>

--- a/independent-projects/resteasy-reactive/pom.xml
+++ b/independent-projects/resteasy-reactive/pom.xml
@@ -55,7 +55,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jakarta.json.version>1.1.6</jakarta.json.version>
-        <mutiny.version>1.7.0</mutiny.version>
+        <mutiny.version>1.8.0</mutiny.version>
         <smallrye-common.version>1.13.2</smallrye-common.version>
         <vertx.version>4.3.4</vertx.version>
         <rest-assured.version>4.5.1</rest-assured.version>


### PR DESCRIPTION
This is a maintenance release, safe to upgrade.