### PR TITLE
quarkus-liquibase-mongodb enhancements

### DIFF
--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/LiquibaseMongodbFactory.java
@@ -40,7 +40,7 @@ public class LiquibaseMongodbFactory {
 
     public Liquibase createLiquibase() {
         String databaseName = this.defaultDatabaseName.orElseThrow(() -> {
-            String propertyName = MongoClientBeanUtil.isDefault(this.liquibaseMongodbConfig.mongoClientName)
+            String propertyName = MongoClientBeanUtil.isDefault(this.mongoClientName)
                     ? "quarkus.mongodb.database"
                     : "quarkus.mongodb." + this.mongoClientName + ".database";
             return new IllegalArgumentException("Config property '" + propertyName + "' must be defined");

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbConfig.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -14,6 +15,12 @@ import io.quarkus.runtime.annotations.ConfigRoot;
  */
 @ConfigRoot(name = "liquibase-mongodb", phase = ConfigPhase.RUN_TIME)
 public class LiquibaseMongodbConfig {
+
+    /**
+     * The name of mongo client
+     */
+    @ConfigItem(defaultValue = MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME)
+    public String mongoClientName;
 
     /**
      * The migrate at start flag

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
@@ -26,7 +26,7 @@ public class LiquibaseMongodbRecorder {
                 MongoClientConfig mongoClientConfig = MongoClientBeanUtil.isDefault(config.mongoClientName)
                         ? mongodbConfig.defaultMongoClientConfig
                         : mongodbConfig.mongoClientConfigs.get(config.mongoClientName);
-                return new LiquibaseMongodbFactory(config, buildTimeConfig, config.mongoClientName, mongoClientConfig.database);
+                return new LiquibaseMongodbFactory(config, buildTimeConfig, config.mongoClientName, mongoClientConfig);
             }
         };
     }

--- a/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
+++ b/extensions/liquibase-mongodb/runtime/src/main/java/io/quarkus/liquibase/mongodb/runtime/LiquibaseMongodbRecorder.java
@@ -20,11 +20,14 @@ public class LiquibaseMongodbRecorder {
 
     public Supplier<LiquibaseMongodbFactory> liquibaseSupplier(LiquibaseMongodbConfig config,
             LiquibaseMongodbBuildTimeConfig buildTimeConfig, MongodbConfig mongodbConfig) {
-        return () -> {
-            MongoClientConfig mongoClientConfig = MongoClientBeanUtil.isDefault(config.mongoClientName)
-                    ? mongodbConfig.defaultMongoClientConfig
-                    : mongodbConfig.mongoClientConfigs.get(config.mongoClientName);
-            return new LiquibaseMongodbFactory(config, buildTimeConfig, config.mongoClientName, mongoClientConfig.database);
+        return new Supplier<LiquibaseMongodbFactory>() {
+            @Override
+            public LiquibaseMongodbFactory get() {
+                MongoClientConfig mongoClientConfig = MongoClientBeanUtil.isDefault(config.mongoClientName)
+                        ? mongodbConfig.defaultMongoClientConfig
+                        : mongodbConfig.mongoClientConfigs.get(config.mongoClientName);
+                return new LiquibaseMongodbFactory(config, buildTimeConfig, config.mongoClientName, mongoClientConfig.database);
+            }
         };
     }
 


### PR DESCRIPTION
This PR introduce the following enhancements to `quarkus-liquibase-mongodb` extension:
* Utilize the existing `MongoClient` for running liquibase migration scripts instead of opening a separate connection
* Allow named `MongoClient` to be used with liquibase
* Allow configurable database, changeLog & changeLogParameters for programatic access using `LiquibaseMongodbFactory`