### PR TITLE
Disable tests failing regularly on M1 host

### DIFF
--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
@@ -112,6 +112,7 @@ public class MailerTest {
     }
 
     @Test
+    @DisabledOnOs(OS.MAC)
     public void sendHtmlEmail() {
         RestAssured.get("/mail/html");
 

--- a/integration-tests/smallrye-opentracing/src/test/java/io/quarkus/it/opentracing/OpenTracingTestCase.java
+++ b/integration-tests/smallrye-opentracing/src/test/java/io/quarkus/it/opentracing/OpenTracingTestCase.java
@@ -22,7 +22,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.common.mapper.TypeRef;
 
 @QuarkusTest
-@DisabledOnOs(OS.WINDOWS)
+@DisabledOnOs({ OS.WINDOWS, OS.MAC })
 public class OpenTracingTestCase {
 
     static GenericContainer postgreSQLContainer;


### PR DESCRIPTION
@holly-cummins it might require some investigation but they are in the way so disabling them for now.