### PR TITLE
Add http active requests gauge metric

### DIFF
--- a/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpBinderConfiguration.java
+++ b/extensions/micrometer/runtime/src/main/java/io/quarkus/micrometer/runtime/binder/HttpBinderConfiguration.java
@@ -161,6 +161,10 @@ public class HttpBinderConfiguration {
         return "http.server.requests";
     }
 
+    public String getHttpServerActiveRequestsName() {
+        return "http.server.active.requests";
+    }
+
     public String getHttpServerPushName() {
         return "http.server.push";
     }

--- a/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
+++ b/extensions/micrometer/runtime/src/test/java/io/quarkus/micrometer/runtime/binder/vertx/VertxHttpServerMetricsTest.java
@@ -1,5 +1,7 @@
 package io.quarkus.micrometer.runtime.binder.vertx;
 
+import java.util.concurrent.atomic.LongAdder;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,7 @@ public class VertxHttpServerMetricsTest {
 
     @BeforeEach
     public void init() {
-        requestMetric = new HttpRequestMetric("/irrelevant");
+        requestMetric = new HttpRequestMetric("/irrelevant", new LongAdder());
 
         routingContext = Mockito.mock(RoutingContext.class);
         request = Mockito.mock(HttpServerRequestInternal.class);


### PR DESCRIPTION
The original Vertx micrometer metric include the gauge `vertx_http_server_active_requests` which is pretty handy. I was hoping we could add a similar gauge here.