### PR TITLE
Pass quarkus args to dev mode gradle task

### DIFF
--- a/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
+++ b/devtools/gradle/gradle-application-plugin/src/main/java/io/quarkus/gradle/tasks/QuarkusDev.java
@@ -371,6 +371,7 @@ public class QuarkusDev extends QuarkusTask {
                 .debug(System.getProperty("debug"))
                 .debugHost(System.getProperty("debugHost"))
                 .debugPort(System.getProperty("debugPort"))
+                .applicationArgs(System.getProperty("quarkus.args"))
                 .suspend(System.getProperty("suspend"));
         if (System.getProperty(IO_QUARKUS_DEVMODE_ARGS) == null) {
             builder.jvmArgs("-Dquarkus.test.basic-console=true")

--- a/integration-tests/gradle/src/main/resources/basic-java-main-application-project/build.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-main-application-project/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'java'
+    id 'io.quarkus'
+    id 'application'
+}
+
+repositories {
+    mavenLocal {
+        content {
+            includeGroupByRegex 'io.quarkus.*'
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-arc'
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
+application {
+    mainClass = 'org.acme.EntryPoint'
+}
+
+run {
+    // propagate the custom local maven repo, in case it's configured
+    if (System.properties.containsKey('maven.repo.local')) {
+        systemProperty 'maven.repo.local', System.properties.get('maven.repo.local')
+    }
+}
+
+test {
+    systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+}

--- a/integration-tests/gradle/src/main/resources/basic-java-main-application-project/gradle.properties
+++ b/integration-tests/gradle/src/main/resources/basic-java-main-application-project/gradle.properties
@@ -1,0 +1,2 @@
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformGroupId=io.quarkus

--- a/integration-tests/gradle/src/main/resources/basic-java-main-application-project/settings.gradle
+++ b/integration-tests/gradle/src/main/resources/basic-java-main-application-project/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenLocal {
+            content {
+                includeGroupByRegex 'io.quarkus.*'
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+      id 'io.quarkus' version "${quarkusPluginVersion}"
+    }
+}
+rootProject.name='code-with-quarkus'

--- a/integration-tests/gradle/src/main/resources/basic-java-main-application-project/src/main/java/org/acme/EntryPoint.java
+++ b/integration-tests/gradle/src/main/resources/basic-java-main-application-project/src/main/java/org/acme/EntryPoint.java
@@ -1,0 +1,15 @@
+package org.acme;
+
+import java.util.Arrays;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class EntryPoint {
+
+    public static void main(String[] args) {
+        System.out.println("basic-java-main-application-project: args.length: " + args.length);
+        System.out.println("basic-java-main-application-project: args: " + Arrays.toString(args));
+    }
+}

--- a/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicJavaMainApplicationModuleDevModeTest.java
+++ b/integration-tests/gradle/src/test/java/io/quarkus/gradle/devmode/BasicJavaMainApplicationModuleDevModeTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.gradle.devmode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class BasicJavaMainApplicationModuleDevModeTest extends QuarkusDevGradleTestBase {
+    private static final String ARGS_LOG_LINE_PREFIX = "basic-java-main-application-project: args";
+
+    @Override
+    protected String projectDirectoryName() {
+        return "basic-java-main-application-project";
+    }
+
+    @Override
+    protected String[] buildArguments() {
+        return new String[] { "clean", "quarkusDev", "-s", "-Dquarkus.args=param1=1 param2=2" };
+    }
+
+    protected void testDevMode() throws Exception {
+        File logOutput = new File(projectDir, "command-output.log");
+        await().atMost(30, TimeUnit.SECONDS).until(() -> {
+            try {
+                String logLine;
+                RandomAccessFile commandOutputLogFile = new RandomAccessFile(logOutput, "r");
+                while ((logLine = commandOutputLogFile.readLine()) != null) {
+                    if (logLine.startsWith(ARGS_LOG_LINE_PREFIX)) {
+                        commandOutputLogFile.close();
+                        return true;
+                    }
+                }
+                commandOutputLogFile.close();
+                return false;
+            } catch (Exception e) {
+                System.out.println(String.format("e: <message, %s>, <cause, %s>", e.getMessage(), e.getCause()));
+                System.out.println("e: " + Arrays.toString(e.getStackTrace()));
+                return false;
+            }
+        });
+        String argsLengthLogLine = null;
+        String argsLogLine = null;
+        if (logOutput.exists()) {
+            try (BufferedReader reader = Files.newBufferedReader(logOutput.toPath())) {
+                String line = reader.readLine();
+                while (line != null) {
+                    if (line.startsWith(ARGS_LOG_LINE_PREFIX)) {
+                        if (line.contains("length")) {
+                            argsLengthLogLine = line;
+                        } else {
+                            argsLogLine = line;
+                        }
+                    }
+                    line = reader.readLine();
+                }
+            }
+        }
+        assertThat(argsLengthLogLine).isNotNull();
+        assertThat(argsLengthLogLine).isNotEmpty();
+        assertThat(argsLogLine).isNotNull();
+        assertThat(argsLogLine).isNotEmpty();
+        assertThat(argsLengthLogLine).contains("basic-java-main-application-project: args.length: 2");
+        assertThat(argsLogLine).contains("basic-java-main-application-project: args: [param1=1, param2=2]");
+    }
+}


### PR DESCRIPTION
~Tried to build a test case for this fix but wasn't able to do so as `dev` mode doesn't end until you either press `CTRL+C` or `q` (quit) on the console .~

Tested the fix using the [jacobdotcosta/quarkus-issue-28443](https://github.com/jacobdotcosta/quarkus-issue-28443/) project.

Closes #28443 