### PR TITLE
Support setting Reactive MySql connection timeout and authentication plugin configuration

### DIFF
--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/DataSourceReactiveMySQLConfig.java
@@ -1,9 +1,11 @@
 package io.quarkus.reactive.mysql.client.runtime;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.vertx.mysqlclient.MySQLAuthenticationPlugin;
 import io.vertx.mysqlclient.SslMode;
 
 @ConfigGroup
@@ -38,4 +40,17 @@ public class DataSourceReactiveMySQLConfig {
      */
     @ConfigItem(defaultValueDocumentation = "disabled")
     public Optional<SslMode> sslMode = Optional.empty();
+
+    /**
+     * Connection timeout in seconds
+     */
+    @ConfigItem()
+    public OptionalInt connectionTimeout = OptionalInt.empty();
+
+    /**
+     * The authentication plugin the client should use.
+     * By default, it uses the plugin name specified by the server in the initial handshake packet.
+     */
+    @ConfigItem(defaultValueDocumentation = "default")
+    public Optional<MySQLAuthenticationPlugin> authenticationPlugin = Optional.empty();
 }

--- a/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
+++ b/extensions/reactive-mysql-client/runtime/src/main/java/io/quarkus/reactive/mysql/client/runtime/MySQLPoolRecorder.java
@@ -103,6 +103,11 @@ public class MySQLPoolRecorder {
             poolOptions.setEventLoopSize(Math.max(0, eventLoopCount));
         }
 
+        if (dataSourceReactiveMySQLConfig.connectionTimeout.isPresent()) {
+            poolOptions.setConnectionTimeout(dataSourceReactiveMySQLConfig.connectionTimeout.getAsInt());
+            poolOptions.setConnectionTimeoutUnit(TimeUnit.SECONDS);
+        }
+
         return poolOptions;
     }
 
@@ -189,6 +194,10 @@ public class MySQLPoolRecorder {
         if (dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm.isPresent()) {
             mysqlConnectOptions.setHostnameVerificationAlgorithm(
                     dataSourceReactiveRuntimeConfig.hostnameVerificationAlgorithm.get());
+        }
+
+        if (dataSourceReactiveMySQLConfig.authenticationPlugin.isPresent()) {
+            mysqlConnectOptions.setAuthenticationPlugin(dataSourceReactiveMySQLConfig.authenticationPlugin.get());
         }
 
         dataSourceReactiveRuntimeConfig.additionalProperties.forEach(mysqlConnectOptions::addProperty);


### PR DESCRIPTION
Support setting authentication plugin - enabling support for rds IAM authentication using mysql_clear_password
Support setting a custom connection time
Fixes #29257