### PR TITLE
Fix AuthenticationRedirectException handling with disabled proactive security

### DIFF
--- a/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
+++ b/extensions/reactive-routes/runtime/src/main/java/io/quarkus/vertx/web/runtime/VertxWebRecorder.java
@@ -146,12 +146,7 @@ public class VertxWebRecorder {
                         @Override
                         protected void proceed(Throwable throwable) {
 
-                            if (event.failed()) {
-                                //auth failure handler should never get called from route failure handlers
-                                //but if we get to this point bad things have happened,
-                                //so it is better to send a response than to hang
-                                event.end();
-                            } else {
+                            if (!event.failed()) {
                                 event.fail(throwable);
                             }
                         }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationRedirectExceptionMapperTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/AuthenticationRedirectExceptionMapperTest.java
@@ -1,0 +1,97 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.FOUND;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class AuthenticationRedirectExceptionMapperTest {
+
+    private static final int EXPECTED_STATUS = 409;
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.proactive=false\n" +
+            "quarkus.http.auth.permission.default.paths=/*\n" +
+            "quarkus.http.auth.permission.default.policy=authenticated";
+
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties"));
+
+    @Test
+    public void testAuthenticationRedirectExceptionMapper() {
+        RestAssured
+                .given()
+                .redirects()
+                .follow(false)
+                .when()
+                .get("/secured-route")
+                .then()
+                .statusCode(EXPECTED_STATUS);
+    }
+
+    public static final class AuthenticationRedirectExceptionMapper {
+
+        @ServerExceptionMapper(AuthenticationRedirectException.class)
+        public Response authenticationRedirectException() {
+            return Response.status(EXPECTED_STATUS).build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class RedirectingAuthenticator implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            throw new AuthenticationRedirectException(FOUND, "https://quarkus.io/");
+        }
+
+        @Override
+        public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+            return Set.of(BaseAuthenticationRequest.class);
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(FOUND, "header-name", "header-value"));
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class BasicIdentityProvider implements IdentityProvider<BaseAuthenticationRequest> {
+
+        @Override
+        public Class<BaseAuthenticationRequest> getRequestType() {
+            return BaseAuthenticationRequest.class;
+        }
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(
+                BaseAuthenticationRequest simpleAuthenticationRequest,
+                AuthenticationRequestContext authenticationRequestContext) {
+            return Uni.createFrom().nothing();
+        }
+    }
+}

--- a/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
+++ b/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/FilterBuildItem.java
@@ -18,6 +18,7 @@ public final class FilterBuildItem extends MultiBuildItem {
 
     private final Handler<RoutingContext> handler;
     private final int priority;
+    private final boolean isFailureHandler;
 
     /**
      * Creates a new instance of {@link FilterBuildItem}.
@@ -28,10 +29,30 @@ public final class FilterBuildItem extends MultiBuildItem {
      */
     public FilterBuildItem(Handler<RoutingContext> handler, int priority) {
         this.handler = handler;
+        checkPriority(priority);
+        this.priority = priority;
+        this.isFailureHandler = false;
+    }
+
+    /**
+     * Creates a new instance of {@link FilterBuildItem}.
+     *
+     * @param handler the handler, if {@code null} the filter won't be used.
+     * @param priority the priority, higher priority gets invoked first. Priority is only used to sort filters, user
+     *        routes are called afterwards. Must be positive.
+     * @param isFailureHandler whether an HTTP request or failure should be routed to a handler.
+     */
+    public FilterBuildItem(Handler<RoutingContext> handler, int priority, boolean isFailureHandler) {
+        this.handler = handler;
+        checkPriority(priority);
+        this.priority = priority;
+        this.isFailureHandler = isFailureHandler;
+    }
+
+    private void checkPriority(int priority) {
         if (priority < 0) {
             throw new IllegalArgumentException("`priority` must be positive");
         }
-        this.priority = priority;
     }
 
     public Handler<RoutingContext> getHandler() {
@@ -42,11 +63,15 @@ public final class FilterBuildItem extends MultiBuildItem {
         return priority;
     }
 
+    public boolean isFailureHandler() {
+        return isFailureHandler;
+    }
+
     /**
      * @return a filter object wrapping the handler and priority.
      */
     public Filter toFilter() {
-        return new Filters.SimpleFilter(handler, priority);
+        return new Filters.SimpleFilter(handler, priority, isFailureHandler);
     }
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java
@@ -366,8 +366,13 @@ public class VertxHttpRecorder {
 
         for (Filter filter : filterList) {
             if (filter.getHandler() != null) {
-                // Filters with high priority gets called first.
-                httpRouteRouter.route().order(-1 * filter.getPriority()).handler(filter.getHandler());
+                if (filter.isFailureHandler()) {
+                    // Filters handling failures with high priority gets called first.
+                    httpRouteRouter.route().order(-1 * filter.getPriority()).failureHandler(filter.getHandler());
+                } else {
+                    // Filters handling HTTP requests with high priority gets called first.
+                    httpRouteRouter.route().order(-1 * filter.getPriority()).handler(filter.getHandler());
+                }
             }
         }
 

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/Filter.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/Filter.java
@@ -1,16 +1,17 @@
 package io.quarkus.vertx.http.runtime.filters;
 
 import io.vertx.core.Handler;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
 /**
- * Represents a Filter, i.e. a route called on every HTTP request.
+ * Represents a Filter, i.e. a route called on every HTTP request or failure (depending on {@link #isFailureHandler()}).
  * The priority attribute allows sorting the filters. Highest priority are called first.
  */
 public interface Filter {
 
     /**
-     * The handler called on HTTP request.
+     * The handler called on HTTP request or failure.
      * It's important that the handler call {@link RoutingContext#next()} to invoke the next filter or the user routes.
      *
      * @return the handler
@@ -21,5 +22,15 @@ public interface Filter {
      * @return the priority of the filter.
      */
     int getPriority();
+
+    /**
+     * Whether to add {@link #getHandler()} as HTTP request handler (via {@link Route#handler(Handler)}) or
+     * as failure handler (via {@link Route#failureHandler(Handler)}).
+     *
+     * @return true if filter should be applied on failures rather than HTTP requests
+     */
+    default boolean isFailureHandler() {
+        return false;
+    }
 
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/Filters.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/filters/Filters.java
@@ -56,6 +56,7 @@ public class Filters {
 
         private Handler<RoutingContext> handler;
         private int priority;
+        private boolean isFailureHandler = false;
 
         @SuppressWarnings("unused")
         public SimpleFilter() {
@@ -63,11 +64,22 @@ public class Filters {
         }
 
         public SimpleFilter(Handler<RoutingContext> handler, int priority) {
+            checkPriority(priority);
+            this.handler = handler;
+            this.priority = priority;
+        }
+
+        public SimpleFilter(Handler<RoutingContext> handler, int priority, boolean isFailureHandler) {
+            checkPriority(priority);
+            this.handler = handler;
+            this.priority = priority;
+            this.isFailureHandler = isFailureHandler;
+        }
+
+        private void checkPriority(int priority) {
             if (priority < 0) {
                 throw new IllegalArgumentException("`priority` cannot be negative");
             }
-            this.handler = handler;
-            this.priority = priority;
         }
 
         public void setHandler(Handler<RoutingContext> handler) {
@@ -88,5 +100,13 @@ public class Filters {
             return priority;
         }
 
+        @Override
+        public boolean isFailureHandler() {
+            return isFailureHandler;
+        }
+
+        public void setFailureHandler(boolean failureHandler) {
+            isFailureHandler = failureHandler;
+        }
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -76,12 +76,7 @@ public class HttpSecurityRecorder {
                         @Override
                         protected void proceed(Throwable throwable) {
 
-                            if (event.failed()) {
-                                //default auth failure handler should never get called from route failure handlers
-                                //but if we get to this point bad things have happened,
-                                //so it is better to send a response than to hang
-                                event.end();
-                            } else {
+                            if (!event.failed()) {
                                 //failing event makes it possible to customize response via failure handlers
                                 //QuarkusErrorHandler will send response if no other failure handler did
                                 event.fail(throwable);
@@ -356,7 +351,7 @@ public class HttpSecurityRecorder {
             return event.get(HttpAuthenticator.class.getName());
         }
 
-        private static Throwable extractRootCause(Throwable throwable) {
+        public static Throwable extractRootCause(Throwable throwable) {
             while ((throwable instanceof CompletionException && throwable.getCause() != null) ||
                     (throwable instanceof CompositeException)) {
                 if (throwable instanceof CompositeException) {


### PR DESCRIPTION
fixes `io.quarkus.it.keycloak.CodeFlowTest.testRPInitiatedLogout`; follow-up for #28539 and #29228

Code flow fails at `testRPInitiatedLogout` as event is failed on HTTP route not created by RESTEasy classic (reactive would fail for same reason). I checked all usages of default auth failure handler and it's not used from failure route (invoked from within failure handler), therefore if event is failed, we can't call next (it would skip one failure handler) neither we can't call end() (as then failed event is never passed to failure handler). For that reason I removed ending event in default auth failure handler, which is de facto same as when default auth failure handler is null (nothing happens); the handler is nullable and always called like this:

```Java
@Override
public void onFailure(Throwable failure) {
    BiConsumer<RoutingContext, Throwable> handler = routingContext
            .get(QuarkusHttpUser.AUTH_FAILURE_HANDLER);
    if (handler != null) {
        handler.accept(routingContext, failure);
    }
}
```

This PR:
- ensures failure handlers that handles auth security exceptions is applied on all routes failures
- takes into consideration that event could be failed already