### PR TITLE
Improve Form based authentication with single-page application

### DIFF
--- a/docs/src/main/asciidoc/security-built-in-authentication-support-concept.adoc
+++ b/docs/src/main/asciidoc/security-built-in-authentication-support-concept.adoc
@@ -30,6 +30,18 @@ value. This cookie contains an expiry time as part of the encrypted value, so al
 clocks synchronized. At one minute intervals a new cookie will be generated with an updated expiry time if the session
 is in use.
 
+Single Page Application (SPA) typically wants to avoid redirects, this can be done by removing default page paths:
+
+[source,properties]
+----
+# do not redirect, respond with HTTP 200 OK
+quarkus.http.auth.form.landing-page=
+
+# do not redirect, respond with HTTP 401 Unauthorized
+quarkus.http.auth.form.login-page=
+quarkus.http.auth.form.error-page=
+----
+
 The following properties can be used to configure form based auth:
 
 include::{generated-dir}/config/quarkus-vertx-http-config-group-form-auth-config.adoc[opts=optional, leveloffset=+1]

--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthNoRedirectAfterLoginTestCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/security/FormAuthNoRedirectAfterLoginTestCase.java
@@ -1,9 +1,6 @@
 package io.quarkus.vertx.http.security;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 import java.util.function.Supplier;
 
@@ -20,13 +17,14 @@ import io.quarkus.test.QuarkusUnitTest;
 import io.restassured.RestAssured;
 import io.restassured.filter.cookie.CookieFilter;
 
