### PR TITLE
Use wildcards instead of null when creating dependency exclusions

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1268,7 +1268,7 @@ public class DevMojo extends AbstractMojo {
             final List<Exclusion> exclusions;
             if (!d.getExclusions().isEmpty()) {
                 exclusions = new ArrayList<>(d.getExclusions().size());
-                d.getExclusions().forEach(e -> exclusions.add(new Exclusion(e.getGroupId(), e.getArtifactId(), null, null)));
+                d.getExclusions().forEach(e -> exclusions.add(new Exclusion(e.getGroupId(), e.getArtifactId(), "*", "*")));
             } else {
                 exclusions = List.of();
             }


### PR DESCRIPTION
Otherwise excluded JAR dependencies won't actually be excluded.