### PR TITLE
Exclude Netty's reflection configuration files

### DIFF
--- a/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOverrideMetadata.java
+++ b/extensions/netty/deployment/src/main/java/io/quarkus/netty/deployment/NettyOverrideMetadata.java
@@ -1,0 +1,21 @@
+package io.quarkus.netty.deployment;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.nativeimage.ExcludeConfigBuildItem;
+
+public class NettyOverrideMetadata {
+
+    static final String NETTY_CODEC_JAR_MATCH_REGEX = "io\\.netty\\.netty-codec";
+    static final String NETTY_CODEC_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/io\\.netty/netty-codec/generated/handlers/reflect-config\\.json";
+    static final String NETTY_HANDLER_JAR_MATCH_REGEX = "io\\.netty\\.netty-handler";
+    static final String NETTY_HANDLER_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/io\\.netty/netty-handler/generated/handlers/reflect-config\\.json";
+
+    @BuildStep
+    void excludeNettyDirectives(BuildProducer<ExcludeConfigBuildItem> nativeImageExclusions) {
+        nativeImageExclusions
+                .produce(new ExcludeConfigBuildItem(NETTY_CODEC_JAR_MATCH_REGEX, NETTY_CODEC_REFLECT_CONFIG_MATCH_REGEX));
+        nativeImageExclusions
+                .produce(new ExcludeConfigBuildItem(NETTY_HANDLER_JAR_MATCH_REGEX, NETTY_HANDLER_REFLECT_CONFIG_MATCH_REGEX));
+    }
+}


### PR DESCRIPTION
These are causing warnigns during native image compilation as they try to access classes that are not on the
classpath (e.g. `net.jpountz.lz4.LZ4Exception`).

Closes #29413