### PR TITLE
Expose additional methods in REST Data with Panache

### DIFF
--- a/docs/src/main/asciidoc/rest-data-panache.adoc
+++ b/docs/src/main/asciidoc/rest-data-panache.adoc
@@ -322,6 +322,24 @@ Default is `false`.
 * `path` - operation path (this is appended to the resource base path). Default is an empty string.
 * `rolesAllowed` - List of the security roles permitted to access this operation. It needs a Quarkus security extension to be present, otherwise it will be ignored. Default is empty.
 
+== Adding additional methods to the generated resource
+
+You can add additional methods to the generated resources by the REST Data with Panache extension by adding these methods to the resource interface, for example:
+
+[source,java]
+----
+@ResourceProperties
+public interface PeopleResource extends PanacheEntityResource<Person, Long> {
+    @GET
+    @Path("/name/{name}")
+    default List<Person> findByName(@PathParam("name") String name) {
+        return Person.find("name = :name", Collections.singletonMap("name", name)).list();
+    }
+}
+----
+
+And this method will be exposed along with the generated methods using `http://localhost:8080/people/name/Johan`.
+
 == Securing endpoints
 
 REST Data with Panache will use the Security annotations within the package `javax.annotation.security` that are defined on your resource interfaces:

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsResource.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/CollectionsResource.java
@@ -1,8 +1,25 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.rest.data.panache.ResourceProperties;
 
 @ResourceProperties(hal = true, paged = false, halCollectionName = "item-collections")
 public interface CollectionsResource extends PanacheEntityResource<Collection, String> {
+    @GET
+    @Path("/name/{name}")
+    default Collection findByName(@PathParam("name") String name) {
+        List<Collection> collections = Collection.find("name = :name", Collections.singletonMap("name", name)).list();
+        if (collections.isEmpty()) {
+            return null;
+        }
+
+        return collections.get(0);
+    }
 }

--- a/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
+++ b/extensions/panache/hibernate-orm-rest-data-panache/deployment/src/test/java/io/quarkus/hibernate/orm/rest/data/panache/deployment/entity/PanacheEntityResourceGetMethodTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.hibernate.orm.rest.data.panache.deployment.entity;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.hibernate.orm.rest.data.panache.deployment.AbstractGetMethodTest;
@@ -15,4 +19,14 @@ class PanacheEntityResourceGetMethodTest extends AbstractGetMethodTest {
                             EmptyListItem.class, EmptyListItemsResource.class)
                     .addAsResource("application.properties")
                     .addAsResource("import.sql"));
+
+    @Test
+    void shouldCopyAdditionalMethodsAsResources() {
+        given().accept("application/json")
+                .when().get("/collections/name/full collection")
+                .then().statusCode(200)
+                .and().body("id", is("full"))
+                .and().body("name", is("full collection"));
+    }
+
 }

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/JaxRsResourceImplementor.java
@@ -72,6 +72,7 @@ class JaxRsResourceImplementor {
         LOGGER.tracef("Starting generation of '%s'", controllerClassName);
         ClassCreator classCreator = ClassCreator.builder()
                 .classOutput(classOutput).className(controllerClassName)
+                .interfaces(resourceMetadata.getResourceInterface())
                 .build();
 
         implementClassAnnotations(classCreator, resourceMetadata, resourceProperties, capabilities);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/AddMethodImplementor.java
@@ -5,6 +5,7 @@ import static io.quarkus.rest.data.panache.deployment.utils.SignatureMethodCreat
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.gizmo.ClassCreator;
@@ -102,13 +103,14 @@ public final class AddMethodImplementor extends StandardMethodImplementor {
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
                 isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getEntityType());
-        methodCreator.setParameterNames(new String[] { "entity" });
+                resourceMetadata.getEntityType(), UriInfo.class);
+        methodCreator.setParameterNames(new String[] { "entity", "uriInfo" });
 
         // Add method annotations
         addPathAnnotation(methodCreator, resourceProperties.getPath(RESOURCE_METHOD_NAME));
         addMethodAnnotations(methodCreator, resourceProperties.getMethodAnnotations(RESOURCE_METHOD_NAME));
         addPostAnnotation(methodCreator);
+        addContextAnnotation(methodCreator.getParameterAnnotations(1));
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);

--- a/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
+++ b/extensions/panache/rest-data-panache/deployment/src/main/java/io/quarkus/rest/data/panache/deployment/methods/UpdateMethodImplementor.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -134,13 +135,14 @@ public final class UpdateMethodImplementor extends StandardMethodImplementor {
             ResourceProperties resourceProperties, FieldDescriptor resourceField) {
         MethodCreator methodCreator = SignatureMethodCreator.getMethodCreator(METHOD_NAME, classCreator,
                 isNotReactivePanache() ? ofType(Response.class) : ofType(Uni.class, resourceMetadata.getEntityType()),
-                resourceMetadata.getIdType(), resourceMetadata.getEntityType());
-        methodCreator.setParameterNames(new String[] { "id", "entity" });
+                resourceMetadata.getIdType(), resourceMetadata.getEntityType(), UriInfo.class);
+        methodCreator.setParameterNames(new String[] { "id", "entity", "uriInfo" });
 
         // Add method annotations
         addPathAnnotation(methodCreator, appendToPath(resourceProperties.getPath(RESOURCE_UPDATE_METHOD_NAME), "{id}"));
         addPutAnnotation(methodCreator);
         addPathParamAnnotation(methodCreator.getParameterAnnotations(0), "id");
+        addContextAnnotation(methodCreator.getParameterAnnotations(2));
         addConsumesAnnotation(methodCreator, APPLICATION_JSON);
         addProducesJsonAnnotation(methodCreator, resourceProperties);
         addLinksAnnotation(methodCreator, resourceMetadata.getEntityType(), REL);


### PR DESCRIPTION
With these changes, you can add additional methods to the generated resources by the REST Data with Panache extension by adding these methods to the resource interface, for example:

```java
@ResourceProperties
public interface PeopleResource extends PanacheEntityResource<Person, Long> {
    @GET
    @Path("/name/{name}")
    default List<Person> findByName(@PathParam("name") String name) {
        return Person.find("name = :name", Collections.singletonMap("name", name)).list();
    }
}
```

And this method will be exposed along with the generated methods using `http://localhost:8080/people/name/Johan`.

Related to https://groups.google.com/g/quarkus-dev/c/c2FTXsX1fNo/m/qEWtOpzlBQAJ?utm_medium=email&utm_source=footer