### PR TITLE
Docs: Fix Typo in RabbitMQ Channel Config

### DIFF
--- a/docs/src/main/asciidoc/rabbitmq-reference.adoc
+++ b/docs/src/main/asciidoc/rabbitmq-reference.adoc
@@ -633,15 +633,15 @@ Type: _long_ | false |
 
 | [.no-hyphens]#*queue.single-active-consumer*# | If set to true, only one consumer can actively consume messages
 
-Type: _boolean_ | false | 'false'
+Type: _boolean_ | false | `false`
 
 | [.no-hyphens]#*queue.x-queue-type*# | If automatically declare queue, we can choose different types of queue [quorum, classic, stream]
 
-Type: _string_ | false | 'classic'
+Type: _string_ | false | `classic`
 
 | [.no-hyphens]#*queue.x-queue-mode*# | If automatically declare queue, we can choose different modes of queue [lazy, default]
 
-Type: _string_ | false | 'default'
+Type: _string_ | false | `default`
 
 | [.no-hyphens]#*max-incoming-internal-queue-size*# | The maximum size of the incoming internal queue
 
@@ -649,7 +649,7 @@ Type: _int_ | false |
 
 | [.no-hyphens]#*connection-count*# | The number of RabbitMQ connections to create for consuming from this queue. This might be necessary to consume from a sharded queue with a single client.
 
-Type: _int_ | false | '1'
+Type: _int_ | false | `1`
 
 | [.no-hyphens]#*auto-bind-dlq*# | Whether to automatically declare the DLQ and bind it to the binder DLX
 


### PR DESCRIPTION
This PR will fix typo made in recent change to Rabbit MQ Connection Documentation #29267.
There are wrong ' so I replaced them with correct ones.

Please squash and merge after review