### PR TITLE
RESTEasy Classic - apply exception mappers for auth failures before request processing started

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/HttpPolicyAuthFailureExceptionMapperTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/HttpPolicyAuthFailureExceptionMapperTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.resteasy.test.security;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class HttpPolicyAuthFailureExceptionMapperTest {
+
+    private static final String EXPECTED_RESPONSE = "expect response";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class)
+                    .addAsResource(
+                            new StringAsset("quarkus.http.auth.proactive=false\n" +
+                                    "quarkus.http.auth.permission.basic.paths=/*\n" +
+                                    "quarkus.http.auth.permission.basic.policy=authenticated\n"),
+                            "application.properties"));
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("user", "user", "user");
+    }
+
+    @Test
+    public void testAuthFailedExceptionMapper() {
+        RestAssured
+                .given()
+                .auth().basic("user", "unknown-pwd")
+                .get("/")
+                .then()
+                .statusCode(401)
+                .body(Matchers.equalTo(EXPECTED_RESPONSE));
+    }
+
+    @Provider
+    public static class AuthFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
+
+        @Override
+        public Response toResponse(AuthenticationFailedException exception) {
+            return Response.status(401).entity(EXPECTED_RESPONSE).build();
+        }
+    }
+
+    @Path("hello")
+    public static final class HelloResource {
+
+        @GET
+        public String hello() {
+            return "hello world";
+        }
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/RequestDispatcher.java
@@ -1,6 +1,7 @@
 package io.quarkus.resteasy.runtime.standalone;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.core.ResteasyContext;
@@ -54,7 +55,7 @@ public class RequestDispatcher {
     public void service(Context context,
             HttpServerRequest req,
             HttpServerResponse resp,
-            HttpRequest vertxReq, HttpResponse vertxResp, boolean handleNotFound) throws IOException {
+            HttpRequest vertxReq, HttpResponse vertxResp, boolean handleNotFound, Throwable throwable) throws IOException {
 
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
@@ -69,7 +70,15 @@ public class RequestDispatcher {
                 ResteasyContext.pushContext(HttpServerRequest.class, req);
                 ResteasyContext.pushContext(HttpServerResponse.class, resp);
                 ResteasyContext.pushContext(Vertx.class, context.owner());
-                if (handleNotFound) {
+                if (throwable != null) {
+                    dispatcher.pushContextObjects(vertxReq, vertxResp);
+                    dispatcher.writeException(vertxReq, vertxResp, throwable, new Consumer<Throwable>() {
+                        @Override
+                        public void accept(Throwable throwable) {
+
+                        }
+                    });
+                } else if (handleNotFound) {
                     dispatcher.invoke(vertxReq, vertxResp);
                 } else {
                     dispatcher.invokePropagateNotFound(vertxReq, vertxResp);

--- a/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/AuthFailedExceptionMapper.java
+++ b/integration-tests/elytron-resteasy/src/main/java/io/quarkus/it/resteasy/elytron/AuthFailedExceptionMapper.java
@@ -1,0 +1,18 @@
+package io.quarkus.it.resteasy.elytron;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import io.quarkus.security.AuthenticationFailedException;
+
+@Provider
+public class AuthFailedExceptionMapper implements ExceptionMapper<AuthenticationFailedException> {
+
+    static final String EXPECTED_RESPONSE = "expected response";
+
+    @Override
+    public Response toResponse(AuthenticationFailedException exception) {
+        return Response.status(401).entity(EXPECTED_RESPONSE).build();
+    }
+}

--- a/integration-tests/elytron-resteasy/src/main/resources/application.properties
+++ b/integration-tests/elytron-resteasy/src/main/resources/application.properties
@@ -7,3 +7,7 @@ quarkus.security.users.embedded.users.poul=poul
 quarkus.security.users.embedded.roles.poul=interns
 quarkus.security.users.embedded.plain-text=true
 quarkus.http.auth.basic=true
+
+%auth-failed-ex-mapper.quarkus.http.auth.permission.basic.paths=/*
+%auth-failed-ex-mapper.quarkus.http.auth.permission.basic.policy=authenticated
+%auth-failed-ex-mapper.quarkus.http.auth.proactive=false

--- a/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/HttpPolicyAuthFailedExMapperTest.java
+++ b/integration-tests/elytron-resteasy/src/test/java/io/quarkus/it/resteasy/elytron/HttpPolicyAuthFailedExMapperTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.it.resteasy.elytron;
+
+import static io.quarkus.it.resteasy.elytron.AuthFailedExceptionMapper.EXPECTED_RESPONSE;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+@TestProfile(HttpPolicyAuthFailedExMapperTest.CustomTestProfile.class)
+public class HttpPolicyAuthFailedExMapperTest {
+
+    @Test
+    public void testAuthFailedExceptionMapper() {
+        RestAssured
+                .given()
+                .auth().basic("unknown-user", "unknown-pwd")
+                .contentType(ContentType.TEXT)
+                .get("/")
+                .then()
+                .statusCode(401)
+                .body(Matchers.equalTo(EXPECTED_RESPONSE));
+    }
+
+    public static class CustomTestProfile implements QuarkusTestProfile {
+
+        @Override
+        public String getConfigProfile() {
+            return "auth-failed-ex-mapper";
+        }
+
+    }
+}


### PR DESCRIPTION
fixes: #24790

`ElytronPasswordIdentityProvider` throws `AuthenticationFailedException` when incorrect credentials are provided, in #24790 RESTEasy Classic is used with `quarkus-elytron-security-properties-file` and disabled proactive auth, however it is common issue for all providers that throws auth security exception before RESTEasy Classic started processing the request. This PR fails `RoutingContext` rather than sending response in default auth failure handler. Failure handler then passes exception straight to RESTEasy Classic exception handler. I've done something similar for RESTEasy Reactive here https://github.com/quarkusio/quarkus/pull/28539 and therefore the issue can't be reproduced with RR. Also users expect their exception mappers to handle this situations, because we had multiple similar issues reported in past.