### PR TITLE
Optionally include OIDC application endpoint in generated OpenAPI document

### DIFF
--- a/extensions/oidc/deployment/pom.xml
+++ b/extensions/oidc/deployment/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>quarkus-jsonp-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <exclusions>

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcBuildTimeConfig.java
@@ -27,4 +27,14 @@ public class OidcBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "true")
     public boolean defaultTokenCacheEnabled;
+
+    /**
+     * Whether to include the OIDC application endpoints in the generated OpenAPI document.
+     * For example, OIDC may expose logout endpoints that are not included by default.
+     * If you want the OpenAPI document to include paths defined by runtime configuration property, as are
+     * `quarkus.oidc.logout.path`, `quarkus.oidc.logout.backchannel.path` and `quarkus.oidc.logout.frontchannel.path`,
+     * you must define them in the Quarkus configuration file at build time.
+     */
+    @ConfigItem(defaultValue = "false", name = "openapi.included")
+    public boolean openapiIncluded;
 }

--- a/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcOpenAPIFilter.java
+++ b/extensions/oidc/deployment/src/main/java/io/quarkus/oidc/deployment/OidcOpenAPIFilter.java
@@ -1,0 +1,163 @@
+package io.quarkus.oidc.deployment;
+
+import static io.quarkus.oidc.common.runtime.OidcConstants.BACK_CHANNEL_LOGOUT_SID_CLAIM;
+import static io.quarkus.oidc.common.runtime.OidcConstants.BACK_CHANNEL_LOGOUT_TOKEN;
+import static io.quarkus.oidc.common.runtime.OidcConstants.FRONT_CHANNEL_LOGOUT_SID_PARAM;
+
+import java.util.List;
+
+import org.eclipse.microprofile.jwt.Claims;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.models.responses.APIResponse;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
+
+import io.smallrye.openapi.api.models.ComponentsImpl;
+import io.smallrye.openapi.api.models.OperationImpl;
+import io.smallrye.openapi.api.models.PathItemImpl;
+import io.smallrye.openapi.api.models.PathsImpl;
+import io.smallrye.openapi.api.models.media.ContentImpl;
+import io.smallrye.openapi.api.models.media.MediaTypeImpl;
+import io.smallrye.openapi.api.models.parameters.ParameterImpl;
+import io.smallrye.openapi.api.models.parameters.RequestBodyImpl;
+import io.smallrye.openapi.api.models.responses.APIResponseImpl;
+import io.smallrye.openapi.api.models.responses.APIResponsesImpl;
+
+/**
+ * Create OpenAPI entries (if configured) for OIDC application endpoints.
+ */
+public class OidcOpenAPIFilter implements OASFilter {
+    private static final List<String> OIDC_TAG = List.of("OpenID Connect application endpoint");
+    private final String logoutPath;
+    private final String backchannelPath;
+    private final String frontchannelPath;
+
+    public OidcOpenAPIFilter(String logoutPath, String backchannelPath, String frontchannelPath) {
+        this.logoutPath = logoutPath;
+        this.backchannelPath = backchannelPath;
+        this.frontchannelPath = frontchannelPath;
+    }
+
+    @Override
+    public void filterOpenAPI(OpenAPI openAPI) {
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new ComponentsImpl());
+        }
+
+        if (openAPI.getPaths() == null) {
+            openAPI.setPaths(new PathsImpl());
+        }
+        Paths paths = openAPI.getPaths();
+
+        // Logout
+        paths.addPathItem(logoutPath, createLogoutPathItem());
+
+        // Back-Channel Logout
+        paths.addPathItem(backchannelPath, createBackchannelPathItem());
+
+        // Front-Channel Logout
+        paths.addPathItem(frontchannelPath, createFrontchannelPathItem());
+    }
+
+    private PathItem createLogoutPathItem() {
+        PathItem pathItem = new PathItemImpl();
+        pathItem.setSummary("OpenID Connect - RP-Initiated Logout");
+        pathItem.setDescription("See https://openid.net/specs/openid-connect-rpinitiated-1_0.html");
+        pathItem.setGET(createLogoutOperation());
+        return pathItem;
+    }
+
+    private PathItem createBackchannelPathItem() {
+        PathItem pathItem = new PathItemImpl();
+        pathItem.setSummary("OpenID Connect - Back-Channel Logout Endpoint");
+        pathItem.setDescription("See https://openid.net/specs/openid-connect-backchannel-1_0.html");
+        pathItem.setPOST(createBackchannelOperation());
+        return pathItem;
+    }
+
+    private PathItem createFrontchannelPathItem() {
+        PathItem pathItem = new PathItemImpl();
+        pathItem.setSummary("OpenID Connect - Front-Channel Logout Endpoint");
+        pathItem.setDescription("See https://openid.net/specs/openid-connect-frontchannel-1_0.html");
+        pathItem.setGET(createFrontchannelOperation());
+        return pathItem;
+    }
+
+    private Operation createLogoutOperation() {
+        Operation operation = new OperationImpl();
+        operation.setDescription(
+                "The application is able to initiate the logout through this endpoint in conformance with the OpenID Connect RP-Initiated Logout specification.");
+        operation.setOperationId("oidc_logout");
+        operation.setTags(OIDC_TAG);
+        operation.setSummary("The logout endpoint of this application");
+        operation.setResponses(createRedirectAPIResponses());
+        return operation;
+    }
+
+    private Operation createBackchannelOperation() {
+        Operation operation = new OperationImpl();
+        // formData contains logout_token passed as parameter
+        operation.requestBody(createFormDataRequestBody());
+        operation.setDescription("See https://openid.net/specs/openid-connect-backchannel-1_0.html");
+        operation.setOperationId("oidc_backchannel_logout");
+        operation.setTags(OIDC_TAG);
+        operation.setSummary("The Back-Channel Logout endpoint at the application");
+        // param description comes from specs
+        Parameter sidQueryParam = new ParameterImpl().name(BACK_CHANNEL_LOGOUT_SID_CLAIM).description(
+                "Session ID - String identifier for a Session. This represents a Session of a User Agent or device for a logged-in End-User at an RP.");
+        Parameter logoutTokenParam = new ParameterImpl().style(Parameter.Style.FORM).name(BACK_CHANNEL_LOGOUT_TOKEN);
+        operation.setParameters(List.of(sidQueryParam, logoutTokenParam));
+        operation.setResponses(createBackchannelAPIResponses());
+        return operation;
+    }
+
+    private RequestBody createFormDataRequestBody() {
+        return new RequestBodyImpl()
+                .content(new ContentImpl().addMediaType("application/x-www-form-urlencoded", new MediaTypeImpl()));
+    }
+
+    private Operation createFrontchannelOperation() {
+        Operation operation = new OperationImpl();
+        operation.setDescription("See https://openid.net/specs/openid-connect-frontchannel-1_0.html");
+        operation.setOperationId("oidc_frontchannel_logout");
+        operation.setTags(OIDC_TAG);
+        operation.setSummary("The Front-Channel Logout endpoint at the application");
+        // param description comes partially from specs
+        Parameter issQueryParam = new ParameterImpl().name(Claims.iss.name()).description(
+                "Issuer Identifier for the OP issuing the front-channel logout request. Frontchannel issuer parameter must match the ID token issuer.");
+        Parameter sidQueryParam = new ParameterImpl().name(FRONT_CHANNEL_LOGOUT_SID_PARAM).description(
+                "Identifier for the Session. Frontchannel session id parameter must match the ID token session id.");
+        operation.setParameters(List.of(issQueryParam, sidQueryParam));
+        operation.setResponses(createRedirectAPIResponses());
+        return operation;
+    }
+
+    private APIResponses createRedirectAPIResponses() {
+        APIResponses responses = new APIResponsesImpl();
+        responses.addAPIResponse("302", createAPIResponse("Found"));
+        responses.addAPIResponse("401", createAPIResponse("Unauthorized"));
+        responses.addAPIResponse("500", createAPIResponse("Internal Server Error"));
+        return responses;
+    }
+
+    private APIResponses createBackchannelAPIResponses() {
+        APIResponses responses = new APIResponsesImpl();
+        responses.addAPIResponse("200", createAPIResponse("OK"));
+        responses.addAPIResponse("400", createAPIResponse("Bad Request"));
+        responses.addAPIResponse("401", createAPIResponse("Unauthorized"));
+        responses.addAPIResponse("500", createAPIResponse("Internal Server Error"));
+        return responses;
+    }
+
+    private APIResponse createAPIResponse(String description) {
+        APIResponse response = new APIResponseImpl();
+        response.setDescription(description);
+        return response;
+    }
+
+}

