### PR TITLE
Disable MailerTest entirely on macOS and disable Kubernetes Dev Services in micrometer-prometheus IT

### DIFF
--- a/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
+++ b/integration-tests/mailer/src/test/java/io/quarkus/it/mailer/MailerTest.java
@@ -19,7 +19,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
-@DisabledOnOs(OS.WINDOWS)
+@DisabledOnOs({ OS.WINDOWS, OS.MAC })
 @QuarkusTest
 @QuarkusTestResource(FakeMailerTestResource.class)
 public class MailerTest {
@@ -112,7 +112,6 @@ public class MailerTest {
     }
 
     @Test
-    @DisabledOnOs(OS.MAC)
     public void sendHtmlEmail() {
         RestAssured.get("/mail/html");
 

--- a/integration-tests/micrometer-prometheus/pom.xml
+++ b/integration-tests/micrometer-prometheus/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Hibernate -->

--- a/integration-tests/micrometer-prometheus/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus/src/main/resources/application.properties
@@ -25,3 +25,6 @@ quarkus.rest-client.pingpong.url=${test.url}
 quarkus.rest-client.read-timeout=1000
 
 deployment.env=test
+
+# Disable Kubernetes dev services as not supported on Windows
+quarkus.kubernetes-client.devservices.enabled=false


### PR DESCRIPTION
Docker containers are not supported on Windows so we cannot start the Kubernetes Dev Service there.