### PR TITLE
Use Mandrel by default for container build

### DIFF
--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -719,10 +719,6 @@ jobs:
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install native-image component
-        if: startsWith(matrix.os-name, 'windows')
-        run: |
-          gu.cmd install native-image
       # We do this so we can get better analytics for the downloaded version of the build images
       - name: Update Docker Client User Agent
         shell: bash

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -715,7 +715,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         if: startsWith(matrix.os-name, 'windows')
         with:
-          version: 'latest'
+          version: 'mandrel-latest'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -159,7 +159,7 @@
         <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
 
         <!-- platform properties - this is a floating tag -->
-        <platform.quarkus.native.builder-image>graalvm</platform.quarkus.native.builder-image>
+        <platform.quarkus.native.builder-image>mandrel</platform.quarkus.native.builder-image>
 
         <script.extension>sh</script.extension>
         <docker-prune.location>${maven.multiModuleProjectDirectory}/.github/docker-prune.${script.extension}</docker-prune.location>


### PR DESCRIPTION
Due to a bug in GraalVM, let's default to using Mandrel containers for now.

See:
- https://github.com/quarkusio/quarkus/issues/29124
- https://github.com/oracle/graal/issues/5303

@cescoffier @galderz @zakkak I think that's all that's needed to switch to Mandrel container builds.

@galderz I will wait for your green light before merging this.