### PR TITLE
Improve support for conditional bean and declarative filter annotations combination

### DIFF
--- a/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
+++ b/extensions/arc/deployment/src/main/java/io/quarkus/arc/deployment/LookupConditionsProcessor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -30,6 +31,9 @@ public class LookupConditionsProcessor {
     private static final DotName LOOK_UP_UNLESS_PROPERTY = DotName.createSimple(LookupUnlessProperty.class.getName());
     private static final DotName LOOK_UP_UNLESS_PROPERTY_CONTAINER = DotName
             .createSimple(LookupUnlessProperty.List.class.getName());
+
+    public static final Set<DotName> LOOKUP_BEAN_ANNOTATIONS = Set.of(LOOK_UP_IF_PROPERTY, LOOK_UP_IF_CONTAINER,
+            LOOK_UP_UNLESS_PROPERTY, LOOK_UP_UNLESS_PROPERTY_CONTAINER);
 
     private static final String NAME = "name";
     private static final String STRING_VALUE = "stringValue";

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -50,6 +50,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BuildTimeEnabledProcessor;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
+import io.quarkus.arc.deployment.LookupConditionsProcessor;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -80,6 +81,13 @@ import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
  * Processor that handles scanning for types and turning them into build items
  */
 public class ResteasyReactiveScanningProcessor {
+
+    public static final Set<DotName> CONDITIONAL_BEAN_ANNOTATIONS;
+
+    static {
+        CONDITIONAL_BEAN_ANNOTATIONS = new HashSet<>(BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS);
+        CONDITIONAL_BEAN_ANNOTATIONS.addAll(LookupConditionsProcessor.LOOKUP_BEAN_ANNOTATIONS);
+    }
 
     @BuildStep
     public MethodScannerBuildItem asyncSupport() {
@@ -315,7 +323,7 @@ public class ResteasyReactiveScanningProcessor {
                 (methodInfo -> {
                     List<AnnotationInstance> methodAnnotations = methodInfo.annotations();
                     for (AnnotationInstance methodAnnotation : methodAnnotations) {
-                        if (BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS.contains(methodAnnotation.name())) {
+                        if (CONDITIONAL_BEAN_ANNOTATIONS.contains(methodAnnotation.name())) {
                             throw new RuntimeException("The combination of '@" + methodAnnotation.name().withoutPackagePrefix()
                                     + "' and '@ServerRequestFilter' or '@ServerResponseFilter' is not allowed. Offending method is '"
                                     + methodInfo.name() + "' of class '" + methodInfo.declaringClass().name() + "'");
@@ -324,7 +332,7 @@ public class ResteasyReactiveScanningProcessor {
 
                     List<AnnotationInstance> classAnnotations = methodInfo.declaringClass().declaredAnnotations();
                     for (AnnotationInstance classAnnotation : classAnnotations) {
-                        if (BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS.contains(classAnnotation.name())) {
+                        if (CONDITIONAL_BEAN_ANNOTATIONS.contains(classAnnotation.name())) {
                             return true;
                         }
                     }

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/main/java/io/quarkus/resteasy/reactive/server/deployment/ResteasyReactiveScanningProcessor.java
@@ -313,6 +313,15 @@ public class ResteasyReactiveScanningProcessor {
         List<FilterGeneration.GeneratedFilter> generatedFilters = FilterGeneration.generate(index,
                 Set.of(HTTP_SERVER_REQUEST, HTTP_SERVER_RESPONSE, ROUTING_CONTEXT), Set.of(Unremovable.class.getName()),
                 (methodInfo -> {
+                    List<AnnotationInstance> methodAnnotations = methodInfo.annotations();
+                    for (AnnotationInstance methodAnnotation : methodAnnotations) {
+                        if (BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS.contains(methodAnnotation.name())) {
+                            throw new RuntimeException("The combination of '@" + methodAnnotation.name().withoutPackagePrefix()
+                                    + "' and '@ServerRequestFilter' or '@ServerResponseFilter' is not allowed. Offending method is '"
+                                    + methodInfo.name() + "' of class '" + methodInfo.declaringClass().name() + "'");
+                        }
+                    }
+
                     List<AnnotationInstance> classAnnotations = methodInfo.declaringClass().declaredAnnotations();
                     for (AnnotationInstance classAnnotation : classAnnotations) {
                         if (BuildTimeEnabledProcessor.BUILD_TIME_ENABLED_BEAN_ANNOTATIONS.contains(classAnnotation.name())) {

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/InvalidConditionalBeanFiltersTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/customproviders/InvalidConditionalBeanFiltersTest.java
@@ -1,0 +1,62 @@
+package io.quarkus.resteasy.reactive.server.test.customproviders;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InvalidConditionalBeanFiltersTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(new Supplier<>() {
+                @Override
+                public JavaArchive get() {
+                    return ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(TestResource.class, Filters.class);
+                }
+            }).assertException(t -> {
+                String message = t.getMessage();
+                assertTrue(message.contains("@IfBuildProfile"));
+                assertTrue(message.contains("request"));
+                assertTrue(message.contains(InvalidConditionalBeanFiltersTest.Filters.class.getName()));
+            });
+
+    @Test
+    public void test() {
+        fail("Should never have been called");
+    }
+
+    @Path("test")
+    public static class TestResource {
+
+        @GET
+        public String hello() {
+            return "hello";
+        }
+
+    }
+
+    public static class Filters {
+
+        @IfBuildProfile("test")
+        @ServerRequestFilter
+        public void request(UriInfo info) {
+
+        }
+
+    }
+}


### PR DESCRIPTION
This PR does two things:

* Disallow conditional annotations and declarative filter annotations on methods
   * Although we can make this work in the future, it involves a fair amount of work for a very small gain, so let's make it explicit for now that this combination is not allowed.
* Support the use of lookup conditional bean annotations along with declarative filter annotations
   * This brings support for `@LookupIfProperty`  and `@LookupUnlessProperty`


Follows up on: #29118