### PR TITLE
Docs - Fix typo in Front-Channel Logout documentation section

### DIFF
--- a/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
+++ b/docs/src/main/asciidoc/security-openid-connect-web-authentication.adoc
@@ -525,7 +525,7 @@ quarkus.oidc.application-type=web-app
 quarkus.oidc.logout.frontchannel.path=/front-channel-logout
 ----
 
-This path will be compared against the current request's path and the user willbe logged out if these paths match.
+This path will be compared against the current request's path and the user will be logged out if these paths match.
 
 [[local-logout]]
 ==== Local Logout


### PR DESCRIPTION
Fixes single typo.