### PR TITLE
Wait Redis Search Tests - indexation is async

### DIFF
--- a/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
+++ b/extensions/redis-client/runtime/src/test/java/io/quarkus/redis/datasource/SearchCommandsTest.java
@@ -699,8 +699,10 @@ public class SearchCommandsTest extends DatasourceTestBase {
 
         assertThatThrownBy(() -> search.ftAliasAdd("my-index", "idx:movie"));
 
-        var result2 = search.ftAggregate("my-index", "*", new AggregateArgs().allFields());
-        assertThat(result2.count()).isEqualTo(5);
+        await().untilAsserted(() -> {
+            var res = search.ftAggregate("my-index", "*", new AggregateArgs().allFields());
+            assertThat(res.count()).isEqualTo(5);
+        });
 
         search.ftAliasDel("my-index");
         assertThatThrownBy(() -> search.ftAggregate("my-index", "*", new AggregateArgs().allFields()));


### PR DESCRIPTION
Wait until the indexation completes before executing the aggregate query.

The instability comes from the indexation process that runs in the background (asynchronously). So, queries may not have the expected result if the indexation is in progress. 