### PR TITLE
Arc - improve transactional OM error logging to include more information by default

### DIFF
--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/EventImpl.java
@@ -473,8 +473,13 @@ class EventImpl<T> implements Event<T> {
             } catch (Exception e) {
                 // swallow exception and log errors for every problematic OM
                 LOG.errorf(
-                        "Failure occurred while notifying a transational %s for event of type %s \n- please enable debug logging to see the full stack trace",
-                        observerMethod, eventContext.getMetadata().getType().getTypeName());
+                        "Failure occurred while notifying a transational %s for event of type %s " +
+                                "\n- please enable debug logging to see the full stack trace" +
+                                "\n %s",
+                        observerMethod, eventContext.getMetadata().getType().getTypeName(),
+                        e.getCause() != null && e.getMessage() != null
+                                ? "Cause: " + e.getCause() + " Message: " + e.getMessage()
+                                : "Exception caught: " + e);
                 LOG.debugf(e, "Failure occurred while notifying a transational %s for event of type %s",
                         observerMethod, eventContext.getMetadata().getType().getTypeName());
             }


### PR DESCRIPTION
Fixes #29429 


The exception from `TransactionalObserversErrorHandlingTest` now looks like this:

```
2022-11-23 13:02:14,001 ERROR [io.qua.arc.imp.EventImpl$DeferredEventNotification] (main) Failure occurred while notifying a transational Observer [method=io.quarkus.narayana.observers.TransactionalObserversErrorHandlingTest$ObservingBean#observeAfterSuccess2(java.lang.String)] for event of type java.lang.String 
- please enable debug logging to see the full stack trace
 Exception caught: java.lang.IllegalStateException: This is an expected exception within test

```