### PR TITLE
Update the definition of ignored Kafka client messages

### DIFF
--- a/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
+++ b/extensions/kafka-client/deployment/src/main/java/io/quarkus/kafka/client/deployment/KafkaProcessor.java
@@ -179,7 +179,7 @@ public class KafkaProcessor {
         List<String> ignoredMessages = new ArrayList<>();
         for (String ignoredConfigProperty : ignoredConfigProperties) {
             ignoredMessages
-                    .add("The configuration '" + ignoredConfigProperty + "' was supplied but isn't a known config.");
+                    .add("These configurations '[" + ignoredConfigProperty + "]' were supplied but are not used yet.");
         }
 
         logCleanupFilters.produce(new LogCleanupFilterBuildItem("org.apache.kafka.clients.consumer.ConsumerConfig",


### PR DESCRIPTION
Update the definition of ignored Kafka client messages

Fixes https://github.com/quarkusio/quarkus/issues/29215

Some context:
 - https://github.com/apache/kafka/commit/c5bc2688da5902015e658667186611d5d060070c changes the format of the message
 - `silenceUnwantedConfigLogs` build step was introduced in https://github.com/quarkusio/quarkus/pull/22504