### PR TITLE
Fix broken markup for a list in security guide

### DIFF
--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -247,6 +247,7 @@ For more information about RBAC and other authorization options in Quarkus, see 
 == Quarkus Security customization
 
 Quarkus Security is highly customizable. You can customize the following core security components of Quarkus:
+
 * `HttpAuthenticationMechanism` 
 * `IdentityProvider` 
 * `SecurityidentityAugmentor`


### PR DESCRIPTION
In [this paragraph](https://quarkus.io/guides/security#quarkus-security-customization), a bulleted list is not properly formatted.