### PR TITLE
Prevent on-demand-indexing warnings for missing meta-annotations

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanArchives.java
@@ -55,12 +55,11 @@ public final class BeanArchives {
      * @return the final bean archive index
      */
     public static IndexView buildBeanArchiveIndex(ClassLoader deploymentClassLoader,
-            Map<DotName, Optional<ClassInfo>> persistentClassIndex,
-            IndexView... applicationIndexes) {
+            Map<DotName, Optional<ClassInfo>> additionalClasses, IndexView... applicationIndexes) {
         List<IndexView> indexes = new ArrayList<>();
         Collections.addAll(indexes, applicationIndexes);
         indexes.add(buildAdditionalIndex());
-        return new IndexWrapper(CompositeIndex.create(indexes), deploymentClassLoader, persistentClassIndex);
+        return new IndexWrapper(CompositeIndex.create(indexes), deploymentClassLoader, additionalClasses);
     }
 
     private static IndexView buildAdditionalIndex() {


### PR DESCRIPTION
When the bean archive index is created, annotations present directly on classes are indexed as well. Meta-annotations are not.

On the other hand, the Spring DI extension tries to obtain all meta-annotations from each indexed annotation, transitively, so when it stumbles upon a missing annotation class, the on-demand-indexing `IndexWrapper` prints a warning before remembering that such class doesn't exist.

With this commit, the bean archive index creation process looks at all meta-annotations (only direct, not transitive) and if some of them is missing, the `IndexWrapper` remembers that and can later immediately return `null` without attempting to load the class.

This prevents a meaningless warning for missing annotation classes, which is safe, because annotations in Java are designed to be potentially missing.

Fixes #29206