### PR TITLE
Bypass standard Validation resolution process

### DIFF
--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ValidatorFromValidationTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/ValidatorFromValidationTest.java
@@ -1,0 +1,42 @@
+package io.quarkus.hibernate.validator.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.hibernate.validator.test.injection.TestBean;
+import io.quarkus.hibernate.validator.test.injection.TestConstraint;
+import io.quarkus.hibernate.validator.test.injection.TestInjectedBean;
+import io.quarkus.hibernate.validator.test.injection.TestInjectionValidator;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ValidatorFromValidationTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(TestBean.class, TestConstraint.class, TestInjectedBean.class, TestInjectionValidator.class));
+
+    @Test
+    public void testValidationWithInjection() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Set<ConstraintViolation<TestBean>> constraintViolations = validator.validate(new TestBean());
+
+        assertThat(constraintViolations).isNotEmpty();
+
+        TestBean bean = new TestBean();
+        bean.name = "Alpha";
+        constraintViolations = validator.validate(bean);
+        assertThat(constraintViolations).isEmpty();
+    }
+
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationCustomizerTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationCustomizerTest.java
@@ -1,0 +1,44 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Min;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ValidatorFactoryFromValidationCustomizerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class)
+            .addClasses(MyMultipleValidatorFactoryCustomizer.class, MyEmailValidator.class,
+                    MyNumValidator.class));
+
+    @Test
+    public void testOverrideConstraintValidatorConstraint() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        assertThat(validatorFactory.getValidator().validate(new TestBean())).hasSize(2);
+    }
+
+    static class TestBean {
+        @Email
+        public String email;
+
+        @Min(-1)
+        public int num;
+
+        public TestBean() {
+            this.email = "test@acme.com";
+            this.num = -1;
+        }
+    }
+
+}

--- a/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationTest.java
+++ b/extensions/hibernate-validator/deployment/src/test/java/io/quarkus/hibernate/validator/test/validatorfactory/ValidatorFactoryFromValidationTest.java
@@ -1,0 +1,31 @@
+package io.quarkus.hibernate.validator.test.validatorfactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ValidatorFactoryFromValidationTest {
+
+    @Inject
+    ValidatorFactory validatorFactoryFromInjection;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap
+            .create(JavaArchive.class));
+
+    @Test
+    public void testOverrideConstraintValidatorConstraint() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        assertThat(validatorFactoryFromInjection).isSameAs(validatorFactory);
+    }
+
+}

--- a/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidationSupport.java
+++ b/extensions/hibernate-validator/runtime/src/main/java/io/quarkus/hibernate/validator/runtime/ValidationSupport.java
@@ -1,0 +1,34 @@
+package io.quarkus.hibernate.validator.runtime;
+
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+
+public final class ValidationSupport {
+
+    private ValidationSupport() {
+    }
+
+    @SuppressWarnings("unused")
+    public static ValidatorFactory buildDefaultValidatorFactory() {
+        ArcContainer container = Arc.container();
+        if (container == null) {
+            return fallback();
+        }
+
+        InstanceHandle<ValidatorFactory> instance = container.instance(ValidatorFactory.class);
+        if (!instance.isAvailable()) {
+            return fallback();
+        }
+
+        return instance.get();
+    }
+
+    // the point of having this is to support non-Quarkus tests that could be using Hibernate Validator
+    private static ValidatorFactory fallback() {
+        return Validation.byDefaultProvider().configure().buildValidatorFactory();
+    }
+}

--- a/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/Startup.java
+++ b/integration-tests/hibernate-validator/src/main/java/io/quarkus/it/hibernate/validator/Startup.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.hibernate.validator;
+
+import java.util.Objects;
+
+import javax.enterprise.event.Observes;
+import javax.validation.Validation;
+
+import io.quarkus.runtime.StartupEvent;
+
+public class Startup {
+
+    public void onStart(@Observes StartupEvent ev) {
+        Objects.requireNonNull(Validation.buildDefaultValidatorFactory().getValidator());
+    }
+}


### PR DESCRIPTION
The reasoning behind this short-circuiting is to clean up the code-path used when obtaining a Validator object programmatically.
This ultimately makes it possible for code that obtains the Validator object programmatically to work in native mode.

Fixes: #29028
Supersedes: #29205