### PR TITLE
Add custom gRPC exception handling

### DIFF
--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandler.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandler.java
@@ -1,0 +1,51 @@
+package io.quarkus.grpc;
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+
+/**
+ * Generic exception handler
+ */
+public abstract class ExceptionHandler<ReqT, RespT> extends
+        ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+
+    private final ServerCall<ReqT, RespT> call;
+    private final Metadata metadata;
+
+    public ExceptionHandler(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> call, Metadata metadata) {
+        super(listener);
+        this.metadata = metadata;
+        this.call = call;
+    }
+
+    protected abstract void handleException(Throwable t, ServerCall<ReqT, RespT> call, Metadata metadata);
+
+    @Override
+    public void onMessage(ReqT message) {
+        try {
+            super.onMessage(message);
+        } catch (Throwable t) {
+            handleException(t, call, metadata);
+        }
+    }
+
+    @Override
+    public void onHalfClose() {
+        try {
+            super.onHalfClose();
+        } catch (Throwable t) {
+            handleException(t, call, metadata);
+        }
+    }
+
+    @Override
+    public void onReady() {
+        try {
+            super.onReady();
+        } catch (Throwable t) {
+            handleException(t, call, metadata);
+        }
+    }
+
+}

--- a/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java
+++ b/extensions/grpc/api/src/main/java/io/quarkus/grpc/ExceptionHandlerProvider.java
@@ -1,0 +1,103 @@
+package io.quarkus.grpc;
+
+import java.util.Optional;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Provider for ExceptionHandler.
+ *
+ * To use a custom ExceptionHandler, extend {@link ExceptionHandler} and implement
+ * an {@link ExceptionHandlerProvider}, and expose it as a CDI bean.
+ */
+public interface ExceptionHandlerProvider {
+    <ReqT, RespT> ExceptionHandler<ReqT, RespT> createHandler(Listener<ReqT> listener,
+            ServerCall<ReqT, RespT> serverCall, Metadata metadata);
+
+    default Throwable transform(Throwable t) {
+        return toStatusException(t, false); // previous default was false
+    }
+
+    /**
+     * Throw Status exception.
+     *
+     * @param t the throwable to transform
+     * @param runtime true if we should throw StatusRuntimeException, false for StatusException
+     * @return Status(Runtime)Exception
+     */
+    static Exception toStatusException(Throwable t, boolean runtime) {
+        if (t instanceof StatusException || t instanceof StatusRuntimeException) {
+            if (runtime) {
+                if (t instanceof StatusRuntimeException) {
+                    return (Exception) t;
+                } else {
+                    StatusException se = (StatusException) t;
+                    return new StatusRuntimeException(se.getStatus(), se.getTrailers());
+                }
+            } else {
+                if (t instanceof StatusException) {
+                    return (Exception) t;
+                } else {
+                    StatusRuntimeException sre = (StatusRuntimeException) t;
+                    return new StatusException(sre.getStatus(), sre.getTrailers());
+                }
+            }
+        } else {
+            String desc = t.getClass().getName();
+            if (t.getMessage() != null) {
+                desc += " - " + t.getMessage();
+            }
+            Status status;
+            if (t instanceof IllegalArgumentException) {
+                status = Status.INVALID_ARGUMENT.withDescription(desc);
+            } else {
+                status = Status.fromThrowable(t).withDescription(desc);
+            }
+            return runtime ? status.asRuntimeException() : status.asException();
+        }
+    }
+
+    /**
+     * Get Status from exception.
+     *
+     * @param t the throwable to read or create status from
+     * @return gRPC Status instance
+     */
+    static Status toStatus(Throwable t) {
+        if (t instanceof StatusException) {
+            return ((StatusException) t).getStatus();
+        } else if (t instanceof StatusRuntimeException) {
+            return ((StatusRuntimeException) t).getStatus();
+        } else {
+            String desc = t.getClass().getName();
+            if (t.getMessage() != null) {
+                desc += " - " + t.getMessage();
+            }
+            if (t instanceof IllegalArgumentException) {
+                return Status.INVALID_ARGUMENT.withDescription(desc);
+            }
+            return Status.fromThrowable(t).withDescription(desc);
+        }
+    }
+
+    /**
+     * Get optional Metadata from exception.
+     *
+     * @param t the throwable to read or create metadata from
+     * @return optional gRPC Metadata instance
+     */
+    static Optional<Metadata> toTrailers(Throwable t) {
+        Metadata trailers = null;
+        if (t instanceof StatusException) {
+            trailers = ((StatusException) t).getTrailers();
+        } else if (t instanceof StatusRuntimeException) {
+            trailers = ((StatusRuntimeException) t).getTrailers();
+        }
+        return Optional.ofNullable(trailers);
+    }
+}

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/FailingInInterceptorTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/FailingInInterceptorTest.java
@@ -41,7 +41,7 @@ public class FailingInInterceptorTest {
         Uni<HelloReply> result = greeter.sayHello(HelloRequest.newBuilder().setName("ServiceA").build());
         assertThatThrownBy(() -> result.await().atMost(Duration.ofSeconds(4)))
                 .isInstanceOf(StatusRuntimeException.class)
-                .hasMessageContaining("UNKNOWN");
+                .hasMessageContaining("INVALID_ARGUMENT");
     }
 
     @ApplicationScoped

