### PR TITLE
Update guide link in metadata

### DIFF
--- a/extensions/security-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/security-jpa/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,7 +7,7 @@ metadata:
   - "jpa"
   - "orm"
   - "panache"
-  guide: "https://quarkus.io/guides/security-jpa"
+  guide: "https://quarkus.io/guides/security-getting-started"
   categories:
   - "security"
   status: "stable"


### PR DESCRIPTION
The security-jpa guide has moved to https://quarkus.io/guides/security-getting-started, so we need to update the metadata in the extension yaml.