### PR TITLE
Allow to customize response body of 403 issued by HTTP policy

### DIFF
--- a/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ProactiveAuthHttpPolicyCustomForbiddenExMapperTest.java
+++ b/extensions/resteasy-classic/resteasy/deployment/src/test/java/io/quarkus/resteasy/test/security/ProactiveAuthHttpPolicyCustomForbiddenExMapperTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.resteasy.test.security;
+
+import static io.quarkus.resteasy.test.security.ProactiveAuthHttpPolicyCustomForbiddenExMapperTest.CustomForbiddenExceptionMapper.CUSTOM_FORBIDDEN_EXCEPTION_MAPPER;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import javax.annotation.Priority;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class ProactiveAuthHttpPolicyCustomForbiddenExMapperTest {
+
+    private static final String PROPERTIES = "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.user-policy.roles-allowed=user\n" +
+            "quarkus.http.auth.permission.roles.paths=/secured\n" +
+            "quarkus.http.auth.permission.roles.policy=user-policy";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, CustomForbiddenExceptionMapper.class)
+                    .addAsResource(new StringAsset(PROPERTIES), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testDeniedAccessAdminResource() {
+        RestAssured.given()
+                .auth().basic("a d m i n", "a d m i n")
+                .when().get("/secured")
+                .then()
+                .statusCode(403)
+                .body(equalTo(CUSTOM_FORBIDDEN_EXCEPTION_MAPPER));
+    }
+
+    @Path("/secured")
+    public static class SecuredResource {
+
+        @GET
+        public String get() {
+            throw new IllegalStateException();
+        }
+
+    }
+
+    @Priority(Priorities.USER)
+    @Provider
+    public static class CustomForbiddenExceptionMapper implements ExceptionMapper<ForbiddenException> {
+
+        public static final String CUSTOM_FORBIDDEN_EXCEPTION_MAPPER = CustomForbiddenExceptionMapper.class.getName();
+
+        @Override
+        public Response toResponse(ForbiddenException e) {
+            return Response.status(FORBIDDEN).entity(CUSTOM_FORBIDDEN_EXCEPTION_MAPPER).build();
+        }
+    }
+
+}

--- a/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
+++ b/extensions/resteasy-classic/resteasy/runtime/src/main/java/io/quarkus/resteasy/runtime/standalone/ResteasyStandaloneRecorder.java
@@ -19,6 +19,7 @@ import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.security.AuthenticationCompletionException;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.AuthenticationRedirectException;
+import io.quarkus.security.ForbiddenException;
 import io.quarkus.vertx.http.runtime.HttpConfiguration;
 import io.quarkus.vertx.http.runtime.security.HttpSecurityRecorder.DefaultAuthFailureHandler;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
@@ -91,7 +92,8 @@ public class ResteasyStandaloneRecorder {
                 public void handle(RoutingContext request) {
                     if (request.failure() instanceof AuthenticationFailedException
                             || request.failure() instanceof AuthenticationCompletionException
-                            || request.failure() instanceof AuthenticationRedirectException) {
+                            || request.failure() instanceof AuthenticationRedirectException
+                            || request.failure() instanceof ForbiddenException) {
                         super.handle(request);
                     } else {
                         request.next();

--- a/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthHttpPolicyForbiddenHandlerTest.java
+++ b/extensions/resteasy-reactive/quarkus-resteasy-reactive/deployment/src/test/java/io/quarkus/resteasy/reactive/server/test/security/ProactiveAuthHttpPolicyForbiddenHandlerTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.resteasy.reactive.server.test.security;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.web.Route;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpServerResponse;
+
+public class ProactiveAuthHttpPolicyForbiddenHandlerTest {
+
+    private static final String PROPERTIES = "quarkus.http.auth.basic=true\n" +
+            "quarkus.http.auth.policy.user-policy.roles-allowed=user\n" +
+            "quarkus.http.auth.permission.roles.paths=/secured\n" +
+            "quarkus.http.auth.permission.roles.policy=user-policy";
+
+    @RegisterExtension
+    static QuarkusUnitTest test = new QuarkusUnitTest().setArchiveProducer(new Supplier<>() {
+        @Override
+        public JavaArchive get() {
+            return ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(TestIdentityProvider.class, TestIdentityController.class, CustomForbiddenFailureHandler.class)
+                    .addAsResource(new StringAsset(PROPERTIES), "application.properties");
+        }
+    });
+
+    @BeforeAll
+    public static void setup() {
+        TestIdentityController.resetRoles().add("a d m i n", "a d m i n", "a d m i n");
+    }
+
+    @Test
+    public void testDeniedAccessAdminResource() {
+        RestAssured.given()
+                .auth().basic("a d m i n", "a d m i n")
+                .when().get("/secured")
+                .then()
+                .statusCode(403)
+                .body(equalTo(CustomForbiddenFailureHandler.CUSTOM_FORBIDDEN_EXCEPTION_MAPPER));
+    }
+
+    @Path("/secured")
+    public static class SecuredResource {
+
+        @GET
+        public String get() {
+            throw new IllegalStateException();
+        }
+
+    }
+
+    /**
+     * Use failure handler as when proactive security is enabled, JAX-RS exception mappers won't do.
+     */
+    public static final class CustomForbiddenFailureHandler {
+
+        public static final String CUSTOM_FORBIDDEN_EXCEPTION_MAPPER = CustomForbiddenFailureHandler.class.getName();
+
+        @Route(type = Route.HandlerType.FAILURE)
+        void handle(ForbiddenException e, HttpServerResponse response) {
+            response.setStatusCode(FORBIDDEN.getStatusCode()).end(CUSTOM_FORBIDDEN_EXCEPTION_MAPPER);
+        }
+
+    }
+
+}

--- a/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
+++ b/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/security/HttpAuthorizer.java
@@ -14,6 +14,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.runtime.BlockingOperationControl;
 import io.quarkus.runtime.ExecutorRecorder;
 import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.spi.runtime.AuthorizationController;
@@ -186,7 +187,7 @@ public class HttpAuthorizer {
                         }
                     });
                 } else {
-                    routingContext.fail(403);
+                    routingContext.fail(new ForbiddenException());
                 }
             }
 


### PR DESCRIPTION
closes: #5751

Allow to customize response body of 403 that comes from HTTP policy by exception mappers. IMO the rest of #5751 has already been fixed as explain in https://github.com/quarkusio/quarkus/issues/5751#issuecomment-1329673303. This PR throws `ForbiddenException` rather simply failing event with 403, that allows builtin exception mappers that are present in both RESTEasy Reactive and Classic to handle the exception.