### PR TITLE
Allows @InjectMock with gRPC Mutiny clients

### DIFF
--- a/docs/src/main/asciidoc/grpc-service-consumption.adoc
+++ b/docs/src/main/asciidoc/grpc-service-consumption.adoc
@@ -404,3 +404,28 @@ By default, when starting the application in dev mode, a gRPC server is started,
 You can configure the gRPC extension's dev mode behavior using the following properties.
 
 include::{generated-dir}/config/quarkus-grpc-config-group-grpc-dev-mode-config.adoc[opts=optional, leveloffset=+1]
+
+== Inject mock clients
+
+In your `@QuarkuTest`, you can use `@InjectMock` to inject the Mutiny client of a gRPC service:
+
+[source, java]
+----
+@QuarkusTest
+public class GrpcMockTest {
+
+    @InjectMock
+    @GrpcClient("hello")
+    Greeter greeter;
+
+    @Test
+    void test1() {
+        HelloRequest request = HelloRequest.newBuilder().setName("neo").build();
+        Mockito.when(greeter.sayHello(Mockito.any(HelloRequest.class)))
+                .thenReturn(Uni.createFrom().item(HelloReply.newBuilder().setMessage("hello neo").build()));
+        Assertions.assertEquals(greeter.sayHello(request).await().indefinitely().getMessage(), "hello neo");
+    }
+}
+----
+
+IMPORTANT: Only the Mutiny client can be _mocked_, channels, and other stubs cannot be mocked.

--- a/extensions/grpc/api/pom.xml
+++ b/extensions/grpc/api/pom.xml
@@ -12,6 +12,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <exclusions>

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcClientUtils.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/GrpcClientUtils.java
@@ -3,6 +3,7 @@ package io.quarkus.grpc;
 import io.grpc.Metadata;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
+import io.quarkus.arc.ClientProxy;
 
 /**
  * gRPC client utilities
@@ -24,6 +25,9 @@ public class GrpcClientUtils {
         if (client == null) {
             throw new NullPointerException("Cannot attach headers to a null client");
         }
+
+        client = getProxiedObject(client);
+
         if (client instanceof AbstractStub) {
             return (T) MetadataUtils.attachHeaders((AbstractStub) client, extraHeaders);
         } else if (client instanceof MutinyClient) {
@@ -33,5 +37,14 @@ public class GrpcClientUtils {
         } else {
             throw new IllegalArgumentException("Unsupported client type " + client.getClass());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getProxiedObject(T client) {
+        // If we get a proxy, get the actual instance.
+        if (client instanceof ClientProxy) {
+            client = (T) ((ClientProxy) client).arc_contextualInstance();
+        }
+        return client;
     }
 }

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/ClientServiceInterfaceCompressionTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/ClientServiceInterfaceCompressionTest.java
@@ -14,6 +14,7 @@ import io.grpc.examples.helloworld.Greeter;
 import io.grpc.examples.helloworld.GreeterClient;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcClientUtils;
 import io.quarkus.grpc.server.services.HelloService;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -31,7 +32,7 @@ public class ClientServiceInterfaceCompressionTest {
 
     @Test
     public void testCallOptions() {
-        GreeterClient client = (GreeterClient) consumer.service;
+        GreeterClient client = (GreeterClient) GrpcClientUtils.getProxiedObject(consumer.service);
         assertEquals("gzip", client.getStub().getCallOptions().getCompressor());
     }
 

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/deadline/ClientDeadlineTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/client/deadline/ClientDeadlineTest.java
@@ -20,6 +20,7 @@ import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.quarkus.grpc.GrpcClient;
+import io.quarkus.grpc.GrpcClientUtils;
 import io.quarkus.test.QuarkusUnitTest;
 
 public class ClientDeadlineTest {
@@ -36,7 +37,7 @@ public class ClientDeadlineTest {
 
     @Test
     public void testCallOptions() {
-        GreeterClient client = (GreeterClient) consumer.service;
+        GreeterClient client = (GreeterClient) GrpcClientUtils.getProxiedObject(consumer.service);
         Deadline deadline = client.getStub().getCallOptions().getDeadline();
         assertNotNull(deadline);
         HelloReply reply = client.sayHello(HelloRequest.newBuilder().setName("Scaladar").build()).onFailure()

--- a/integration-tests/grpc-plain-text-mutiny/pom.xml
+++ b/integration-tests/grpc-plain-text-mutiny/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-test-grpc</artifactId>
       <version>${project.version}</version> <!--kept here to not pollute the BOM-->
       <scope>test</scope>

--- a/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/GrpcMockTest.java
+++ b/integration-tests/grpc-plain-text-mutiny/src/test/java/io/quarkus/grpc/examples/hello/GrpcMockTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.grpc.examples.hello;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import examples.Greeter;
+import examples.HelloReply;
+import examples.HelloRequest;
+import io.quarkus.grpc.GrpcClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.smallrye.mutiny.Uni;
+
+@QuarkusTest
+public class GrpcMockTest {
+
+    @InjectMock
+    @GrpcClient("hello")
+    Greeter greeter;
+
+    @Inject
+    BeanCallingservice beanCallingService;
+
+    @Test
+    void test1() {
+        HelloRequest request = HelloRequest.newBuilder().setName("clement").build();
+        Mockito.when(greeter.sayHello(Mockito.any(HelloRequest.class)))
+                .thenReturn(Uni.createFrom().item(HelloReply.newBuilder().setMessage("hello clement").build()));
+        Assertions.assertEquals(greeter.sayHello(request).await().indefinitely().getMessage(), "hello clement");
+    }
+
+    @Test
+    void test2() {
+        HelloRequest request = HelloRequest.newBuilder().setName("roxanne").build();
+        Mockito.when(greeter.sayHello(request))
+                .thenReturn(Uni.createFrom().item(HelloReply.newBuilder().setMessage("hello roxanne").build()));
+        Assertions.assertEquals(beanCallingService.call(), "hello roxanne");
+    }
+
+    @ApplicationScoped
+    public static class BeanCallingservice {
+        @InjectMock
+        @GrpcClient("hello")
+        Greeter greeter;
+
+        public String call() {
+            return greeter.sayHello(HelloRequest.newBuilder().setName("roxanne").build())
+                    .map(HelloReply::getMessage)
+                    .await().indefinitely();
+        }
+    }
+}


### PR DESCRIPTION
Not completely happy with the solution, but it will allow using `@InjectMock` with gRPC Mutiny clients. 

Fix #23618 
