### PR TITLE
Image cli forced dependency / extension support in gradle projects

### DIFF
--- a/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/build/BaseBuildCommand.java
@@ -2,6 +2,8 @@ package io.quarkus.cli.build;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.quarkus.cli.common.HelpOption;
 import io.quarkus.cli.common.OutputOptionMixin;
@@ -28,6 +30,7 @@ public class BaseBuildCommand {
     protected PropertiesOptions propertiesOptions = new PropertiesOptions();
 
     Path projectRoot;
+    protected List<String> forcedExtensions = new ArrayList<>();
 
     public Path projectRoot() {
         if (projectRoot == null) {
@@ -43,4 +46,20 @@ public class BaseBuildCommand {
         BuildTool buildTool = QuarkusProjectHelper.detectExistingBuildTool(projectRoot()); // nullable
         return BuildSystemRunner.getRunner(output, propertiesOptions, registryClient, projectRoot(), buildTool);
     }
+
+    public List<String> getForcedExtensions() {
+        return forcedExtensions;
+    }
+
+    /**
+     * Commands using `@ParentCommand` need to set the ouput.
+     * This is needed for testing purposes.
+     * More specifically --cli-test-dir relies on this.
+     *
+     * @param output The command ouput
+     */
+    public void setOutput(OutputOptionMixin output) {
+        this.output = output;
+    }
+
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/BaseImageCommand.java
@@ -7,16 +7,18 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import io.quarkus.cli.build.BaseBuildCommand;
+import io.quarkus.cli.build.BuildSystemRunner;
 import io.quarkus.cli.common.BuildOptions;
 import io.quarkus.cli.common.PropertiesOptions;
 import io.quarkus.cli.common.RunModeOption;
+import io.quarkus.cli.utils.GradleInitScript;
 import io.quarkus.devtools.project.BuildTool;
 import picocli.CommandLine;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
 
 public class BaseImageCommand extends BaseBuildCommand implements Callable<Integer> {
 
-    protected static final String QUARKUS_FORCED_EXTENSIONS = "quarkus.application.forced-extensions";
     protected static final String QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX = "io.quarkus:quarkus-container-image-";
 
     protected static final String QUARKUS_CONTAINER_IMAGE_BUILDER = "quarkus.container-image.builder";
@@ -24,7 +26,6 @@ public class BaseImageCommand extends BaseBuildCommand implements Callable<Integ
     private static final String QUARKUS_CONTAINER_IMAGE_NAME = "quarkus.container-image.name";
     private static final String QUARKUS_CONTAINER_IMAGE_TAG = "quarkus.container-image.tag";
     protected static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
-    protected static final String QUARKUS_CONTAINER_IMAGE_DRY_RUN = "quarkus.container-image.dry-run";
 
     protected static final Map<BuildTool, String> ACTION_MAPPING = Map.of(BuildTool.MAVEN, "quarkus:image-build",
             BuildTool.GRADLE, "imageBuild");
@@ -46,8 +47,54 @@ public class BaseImageCommand extends BaseBuildCommand implements Callable<Integ
         imageOptions.name.ifPresent(name -> properties.put(QUARKUS_CONTAINER_IMAGE_NAME, name));
         imageOptions.tag.ifPresent(tag -> properties.put(QUARKUS_CONTAINER_IMAGE_TAG, tag));
         imageOptions.registry.ifPresent(registry -> properties.put(QUARKUS_CONTAINER_IMAGE_REGISTRY, registry));
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        try {
+            populateImageConfiguration(propertiesOptions.properties);
+            BuildSystemRunner runner = getRunner();
+
+            String action = getAction()
+                    .orElseThrow(() -> new IllegalStateException("Unknown image action for " + runner.getBuildTool().name()));
+
+            if (runner.getBuildTool() == BuildTool.GRADLE) {
+                prepareGradle();
+            }
+
+            if (runner.getBuildTool() == BuildTool.MAVEN) {
+                prepareMaven();
+            }
+            BuildSystemRunner.BuildCommandArgs commandArgs = runner.prepareAction(action, buildOptions, runMode, params);
+            if (runMode.isDryRun()) {
+                System.out.println("Dry run option detected. Target command:");
+                System.out.println(" " + commandArgs.showCommand());
+                return ExitCode.OK;
+            }
+            return runner.run(commandArgs);
+        } catch (Exception e) {
+            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
+        }
+    }
+
+    public void prepareMaven() {
         if (runMode.isDryRun()) {
-            properties.put(QUARKUS_CONTAINER_IMAGE_DRY_RUN, "true");
+            return;
+        }
+        BuildSystemRunner runner = getRunner();
+        BuildSystemRunner.BuildCommandArgs compileArgs = runner.prepareAction("compiler:compile", buildOptions, runMode,
+                params);
+        int compileExitCode = runner.run(compileArgs);
+        if (compileExitCode != ExitCode.OK) {
+            throw new RuntimeException("Failed to compile. Compilation exited with exit code:" + compileExitCode);
+        }
+    }
+
+    public void prepareGradle() {
+        if (!getForcedExtensions().isEmpty()) {
+            // Ensure that params is modifiable
+            params = new ArrayList<>(this.params);
+            GradleInitScript.populateForExtensions(getForcedExtensions(), params);
         }
     }
 
@@ -59,8 +106,4 @@ public class BaseImageCommand extends BaseBuildCommand implements Callable<Integ
         return this.propertiesOptions;
     }
 
-    @Override
-    public Integer call() throws Exception {
-        return 0;
-    }
 }

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Buildpack.java
@@ -1,6 +1,8 @@
 package io.quarkus.cli.image;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -51,10 +53,9 @@ public class Buildpack extends BaseImageCommand {
     BaseImageCommand parent;
 
     @Override
-    public void populateImageConfiguration(Map<String, String> properties) {
-        super.populateImageConfiguration(properties);
+    public Integer call() throws Exception {
+        Map<String, String> properties = parent.getPropertiesOptions().properties;
         properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, BUILDPACK);
-        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + BUILDPACK);
 
         builderImage.ifPresent(i -> properties
                 .put(BUILDPACK_CONFIG_PREFIX + (buildOptions.buildNative ? NATIVE_BUILDER_IMAGE : JVM_BUILDER_IMAGE), i));
@@ -64,16 +65,18 @@ public class Buildpack extends BaseImageCommand {
         dockerHost.ifPresent(h -> properties.put(BUILDPACK_CONFIG_PREFIX + DOCKER_HOST, h));
         runImage.ifPresent(i -> properties.put(BUILDPACK_CONFIG_PREFIX + RUN_IMAGE, i));
         buildEnv.forEach((k, v) -> properties.put(BUILDPACK_CONFIG_PREFIX + BUILDER_ENV + "." + k, v));
+
+        parent.getForcedExtensions().add(QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + BUILDPACK);
+        parent.runMode = runMode;
+        parent.buildOptions = buildOptions;
+        parent.imageOptions = imageOptions;
+        parent.setOutput(output);
+        return parent.call();
     }
 
     @Override
-    public Integer call() throws Exception {
-        try {
-            populateImageConfiguration(parent.getPropertiesOptions().properties);
-            return parent.call();
-        } catch (Exception e) {
-            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
-        }
+    public List<String> getForcedExtensions() {
+        return Arrays.asList(QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + BUILDPACK);
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Docker.java
@@ -23,22 +23,18 @@ public class Docker extends BaseImageCommand {
     BaseImageCommand parent;
 
     @Override
-    public void populateImageConfiguration(Map<String, String> properties) {
-        super.populateImageConfiguration(properties);
-        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, DOCKER);
-        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + DOCKER);
-        dockerFile.ifPresent(d -> properties.put(DOCKER_CONFIG_PREFIX
-                + (buildOptions.buildNative ? DOCKERFILE_NATIVE_PATH : DOCKERFILE_JVM_PATH), d));
-    }
-
-    @Override
     public Integer call() throws Exception {
-        try {
-            populateImageConfiguration(parent.getPropertiesOptions().properties);
-            return parent.call();
-        } catch (Exception e) {
-            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
-        }
+        Map<String, String> properties = parent.getPropertiesOptions().properties;
+        properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, DOCKER);
+        dockerFile.ifPresent(d -> properties
+                .put(DOCKER_CONFIG_PREFIX + (buildOptions.buildNative ? DOCKERFILE_NATIVE_PATH : DOCKERFILE_JVM_PATH), d));
+
+        parent.getForcedExtensions().add(QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + DOCKER);
+        parent.runMode = runMode;
+        parent.buildOptions = buildOptions;
+        parent.imageOptions = imageOptions;
+        parent.setOutput(output);
+        return parent.call();
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/image/Jib.java
@@ -1,6 +1,7 @@
 package io.quarkus.cli.image;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -77,11 +78,9 @@ public class Jib extends BaseImageCommand {
     BaseImageCommand parent;
 
     @Override
-    public void populateImageConfiguration(Map<String, String> properties) {
-        super.populateImageConfiguration(properties);
+    public Integer call() throws Exception {
+        Map<String, String> properties = parent.getPropertiesOptions().properties;
         properties.put(QUARKUS_CONTAINER_IMAGE_BUILDER, JIB);
-        properties.put(QUARKUS_FORCED_EXTENSIONS, QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + JIB);
-
         baseImage.ifPresent(
                 d -> properties.put(JIB_CONFIG_PREFIX + (buildOptions.buildNative ? BASE_NATIVE_IMAGE : BASE_JVM_IMAGE), d));
 
@@ -133,16 +132,18 @@ public class Jib extends BaseImageCommand {
         if (buildOptions.offline) {
             properties.put(JIB_CONFIG_PREFIX + OFFLINE_MODE, "true");
         }
+
+        parent.getForcedExtensions().add(QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + JIB);
+        parent.runMode = runMode;
+        parent.buildOptions = buildOptions;
+        parent.imageOptions = imageOptions;
+        parent.setOutput(output);
+        return parent.call();
     }
 
     @Override
-    public Integer call() throws Exception {
-        try {
-            populateImageConfiguration(parent.getPropertiesOptions().properties);
-            return parent.call();
-        } catch (Exception e) {
-            return output.handleCommandException(e, "Unable to build image: " + e.getMessage());
-        }
+    public List<String> getForcedExtensions() {
+        return Arrays.asList(QUARKUS_CONTAINER_IMAGE_EXTENSION_KEY_PREFIX + JIB);
     }
 
     @Override

--- a/devtools/cli/src/main/java/io/quarkus/cli/utils/GradleInitScript.java
+++ b/devtools/cli/src/main/java/io/quarkus/cli/utils/GradleInitScript.java
@@ -1,0 +1,65 @@
+package io.quarkus.cli.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GradleInitScript {
+
+    public static final String ALL_PROJECTS = "allprojects {";
+    public static final String APPLY_PLUGIN_JAVA = "apply plugin: 'java'";
+    public static final String DEPENDENCIES = "dependencies {";
+    public static final String DEPENDENCY = "implementation '%s'";
+    public static final String CLOSE = "}";
+    public static final String TAB = "    ";
+    public static final String NEWLINE = "\n";
+
+    /**
+     * Create an init script that adds the specidied extensions and populate the arguments
+     * that should be passed to the gradle command, so that it loads the generated init script.
+     * The command will append to the specified argument list: `--init-script=</path/to/temporary/initscript>`
+     *
+     * @param forcedExtensions The forcced extension to add to the init script
+     * @param args The argument list
+     */
+    public static void populateForExtensions(Collection<String> forcedExtensions, Collection<String> args) {
+        List<String> gavs = forcedExtensions.stream()
+                .map(String::trim)
+                .map(e -> e + ":${quarkusPlatformVersion}")
+                .collect(Collectors.toList());
+        Path initScriptPath = GradleInitScript.createInitScript(gavs);
+        args.add("--init-script=" + initScriptPath.toAbsolutePath().toString());
+    }
+
+    public static Path createInitScript(List<String> gavs) {
+        try {
+            Path path = Files.createTempFile("quarkus-gradle-init", "");
+            createInitScript(path, gavs);
+            return path;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void createInitScript(Path path, List<String> gavs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ALL_PROJECTS).append(NEWLINE);
+        sb.append(TAB).append(APPLY_PLUGIN_JAVA).append(NEWLINE);
+        sb.append(TAB).append(DEPENDENCIES).append(NEWLINE);
+
+        for (String gav : gavs) {
+            sb.append(TAB).append(TAB).append(String.format(DEPENDENCY, gav)).append(NEWLINE);
+        }
+
+        sb.append(TAB).append(CLOSE).append(NEWLINE);
+        sb.append(CLOSE).append(NEWLINE);
+        try {
+            Files.writeString(path, sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
+++ b/devtools/cli/src/test/java/io/quarkus/cli/image/CliImageGradleTest.java
@@ -1,0 +1,141 @@
+package io.quarkus.cli.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.cli.CliDriver;
+import io.quarkus.cli.build.ExecuteUtil;
+import io.quarkus.cli.build.GradleRunner;
+import io.quarkus.devtools.testing.RegistryClientTestHelper;
+import picocli.CommandLine;
+
+/**
+ * Similar to CliProjecGradleTest ..
+ */
+public class CliImageGradleTest {
+
+    static final Path testProjectRoot = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            .resolve("target/test-project/");
+    static final Path workspaceRoot = testProjectRoot.resolve("CliImageGradleTest");
+    static final Path wrapperRoot = testProjectRoot.resolve("gradle-wrapper");
+
+    Path project;
+    static File gradle;
+
+    @BeforeAll
+    public static void setupTestRegistry() {
+        RegistryClientTestHelper.enableRegistryClientTestConfig();
+    }
+
+    @AfterAll
+    public static void cleanupTestRegistry() {
+        RegistryClientTestHelper.disableRegistryClientTestConfig();
+    }
+
+    @BeforeEach
+    public void setupTestDirectories() throws Exception {
+        CliDriver.deleteDir(workspaceRoot);
+        project = workspaceRoot.resolve("code-with-quarkus");
+    }
+
+    @BeforeAll
+    static void startGradleDaemon() throws Exception {
+        CliDriver.deleteDir(wrapperRoot);
+
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B",
+                "--no-code",
+                "-o", testProjectRoot.toString(),
+                "gradle-wrapper");
+        Assertions.assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        Assertions.assertTrue(result.getStdout().contains("SUCCESS"),
+                "Expected confirmation that the project has been created." + result);
+
+        gradle = ExecuteUtil.findWrapper(wrapperRoot, GradleRunner.windowsWrapper, GradleRunner.otherWrapper);
+
+        List<String> args = new ArrayList<>();
+        args.add(gradle.getAbsolutePath());
+        args.add("--daemon");
+        CliDriver.preserveLocalRepoSettings(args);
+
+        result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
+        Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should start properly");
+    }
+
+    @AfterAll
+    static void stopGradleDaemon() throws Exception {
+        if (gradle != null) {
+            List<String> args = new ArrayList<>();
+            args.add(gradle.getAbsolutePath());
+            args.add("--stop");
+            CliDriver.preserveLocalRepoSettings(args);
+
+            CliDriver.Result result = CliDriver.executeArbitraryCommand(wrapperRoot, args.toArray(new String[0]));
+            Assertions.assertEquals(0, result.getExitCode(), "Gradle daemon should stop properly");
+        }
+    }
+
+    @Test
+    public void testUsage() throws Exception {
+        CliDriver.Result result = CliDriver.execute(workspaceRoot, "create", "app", "--gradle", "--verbose", "-e", "-B");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+
+        // 1 image --dry-run
+        result = CliDriver.execute(project, "image", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+
+        // 2 image build --dry-run
+        result = CliDriver.execute(project, "image", "build", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("--builder=docker")); // Should fallback to docker
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        result = CliDriver.execute(project, "image", "build", "docker", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("--builder=docker"));
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        result = CliDriver.execute(project, "image", "build", "jib", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("--builder=jib"));
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        result = CliDriver.execute(project, "image", "build", "buildpack", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("--builder=buildpack"));
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        result = CliDriver.execute(project, "image", "build", "openshift", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("--builder=openshift"));
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        result = CliDriver.execute(project, "image", "build", "--group=mygroup", "--name=myname", "--tag=1.0", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.group=mygroup"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.name=myname"));
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.tag=1.0"));
+
+        // 3 image push --dry-run
+        result = CliDriver.execute(project, "image", "push", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=false"));
+        assertTrue(result.getStdout().contains("--init-script="));
+
+        // 4 image push --also-build --dry-run
+        result = CliDriver.execute(project, "image", "push", "--also-build", "--dry-run");
+        assertEquals(CommandLine.ExitCode.OK, result.getExitCode(), "Expected OK return code." + result);
+        assertTrue(result.getStdout().contains("-Dquarkus.container-image.build=true"));
+    }
+}


### PR DESCRIPTION
The pull request addresses the following:

- It's now possible to force container image extension for gradle projects (using init scripts). 
- Fixes dry-run handling for nested commands (e.g. docker, jib, openshift, buildpack).


To explain the init script thing, which was BTW @maxandersen idea:

When the image commands are run inside gradle projects, the delegate to the gradle image tasks. Since, those tasks cannot (yet) change on the fly the dependencies, we instead feed them with a generated init script that contains all the needed dependencies.

The init script looks like:

```groovy
allprojects {
    apply plugin: 'java'
    dependencies {
        implementation 'io.quarkus:quarkus-container-image-jib:${quarkusPlatformVersion}'
    }
}
```

