### PR TITLE
Support HMAC signatures for CSRF tokens

### DIFF
--- a/docs/src/main/asciidoc/security-csrf-prevention.adoc
+++ b/docs/src/main/asciidoc/security-csrf-prevention.adoc
@@ -9,7 +9,7 @@ include::_attributes.adoc[]
 
 https://owasp.org/www-community/attacks/csrf[Cross-Site Request Forgery (CSRF)] is an attack that forces an end user to execute unwanted actions on a web application in which they are currently authenticated.
 
-Quarkus Security provides a CSRF prevention feature which consists of a xref:resteasy-reactive.adoc[RESTEasy Reactive] server filter which creates and verifies CSRF tokens in 'application/x-www-form-urlencoded' and 'multipart/form-data' forms and a Qute HTML form parameter provider which supports the xref:qute-reference.adoc#injecting-beans-directly-in-templates[injection of CSRF tokens in Qute templates].
+Quarkus Security provides a CSRF prevention feature which consists of a xref:resteasy-reactive.adoc[RESTEasy Reactive] server filter which creates and verifies CSRF tokens in `application/x-www-form-urlencoded` and `multipart/form-data` forms and a Qute HTML form parameter provider which supports the xref:qute-reference.adoc#injecting-beans-directly-in-templates[injection of CSRF tokens in Qute templates].
 
 == Creating the Project
 
