### PR TITLE
Update to protoc 3.21.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.50.2</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <grpc-jprotoc.version>1.2.1</grpc-jprotoc.version>
-        <protoc.version>3.19.6</protoc.version>
+        <protoc.version>3.21.9</protoc.version>
         <protobuf-java.version>${protoc.version}</protobuf-java.version>
         <proto-google-common-protos.version>2.10.0</proto-google-common-protos.version>
 


### PR DESCRIPTION
This update uses https://github.com/protocolbuffers/protobuf/releases/tag/v21.7, which contains a fix for https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2.
Note that because the fix for that CVE was backported to 3.19, Quarkus is not affected, but better to stay up to date when we can.

Fix #29317