--- a/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/FailingInterceptorTest.java
+++ b/extensions/grpc/deployment/src/test/java/io/quarkus/grpc/server/interceptors/FailingInterceptorTest.java
@@ -43,7 +43,7 @@ public class FailingInterceptorTest {
         Uni<HelloReply> result = greeter.sayHello(HelloRequest.newBuilder().setName("ServiceA").build());
         assertThatThrownBy(() -> result.await().atMost(Duration.ofSeconds(4)))
                 .isInstanceOf(StatusRuntimeException.class)
-                .hasMessageContaining("UNKNOWN");
+                .hasMessageContaining("INVALID_ARGUMENT");
     }
 
     @ApplicationScoped

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/AuthExceptionHandler.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/auth/AuthExceptionHandler.java
@@ -2,10 +2,10 @@ package io.quarkus.grpc.auth;
 
 import javax.enterprise.inject.spi.Prioritized;
 
-import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import io.quarkus.grpc.ExceptionHandler;
 import io.quarkus.security.AuthenticationFailedException;
 
 /**
@@ -14,44 +14,11 @@ import io.quarkus.security.AuthenticationFailedException;
  * To alter mapping exceptions, create a subclass of this handler and create an appropriate
  * {@link AuthExceptionHandlerProvider}
  */
-public class AuthExceptionHandler<ReqT, RespT>
-        extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> implements Prioritized {
-
-    private final ServerCall<ReqT, RespT> serverCall;
-    private final Metadata metadata;
+public class AuthExceptionHandler<ReqT, RespT> extends ExceptionHandler<ReqT, RespT> implements Prioritized {
 
     public AuthExceptionHandler(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> serverCall,
             Metadata metadata) {
-        super(listener);
-        this.metadata = metadata;
-        this.serverCall = serverCall;
-    }
-
-    @Override
-    public void onMessage(ReqT message) {
-        try {
-            super.onMessage(message);
-        } catch (RuntimeException e) {
-            handleException(e, serverCall, metadata);
-        }
-    }
-
-    @Override
-    public void onHalfClose() {
-        try {
-            super.onHalfClose();
-        } catch (RuntimeException e) {
-            handleException(e, serverCall, metadata);
-        }
-    }
-
-    @Override
-    public void onReady() {
-        try {
-            super.onReady();
-        } catch (RuntimeException e) {
-            handleException(e, serverCall, metadata);
-        }
+        super(listener, serverCall, metadata);
     }
 
     /**
@@ -61,13 +28,15 @@ public class AuthExceptionHandler<ReqT, RespT>
      * @param serverCall server call to close with error
      * @param metadata call metadata
      */
-    protected void handleException(RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+    protected void handleException(Throwable exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
         if (exception instanceof AuthenticationFailedException) {
             serverCall.close(Status.UNAUTHENTICATED.withDescription(exception.getMessage()), metadata);
         } else if (exception instanceof SecurityException) {
             serverCall.close(Status.PERMISSION_DENIED.withDescription(exception.getMessage()), metadata);
+        } else if (exception instanceof RuntimeException) {
+            throw (RuntimeException) exception;
         } else {
-            throw exception;
+            throw new RuntimeException(exception);
         }
     }
 

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/Interceptors.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/Interceptors.java
@@ -12,7 +12,11 @@ import javax.enterprise.inject.spi.Prioritized;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 
-final class Interceptors {
+public final class Interceptors {
+
+    public static final int DUPLICATE_CONTEXT = Integer.MAX_VALUE - 5;
+    public static final int EXCEPTION_HANDLER = Integer.MAX_VALUE - 10;
+    public static final int REQUEST_CONTEXT = Integer.MAX_VALUE - 50;
 
     static <T> List<T> getSortedPerServiceInterceptors(String name, Set<Class<?>> interceptorClasses) {
         if (interceptorClasses.isEmpty()) {

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/context/GrpcRequestContextGrpcInterceptor.java
@@ -14,6 +14,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableContext;
 import io.quarkus.arc.ManagedContext;
 import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.grpc.runtime.Interceptors;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 
@@ -141,6 +142,6 @@ public class GrpcRequestContextGrpcInterceptor implements ServerInterceptor, Pri
 
     @Override
     public int getPriority() {
-        return Integer.MAX_VALUE - 50;
+        return Interceptors.REQUEST_CONTEXT;
     }
 }

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/DefaultExceptionHandlerProvider.java
@@ -1,0 +1,34 @@
+package io.quarkus.grpc.runtime.supports.exc;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.StatusException;
+import io.quarkus.arc.DefaultBean;
+import io.quarkus.grpc.ExceptionHandler;
+import io.quarkus.grpc.ExceptionHandlerProvider;
+
+@ApplicationScoped
+@DefaultBean
+public class DefaultExceptionHandlerProvider implements ExceptionHandlerProvider {
+    @Override
+    public <ReqT, RespT> ExceptionHandler<ReqT, RespT> createHandler(ServerCall.Listener<ReqT> listener,
+            ServerCall<ReqT, RespT> call, Metadata metadata) {
+        return new DefaultExceptionHandler<>(listener, call, metadata);
+    }
+
+    private static class DefaultExceptionHandler<ReqT, RespT> extends ExceptionHandler<ReqT, RespT> {
+        public DefaultExceptionHandler(ServerCall.Listener<ReqT> listener, ServerCall<ReqT, RespT> call,
+                Metadata metadata) {
+            super(listener, call, metadata);
+        }
+
+        @Override
+        protected void handleException(Throwable exception, ServerCall<ReqT, RespT> call, Metadata metadata) {
+            StatusException se = (StatusException) ExceptionHandlerProvider.toStatusException(exception, false);
+            Metadata trailers = se.getTrailers() != null ? se.getTrailers() : metadata;
+            call.close(se.getStatus(), trailers);
+        }
+    }
+}

--- a/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/ExceptionInterceptor.java
+++ b/extensions/grpc/runtime/src/main/java/io/quarkus/grpc/runtime/supports/exc/ExceptionInterceptor.java
@@ -1,0 +1,34 @@
+package io.quarkus.grpc.runtime.supports.exc;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Prioritized;
+import javax.inject.Inject;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.quarkus.grpc.ExceptionHandlerProvider;
+import io.quarkus.grpc.GlobalInterceptor;
+import io.quarkus.grpc.runtime.Interceptors;
+
+@ApplicationScoped
+@GlobalInterceptor
+public class ExceptionInterceptor implements ServerInterceptor, Prioritized {
+
+    @Inject
+    ExceptionHandlerProvider provider;
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        return provider.createHandler(next.startCall(call, headers), call, headers);
+    }
+
+    @Override
+    public int getPriority() {
+        return Interceptors.EXCEPTION_HANDLER;
+    }
+}

--- a/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
+++ b/extensions/grpc/runtime/src/test/java/io/quarkus/grpc/runtime/ClientAndServerCallsTest.java
@@ -4,14 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletionException;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.quarkus.grpc.ExceptionHandler;
+import io.quarkus.grpc.ExceptionHandlerProvider;
 import io.quarkus.grpc.stubs.ClientCalls;
 import io.quarkus.grpc.stubs.ServerCalls;
 import io.smallrye.mutiny.Multi;
@@ -21,6 +28,33 @@ public class ClientAndServerCallsTest {
 
     protected static final Duration TIMEOUT = Duration.ofSeconds(5);
     private FakeServiceClient client = new FakeServiceClient();
+
+    private static class EHP implements ExceptionHandlerProvider {
+        @Override
+        public <ReqT, RespT> ExceptionHandler<ReqT, RespT> createHandler(ServerCall.Listener<ReqT> listener,
+                ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+            return new ExceptionHandler<>(listener, serverCall, metadata) {
+                @Override
+                protected void handleException(Throwable t, ServerCall<ReqT, RespT> call, Metadata metadata) {
+                    Status status = ExceptionHandlerProvider.toStatus(t);
+                    Optional<Metadata> trailers = ExceptionHandlerProvider.toTrailers(t);
+                    call.close(status, trailers.orElse(metadata));
+                }
+            };
+        }
+
+        @Override
+        public Throwable transform(Throwable t) {
+            return ExceptionHandlerProvider.toStatusException(t, false);
+        }
+    }
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        Field ehp = ServerCalls.class.getDeclaredField("ehp");
+        ehp.setAccessible(true);
+        ehp.set(null, new EHP());
+    }
 
     @Test
     public void oneToOneSuccess() {
@@ -77,7 +111,7 @@ public class ClientAndServerCallsTest {
         assertThatThrownBy(() -> client.propagateFailure("hello").await().atMost(TIMEOUT))
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StatusException.class)
-                .getCause().satisfies(t -> {
+                .cause().satisfies(t -> {
                     assertThat(t).isInstanceOf(StatusException.class);
                     assertThat(((StatusException) t).getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
                     assertThat((t).getMessage()).contains("boom").contains("Exception");
@@ -86,7 +120,7 @@ public class ClientAndServerCallsTest {
         assertThatThrownBy(() -> client.immediateFailure("hello").await().atMost(TIMEOUT))
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StatusException.class)
-                .getCause().satisfies(t -> {
+                .cause().satisfies(t -> {
                     assertThat(t).isInstanceOf(StatusException.class);
                     assertThat(((StatusException) t).getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
                     assertThat((t).getMessage()).contains("runtime boom").contains("RuntimeException");
@@ -95,7 +129,7 @@ public class ClientAndServerCallsTest {
         assertThatThrownBy(() -> client.illegalArgumentException("hello").await().atMost(TIMEOUT))
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StatusException.class)
-                .getCause().satisfies(t -> {
+                .cause().satisfies(t -> {
                     assertThat(t).isInstanceOf(StatusException.class);
                     assertThat(((StatusException) t).getStatus().getCode()).isEqualTo(Status.INVALID_ARGUMENT.getCode());
                     assertThat((t).getMessage()).contains("bad").contains("IllegalArgumentException");
@@ -104,7 +138,7 @@ public class ClientAndServerCallsTest {
         assertThatThrownBy(() -> client.npe("hello").await().atMost(TIMEOUT))
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StatusException.class)
-                .getCause().satisfies(t -> {
+                .cause().satisfies(t -> {
                     assertThat(t).isInstanceOf(StatusException.class);
                     assertThat(((StatusException) t).getStatus().getCode()).isEqualTo(Status.UNKNOWN.getCode());
                     assertThat((t).getMessage()).contains("NullPointerException");

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/CopycatService.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/CopycatService.java
@@ -1,0 +1,30 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyCopycatGrpc;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+@GrpcService
+public class CopycatService extends MutinyCopycatGrpc.CopycatImplBase {
+
+    private HelloReply getReply(HelloRequest request) {
+        String name = request.getName();
+        if (name.equals("Fail")) {
+            throw new HelloException(name);
+        }
+        return HelloReply.newBuilder().setMessage("Hello " + name).build();
+    }
+
+    @Override
+    public Uni<HelloReply> sayCat(HelloRequest request) {
+        return Uni.createFrom().item(getReply(request));
+    }
+
+    @Override
+    public Multi<HelloReply> multiCat(Multi<HelloRequest> request) {
+        return request.map(this::getReply);
+    }
+}

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloException.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloException.java
@@ -1,0 +1,13 @@
+package io.quarkus.grpc.examples.interceptors;
+
+public class HelloException extends RuntimeException {
+    private final String name;
+
+    public HelloException(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloExceptionHandlerProvider.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloExceptionHandlerProvider.java
@@ -1,0 +1,46 @@
+package io.quarkus.grpc.examples.interceptors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.grpc.ExceptionHandler;
+import io.quarkus.grpc.ExceptionHandlerProvider;
+
+@ApplicationScoped
+public class HelloExceptionHandlerProvider implements ExceptionHandlerProvider {
+    public static boolean invoked;
+
+    @Override
+    public <ReqT, RespT> ExceptionHandler<ReqT, RespT> createHandler(ServerCall.Listener<ReqT> listener,
+            ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+        return new HelloExceptionHandler<>(listener, serverCall, metadata);
+    }
+
+    @Override
+    public Throwable transform(Throwable t) {
+        invoked = true;
+        if (t instanceof HelloException) {
+            HelloException he = (HelloException) t;
+            return new StatusRuntimeException(Status.ABORTED.withDescription(he.getName()));
+        } else {
+            return ExceptionHandlerProvider.toStatusException(t, true);
+        }
+    }
+
+    private static class HelloExceptionHandler<A, B> extends ExceptionHandler<A, B> {
+        public HelloExceptionHandler(ServerCall.Listener<A> listener, ServerCall<A, B> call, Metadata metadata) {
+            super(listener, call, metadata);
+        }
+
+        @Override
+        protected void handleException(Throwable t, ServerCall<A, B> call, Metadata metadata) {
+            invoked = true;
+            StatusRuntimeException sre = (StatusRuntimeException) ExceptionHandlerProvider.toStatusException(t, true);
+            Metadata trailers = sre.getTrailers() != null ? sre.getTrailers() : metadata;
+            call.close(sre.getStatus(), trailers);
+        }
+    }
+}

--- a/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldService.java
+++ b/integration-tests/grpc-interceptors/src/main/java/io/quarkus/grpc/examples/interceptors/HelloWorldService.java
@@ -1,18 +1,45 @@
 package io.quarkus.grpc.examples.interceptors;
 
+import examples.GreeterGrpc;
 import examples.HelloReply;
 import examples.HelloRequest;
-import examples.MutinyGreeterGrpc;
+import io.grpc.stub.StreamObserver;
 import io.quarkus.grpc.GrpcService;
-import io.smallrye.mutiny.Uni;
 
 @GrpcService
-public class HelloWorldService extends MutinyGreeterGrpc.GreeterImplBase {
+public class HelloWorldService extends GreeterGrpc.GreeterImplBase {
+
+    private HelloReply getReply(HelloRequest request) {
+        String name = request.getName();
+        if (name.equals("Fail")) {
+            throw new HelloException(name);
+        }
+        return HelloReply.newBuilder().setMessage("Hello " + name).build();
+    }
 
     @Override
-    public Uni<HelloReply> sayHello(HelloRequest request) {
-        String name = request.getName();
-        return Uni.createFrom().item("Hello " + name)
-                .map(res -> HelloReply.newBuilder().setMessage(res).build());
+    public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        responseObserver.onNext(getReply(request));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public StreamObserver<HelloRequest> multiHello(StreamObserver<HelloReply> responseObserver) {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(HelloRequest helloRequest) {
+                responseObserver.onNext(getReply(helloRequest));
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseObserver.onCompleted();
+            }
+        };
     }
 }

--- a/integration-tests/grpc-interceptors/src/main/proto/helloworld.proto
+++ b/integration-tests/grpc-interceptors/src/main/proto/helloworld.proto
@@ -40,6 +40,13 @@ package helloworld;
 service Greeter {
     // Sends a greeting
     rpc SayHello (HelloRequest) returns (HelloReply) {}
+    rpc MultiHello (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+service Copycat {
+    // Sends a greeting
+    rpc SayCat (HelloRequest) returns (HelloReply) {}
+    rpc MultiCat (stream HelloRequest) returns (stream HelloReply) {}
 }
 
 // The request message containing the user's name.

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceTest.java
@@ -1,0 +1,7 @@
+package io.quarkus.grpc.example.interceptors;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class HelloWorldServiceTest extends HelloWorldServiceTestBase {
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceTestBase.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceTestBase.java
@@ -1,0 +1,139 @@
+package io.quarkus.grpc.example.interceptors;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import examples.GreeterGrpc;
+import examples.HelloReply;
+import examples.HelloRequest;
+import examples.MutinyCopycatGrpc;
+import io.grpc.Channel;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.grpc.examples.interceptors.HelloExceptionHandlerProvider;
+import io.quarkus.grpc.test.utils.GRPCTestUtils;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+
+class HelloWorldServiceTestBase {
+
+    private Channel channel;
+    private Vertx _vertx;
+
+    protected Vertx vertx() {
+        return null;
+    }
+
+    protected void close(Vertx vertx) {
+    }
+
+    @BeforeEach
+    public void init() {
+        _vertx = vertx();
+        channel = GRPCTestUtils.channel(_vertx);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        GRPCTestUtils.close(channel);
+        close(_vertx);
+    }
+
+    private static void assertException(Throwable t) {
+        // TODO
+        System.out.println("Exception > " + t);
+        Assertions.assertTrue(HelloExceptionHandlerProvider.invoked);
+    }
+
+    @Test
+    public void testExceptionHandlerObserver() throws Exception {
+        HelloExceptionHandlerProvider.invoked = false;
+        CompletableFuture<Boolean> failed = new CompletableFuture<>();
+        GreeterGrpc.GreeterStub client = GreeterGrpc.newStub(channel);
+        StreamObserver<HelloRequest> requests = client.multiHello(new StreamObserver<>() {
+            @Override
+            public void onNext(HelloReply helloReply) {
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                try {
+                    assertException(throwable);
+                    failed.complete(true);
+                } catch (Throwable t) {
+                    failed.completeExceptionally(t);
+                }
+            }
+
+            @Override
+            public void onCompleted() {
+            }
+        });
+        requests.onNext(HelloRequest.newBuilder().setName("Test").build());
+        requests.onNext(HelloRequest.newBuilder().setName("Fail").build());
+        //requests.onCompleted(); // onError should complete it
+        if (!failed.get(10, TimeUnit.SECONDS)) {
+            fail("Should fail!");
+        }
+    }
+
+    @Test
+    public void testExceptionHandlerOne() {
+        HelloExceptionHandlerProvider.invoked = false;
+        GreeterGrpc.GreeterBlockingStub client = GreeterGrpc.newBlockingStub(channel);
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            client.sayHello(HelloRequest.newBuilder().setName("Fail").build());
+            fail("Should fail!");
+        } catch (Exception e) {
+            assertException(e);
+        }
+    }
+
+    @Test
+    public void testExceptionHandlerMultiMutiny() throws Exception {
+        HelloExceptionHandlerProvider.invoked = false;
+        CompletableFuture<Boolean> failed = new CompletableFuture<>();
+        MutinyCopycatGrpc.MutinyCopycatStub client = MutinyCopycatGrpc.newMutinyStub(channel);
+        List<HelloRequest> requests = List.of(
+                HelloRequest.newBuilder().setName("Test").build(),
+                HelloRequest.newBuilder().setName("Fail").build());
+        Multi<HelloReply> response = client.multiCat(Multi.createFrom().items(requests.stream()));
+        response.subscribe().with(
+                r -> System.out.println(r.toString()),
+                t -> {
+                    assertException(t);
+                    failed.complete(true);
+                },
+                () -> failed.complete(false));
+        if (!failed.get(10, TimeUnit.SECONDS)) {
+            fail("Should fail!");
+        }
+    }
+
+    @Test
+    public void testExceptionHandlerUniMutiny() throws Exception {
+        HelloExceptionHandlerProvider.invoked = false;
+        CompletableFuture<Boolean> failed = new CompletableFuture<>();
+        MutinyCopycatGrpc.MutinyCopycatStub client = MutinyCopycatGrpc.newMutinyStub(channel);
+        Uni<HelloReply> response = client.sayCat(HelloRequest.newBuilder().setName("Fail").build());
+        response.subscribe().with(
+                r -> {
+                },
+                t -> {
+                    assertException(t);
+                    failed.complete(true);
+                });
+        if (!failed.get(10, TimeUnit.SECONDS)) {
+            fail("Should fail!");
+        }
+    }
+}

--- a/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceVertxTest.java
+++ b/integration-tests/grpc-interceptors/src/test/java/io/quarkus/grpc/example/interceptors/HelloWorldServiceVertxTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.grpc.example.interceptors;
+
+import javax.inject.Inject;
+
+import io.quarkus.grpc.test.utils.VertxGRPCTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+
+@QuarkusTest
+@TestProfile(VertxGRPCTestProfile.class)
+class HelloWorldServiceVertxTest extends HelloWorldServiceTestBase {
+
+    @Inject
+    Vertx vertx;
+
+    protected Vertx vertx() {
+        return vertx;
+    }
+}


### PR DESCRIPTION
This helps with the issue #26869.

It adds a way for user to map its (custom) non-gRPC exceptions to gRPC's Status exceptions.
There is a default ExceptionHandlerProvider with default ExceptionHandler.

ExceptionHandler is used in newly added ExceptionInterceptor - which wraps the calls / invocations,
whereas `ExceptionHandlerProvider::transformToStatusRuntimeException` is used in static calls to ServerCalls from Mutiny integration.

We test both - plain and mutiny type of services.