### PR TITLE
Include interfaces as bean types of RR resources

### DIFF
--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Alpha.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Alpha.java
@@ -1,0 +1,4 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+public interface Alpha extends Delta {
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Beta.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Beta.java
@@ -1,0 +1,4 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+public interface Beta extends Delta {
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Charlie.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Charlie.java
@@ -1,0 +1,4 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+public interface Charlie extends Beta {
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Client.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Client.java
@@ -1,0 +1,17 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/")
+@RegisterRestClient(configKey = "hello2")
+public interface Client extends Alpha {
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    String test();
+
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/ClientMock.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/ClientMock.java
@@ -1,0 +1,20 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.arc.Priority;
+
+@Alternative()
+@Priority(1)
+@ApplicationScoped
+@RestClient
+public class ClientMock implements Client, Charlie {
+
+    @Override
+    public String test() {
+        return "hello from " + ClientMock.class;
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Delta.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/Delta.java
@@ -1,0 +1,4 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+public interface Delta {
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/MyBean.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/MyBean.java
@@ -1,0 +1,18 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@ApplicationScoped
+public class MyBean {
+
+    @Inject
+    @RestClient
+    Client client;
+
+    String test() {
+        return client.test();
+    }
+}

--- a/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/ResourceBeanTypeTest.java
+++ b/extensions/resteasy-reactive/rest-client-reactive/deployment/src/test/java/io/quarkus/rest/client/reactive/beanTypes/ResourceBeanTypeTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.rest.client.reactive.beanTypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that resources processed by RR have bean types equivalent to that of the impl class plus all interfaces in
+ * their hierarchy
+ */
+public class ResourceBeanTypeTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(Client.class, ClientMock.class, MyBean.class, Alpha.class, Beta.class,
+                            Charlie.class, Delta.class));
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    void shouldHaveAllInterfaceTypes() {
+        // firstly, sanity check
+        assertThat(myBean.test()).isEqualTo("hello from " + ClientMock.class);
+
+        // now see what types does the Client bean have - the impl class and all interfaces should be in place
+        BeanManager beanManager = Arc.container().beanManager();
+        Set<Bean<?>> beans = beanManager.getBeans(Client.class, RestClient.LITERAL);
+        Bean<?> resolvedBean = beanManager.resolve(beans);
+        assertThat(resolvedBean.getScope()).isEqualTo(ApplicationScoped.class);
+        assertThat(resolvedBean.getTypes()).contains(Client.class, ClientMock.class, Alpha.class, Beta.class, Charlie.class,
+                Delta.class);
+    }
+}


### PR DESCRIPTION
Fixes #29128 

This is a suggestion on how to fix the issue and works with the reproducer provided there. I've also run some basic tests in RR to see if it breaks anything and so far so good.

However, it isn't a silver bullet because there are other scenarios in which this won't suffice. For instance if these resources extend any user defined class and then injection is performed based on that class (which might be uncommon for RR resources anyway?).