@@ -111,11 +111,11 @@ public class UserNameResource {
 ----
 <1> Inject the `csrfToken.html` as a `Template`.
 <2> Return the HTML form with a hidden form field containing a CSRF token created by the CSRF filter.
-<3> Handle the form POST request, this method can only be invoked if the CSRF filter has successfully verified the token.
+<3> Handle the POST form request, this method can only be invoked if the CSRF filter has successfully verified the token.
 
 The form POST request will fail with HTTP status `400` if the filter finds the hidden CSRF form field is missing, the CSRF cookie is missing, or if the CSRF form field and CSRF cookie values do not match.
 
-At this stage no additional configuration is needed - by default the CSRF form field and cookie name will be set to `csrf_token`, and the filter will verify the token. But let's change these names:
+At this stage no additional configuration is needed - by default the CSRF form field and cookie name will be set to `csrf_token`, and the filter will verify the token. But you can change these names if you would like:
 
 [source,properties]
 ----
@@ -123,7 +123,105 @@ quarkus.csrf-reactive.form-field-name=csrftoken
 quarkus.csrf-reactive.cookie-name=csrftoken
 ----
 
-Note that the CSRF filter has to read and cache the input stream in order to verify the token. However if you prefer you can compare the CSRF form field and cookie values in the application code:
+== Sign CSRF token
+
+You can get `HMAC` signatures created for the generated CSRF tokens and have these `HMAC` values stored as CSRF token cookies if you would like to avoid the risk of the attackers recreating the CSRF cookie token. All you need to do is to configure a token signature secret which must be at least 32 characters long:
+
+[source,properties]
+----
+quarkus.csrf-reactive.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
+----
+
+== Restrict CSRF token verification
+
+Your JAX-RS endpoint may accept not only HTTP POST requests with `application/x-www-form-urlencoded` or `multipart/form-data` payloads but also payloads with other media types, either on the same or different URL paths, and therefore you would like to avoid verifying the CSRF token in such cases, for example:
+
+[source,java]
+----
+package io.quarkus.it.csrf;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("/service")
+public class UserNameResource {
+
+    @Inject
+    Template csrfToken;
+
+    @GET
+    @Path("/user")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getCsrfTokenForm() {
+        return csrfToken.instance();
+    }
+
+    <1>
+    @POST
+    @Path("/user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postCsrfTokenForm(@FormParam("name") String userName) {
+        return userName;
+    }
+
+    <2>
+    @POST
+    @Path("/user")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postJson(User user) {
+        return user.name;
+    }
+
+    <3>
+    @POST
+    @Path("/users")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String postJson(User user) {
+        return user.name;
+    }
+
+    public static class User {
+        private String name;
+        public String getName() {
+            return this.name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}
+----
+<1> POST form request to `/user`, CSRF token verification is enforced by the CSRF filter
+<2> POST json request to `/user`, CSRF token verification is not needed
+<3> POST json request to `/users`, CSRF token verification is not needed
+
+As you can see a CSRF token verification will be required at the `/service/user` path accepting the `application/x-www-form-urlencoded` payload, but `User` JSON representation posted to both `/service/user` and `/service/users` method will have no CSRF token and therefore the token verification has to be skipped in these cases by restricting it to the specific `/service/user` request path but also allowing not only `application/x-www-form-urlencoded` on this path:
+
+[source,properties]
+----
+# Verify CSRF token only for the `/service/user` path, ignore other paths such as `/service/users`
+quarkus.csrf-reactive.create-token-path=/service/user
+
+# If `/service/user` path accepts not only `application/x-www-form-urlencoded` payloads but also other ones such as JSON then allow them
+quarkus.csrf-reactive.require-form-url-encoded=false
+----
+
+== Verify CSRF token in the application code
+
+If you prefer to compare the CSRF form field and cookie values in the application code then you can do it as follows:
 
 [source,java]
 ----

--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfReactiveConfig.java
@@ -60,10 +60,16 @@ public class CsrfReactiveConfig {
     public Optional<Set<String>> createTokenPath;
 
     /**
-     * The random CSRF token size in bytes.
+     * Random CSRF token size in bytes.
      */
     @ConfigItem(defaultValue = "16")
     public int tokenSize;
+
+    /**
+     * CSRF token HMAC signature key, if this key is set then it must be at least 32 characters long.
+     */
+    @ConfigItem
+    public Optional<String> tokenSignatureKey;
 
     /**
      * Verify CSRF token in the CSRF filter.

--- a/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenUtils.java
+++ b/extensions/csrf-reactive/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenUtils.java
@@ -1,0 +1,42 @@
+package io.quarkus.csrf.reactive.runtime;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jboss.logging.Logger;
+
+public class CsrfTokenUtils {
+    private static final Logger LOG = Logger.getLogger(CsrfTokenUtils.class);
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
+    private CsrfTokenUtils() {
+    }
+
+    public static String signCsrfToken(String encodedCsrfToken, String secretKey) {
+        return signCsrfToken(Base64.getUrlDecoder().decode(encodedCsrfToken), secretKey);
+    }
+
+    public static String signCsrfToken(byte[] csrfToken, String secretKey) {
+        if (secretKey.length() < 32) {
+            LOG.error("Secret keys for signing CSRF tokens must be at least 32 characters long");
+            throw new RuntimeException();
+        }
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(), HMAC_SHA256);
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(secretKeySpec);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(csrfToken));
+        } catch (InvalidKeyException ex) {
+            LOG.error("Invalid secret key for signing the CSRF token");
+            throw new RuntimeException();
+        } catch (NoSuchAlgorithmException ex) {
+            LOG.error("Invalid algorithm for signing the CSRF token");
+            throw new RuntimeException();
+        }
+
+    }
+}

--- a/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
+++ b/integration-tests/csrf-reactive/src/main/java/io/quarkus/it/csrf/TestResource.java
@@ -11,6 +11,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.csrf.reactive.runtime.CsrfTokenUtils;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.vertx.ext.web.RoutingContext;
@@ -56,7 +59,10 @@ public class TestResource {
     public String postCsrfTokenMultipart(@FormParam("name") String name,
             @FormParam("csrf-token") String csrfTokenParam, @CookieParam("csrftoken") Cookie csrfTokenCookie) {
         return name + ":" + routingContext.get("csrf_token_verified", false) + ":"
-                + csrfTokenCookie.getValue().equals(csrfTokenParam);
+                + csrfTokenCookie.getValue().equals(
+                        CsrfTokenUtils.signCsrfToken(csrfTokenParam,
+                                ConfigProvider.getConfig().getValue("quarkus.csrf-reactive.token-signature-key",
+                                        String.class)));
     }
 
     @GET

--- a/integration-tests/csrf-reactive/src/main/resources/application.properties
+++ b/integration-tests/csrf-reactive/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 quarkus.csrf-reactive.cookie-name=csrftoken
 quarkus.csrf-reactive.create-token-path=/service/csrfTokenForm,/service/csrfTokenMultipart
+quarkus.csrf-reactive.token-signature-key=AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow
 


### PR DESCRIPTION
Fixes #28860

I'd like to address this enhancement request first before handling #29187

This PR adds an optional `token-signature-key` property and if it is set then the generated CSRF token cookie will be set as is in the returned hidden form field but the corresponding cookie value will have an HMAC signature of this token instead, and when the user submits the data back to Quarkus it is the signature of the hidden form token which will be compared against this cookie value.

It is simple enough but hard to add new dedicated negative tests since the current tests already fail whenever the cookie and the hidden form token do not match - but we have one test which additionally does the verification directly in the code and thankfully it started failing so it had to be fixed to get the token signature before comparing it with the cookie.

The required secret key length is 32 - since this is recommended everywhere for SHA-256 based functions, so rather than allowing users to set just 4 or similar length secret, it just makes sense to get it right if such kind of CSRF token security is indeed required in production. It will be possible to relax if really necessary though.

Also updated the docs, added more info related to restricting the CSRF token verification