### PR TITLE
Fix Vert.x event bus codec registration

### DIFF
--- a/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
+++ b/extensions/vertx/deployment/src/main/java/io/quarkus/vertx/deployment/EventBusCodecProcessor.java
@@ -42,7 +42,7 @@ public class EventBusCodecProcessor {
 
         final IndexView index = beanArchiveIndexBuildItem.getIndex();
         Collection<AnnotationInstance> consumeEventAnnotationInstances = index.getAnnotations(CONSUME_EVENT);
-        Map<Type, DotName> codecByTypes = new HashMap<>();
+        Map<DotName, DotName> codecByTypes = new HashMap<>();
         for (AnnotationInstance consumeEventAnnotationInstance : consumeEventAnnotationInstances) {
             AnnotationTarget typeTarget = consumeEventAnnotationInstance.target();
             if (typeTarget.kind() != AnnotationTarget.Kind.METHOD) {
@@ -59,7 +59,7 @@ public class EventBusCodecProcessor {
                 if (codecTargetFromParameter == null) {
                     throw new IllegalStateException("Invalid `codec` argument in @ConsumeEvent - no parameter");
                 }
-                codecByTypes.put(codecTargetFromParameter, codec.asClass().asClassType().name());
+                codecByTypes.put(codecTargetFromParameter.name(), codec.asClass().asClassType().name());
             } else if (codecTargetFromParameter != null) {
                 // Codec is not set, check if we have a built-in codec
                 if (!hasBuiltInCodec(codecTargetFromParameter)) {
@@ -70,24 +70,24 @@ public class EventBusCodecProcessor {
                                 "The generic message codec can only be used for local delivery,"
                                         + ", implement your own event bus codec for " + codecTargetFromParameter.name()
                                                 .toString());
-                    } else if (!codecByTypes.containsKey(codecTargetFromParameter)) {
+                    } else if (!codecByTypes.containsKey(codecTargetFromParameter.name())) {
                         LOGGER.infof("Local Message Codec registered for type %s",
                                 codecTargetFromParameter.toString());
-                        codecByTypes.put(codecTargetFromParameter, LOCAL_EVENT_BUS_CODEC);
+                        codecByTypes.put(codecTargetFromParameter.name(), LOCAL_EVENT_BUS_CODEC);
                     }
                 }
             }
 
             if (codecTargetFromReturnType != null && !hasBuiltInCodec(codecTargetFromReturnType)
-                    && !codecByTypes.containsKey(codecTargetFromReturnType)) {
+                    && !codecByTypes.containsKey(codecTargetFromReturnType.name())) {
 
                 LOGGER.infof("Local Message Codec registered for type %s", codecTargetFromReturnType.toString());
-                codecByTypes.put(codecTargetFromReturnType, LOCAL_EVENT_BUS_CODEC);
+                codecByTypes.put(codecTargetFromReturnType.name(), LOCAL_EVENT_BUS_CODEC);
             }
         }
 
         // Produce the build items
-        for (Map.Entry<Type, DotName> entry : codecByTypes.entrySet()) {
+        for (Map.Entry<DotName, DotName> entry : codecByTypes.entrySet()) {
             messageCodecs.produce(new MessageCodecBuildItem(entry.getKey().toString(), entry.getValue().toString()));
         }
 

--- a/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/EventBusCodecTest.java
+++ b/extensions/vertx/deployment/src/test/java/io/quarkus/vertx/EventBusCodecTest.java
@@ -2,6 +2,10 @@ package io.quarkus.vertx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -73,6 +77,11 @@ public class EventBusCodecTest {
         }
     }
 
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.TYPE_USE)
+    @interface NonNull {
+    }
+
     static class MyBean {
         @ConsumeEvent("person")
         public CompletionStage<Greeting> hello(Person p) {
@@ -82,6 +91,12 @@ public class EventBusCodecTest {
         @ConsumeEvent(value = "pet", codec = MyPetCodec.class)
         public CompletionStage<Greeting> hello(Pet p) {
             return CompletableFuture.completedFuture(new Greeting("Hello " + p.getName()));
+        }
+
+        // presence of this method is enough to verify that type annotation
+        // on the message type doesn't cause failure
+        @ConsumeEvent("message-type-with-type-annotation")
+        void messageTypeWithTypeAnnotation(@NonNull Person person) {
         }
     }
 


### PR DESCRIPTION
The `EventBusCodecProcessor` used to create a map from Jandex `Type` of message to a `DotName` of the corresponding codec, and then expose that map as a repeatable `MessageCodecBuildItem`. When creating each build item, the code used to call `Type.toString()`, which is never the right thing to do when obtaining a class name from Jandex `Type`.

With this commit, the map is from type `DotName` to codec `DotName`, and the key in the map is obtained by `Type.name()`.

Fixes #29434