--- a/integration-tests/oidc-wiremock/pom.xml
+++ b/integration-tests/oidc-wiremock/pom.xml
@@ -22,6 +22,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -67,6 +71,19 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/integration-tests/oidc-wiremock/src/main/resources/application.properties
+++ b/integration-tests/oidc-wiremock/src/main/resources/application.properties
@@ -135,3 +135,6 @@ quarkus.http.auth.permission.backchannellogout.paths=/back-channel-logout
 quarkus.http.auth.permission.backchannellogout.policy=permit
 
 quarkus.native.additional-build-args=-H:IncludeResources=private.*\\.*
+
+# include the OIDC application endpoints in the generated OpenAPI document
+quarkus.oidc.openapi.included=true

--- a/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/OpenApiOidcApplicationEndpointsTest.java
+++ b/integration-tests/oidc-wiremock/src/test/java/io/quarkus/it/keycloak/OpenApiOidcApplicationEndpointsTest.java
@@ -1,0 +1,22 @@
+package io.quarkus.it.keycloak;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class OpenApiOidcApplicationEndpointsTest {
+
+    @Test
+    public void testOidcApplicationEndpointsAreListed() {
+        RestAssured.given().queryParam("format", "JSON")
+                .when().get("/q/openapi")
+                .then()
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .body("paths", Matchers.hasKey("/code-flow-form-post/front-channel-logout"))
+                .body("paths", Matchers.hasKey("/back-channel-logout"))
+                .body("paths", Matchers.hasKey("/code-flow/logout"));
+    }
+}


### PR DESCRIPTION
closes: #26015

Add an option to include OIDC application endpoints in generated OpenAPI document. I found 3 application endpoints exposed by OIDC - rp-initiated logout, backchannel logout and frontchannel logout and they are all defined by runtime configuration properties. OpenAPI document is generated at build time, therefore the endpoints are only included in the document if user defined them at build time.

IMHO there are at least 3 reasons why it's good thing to have endpoints included:

- user opened issue for Swagger UI that uses OpenAPI document
- OpenAPI document is commonly used by FE developers to generate HTTP client and serves as contract between FE and BE, if we don't include the endpoints in the document, developers has to write a client himself or BE developer has to produce custom extension that adds the endpoints.
- OpenAPI document is sometimes part of documentation provided as contractor, f.e. when multiple teams from different companies work on big project and generated document should include full interface. While we don't include some other endpoints as form based auth endpoints, these are less likely to be used in corporate projects.