### PR TITLE
Introduce a workflow for linting with Vale

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -53,8 +53,8 @@ jobs:
           key: q2maven-doc-${{ steps.get-date.outputs.date }}
       - name: Build
         run: |
-          ./mvnw -Dquickly-ci -B -DskipDocs=false --settings .github/mvn-settings.xml install
+          ./mvnw -DquicklyDocs -B --settings .github/mvn-settings.xml
 
       - name: Build Docs
         run: |
-          ./mvnw -e -B --settings .github/mvn-settings.xml clean org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc -pl docs -Ddocumentation-pdf
+          ./mvnw -e -B --settings .github/mvn-settings.xml clean package -pl docs

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,33 @@
+---
+name: Linting with Vale
+on:
+  pull_request:
+    paths:
+      - 'docs/src/main/asciidoc/**'
+      - '.github/workflows/vale.yml'
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'quarkusio/quarkus' }}
+
+jobs:
+  vale:
+    name: Linting with Vale
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Vale Linter
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          fail_on_error: false
+          vale_flags: "--no-exit --config=docs/.vale/vale.ini"
+          filter_mode: diff_context
+          files: docs/src/main/asciidoc/
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Here is the CI setup for Vale.

From what I can see, with `fail_on_error: false`, the build still fails if Vale complains about something. I think it's probably not a big deal as it's probably a good idea to make people aware of it so that we can fine tune the config.

I'm wondering if it could be useful to ping someone from the doc team (Michelle) for failing Vale workflows? At least once we are confident about the setup? Let me know if you think it has value, I can probably do something about it.

Keeping it as a draft for now as I would like to set up the label we talked about with @michelle-purcell today and send an email to the list before actually enabling it.

Fixes #29103