### PR TITLE
Prevent repeated processing of the same authentication failure exception

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/HttpPolicyAuthFailureExceptionMapperTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/HttpPolicyAuthFailureExceptionMapperTest.java
@@ -1,5 +1,9 @@
 package io.quarkus.resteasy.test.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -21,6 +25,11 @@ import io.restassured.RestAssured;
 public class HttpPolicyAuthFailureExceptionMapperTest {
 
     private static final String EXPECTED_RESPONSE = "expect response";
+
+    /**
+     * Number of times exception mappers was invoked.
+     */
+    private static final AtomicInteger EXCEPTION_MAPPER_INVOCATION_COUNT = new AtomicInteger(0);
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
@@ -47,6 +56,9 @@ public class HttpPolicyAuthFailureExceptionMapperTest {
                 .then()
                 .statusCode(401)
                 .body(Matchers.equalTo(EXPECTED_RESPONSE));
+
+        assertEquals(1, EXCEPTION_MAPPER_INVOCATION_COUNT.get(),
+                "Exception mapper was invoked more than once during one request.");
     }
 
     @Provider
@@ -54,6 +66,7 @@ public class HttpPolicyAuthFailureExceptionMapperTest {
 
         @Override
         public Response toResponse(AuthenticationFailedException exception) {
+            EXCEPTION_MAPPER_INVOCATION_COUNT.incrementAndGet();
             return Response.status(401).entity(EXPECTED_RESPONSE).build();
         }
     }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -138,7 +138,9 @@ public class HttpAuthorizer {
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) {
-                        if (!routingContext.response().ended()) {
+                        // we don't fail event if it's already failed with same exception as we don't want to process
+                        // the exception twice;at this point, the exception could be failed by the default auth failure handler
+                        if (!routingContext.response().ended() && !throwable.equals(routingContext.failure())) {
                             routingContext.fail(throwable);
                         } else if (!(throwable instanceof AuthenticationFailedException)) {
                             //don't log auth failure


### PR DESCRIPTION
addresses: https://github.com/quarkusio/quarkus/pull/29342#issuecomment-1319337932

When debugging linked comment, I mentioned authentication failure is failed twice, first time by the default auth failure handler and then, by the permission check throwable consumer here https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java#L142. When failed event is failed with the same exception, failure handler chain is applied second time and exception mapper is invoked second time. It didn't really cause an issue for what I could see, but it's not desirable and might be related to the linked test failure (that I couldn't reproduce a single time).