### PR TITLE
ArC: fix build-time and runtime resolution of beans with recursive generic types

### DIFF
--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AssignabilityCheck.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/AssignabilityCheck.java
@@ -1,5 +1,7 @@
 package io.quarkus.arc.processor;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,22 +33,36 @@ final class AssignabilityCheck {
             return true;
         }
         // type1 is a superclass
-        return getAssignables(type1.name()).contains(type2.name());
+        return getSupertypes(type2.name()).contains(type1.name());
     }
 
-    Set<DotName> getAssignables(DotName name) {
-        return cache.computeIfAbsent(name, this::findAssignables);
+    private Set<DotName> getSupertypes(DotName name) {
+        return cache.computeIfAbsent(name, this::findSupertypes);
     }
 
-    private Set<DotName> findAssignables(DotName name) {
-        Set<DotName> assignables = new HashSet<>();
-        for (ClassInfo subclass : index.getAllKnownSubclasses(name)) {
-            assignables.add(subclass.name());
+    private Set<DotName> findSupertypes(DotName name) {
+        Set<DotName> result = new HashSet<>();
+
+        Deque<DotName> workQueue = new ArrayDeque<>();
+        workQueue.add(name);
+        while (!workQueue.isEmpty()) {
+            DotName type = workQueue.poll();
+            if (result.contains(type)) {
+                continue;
+            }
+            result.add(type);
+
+            ClassInfo clazz = index.getClassByName(type);
+            if (clazz == null) {
+                continue;
+            }
+            if (clazz.superName() != null) {
+                workQueue.add(clazz.superName());
+            }
+            workQueue.addAll(clazz.interfaceNames());
         }
-        for (ClassInfo implementor : index.getAllKnownImplementors(name)) {
-            assignables.add(implementor.name());
-        }
-        return assignables;
+
+        return result;
     }
 
 }

--- a/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
+++ b/independent-projects/arc/processor/src/main/java/io/quarkus/arc/processor/Types.java
@@ -3,12 +3,10 @@ package io.quarkus.arc.processor;
 import static io.quarkus.arc.processor.IndexClassLookupUtils.getClassByName;
 
 import java.lang.reflect.Modifier;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -87,35 +85,52 @@ public final class Types {
 
     public static ResultHandle getTypeHandle(BytecodeCreator creator, Type type, ResultHandle tccl) {
         AssignableResultHandle result = creator.createVariable(Object.class);
-        getTypeHandle(result, creator, type, tccl, null, new ArrayDeque<>());
+        TypeVariables typeVariables = new TypeVariables();
+        getTypeHandle(result, creator, type, tccl, null, typeVariables);
+        typeVariables.patchReferences(creator);
         return result;
     }
 
-    private static class TypeVariableInfo {
-        final String name;
-        ResultHandle handle;
+    private static class TypeVariables {
+        private final Map<String, ResultHandle> typeVariable = new HashMap<>();
+        private final Map<String, ResultHandle> typeVariableReference = new HashMap<>();
 
-        TypeVariableInfo(String name) {
-            this.name = name;
+        ResultHandle getTypeVariable(String identifier) {
+            return typeVariable.get(identifier);
         }
 
-        static TypeVariableInfo find(String name, Deque<TypeVariableInfo> typeVariableStack) {
-            for (TypeVariableInfo typeVariableInfo : typeVariableStack) {
-                if (typeVariableInfo.name.equals(name)) {
-                    return typeVariableInfo;
+        void setTypeVariable(String identifier, ResultHandle handle) {
+            typeVariable.put(identifier, handle);
+        }
+
+        ResultHandle getTypeVariableReference(String identifier) {
+            return typeVariableReference.get(identifier);
+        }
+
+        void setTypeVariableReference(String identifier, ResultHandle handle) {
+            typeVariableReference.put(identifier, handle);
+        }
+
+        void patchReferences(BytecodeCreator creator) {
+            typeVariableReference.forEach((identifier, reference) -> {
+                ResultHandle typeVar = typeVariable.get(identifier);
+                if (typeVar != null) {
+                    creator.invokeVirtualMethod(MethodDescriptor.ofMethod(TypeVariableReferenceImpl.class,
+                            "setDelegate", void.class, TypeVariableImpl.class), reference, typeVar);
                 }
-            }
-            return null;
+            });
         }
     }
 
     static void getTypeHandle(AssignableResultHandle variable, BytecodeCreator creator, Type type, ResultHandle tccl,
             TypeCache cache) {
-        getTypeHandle(variable, creator, type, tccl, cache, new ArrayDeque<>());
+        TypeVariables typeVariables = new TypeVariables();
+        getTypeHandle(variable, creator, type, tccl, cache, typeVariables);
+        typeVariables.patchReferences(creator);
     }
 
     private static void getTypeHandle(AssignableResultHandle variable, BytecodeCreator creator, Type type,
-            ResultHandle tccl, TypeCache cache, Deque<TypeVariableInfo> typeVariableStack) {
+            ResultHandle tccl, TypeCache cache, TypeVariables typeVariables) {
         if (cache != null) {
             ResultHandle cachedType = cache.get(type, creator);
             BranchResult cachedNull = creator.ifNull(cachedType);
@@ -132,42 +147,41 @@ public final class Types {
         } else if (Kind.TYPE_VARIABLE.equals(type.kind())) {
             // E.g. T -> new TypeVariableImpl("T")
             TypeVariable typeVariable = type.asTypeVariable();
-            typeVariableStack.push(new TypeVariableInfo(typeVariable.identifier()));
-            ResultHandle boundsHandle;
-            List<Type> bounds = typeVariable.bounds();
-            if (bounds.isEmpty()) {
-                boundsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(0));
-            } else {
-                boundsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(bounds.size()));
-                for (int i = 0; i < bounds.size(); i++) {
-                    AssignableResultHandle boundHandle = creator.createVariable(Object.class);
-                    getTypeHandle(boundHandle, creator, bounds.get(i), tccl, cache, typeVariableStack);
-                    creator.writeArrayValue(boundsHandle, i, boundHandle);
+            String identifier = typeVariable.identifier();
+
+            ResultHandle typeVariableHandle = typeVariables.getTypeVariable(identifier);
+            if (typeVariableHandle == null) {
+                ResultHandle boundsHandle;
+                List<Type> bounds = typeVariable.bounds();
+                if (bounds.isEmpty()) {
+                    boundsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(0));
+                } else {
+                    boundsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(bounds.size()));
+                    for (int i = 0; i < bounds.size(); i++) {
+                        AssignableResultHandle boundHandle = creator.createVariable(Object.class);
+                        getTypeHandle(boundHandle, creator, bounds.get(i), tccl, cache, typeVariables);
+                        creator.writeArrayValue(boundsHandle, i, boundHandle);
+                    }
                 }
-            }
-            ResultHandle typeVariableHandle = creator.newInstance(
-                    MethodDescriptor.ofConstructor(TypeVariableImpl.class, String.class, java.lang.reflect.Type[].class),
-                    creator.load(typeVariable.identifier()), boundsHandle);
-            if (cache != null) {
-                cache.put(typeVariable, typeVariableHandle, creator);
+                typeVariableHandle = creator.newInstance(
+                        MethodDescriptor.ofConstructor(TypeVariableImpl.class, String.class, java.lang.reflect.Type[].class),
+                        creator.load(identifier), boundsHandle);
+                if (cache != null) {
+                    cache.put(typeVariable, typeVariableHandle, creator);
+                }
+                typeVariables.setTypeVariable(identifier, typeVariableHandle);
             }
             creator.assign(variable, typeVariableHandle);
 
-            TypeVariableInfo recursive = typeVariableStack.pop();
-            if (recursive.handle != null) {
-                creator.invokeVirtualMethod(MethodDescriptor.ofMethod(TypeVariableReferenceImpl.class, "setDelegate",
-                        void.class, TypeVariableImpl.class), recursive.handle, typeVariableHandle);
-            }
-
         } else if (Kind.PARAMETERIZED_TYPE.equals(type.kind())) {
             // E.g. List<String> -> new ParameterizedTypeImpl(List.class, String.class)
-            getParameterizedType(variable, creator, tccl, type.asParameterizedType(), cache, typeVariableStack);
+            getParameterizedType(variable, creator, tccl, type.asParameterizedType(), cache, typeVariables);
 
         } else if (Kind.ARRAY.equals(type.kind())) {
             Type componentType = type.asArrayType().component();
             // E.g. String[] -> new GenericArrayTypeImpl(String.class)
             AssignableResultHandle componentTypeHandle = creator.createVariable(Object.class);
-            getTypeHandle(componentTypeHandle, creator, componentType, tccl, cache, typeVariableStack);
+            getTypeHandle(componentTypeHandle, creator, componentType, tccl, cache, typeVariables);
             ResultHandle arrayHandle = creator.newInstance(
                     MethodDescriptor.ofConstructor(GenericArrayTypeImpl.class, java.lang.reflect.Type.class),
                     componentTypeHandle);
@@ -182,14 +196,14 @@ public final class Types {
             ResultHandle wildcardHandle;
             if (wildcardType.superBound() == null) {
                 AssignableResultHandle extendsBoundHandle = creator.createVariable(Object.class);
-                getTypeHandle(extendsBoundHandle, creator, wildcardType.extendsBound(), tccl, cache, typeVariableStack);
+                getTypeHandle(extendsBoundHandle, creator, wildcardType.extendsBound(), tccl, cache, typeVariables);
                 wildcardHandle = creator.invokeStaticMethod(
                         MethodDescriptor.ofMethod(WildcardTypeImpl.class, "withUpperBound",
                                 java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
                         extendsBoundHandle);
             } else {
                 AssignableResultHandle superBoundHandle = creator.createVariable(Object.class);
-                getTypeHandle(superBoundHandle, creator, wildcardType.superBound(), tccl, cache, typeVariableStack);
+                getTypeHandle(superBoundHandle, creator, wildcardType.superBound(), tccl, cache, typeVariables);
                 wildcardHandle = creator.invokeStaticMethod(
                         MethodDescriptor.ofMethod(WildcardTypeImpl.class, "withLowerBound",
                                 java.lang.reflect.WildcardType.class, java.lang.reflect.Type.class),
@@ -230,29 +244,28 @@ public final class Types {
             }
         } else if (Kind.TYPE_VARIABLE_REFERENCE.equals(type.kind())) {
             String identifier = type.asTypeVariableReference().identifier();
-            TypeVariableInfo recursive = TypeVariableInfo.find(identifier, typeVariableStack);
-            if (recursive != null) {
-                ResultHandle typeVariableHandle = creator.newInstance(
+
+            ResultHandle typeVariableReferenceHandle = typeVariables.getTypeVariableReference(identifier);
+            if (typeVariableReferenceHandle == null) {
+                typeVariableReferenceHandle = creator.newInstance(
                         MethodDescriptor.ofConstructor(TypeVariableReferenceImpl.class, String.class),
                         creator.load(identifier));
-                creator.assign(variable, typeVariableHandle);
-                recursive.handle = typeVariableHandle;
-                return;
+                typeVariables.setTypeVariableReference(identifier, typeVariableReferenceHandle);
             }
 
-            throw new IllegalArgumentException("Can't resolve type variable: " + type);
+            creator.assign(variable, typeVariableReferenceHandle);
         } else {
             throw new IllegalArgumentException("Unsupported bean type: " + type.kind() + ", " + type);
         }
     }
 
     private static void getParameterizedType(AssignableResultHandle variable, BytecodeCreator creator, ResultHandle tccl,
-            ParameterizedType parameterizedType, TypeCache cache, Deque<TypeVariableInfo> typeVariableStack) {
+            ParameterizedType parameterizedType, TypeCache cache, TypeVariables typeVariables) {
         List<Type> arguments = parameterizedType.arguments();
         ResultHandle typeArgsHandle = creator.newArray(java.lang.reflect.Type.class, creator.load(arguments.size()));
         for (int i = 0; i < arguments.size(); i++) {
             AssignableResultHandle argumentHandle = creator.createVariable(Object.class);
-            getTypeHandle(argumentHandle, creator, arguments.get(i), tccl, cache, typeVariableStack);
+            getTypeHandle(argumentHandle, creator, arguments.get(i), tccl, cache, typeVariables);
             creator.writeArrayValue(typeArgsHandle, i, argumentHandle);
         }
         Type rawType = Type.create(parameterizedType.name(), Kind.CLASS);
@@ -278,13 +291,17 @@ public final class Types {
 
     public static void getParameterizedType(AssignableResultHandle variable, BytecodeCreator creator, ResultHandle tccl,
             ParameterizedType parameterizedType) {
-        getParameterizedType(variable, creator, tccl, parameterizedType, null, new ArrayDeque<>());
+        TypeVariables typeVariables = new TypeVariables();
+        getParameterizedType(variable, creator, tccl, parameterizedType, null, typeVariables);
+        typeVariables.patchReferences(creator);
     }
 
     public static ResultHandle getParameterizedType(BytecodeCreator creator, ResultHandle tccl,
             ParameterizedType parameterizedType) {
         AssignableResultHandle result = creator.createVariable(Object.class);
-        getParameterizedType(result, creator, tccl, parameterizedType, null, new ArrayDeque<>());
+        TypeVariables typeVariables = new TypeVariables();
+        getParameterizedType(result, creator, tccl, parameterizedType, null, typeVariables);
+        typeVariables.patchReferences(creator);
         return result;
     }
 

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanTypeAssignabilityRules.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/BeanTypeAssignabilityRules.java
@@ -183,7 +183,7 @@ class BeanTypeAssignabilityRules {
      * Standard Java covariant assignability rules are applied to all other types of bounds.
      * This is not explicitly mentioned in the specification but is implied.
      */
-    Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
+    static Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
         if (bound.getBounds()[0] instanceof TypeVariable<?>) {
             return getUppermostTypeVariableBounds((TypeVariable<?>) bound.getBounds()[0]);
         }

--- a/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ParameterizedTypeImpl.java
+++ b/independent-projects/arc/runtime/src/main/java/io/quarkus/arc/impl/ParameterizedTypeImpl.java
@@ -80,9 +80,9 @@ public class ParameterizedTypeImpl implements ParameterizedType, Serializable {
                 } else {
                     sb.append(actualType);
                 }
-                sb.append(",");
+                sb.append(", ");
             }
-            sb.delete(sb.length() - 1, sb.length());
+            sb.delete(sb.length() - 2, sb.length());
             sb.append(">");
         }
         return sb.toString();

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/GenericBeanTypesTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/bean/types/GenericBeanTypesTest.java
@@ -10,7 +10,9 @@ import java.util.Iterator;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -21,10 +23,10 @@ import io.quarkus.arc.test.ArcTestContainer;
 
 public class GenericBeanTypesTest {
     @RegisterExtension
-    ArcTestContainer container = new ArcTestContainer(MyBean.class);
+    ArcTestContainer container = new ArcTestContainer(MyBean.class, Producer.class);
 
     @Test
-    public void customGenericBean() {
+    public void recursiveGeneric() {
         InjectableBean<Object> bean = Arc.container().instance("myBean").getBean();
         Set<Type> types = bean.getTypes();
 
@@ -38,18 +40,91 @@ public class GenericBeanTypesTest {
                 assertEquals(1, ((ParameterizedType) type).getActualTypeArguments().length);
                 Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
                 assertTrue(typeArg instanceof TypeVariable);
-                assertEquals("T", ((TypeVariable) typeArg).getName());
+                assertEquals("T", ((TypeVariable<?>) typeArg).getName());
 
-                assertEquals(1, ((TypeVariable) typeArg).getBounds().length);
-                Type bound = ((TypeVariable) typeArg).getBounds()[0];
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                Type bound = ((TypeVariable<?>) typeArg).getBounds()[0];
                 assertTrue(bound instanceof ParameterizedType);
                 assertEquals(Comparable.class, ((ParameterizedType) bound).getRawType());
 
                 assertEquals(1, ((ParameterizedType) bound).getActualTypeArguments().length);
                 Type boundTypeArg = ((ParameterizedType) bound).getActualTypeArguments()[0];
                 assertTrue(boundTypeArg instanceof TypeVariable);
-                assertEquals("T", ((TypeVariable) boundTypeArg).getName());
+                assertEquals("T", ((TypeVariable<?>) boundTypeArg).getName());
                 // recursive
+            }
+        }
+    }
+
+    @Test
+    public void duplicateRecursiveGeneric() {
+        InjectableBean<Object> bean = Arc.container().instance("foobar").getBean();
+        Set<Type> types = bean.getTypes();
+        assertEquals(2, types.size());
+        assertTrue(types.contains(Object.class));
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                Type genericClass = ((ParameterizedType) type).getRawType();
+                assertEquals(FooBar.class, genericClass);
+
+                assertEquals(2, ((ParameterizedType) type).getActualTypeArguments().length);
+
+                Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("T", ((TypeVariable<?>) typeArg).getName());
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                Type bound = ((TypeVariable<?>) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(FooBar.class, ((ParameterizedType) bound).getRawType());
+
+                typeArg = ((ParameterizedType) type).getActualTypeArguments()[1];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("U", ((TypeVariable<?>) typeArg).getName());
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                bound = ((TypeVariable<?>) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(Comparable.class, ((ParameterizedType) bound).getRawType());
+            }
+        }
+    }
+
+    @Test
+    public void mutuallyRecursiveGeneric() {
+        InjectableBean<Object> bean = Arc.container().instance("graph").getBean();
+        Set<Type> types = bean.getTypes();
+        System.out.println(types);
+        assertEquals(2, types.size());
+        assertTrue(types.contains(Object.class));
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                Type genericClass = ((ParameterizedType) type).getRawType();
+                assertEquals(Graph.class, genericClass);
+
+                assertEquals(3, ((ParameterizedType) type).getActualTypeArguments().length);
+
+                Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("G", ((TypeVariable<?>) typeArg).getName());
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                Type bound = ((TypeVariable<?>) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(Graph.class, ((ParameterizedType) bound).getRawType());
+
+                typeArg = ((ParameterizedType) type).getActualTypeArguments()[1];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("E", ((TypeVariable<?>) typeArg).getName());
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                bound = ((TypeVariable<?>) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(Edge.class, ((ParameterizedType) bound).getRawType());
+
+                typeArg = ((ParameterizedType) type).getActualTypeArguments()[2];
+                assertTrue(typeArg instanceof TypeVariable);
+                assertEquals("N", ((TypeVariable<?>) typeArg).getName());
+                assertEquals(1, ((TypeVariable<?>) typeArg).getBounds().length);
+                bound = ((TypeVariable<?>) typeArg).getBounds()[0];
+                assertTrue(bound instanceof ParameterizedType);
+                assertEquals(Node.class, ((ParameterizedType) bound).getRawType());
             }
         }
     }
@@ -61,5 +136,36 @@ public class GenericBeanTypesTest {
         public Iterator<T> iterator() {
             return null;
         }
+    }
+
+    @Singleton
+    static class Producer {
+        @Produces
+        @Dependent
+        @Named("foobar")
+        <T extends FooBar<T, U>, U extends Comparable<U>> FooBar<T, U> produceFooBar() {
+            return new FooBar<>() {
+            };
+        }
+
+        @Produces
+        @Dependent
+        @Named("graph")
+        <G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> Graph<G, E, N> produceGraph() {
+            return new Graph<>() {
+            };
+        }
+    }
+
+    interface FooBar<T extends FooBar<?, U>, U extends Comparable<U>> {
+    }
+
+    interface Graph<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Edge<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Node<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
     }
 }

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/MutuallyRecursiveGenericTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/MutuallyRecursiveGenericTest.java
@@ -1,0 +1,66 @@
+package io.quarkus.arc.test.producer.generic;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class MutuallyRecursiveGenericTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class, Target.class)
+            .additionalClasses(Graph.class, Edge.class, Node.class, Map.class, Route.class, City.class)
+            .build();
+
+    @Test
+    public void test() {
+        Target target = Arc.container().instance(Target.class).get();
+        assertNotNull(target.graph);
+
+        assertNotNull(Arc.container().instance(new TypeLiteral<Graph<Map, Route, City>>() {
+        }).get());
+    }
+
+    @Singleton
+    static class Producer {
+        @Produces
+        @Dependent
+        <G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> Graph<G, E, N> produce() {
+            return new Graph<>() {
+            };
+        }
+    }
+
+    @Singleton
+    static class Target {
+        @Inject
+        Graph<Map, Route, City> graph;
+    }
+
+    interface Graph<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Edge<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Node<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    static class Map implements Graph<Map, Route, City> {
+    }
+
+    static class Route implements Edge<Map, Route, City> {
+    }
+
+    static class City implements Node<Map, Route, City> {
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/RecursiveGenericInvalidTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/RecursiveGenericInvalidTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.arc.test.producer.generic;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class RecursiveGenericInvalidTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class, Target.class)
+            .shouldFail()
+            .build();
+
+    @Test
+    public void test() {
+        assertNotNull(container.getFailure());
+        assertTrue(container.getFailure().getMessage().contains("Unsatisfied dependency"),
+                container.getFailure().getMessage());
+    }
+
+    @Singleton
+    static class Producer {
+        @Produces
+        @Dependent
+        <T extends Comparable<T>> List<T> produce() {
+            return new ArrayList<>();
+        }
+    }
+
+    @Singleton
+    static class Target {
+        @Inject
+        List<Object> list; // Object is not Comparable, this injection point can't be resolved
+    }
+}

--- a/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/RecursiveGenericTest.java
+++ b/independent-projects/arc/tests/src/test/java/io/quarkus/arc/test/producer/generic/RecursiveGenericTest.java
@@ -1,0 +1,45 @@
+package io.quarkus.arc.test.producer.generic;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.test.ArcTestContainer;
+
+public class RecursiveGenericTest {
+    @RegisterExtension
+    public ArcTestContainer container = ArcTestContainer.builder()
+            .beanClasses(Producer.class, Target.class)
+            .build();
+
+    @Test
+    public void test() {
+        Target target = Arc.container().instance(Target.class).get();
+        assertNotNull(target.list);
+    }
+
+    @Singleton
+    static class Producer {
+        @Produces
+        @Dependent
+        <T extends Comparable<T>> List<T> produce() {
+            return new ArrayList<>();
+        }
+    }
+
+    @Singleton
+    static class Target {
+        @Inject
+        List<String> list;
+    }
+}


### PR DESCRIPTION
Fixes #17147

Includes 3 commits:

### ArC: fix assignability check during build-time resolution

The `AssignabilityCheck.isAssignableFrom()` method used to search a Jandex index for subtypes of first type to determine if it is assignable from the second type. This doesn't work well with on-demand indexing; for example, if we ask the index for all subtypes of `Comparable`, we don't get anything, because JDK types are not in the index.

This commit reverses the `isAssignableFrom()` logic: instead of searching the index for subtypes of the first type, it searches the index for supertypes of the second. That works well with on-demand indexing and doesn't change meaning.

This change alone is enough to fix build-time resolution that involves recursive generic type. For example, a `@Dependent` producer method for type `List<T>`, where `T extends Comparable<T>`, now correctly matches when resolving an injection point of type `List<String>`.

### ArC: fix runtime representation of recursive bean types

This was already attempted once, but the previous fix only worked well for simple recursive generic types. This commit fixes the runtime representation even for mutually recursive generic types.

The fix uses the following observation: in a type, multiple occurences of a type variable (as denoted by the type variable identifier) always refers to the same type. Therefore, it is not necessary to maintain a stack of type variables as they being processed. Instead, a simple string-keyed map is enough to:

1. canonicalize all occurences of a type variable;
2. canonicalize all occurences of a type variable reference;
3. at the end, patch all type variable references to point to the type variables.

The canonicalization was not performed before, but is necessarsy now (to correctly handle equality of multiple occurences of type variables), plus it also slightly improves runtime footprint of the set of bean types.

### ArC: fix bean type assignability for recursive generic types

This is adapted from [WELD-2738](https://github.com/weld/core/pull/2826).