### PR TITLE
Move scm information to metadata from top-level, and remove nesting

### DIFF
--- a/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
+++ b/devtools/gradle/gradle-extension-plugin/src/main/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTask.java
@@ -313,9 +313,10 @@ public class ExtensionDescriptorTask extends DefaultTask {
     private void computeSourceLocation(ObjectNode extObject) {
         Map<String, String> repo = ScmInfoProvider.getSourceRepo();
         if (repo != null) {
-            ObjectNode scm = extObject.putObject("scm");
+            ObjectNode metadata = getMetadataNode(extObject);
+
             for (Map.Entry<String, String> e : repo.entrySet()) {
-                scm.put(e.getKey(), e.getValue());
+                metadata.put("scm-" + e.getKey(), e.getValue());
 
             }
         }

--- a/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
+++ b/devtools/gradle/gradle-extension-plugin/src/test/java/io/quarkus/extension/gradle/tasks/ExtensionDescriptorTaskTest.java
@@ -200,10 +200,9 @@ public class ExtensionDescriptorTaskTest {
         File extensionDescriptorFile = new File(testProjectDir, "build/resources/main/META-INF/quarkus-extension.yaml");
         assertThat(extensionDescriptorFile).exists();
         ObjectNode extensionDescriptor = TestUtils.readExtensionFile(extensionDescriptorFile.toPath());
-        assertThat(extensionDescriptor.get("scm")).isNotNull();
-        assertThat(extensionDescriptor.get("scm").get("url")).isNotNull();
-        assertThat(extensionDescriptor.get("scm").get("url").asText())
-                .as("Check source location %s", extensionDescriptor.get("scm"))
+        assertThat(extensionDescriptor.get("metadata").get("scm-url")).isNotNull();
+        assertThat(extensionDescriptor.get("metadata").get("scm-url").asText())
+                .as("Check source location %s", extensionDescriptor.get("scm-url"))
                 .isEqualTo("https://github.com/some/repo");
     }
 

--- a/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/bootstrap/maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -660,10 +660,9 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     private void addSource(ObjectNode extObject) throws MojoExecutionException {
         Map<String, String> repo = getSourceRepo();
         if (repo != null) {
-            ObjectNode scm = extObject.putObject("scm");
+            ObjectNode metadata = getMetadataNode(extObject);
             for (Map.Entry<String, String> e : repo.entrySet()) {
-                scm.put(e.getKey(), e.getValue());
-
+                metadata.put("scm-" + e.getKey(), e.getValue());
             }
         }
     }

--- a/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
+++ b/independent-projects/extension-maven-plugin/src/main/java/io/quarkus/maven/ExtensionDescriptorMojo.java
@@ -676,9 +676,10 @@ public class ExtensionDescriptorMojo extends AbstractMojo {
     private void addSource(ObjectNode extObject) throws MojoExecutionException {
         Map<String, String> repo = ScmInfoProvider.getSourceRepo();
         if (repo != null) {
-            ObjectNode scm = extObject.putObject("scm");
+            ObjectNode metadata = getMetadataNode(extObject);
             for (Map.Entry<String, String> e : repo.entrySet()) {
-                scm.put(e.getKey(), e.getValue());
+                // Tools may not be able to handle nesting in metadata, so do fake-nesting
+                metadata.put("scm-" + e.getKey(), e.getValue());
 
             }
         }

--- a/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
+++ b/independent-projects/extension-maven-plugin/src/test/java/io/quarkus/maven/ExtensionDescriptorMojoTest.java
@@ -100,8 +100,7 @@ class ExtensionDescriptorMojoTest extends AbstractMojoTestCase {
         // From maven this property should be set, running in an IDE it won't be unless specially configured
         if (System.getenv("GITHUB_REPOSITORY") != null) {
             // Lazily test that the scm is there but is an object
-            assertYamlContainsObject(fileContents, "scm");
-            assertYamlContains(fileContents, "url", "https://github.com/some/repo");
+            assertYamlContains(fileContents, "scm-url", "https://github.com/some/repo");
         }
 
     }


### PR DESCRIPTION
Follow-up to change the design of https://github.com/quarkusio/quarkus/pull/28009 a bit. Adding scm information at the top level needs schema changes in the registry, and the information should logically be considered metadata. I've moved it down a level, and got rid of nesting to make sure tools don't get confused by nested structures within the nested structure.