### PR TITLE
Configure redis client beans from config for programmatic injection

### DIFF
--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/RedisConfigClientNamesTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/RedisConfigClientNamesTest.java
@@ -1,0 +1,149 @@
+package io.quarkus.redis.client.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+
+public class RedisConfigClientNamesTest {
+
+    SmallRyeConfig config;
+
+    @AfterEach
+    void tearDown() {
+        if (config != null) {
+            ConfigProviderResolver.instance().releaseConfig(config);
+        }
+    }
+
+    private void createConfig(Map<String, String> configMap) {
+        config = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("test", configMap) {
+                })
+                .build();
+    }
+
+    @Test
+    void testWithEmptyConfig() {
+        createConfig(Map.of());
+        DevServicesConfig devservices = new DevServicesConfig();
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservices;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+        redisBuildTimeConfig.additionalDevServices = Map.of();
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).isEmpty();
+    }
+
+    @Test
+    void testWithDefaultConfig() {
+        createConfig(Map.of());
+        DevServicesConfig devservices = new DevServicesConfig();
+        devservices.enabled = true;
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservices;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+        redisBuildTimeConfig.additionalDevServices = Map.of();
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).containsOnly("<default>");
+    }
+
+    @Test
+    void testWithAdditionalDevServices() {
+        createConfig(Map.of());
+        DevServicesConfig devservicesCfg = new DevServicesConfig();
+        devservicesCfg.enabled = true;
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservicesCfg;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+
+        DevServicesConfig additionalDevService = new DevServicesConfig();
+        additionalDevService.enabled = true;
+
+        RedisBuildTimeConfig.DevServiceConfiguration additional = new RedisBuildTimeConfig.DevServiceConfiguration();
+        additional.devservices = additionalDevService;
+        redisBuildTimeConfig.additionalDevServices = Map.of("additional", additional);
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).containsOnly("<default>", "additional");
+    }
+
+    @Test
+    void testWithDisabledDefaultDevServiceConfig() {
+        createConfig(Map.of());
+        DevServicesConfig devservicesCfg = new DevServicesConfig();
+        devservicesCfg.enabled = false;
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservicesCfg;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+
+        DevServicesConfig additionalDevService = new DevServicesConfig();
+        additionalDevService.enabled = true;
+
+        RedisBuildTimeConfig.DevServiceConfiguration additional = new RedisBuildTimeConfig.DevServiceConfiguration();
+        additional.devservices = additionalDevService;
+        redisBuildTimeConfig.additionalDevServices = Map.of("additional", additional);
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).containsOnly("additional");
+    }
+
+    @Test
+    void testWithDisabledDefaultDevServiceWithHostsConfig() {
+        createConfig(Map.of("quarkus.redis.hosts", "redis://localhost:1234"));
+        DevServicesConfig devservicesCfg = new DevServicesConfig();
+        devservicesCfg.enabled = false;
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservicesCfg;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+
+        redisBuildTimeConfig.additionalDevServices = Map.of();
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).containsOnly("<default>");
+    }
+
+    @Test
+    void testWithDisabledDefaultDevServiceWithAdditionalHostsConfig() {
+        createConfig(Map.of("quarkus.redis.my-redis.hosts", "redis://localhost:5678",
+                "quarkus.redis.my-redis-2.hosts-provider-name", "my-redis-2-provider"));
+        DevServicesConfig devservicesCfg = new DevServicesConfig();
+        devservicesCfg.enabled = false;
+
+        RedisBuildTimeConfig.DevServiceConfiguration devService = new RedisBuildTimeConfig.DevServiceConfiguration();
+        devService.devservices = devservicesCfg;
+
+        RedisBuildTimeConfig redisBuildTimeConfig = new RedisBuildTimeConfig();
+        redisBuildTimeConfig.defaultDevService = devService;
+
+        redisBuildTimeConfig.additionalDevServices = Map.of();
+
+        Set<String> names = RedisClientProcessor.configuredClientNames(redisBuildTimeConfig, config);
+        assertThat(names).containsOnly("my-redis", "my-redis-2");
+    }
+}

