### PR TITLE
Ensure that Transfer-Encoding and Content-Length are not both set

### DIFF
--- a/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
+++ b/independent-projects/resteasy-reactive/server/runtime/src/main/java/org/jboss/resteasy/reactive/server/core/ServerSerialisers.java
@@ -522,6 +522,9 @@ public class ServerSerialisers extends Serialisers {
                         vertxResponse.addResponseHeader(header, (CharSequence) HeaderUtil.headerToString(o));
                     }
                 }
+                if (header.equals("Transfer-Encoding")) { // using both headers together is not allowed
+                    vertxResponse.removeResponseHeader("Content-Length");
+                }
             } else {
                 List<CharSequence> strValues = new ArrayList<>(entry.getValue().size());
                 for (Object o : entry.getValue()) {

--- a/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/headers/ChunkedHeaderTest.java
+++ b/independent-projects/resteasy-reactive/server/vertx/src/test/java/org/jboss/resteasy/reactive/server/vertx/test/headers/ChunkedHeaderTest.java
@@ -1,0 +1,40 @@
+package org.jboss.resteasy.reactive.server.vertx.test.headers;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.reactive.server.vertx.test.framework.ResteasyReactiveUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ChunkedHeaderTest {
+
+    @RegisterExtension
+    static ResteasyReactiveUnitTest TEST = new ResteasyReactiveUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(TestResource.class));
+
+    @Test
+    public void testReturnUni() {
+        given()
+                .get("/test/hello")
+                .then()
+                .statusCode(200)
+                .headers("Transfer-Encoding", "chunked")
+                .headers("Content-Length", is(nullValue()));
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @Path("hello")
+        public Response hello() {
+            return Response.ok("hello").header("Transfer-Encoding", "chunked").build();
+        }
+    }
+}


### PR DESCRIPTION
The combination of these two HTTP headers is illegal, so let's make sure RESTEasy Reactive does not send the Content-Length header when Transfer-Encoding is set

Fixes: #29059