### PR TITLE
Generate ID token if it is not refreshed

### DIFF
--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/CustomTenantConfigResolver.java
@@ -126,7 +126,8 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.getToken().setRefreshExpired(true);
                     config.setAuthServerUrl(getIssuerUrl() + "/realms/quarkus-webapp");
                     config.setClientId("quarkus-app-webapp");
-                    config.getCredentials().setSecret("secret");
+                    config.getCredentials().setSecret(
+                            "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow");
 
                     // Let Keycloak issue a login challenge but use the test token endpoint
                     String uri = context.request().absoluteURI();
@@ -137,6 +138,7 @@ public class CustomTenantConfigResolver implements TenantConfigResolver {
                     config.getToken().setIssuer("any");
                     config.tokenStateManager.setSplitTokens(true);
                     config.getAuthentication().setSessionAgeExtension(Duration.ofMinutes(1));
+                    config.getAuthentication().setIdTokenRequired(false);
                     return config;
                 } else if ("tenant-web-app-dynamic".equals(tenantId)) {
                     OidcTenantConfig config = new OidcTenantConfig();

--- a/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
+++ b/integration-tests/oidc-tenancy/src/main/java/io/quarkus/it/keycloak/OidcResource.java
@@ -208,9 +208,8 @@ public class OidcResource {
             // and does not recycle refresh tokens during  the refresh token grant request.
 
             if (refreshEndpointCallCount++ == 0) {
-                // first refresh token request
-                return "{\"id_token\": \"" + jwt("1") + "\"," +
-                        "\"access_token\": \"" + jwt("1") + "\"," +
+                // first refresh token request, check the original ID token is used
+                return "{\"access_token\": \"" + jwt("1") + "\"," +
                         "   \"token_type\": \"Bearer\"," +
                         "   \"expires_in\": 300 }";
             } else {

--- a/integration-tests/oidc-tenancy/src/main/resources/application.properties
+++ b/integration-tests/oidc-tenancy/src/main/resources/application.properties
@@ -107,6 +107,7 @@ quarkus.oidc.tenant-public-key.client-id=test
 quarkus.oidc.tenant-public-key.public-key=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEqFyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwRTYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5eUF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYnsIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9xnQIDAQAB
 
 smallrye.jwt.sign.key.location=/privateKey.pem
+smallrye.jwt.new-token.lifespan=5
 
 quarkus.log.category."com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet".level=FATAL
 quarkus.http.auth.proactive=false


### PR DESCRIPTION
Fixes #29144

This PR addresses a case where a provider does not return a new ID token after a token refresh in a similar way we handle GitHub and other OAuth2-only provider responses for the initial authorization code flow exchanges which is used in Renarde - we generate an internal ID token but besides we also preserve the orginal ID token claims in the newly generated ID token for the application to keep which needs access to the ID token claims - because it works for such application at the start where an original ID token is returned.

Here is a summary, most of the time was spent on getting the test passing:
- Refresh token grant is activated if ID token has expired or nearly expired in which case it is an auto-refresh after the ID token has been verified and confirmed to be valid - so if the refresh token grant response does not return new ID token, to avoid NPE, we now do the following: 1) if it was auto-refresh then keep using the original ID token which is still valid 2) if ID token was expired then generate a new ID token, but retain the original claims minus issued at and expiry claims
- It won't be done by default though, users need to allow it with `quarkus.oidc.authentication.id-token-required=false`
- Updated the test to verify this flow - the `OidcResource` test resource  emulating OIDC provider does not return ID token during the refresh (Keycloak based tests will have real refresh token returned so all the variations are covered)
- Newly generated tokens have 5 mins lifetime by default, so I had to limit it to 5 secs with a smallrye-jwt-build config property since the test expects the session expire after 6+ secs.

This is really it, no OIDC logic is affected, just a support for extending the session in those users where  providers other than Keycloak do not recycle ID tokens...

CC @pedroigor 