### PR TITLE
Arc - fix InvocationContext parameters for around construct interceptors when there are other interceptors in play

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/BeanGenerator.java
@@ -956,14 +956,15 @@ public class BeanGenerator extends AbstractGenerator {
                 bridgeCreate.getMethodParam(0)));
     }
 
-    private List<ResultHandle> newProviderHandles(BeanInfo bean, ClassCreator beanCreator, MethodCreator createMethod,
+    private void newProviderHandles(BeanInfo bean, ClassCreator beanCreator, MethodCreator createMethod,
             Map<InjectionPointInfo, String> injectionPointToProviderField,
             Map<InterceptorInfo, String> interceptorToProviderField,
             Map<DecoratorInfo, String> decoratorToProviderSupplierField,
             Map<InterceptorInfo, ResultHandle> interceptorToWrap,
-            List<TransientReference> transientReferences) {
+            List<TransientReference> transientReferences,
+            List<ResultHandle> injectableParamHandles,
+            List<ResultHandle> allOtherParamHandles) {
 
-        List<ResultHandle> providerHandles = new ArrayList<>();
         Optional<Injection> constructorInjection = bean.getConstructorInjection();
 
         if (constructorInjection.isPresent()) {
@@ -978,7 +979,7 @@ public class BeanGenerator extends AbstractGenerator {
                         providerHandle, createMethod.getMethodParam(0));
                 ResultHandle referenceHandle = createMethod.invokeInterfaceMethod(MethodDescriptors.INJECTABLE_REF_PROVIDER_GET,
                         providerHandle, childCtx);
-                providerHandles.add(referenceHandle);
+                injectableParamHandles.add(referenceHandle);
                 if (injectionPoint.isDependentTransientReference()) {
                     transientReferences.add(new TransientReference(providerHandle, referenceHandle, childCtx));
                 }
@@ -988,7 +989,7 @@ public class BeanGenerator extends AbstractGenerator {
             for (InterceptorInfo interceptor : bean.getBoundInterceptors()) {
                 ResultHandle wrapped = interceptorToWrap.get(interceptor);
                 if (wrapped != null) {
-                    providerHandles.add(wrapped);
+                    allOtherParamHandles.add(wrapped);
                 } else {
                     ResultHandle interceptorProviderSupplierHandle = createMethod.readInstanceField(
                             FieldDescriptor.of(beanCreator.getClassName(), interceptorToProviderField.get(interceptor),
@@ -996,7 +997,7 @@ public class BeanGenerator extends AbstractGenerator {
                             createMethod.getThis());
                     ResultHandle interceptorProviderHandle = createMethod.invokeInterfaceMethod(
                             MethodDescriptors.SUPPLIER_GET, interceptorProviderSupplierHandle);
-                    providerHandles.add(interceptorProviderHandle);
+                    allOtherParamHandles.add(interceptorProviderHandle);
                 }
             }
             for (DecoratorInfo decorator : bean.getBoundDecorators()) {
@@ -1006,10 +1007,9 @@ public class BeanGenerator extends AbstractGenerator {
                         createMethod.getThis());
                 ResultHandle decoratorProviderHandle = createMethod.invokeInterfaceMethod(
                         MethodDescriptors.SUPPLIER_GET, decoratorProviderSupplierHandle);
-                providerHandles.add(decoratorProviderHandle);
+                allOtherParamHandles.add(decoratorProviderHandle);
             }
         }
-        return providerHandles;
     }
 
     private ResultHandle newInstanceHandle(BeanInfo bean, ClassCreator beanCreator, BytecodeCreator creator,
@@ -1402,14 +1402,20 @@ public class BeanGenerator extends AbstractGenerator {
             }
 
             List<TransientReference> transientReferences = new ArrayList<>();
-            List<ResultHandle> providerHandles = newProviderHandles(bean, beanCreator, create,
+            // List of handles representing injectable parameters
+            List<ResultHandle> injectableCtorParams = new ArrayList<>();
+            // list of handles representing all other parameters, such as injectable interceptors
+            List<ResultHandle> allOtherCtorParams = new ArrayList<>();
+            newProviderHandles(bean, beanCreator, create,
                     injectionPointToProviderSupplierField, interceptorToProviderSupplierField, decoratorToProviderSupplierField,
-                    interceptorToWrap, transientReferences);
+                    interceptorToWrap, transientReferences, injectableCtorParams, allOtherCtorParams);
 
             // Forwarding function
             // Supplier<Object> forward = () -> new SimpleBean_Subclass(ctx,lifecycleInterceptorProvider1)
             FunctionCreator func = create.createFunction(Supplier.class);
             BytecodeCreator funcBytecode = func.getBytecode();
+            List<ResultHandle> providerHandles = new ArrayList<>(injectableCtorParams);
+            providerHandles.addAll(allOtherCtorParams);
             ResultHandle retHandle = newInstanceHandle(bean, beanCreator, funcBytecode, create, providerType.className(),
                     baseName,
                     providerHandles,
@@ -1427,11 +1433,10 @@ public class BeanGenerator extends AbstractGenerator {
                 create.writeArrayValue(bindingsArray, bindingsIndex++,
                         annotationLiterals.create(create, bindingClass, binding));
             }
-
             // ResultHandle of Object[] holding all constructor args
-            ResultHandle ctorArgsArray = create.newArray(Object.class, create.load(providerHandles.size()));
-            for (int i = 0; i < providerHandles.size(); i++) {
-                create.writeArrayValue(ctorArgsArray, i, providerHandles.get(i));
+            ResultHandle ctorArgsArray = create.newArray(Object.class, create.load(injectableCtorParams.size()));
+            for (int i = 0; i < injectableCtorParams.size(); i++) {
+                create.writeArrayValue(ctorArgsArray, i, injectableCtorParams.get(i));
             }
             ResultHandle invocationContextHandle = create.invokeStaticMethod(
                     MethodDescriptors.INVOCATION_CONTEXTS_AROUND_CONSTRUCT, constructorHandle,
@@ -1452,11 +1457,13 @@ public class BeanGenerator extends AbstractGenerator {
 
         } else {
             List<TransientReference> transientReferences = new ArrayList<>();
+            List<ResultHandle> providerHandles = new ArrayList<>();
+            newProviderHandles(bean, beanCreator, create, injectionPointToProviderSupplierField,
+                    interceptorToProviderSupplierField, decoratorToProviderSupplierField,
+                    interceptorToWrap, transientReferences, providerHandles, providerHandles);
             create.assign(instanceHandle,
                     newInstanceHandle(bean, beanCreator, create, create, providerType.className(), baseName,
-                            newProviderHandles(bean, beanCreator, create, injectionPointToProviderSupplierField,
-                                    interceptorToProviderSupplierField, decoratorToProviderSupplierField,
-                                    interceptorToWrap, transientReferences),
+                            providerHandles,
                             reflectionRegistration, isApplicationClass));
             // Destroy injected transient references
             destroyTransientReferences(create, transientReferences);


### PR DESCRIPTION
Related to #28783 

@mkouba this is a quick draft of what I meant by https://github.com/quarkusio/quarkus/issues/28783#issuecomment-1325022112
If you have any better idea than pretending the other parameters don't exist, I am all ears :)

CC @luca-bassoricci 