### PR TITLE
Skip quarkus:dev for modules with packaging pom

### DIFF
--- a/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -29,6 +29,7 @@ import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
 import io.quarkus.bootstrap.app.CuratedApplication;
 import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
 
 /**
  * Builds the Quarkus application.
@@ -77,11 +78,11 @@ public class BuildMojo extends QuarkusBootstrapMojo {
             getLog().info("Skipping Quarkus build");
             return false;
         }
-        if (mavenProject().getPackaging().equals("pom")) {
+        if (mavenProject().getPackaging().equals(ArtifactCoords.TYPE_POM)) {
             getLog().info("Type of the artifact is POM, skipping build goal");
             return false;
         }
-        if (!mavenProject().getArtifact().getArtifactHandler().getExtension().equals("jar")) {
+        if (!mavenProject().getArtifact().getArtifactHandler().getExtension().equals(ArtifactCoords.TYPE_JAR)) {
             throw new MojoExecutionException(
                     "The project artifact's extension is '" + mavenProject().getArtifact().getArtifactHandler().getExtension()
                             + "' while this goal expects it be 'jar'");

--- a/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/devtools/maven/src/main/java/io/quarkus/maven/DevMojo.java
@@ -391,6 +391,11 @@ public class DevMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoFailureException, MojoExecutionException {
 
+        if (project.getPackaging().equals(ArtifactCoords.TYPE_POM)) {
+            getLog().info("Type of the artifact is POM, skipping dev goal");
+            return;
+        }
+
         mavenVersionEnforcer.ensureMavenVersion(getLog(), session);
 
         initToolchain();


### PR DESCRIPTION
Similar to `quarkus:build`, skip `quarkus:dev` for modules with `<packaging>pom</packaging>`.