### PR TITLE
Arc - when adding default scope, check for built-in scopes that might have been added programmatically

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalBeanBuildItem.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/AdditionalBeanBuildItem.java
@@ -128,7 +128,8 @@ public final class AdditionalBeanBuildItem extends MultiBuildItem {
         }
 
         /**
-         * The default scope is only used if there is no scope declared on the bean class.
+         * The default scope is only used if there is no scope declared on the bean class or added by an annotation transformer
+         * with priority higher than {@code io.quarkus.arc.processor.BuildExtension.DEFAULT_PRIORITY}
          * <p>
          * The default scope should be used in cases where a bean class source is not controlled by the extension and the
          * scope annotation cannot be declared directly on the class.

--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/ArcProcessor.java
@@ -260,6 +260,10 @@ public class ArcProcessor {
                     // If it declares a scope no action is needed
                     return;
                 }
+                if (customScopes.isScopeIn(transformationContext.getAnnotations())) {
+                    // if one of annotations (even if added via transformer) is a scope, no action is needed
+                    return;
+                }
                 DotName defaultScope = additionalBeanTypes.get(beanClassName);
                 if (defaultScope != null) {
                     transformationContext.transform().add(defaultScope).done();


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/22211

It seems that when adding default scope, Arc doesn't take into consideration that other annotation transformer might have added a scope in the meantime.