-public class FormAuthNoRedirectTestCase {
+public class FormAuthNoRedirectAfterLoginTestCase {
 
     private static final String APP_PROPS = "" +
             "quarkus.http.auth.form.enabled=true\n" +
-            "quarkus.http.auth.form.login-page=\n" +
-            "quarkus.http.auth.form.error-page=\n" +
-            "quarkus.http.auth.form.landing-page=\n" +
+            "quarkus.http.auth.form.login-page=login\n" +
+            "quarkus.http.auth.form.error-page=error\n" +
+            "quarkus.http.auth.form.landing-page=landing\n" +
+            "quarkus.http.auth.form.redirect-after-login=false\n" +
             "quarkus.http.auth.policy.r1.roles-allowed=a d m i n\n" +
             "quarkus.http.auth.permission.roles1.paths=/admin\n" +
             "quarkus.http.auth.permission.roles1.policy=r1\n";
@@ -50,11 +48,14 @@ public class FormAuthNoRedirectTestCase {
 
     /**
      * First, protected /admin resource is accessed. No quarkus-credential cookie
-     * is presented by the client, so server should respond with 401.
+     * is presented by the client, so server should redirect to /login page.
      *
      * Next, let's assume there was a login form on the /login page,
      * we do POST with valid credentials.
-     * Server should provide a response with quarkus-credential cookie and respond with 200.
+     * Server should provide a response with quarkus-credential cookie
+     * and a redirect to the previously attempted /admin page.
+     * Note the redirect takes place despite having quarkus.http.auth.form.redirect-after-login=false
+     * because there is some previous location to redirect to.
      *
      * Last but not least, client accesses the protected /admin resource again,
      * this time providing server with stored quarkus-credential cookie.
@@ -72,8 +73,9 @@ public class FormAuthNoRedirectTestCase {
                 .get("/admin")
                 .then()
                 .assertThat()
-                .statusCode(401)
-                .header("location", nullValue());
+                .statusCode(302)
+                .header("location", containsString("/login"))
+                .cookie("quarkus-redirect-location", containsString("/admin"));
 
         RestAssured
                 .given()
@@ -85,8 +87,8 @@ public class FormAuthNoRedirectTestCase {
                 .post("/j_security_check")
                 .then()
                 .assertThat()
-                .statusCode(200)
-                .header("location", nullValue())
+                .statusCode(302)
+                .header("location", containsString("/admin"))
                 .cookie("quarkus-credential", notNullValue());
 
         RestAssured
@@ -102,7 +104,7 @@ public class FormAuthNoRedirectTestCase {
     }
 
     @Test
-    public void testFormBasedAuthSuccessNoLocation() {
+    public void testFormBasedAuthSuccessLandingPage() {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
         CookieFilter cookies = new CookieFilter();
         RestAssured
@@ -116,24 +118,6 @@ public class FormAuthNoRedirectTestCase {
                 .then()
                 .assertThat()
                 .statusCode(200)
-                .cookie("quarkus-credential", notNullValue());
-    }
-
-    @Test
-    public void testFormBasedAuthSuccessWithLocation() {
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-        RestAssured
-                .given()
-                .cookie("quarkus-redirect-location", "http://localhost:8081/admin")
-                .redirects().follow(false)
-                .when()
-                .formParam("j_username", "a d m i n")
-                .formParam("j_password", "a d m i n")
-                .post("/j_security_check")
-                .then()
-                .assertThat()
-                .statusCode(302)
-                .header("location", containsString("/admin"))
                 .cookie("quarkus-credential", notNullValue());
     }
 
@@ -151,7 +135,8 @@ public class FormAuthNoRedirectTestCase {
                 .post("/j_security_check")
                 .then()
                 .assertThat()
-                .header("location", nullValue())
-                .statusCode(401);
+                .statusCode(302)
+                .header("location", containsString("/error"))
+                .header("quarkus-credential", nullValue());
     }
 }

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/FormAuthConfig.java
@@ -1,6 +1,7 @@
 package io.quarkus.vertx.http.runtime;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -11,16 +12,16 @@ import io.quarkus.runtime.annotations.ConfigItem;
 @ConfigGroup
 public class FormAuthConfig {
     /**
-     * If form authentication is enabled
+     * If form authentication is enabled.
      */
     @ConfigItem
     public boolean enabled;
 
     /**
-     * The login page
+     * The login page. Redirect to login page can be disabled by setting `quarkus.http.auth.form.login-page=`.
      */
     @ConfigItem(defaultValue = "/login.html")
-    public String loginPage;
+    public Optional<String> loginPage;
 
     /**
      * The post location.
@@ -41,22 +42,28 @@ public class FormAuthConfig {
     public String passwordParameter;
 
     /**
-     * The error page
+     * The error page. Redirect to error page can be disabled by setting `quarkus.http.auth.form.error-page=`.
      */
     @ConfigItem(defaultValue = "/error.html")
-    public String errorPage;
+    public Optional<String> errorPage;
 
     /**
-     * The landing page to redirect to if there is no saved page to redirect back to
+     * The landing page to redirect to if there is no saved page to redirect back to.
+     * Redirect to landing page can be disabled by setting `quarkus.http.auth.form.landing-page=`.
      */
     @ConfigItem(defaultValue = "/index.html")
-    public String landingPage;
+    public Optional<String> landingPage;
 
     /**
      * Option to disable redirect to landingPage if there is no saved page to redirect back to. Form Auth POST is followed
      * by redirect to landingPage by default.
+     *
+     * @deprecated redirect to landingPage can be disabled by removing default landing page
+     *             (via `quarkus.http.auth.form.landing-page=`). Quarkus will ignore this configuration property
+     *             if there is no landing page.
      */
     @ConfigItem(defaultValue = "true")
+    @Deprecated
     public boolean redirectAfterLogin;
 
     /**

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpSecurityRecorder.java
@@ -224,6 +224,7 @@ public class HttpSecurityRecorder {
     public Supplier<FormAuthenticationMechanism> setupFormAuth() {
 
         return new Supplier<FormAuthenticationMechanism>() {
+
             @Override
             public FormAuthenticationMechanism get() {
                 String key;
@@ -243,10 +244,10 @@ public class HttpSecurityRecorder {
                 FormAuthConfig form = buildTimeConfig.auth.form;
                 PersistentLoginManager loginManager = new PersistentLoginManager(key, form.cookieName, form.timeout.toMillis(),
                         form.newCookieInterval.toMillis(), form.httpOnlyCookie);
-                String loginPage = form.loginPage.startsWith("/") ? form.loginPage : "/" + form.loginPage;
-                String errorPage = form.errorPage.startsWith("/") ? form.errorPage : "/" + form.errorPage;
-                String landingPage = form.landingPage.startsWith("/") ? form.landingPage : "/" + form.landingPage;
-                String postLocation = form.postLocation.startsWith("/") ? form.postLocation : "/" + form.postLocation;
+                String loginPage = startWithSlash(form.loginPage.orElse(null));
+                String errorPage = startWithSlash(form.errorPage.orElse(null));
+                String landingPage = startWithSlash(form.landingPage.orElse(null));
+                String postLocation = startWithSlash(form.postLocation);
                 String usernameParameter = form.usernameParameter;
                 String passwordParameter = form.passwordParameter;
                 String locationCookie = form.locationCookie;
@@ -255,6 +256,13 @@ public class HttpSecurityRecorder {
                         errorPage, landingPage, redirectAfterLogin, locationCookie, loginManager);
             }
         };
+    }
+
+    private static String startWithSlash(String page) {
+        if (page == null) {
+            return null;
+        }
+        return page.startsWith("/") ? page : "/" + page;
     }
 
     public Supplier<?> setupBasicAuth(HttpBuildTimeConfig buildTimeConfig) {

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/PersistentLoginManager.java
@@ -63,7 +63,7 @@ public class PersistentLoginManager {
     }
 
     public RestoreResult restore(RoutingContext context, String cookieName) {
-        Cookie existing = context.getCookie(cookieName);
+        Cookie existing = context.request().getCookie(cookieName);
         // If there is no credential cookie, we have nothing to restore.
         if (existing == null) {
             // Enforce new login.


### PR DESCRIPTION
closes: #12457

Our form based authentication redirects from single-page application (SPA) point of view in following situations:

- user landed on secured page unauthenticated (steps):
  - BE request
  - redirect to login page (store original location cookie)
  - login request (post-location)
  - on success redirect to original location; on failure, redirect to error page
- user landed on login page:
  - login request (post-location)
  - on success redirect to original location; on failure, redirect to error page
- session expired:
  - redirect to login page (store original location cookie)
  - login request (post-location)
  - on success redirect to original location; on failure, redirect to error page

Therefore it's clear there are 4 possible redirect locations:

- login page
- landing page
- error page
- original destination stored in `location-cookie` and only stored when redirecting to login page, therefore when there is no redirect to login page, this destination is never stored

While most SPA HTTP client are able to choose to not follow redirect, it requires extra code; SPA want to be in control - serve login/error/... page without reloading based on HTTP response status code. SPA want to receive 401 (login failure/login expired) or 200 (login success).

To cut a long story short, BE for SPA wants to block redirects to

- login page
- landing page
- error page

This PR makes page properties optional with default values (error.html, index.html, login.html), thus behavior is backwards compatible. User that don't want redirects to the pages simply remove default value (optional configuration properties are nullabe). `quarkus.http.auth.form.redirect-after-login` is marked deprecated as it equals `quarkus.http.auth.form.landing-page=` (AKA: if there is no landing page, there is nowhere to redirect. when there is location cookie, redirect still happen).