--- a/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/RedisNoConfTest.java
+++ b/extensions/redis-client/deployment/src/test/java/io/quarkus/redis/client/deployment/RedisNoConfTest.java
@@ -18,7 +18,8 @@ public class RedisNoConfTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
-            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.redis.devservices.enabled", "false");
 
     @Inject
     @Any

--- a/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/RedisStateStore.java
+++ b/extensions/smallrye-reactive-messaging-kafka/runtime/src/main/java/io/quarkus/smallrye/reactivemessaging/kafka/RedisStateStore.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -65,7 +66,7 @@ public class RedisStateStore implements CheckpointStateStore {
                     .orElse(null);
             ReactiveRedisDataSource rds = clientName != null
                     ? redisDataSource.select(RedisClientName.Literal.of(clientName)).get()
-                    : redisDataSource.get();
+                    : redisDataSource.select(Default.Literal.INSTANCE).get();
             ProcessingStateCodec stateCodec = CDIUtils.getInstanceById(stateCodecFactory, config.getChannel(), () -> {
                 if (stateCodecFactory.isUnsatisfied()) {
                     return VertxJsonProcessingStateCodec.FACTORY;

--- a/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithInstanceInjectionResource.java
+++ b/integration-tests/redis-client/src/main/java/io/quarkus/redis/it/RedisWithInstanceInjectionResource.java
@@ -1,0 +1,57 @@
+package io.quarkus.redis.it;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.ValueCommands;
+import io.smallrye.mutiny.Uni;
+
+@Path("/quarkus-redis-with-instance")
+@ApplicationScoped
+public class RedisWithInstanceInjectionResource {
+
+    private final ValueCommands<String, String> blocking;
+    private final ReactiveValueCommands<String, String> reactive;
+
+    public RedisWithInstanceInjectionResource(@Any Instance<RedisDataSource> ds,
+            @Any Instance<ReactiveRedisDataSource> reactiveDs) {
+        blocking = ds.select(RedisClientName.Literal.of("instance-client")).get().value(String.class);
+        reactive = reactiveDs.select(RedisClientName.Literal.of("instance-client")).get().value(String.class);
+    }
+
+    // synchronous
+    @GET
+    @Path("/sync/{key}")
+    public String getSync(@PathParam("key") String key) {
+        return blocking.get(key);
+    }
+
+    @POST
+    @Path("/sync/{key}")
+    public void setSync(@PathParam("key") String key, String value) {
+        blocking.set(key, value);
+    }
+
+    // reactive
+    @GET
+    @Path("/reactive/{key}")
+    public Uni<String> getReactive(@PathParam("key") String key) {
+        return reactive.get(key);
+    }
+
+    @POST
+    @Path("/reactive/{key}")
+    public Uni<Void> setReactive(@PathParam("key") String key, String value) {
+        return this.reactive.set(key, value);
+    }
+
+}

--- a/integration-tests/redis-client/src/main/resources/application.properties
+++ b/integration-tests/redis-client/src/main/resources/application.properties
@@ -4,5 +4,6 @@ quarkus.redis.named-reactive-client.hosts=redis://localhost:6379/1
 quarkus.redis.named-client-legacy.hosts=redis://localhost:6379/4
 quarkus.redis.named-reactive-client-legacy.hosts=redis://localhost:6379/4
 quarkus.redis.parameter-injection.hosts=redis://localhost:6379/2
+quarkus.redis.instance-client.hosts=redis://localhost:6379/5
 # use DB 3
 quarkus.redis.provided-hosts.hosts-provider-name=test-hosts-provider

--- a/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisTest.java
+++ b/integration-tests/redis-client/src/test/java/io/quarkus/redis/it/QuarkusRedisTest.java
@@ -18,6 +18,7 @@ class QuarkusRedisTest {
             "/quarkus-redis",
             "/quarkus-redis-with-name",
             "/quarkus-redis-with-name-legacy",
+            "/quarkus-redis-with-instance",
             "/quarkus-redis-provided-hosts",
             "/quarkus-redis-parameter-injection-legacy"
     };


### PR DESCRIPTION
Take 2 for #29344 (reverted in #29382).

Instead of changing RedisConfig to runtime_fixed, the redis processor searches for configured redis hosts in smallrye config.