### PR TITLE
Rename method names in virtual threads doc

### DIFF
--- a/docs/src/main/asciidoc/virtual-threads.adoc
+++ b/docs/src/main/asciidoc/virtual-threads.adoc
@@ -243,7 +243,7 @@ public class FortuneResource {
 
     @GET
     @Path("/quoted-reactive")
-    public Uni<List<Fortune>> getAllQuoted() {
+    public Uni<List<Fortune>> getAllQuotedReactive() {
         // we first fetch the list of resource and we memoize it
         // to avoid fetching it again everytime need it
         var fortunes = repository.findAllAsync().memoize().indefinitely();
@@ -268,7 +268,7 @@ public class FortuneResource {
     @GET
     @RunOnVirtualThread
     @Path("/quoted-virtual-thread")
-    public List<Fortune> getAllQuotedBlocking() {
+    public List<Fortune> getAllQuotedVirtualThread() {
         //we get the list of fortunes
         var fortunes = repository.findAllAsyncAndAwait();
 


### PR DESCRIPTION
`getAllQuotedBlocking()` is duplicated, so I renamed the methods according to the request path.