### PR TITLE
Expose configuration for quartz scheduler performance tuning

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzRuntimeConfig.java
@@ -20,6 +20,17 @@ public class QuartzRuntimeConfig {
     public String instanceName;
 
     /**
+     * The amount of time in milliseconds that a trigger is allowed to be acquired and fired ahead of its scheduled fire time.
+     */
+    @ConfigItem(defaultValue = "0")
+    public long batchTriggerAcquisitionFireAheadTimeWindow;
+
+    /**
+     * The maximum number of triggers that a scheduler node is allowed to acquire (for firing) at once.
+     */
+    @ConfigItem(defaultValue = "1")
+    public int batchTriggerAcquisitionMaxCount;
+    /**
      * The size of scheduler thread pool. This will initialize the number of worker threads in the pool.
      */
     @ConfigItem(defaultValue = "25")

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzSchedulerImpl.java
@@ -557,6 +557,10 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
         props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_ID, "AUTO");
         props.put("org.quartz.scheduler.skipUpdateCheck", "true");
         props.put(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, quartzSupport.getRuntimeConfig().instanceName);
+        props.put(StdSchedulerFactory.PROP_SCHED_BATCH_TIME_WINDOW,
+                quartzSupport.getRuntimeConfig().batchTriggerAcquisitionFireAheadTimeWindow);
+        props.put(StdSchedulerFactory.PROP_SCHED_MAX_BATCH_SIZE,
+                quartzSupport.getRuntimeConfig().batchTriggerAcquisitionMaxCount);
         props.put(StdSchedulerFactory.PROP_SCHED_WRAP_JOB_IN_USER_TX, "false");
         props.put(StdSchedulerFactory.PROP_SCHED_SCHEDULER_THREADS_INHERIT_CONTEXT_CLASS_LOADER_OF_INITIALIZING_THREAD, "true");
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_CLASS, "org.quartz.simpl.SimpleThreadPool");
@@ -581,9 +585,9 @@ public class QuartzSchedulerImpl implements QuartzScheduler {
                     quartzSupport.getDriverDialect().get());
             props.put(StdSchedulerFactory.PROP_DATASOURCE_PREFIX + "." + dataSource + ".connectionProvider.class",
                     QuarkusQuartzConnectionPoolProvider.class.getName());
+            props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".acquireTriggersWithinLock", "true");
             if (buildTimeConfig.clustered) {
                 props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".isClustered", "true");
-                props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".acquireTriggersWithinLock", "true");
                 props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".clusterCheckinInterval",
                         "" + quartzSupport.getBuildTimeConfig().clusterCheckinInterval);
                 if (buildTimeConfig.selectWithLockSql.isPresent()) {


### PR DESCRIPTION
Allows to configure maxBatchSize and batchTimeWindow to leverage the  batch mode as described in [#29319](https://github.com/quarkusio/quarkus/issues/29319) .
@machi1990