### PR TITLE
Improvements in image cli and extensions

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -16,6 +16,7 @@ public class Push extends BaseImageCommand {
     private static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-push",
             BuildTool.GRADLE, "imagePush");
 
+    private static final String QUARKUS_CONTAINER_IMAGE_BUILD = "quarkus.container-image.build";
     private static final String QUARKUS_CONTAINER_IMAGE_USERNAME = "quarkus.container-image.username";
     private static final String QUARKUS_CONTAINER_IMAGE_PASSWORD = "quarkus.container-image.password";
 
@@ -31,17 +32,26 @@ public class Push extends BaseImageCommand {
             "--registry-password-stdin" }, description = "Read the image registry password from stdin.")
     public boolean registryPasswordStdin;
 
+    @CommandLine.Option(order = 11, names = {
+            "--also-build" }, description = "(Re)build the image before pushing.")
+    public boolean alsoBuild;
+
     @Override
     public void populateImageConfiguration(Map<String, String> properties) {
         super.populateImageConfiguration(properties);
         registryUsername.ifPresent(u -> properties.put(QUARKUS_CONTAINER_IMAGE_USERNAME, u));
 
-        if (registryPasswordStdin) {
+        if (registryPasswordStdin && !runMode.isDryRun()) {
             String password = new String(System.console().readPassword("Registry password:"));
             properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, password);
         } else {
             registryPassword.ifPresent(p -> properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, p));
         }
+
+        if (!alsoBuild) {
+            properties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "false");
+        }
+
         properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION);
     }
 

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Push.java
@@ -48,7 +48,9 @@ public class Push extends BaseImageCommand {
             registryPassword.ifPresent(p -> properties.put(QUARKUS_CONTAINER_IMAGE_PASSWORD, p));
         }
 
-        if (!alsoBuild) {
+        if (alsoBuild) {
+            properties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "true");
+        } else {
             properties.put(QUARKUS_CONTAINER_IMAGE_BUILD, "false");
         }
 

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageMavenTest.java
@@ -57,7 +57,14 @@ public class CliImageMavenTest {
         assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
 
         // 3 image push --dry-run
-        result = CliDriver.execute(project, "image", "push", "--help");
+        result = CliDriver.execute(project, "image", "push", "--dry-run");
         assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
+
+        // 4 image push --also-build --dry-run
+        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
+
     }
 }

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -219,7 +219,7 @@ public class JibProcessor {
 
         log.info("Starting (local) container image build for native binary using jib.");
         JibContainer container = containerize(containerImageConfig, jibConfig, containerImage, jibContainerBuilder,
-                pushRequest.isPresent());
+                pushContainerImage);
         writeOutputFiles(container, jibConfig, outputTarget);
 
         artifactResultProducer.produce(new ArtifactResultBuildItem(null, "native-container",


### PR DESCRIPTION
The pull requests improves the experience of using the image cli and extensions. In detail:

- Fixes: `quarkus.container-image.build=false` in docker and buildpack extensions.
- Fix: Use the correct var to determine when push is needed for jib.
- Fix: push cli command will not trigger build unless `--also-build` is explicitly specified.