### PR TITLE
Update Windows CI to JDK 17 and drop gc.log

### DIFF
--- a/.github/matrix-jvm-tests.json
+++ b/.github/matrix-jvm-tests.json
@@ -20,10 +20,10 @@
   "os-name": "ubuntu-latest"
 }
 , {
-  "name": "11 Windows",
-  "java-version": 11,
+  "name": "17 Windows",
+  "java-version": 17,
   "maven_args": "-DskipDocs -Dformat.skip",
-  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g -Xlog:gc*=debug:file=windows-java-11.txt",
+  "maven_opts": "-Xmx2g -XX:MaxMetaspaceSize=1g",
  "os-name": "windows-latest"
 }
 , {

--- a/.github/workflows/ci-actions-incremental.yml
+++ b/.github/workflows/ci-actions-incremental.yml
@@ -347,14 +347,6 @@ jobs:
             target/build-report.json
             LICENSE.txt
           retention-days: 2
-      - name: Upload gc.log
-        uses: actions/upload-artifact@v3
-        with:
-          name: "GC log - JDK ${{matrix.java.name}}"
-          path: |
-            **/windows-java-11.txt
-            !**/build/tmp/**
-          retention-days: 5
       - name: Upload build.log (if build failed)
         uses: actions/upload-artifact@v3
         if: ${{ failure() || cancelled() }}


### PR DESCRIPTION
Let's keep the Linux build on JDK 11 to check nothing is wrong with JDK 11 but upgrade the Windows build to 17 as it's our default JDK.