### PR TITLE
Fail with 401 if single IdentityProvider produced no SecurityIdentity

### DIFF
--- a/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
+++ b/extensions/amazon-lambda-rest/runtime/src/main/java/io/quarkus/amazon/lambda/http/LambdaHttpAuthenticationMechanism.java
@@ -68,7 +68,8 @@ public class LambdaHttpAuthenticationMechanism implements HttpAuthenticationMech
         final boolean isSamLocal = Boolean.parseBoolean(systemEnvironment.get("AWS_SAM_LOCAL"));
         final String forcedUserName = systemEnvironment.get("QUARKUS_AWS_LAMBDA_FORCE_USER_NAME");
         return (isSamLocal && forcedUserName != null) || (event.getRequestContext() != null
-                && (event.getRequestContext().getAuthorizer() != null || event.getRequestContext().getIdentity() != null));
+                && (event.getRequestContext().getAuthorizer() != null || (event.getRequestContext().getIdentity() != null
+                        && event.getRequestContext().getIdentity().getUser() != null)));
     }
 
     @Override

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/IdentityProviderTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/IdentityProviderTestCase.java
@@ -1,0 +1,83 @@
+package io.quarkus.vertx.http.security;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class IdentityProviderTestCase {
+
+    private static final String APP_PROPS = "" +
+            "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.r1.roles-allowed=test\n" +
+            "quarkus.http.auth.permission.roles1.paths=/secured\n" +
+            "quarkus.http.auth.permission.roles1.policy=r1\n";
+    private static final String AUTHENTICATION_FAILED_EXCEPTION = "AuthenticationFailedException";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(
+                            TestIdentityProvider.class, TestIdentityController.class,
+                            PathHandler.class)
+                    .addAsResource(new StringAsset(APP_PROPS), "application.properties");
+        }
+    });
+
+    @Test
+    public void testAuthFailedExIsThrownIfIdentityIsNull() {
+        // verify that when a matching HttpAuthenticationMechanism requests the request credentials be converted
+        // to SecurityIdentity and IdentityProvider returns null then AuthenticationFailedException is thrown;
+        // previously an anonymous identity was returned and request continued without exception
+        RestAssured
+                .given()
+                .auth().basic("trix", "1234")
+                .get("/secured")
+                .then()
+                .assertThat()
+                .statusCode(401)
+                .body(Matchers.equalTo(AUTHENTICATION_FAILED_EXCEPTION));
+    }
+
+    @ApplicationScoped
+    public static class ExceptionHandler {
+
+        @Inject
+        Router router;
+
+        public void init(@Observes StartupEvent startupEvent) {
+            router.route().failureHandler(new Handler<RoutingContext>() {
+                @Override
+                public void handle(RoutingContext routingContext) {
+                    if (routingContext.failure() instanceof AuthenticationFailedException) {
+                        routingContext.response().end(AUTHENTICATION_FAILED_EXCEPTION);
+                    } else {
+                        routingContext.next();
+                    }
+                }
+            });
+        }
+
+    }
+
+}


### PR DESCRIPTION
fixes: #17591

Currently when multiple identity providers are applied on HTTP request and they all return null, an `AuthenticationFailedException` is thrown. When single identity provider is applied on HTTP request, request is allowed to continue with anonymous identity. In practice, it should still respond with 401 as auth/roles allowed policy still requires non-anonymous identity and response correct status, however that depends from which context is `io.quarkus.security.identity.IdentityProviderManager#authenticate` called. We should make behavior uniform. I believe current behavior for single identity provider has been added by accident in https://github.com/quarkusio/quarkus/pull/8903 as previous behavior also thrown exception (see https://github.com/quarkusio/quarkus/pull/8352)