### PR TITLE
Backchannel logout request forward patch

### DIFF
--- a/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
+++ b/extensions/oidc/runtime/src/main/java/io/quarkus/oidc/runtime/BackChannelLogoutHandler.java
@@ -94,7 +94,11 @@ public class BackChannelLogoutHandler {
 
                                     }
                                 }
-                                context.response().end();
+
+                                if (context.response().getStatusCode() != 200) {
+                                    context.response().end();
+                                }
+                                context.next();
                             }
 
                         });


### PR DESCRIPTION
We are closing the http request before reaching the end-use backchannel logout. This commit will only close the connection on BackChannelLogoutHandler in case The logout token is not valid. Otherwise the request will be forwarded to the next handler.

Fix: https://github.com/quarkusio/quarkus/issues/29442