### PR TITLE
Support for forwarding query params in OIDC

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/OidcTenantConfig.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import io.quarkus.oidc.common.runtime.OidcCommonConfig;
 import io.quarkus.oidc.common.runtime.OidcConstants;
@@ -14,6 +15,9 @@ import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConvertWith;
+import io.quarkus.runtime.configuration.TrimmedStringConverter;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
 
 @ConfigGroup
 public class OidcTenantConfig extends OidcCommonConfig {
@@ -707,7 +711,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
          * Additional properties which will be added as the query parameters to the authentication redirect URI.
          */
         @ConfigItem
-        public Map<String, String> extraParams;
+        public Map<String, String> extraParams = new HashMap<>();
+
+        /**
+         * Request URL query parameters which, if present, will be added to the authentication redirect URI.
+         */
+        @ConfigItem
+        @ConvertWith(TrimmedStringConverter.class)
+        public Optional<List<String>> forwardParams = Optional.empty();
 
         /**
          * If enabled the state, session and post logout cookies will have their 'secure' parameter set to 'true'
@@ -964,6 +975,14 @@ public class OidcTenantConfig extends OidcCommonConfig {
 
         public void setResponseMode(ResponseMode responseMode) {
             this.responseMode = Optional.of(responseMode);
+        }
+
+        public Optional<List<String>> getForwardParams() {
+            return forwardParams;
+        }
+
+        public void setForwardParams(List<String> forwardParams) {
+            this.forwardParams = Optional.of(forwardParams);
         }
     }
 

--- a/integration-tests/oidc-code-flow/src/main/resources/application.properties
+++ b/integration-tests/oidc-code-flow/src/main/resources/application.properties
@@ -100,6 +100,7 @@ quarkus.oidc.tenant-https.client-id=quarkus-app
 quarkus.oidc.tenant-https.credentials.secret=secret
 quarkus.oidc.tenant-https.authentication.scopes=profile,email,phone
 quarkus.oidc.tenant-https.authentication.extra-params.max-age=60
+quarkus.oidc.tenant-https.authentication.forward-params=kc_idp_hint
 quarkus.oidc.tenant-https.application-type=web-app
 quarkus.oidc.tenant-https.authentication.force-redirect-https-scheme=true
 quarkus.oidc.tenant-https.authentication.cookie-suffix=test

--- a/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
+++ b/integration-tests/oidc-code-flow/src/test/java/io/quarkus/it/keycloak/CodeFlowTest.java
@@ -2,6 +2,7 @@ package io.quarkus.it.keycloak;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -221,8 +222,12 @@ public class CodeFlowTest {
 
             WebResponse webResponse = webClient
                     .loadWebResponse(
-                            new WebRequest(URI.create("http://localhost:8081/tenant-https/query?code=b").toURL()));
+                            new WebRequest(
+                                    URI.create("http://localhost:8081/tenant-https/query?code=b&kc_idp_hint=google").toURL()));
             String keycloakUrl = webResponse.getResponseHeaderValue("location");
+            String keycloakUrlQuery = URI.create(keycloakUrl).getQuery();
+            assertTrue(keycloakUrlQuery.contains("kc_idp_hint=google"));
+            assertFalse(keycloakUrlQuery.contains("code=b"));
             verifyLocationHeader(webClient, keycloakUrl, "tenant-https_test", "tenant-https",
                     true);
 


### PR DESCRIPTION
Fixes #29345

Simple PR to allow configuring a list of query parameter names, which, if present in the request URL query scheme, will be included in the redirect URL to Keycloak/etc - users decide if it is possible to do.