### PR TITLE
Add more content to the Basic Auth Howto document

### DIFF
--- a/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
+++ b/docs/src/main/asciidoc/security-basic-authentication-howto.adoc
@@ -8,7 +8,9 @@ Enable Basic authentication for your Quarkus project and allow users to authenti
 == Prerequisites
  
 * You have installed at least one extension that provides an `IdentityProvider` based on username and password, such as xref:security-jdbc.adoc[Elytron JDBC].
- 
+
+== Procedure
+
 . Enable Basic authentication by setting the value of `quarkus.http.auth.basic` property to `true`.
 +
 [source,properties]
@@ -16,7 +18,30 @@ Enable Basic authentication for your Quarkus project and allow users to authenti
 quarkus.http.auth.basic=true
 ----
  
-For a Basic authentication configuration walk-through that uses `JPA`, see the xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication] guide.
+An easy way to configure the required user credentials for Basic authentication to work is to configure the user name, secret, and roles directly in the `application.properties` file.
+
+.Example of Basic authentication properties
+
+[source,properties]
+----
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.alice=alice
+quarkus.security.users.embedded.users.bob=bob
+quarkus.security.users.embedded.roles.alice=admin
+quarkus.security.users.embedded.roles.bob=user
+----
+
+In this configuration the credentials for users `alice` and `bob` are configured: `alice` has a password `alice` and an `admin` role, `bob` has a password `bob` and a `user` role.
+
+For more information, see xref:security-testing.adoc#configuring-user-information[Configuring User Information] in the "Security Testing" guide.
+
+[IMPORTANT]
+====
+Configuring user names, secrets, and roles in the `application.properties` file is only suitable for testing scenarios. If you are securing an application for production, always use a database to store this information.
+====
+
+To walk through how to configure Basic authentication together with JPA for storing user credentials in a database, see the xref:security-basic-authentication-tutorial.adoc[Secure a Quarkus application with Basic authentication] tutorial.
  
 == Additional resources
 


### PR DESCRIPTION
Fixes #29472

This PR adds more content to the Basic Auth Howto document. It provides a short summary of how Basic Auth can be supported in Quarkus, beyond just enabling it: a link to the security testing doc is added where it is shown how to test BasicAuth by embedding all the user configuration directly in `application.properties` but then it is recommended to use DB instead referencing a link to the tutorial using JPA (which is already available in this doc)

@michelle-purcell Please review when you get a chance, please don't hesitate to fix English grammar issues, `a` vs `the`, etc as well :-) 