### PR TITLE
Fix example code for mocking REST Clients in the REST Client Reactive guide

### DIFF
--- a/docs/src/main/asciidoc/rest-client-reactive.adoc
+++ b/docs/src/main/asciidoc/rest-client-reactive.adoc
@@ -1094,9 +1094,11 @@ Then, in your test you can simply use `@InjectMock` to create and inject a mock:
 
 [source,java]
 ----
-import static org.assertj.core.api.Assertions.assertThat;
+package io.quarkus.it.rest.client.main;
+
 import static org.mockito.Mockito.when;
 
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -1107,6 +1109,7 @@ import io.quarkus.test.junit.mockito.InjectMock;
 public class InjectMockTest {
 
     @InjectMock
+    @RestClient
     Client mock;
 
     @BeforeEach
@@ -1126,6 +1129,8 @@ If Mockito doesn't meet your needs, you can create a mock programmatically using
 
 [source,java]
 ----
+package io.quarkus.it.rest.client.main;
+
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
When mocking a rest client in a `@QuarkusTest` with `@InjectMock`, a `@RestClient` qualifier has to be added to the target field, see [#28004 (comment)](https://github.com/quarkusio/quarkus/issues/28004#issuecomment-1250651361), #27582.

[This example](https://quarkus.io/guides/rest-client-reactive#mocking-with-injectmock) in the REST Client Reactive guide still lacks this annotation and therefore stopped working in 2.12.1.Final.