### PR TITLE
Fix JDBC Oracle exclude config for windows native builds

### DIFF
--- a/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
+++ b/extensions/jdbc/jdbc-oracle/deployment/src/main/java/io/quarkus/jdbc/oracle/deployment/OracleMetadataOverrides.java
@@ -34,7 +34,7 @@ import io.quarkus.maven.dependency.ArtifactKey;
  */
 public final class OracleMetadataOverrides {
 
-    static final String DRIVER_JAR_MATCH_REGEX = ".*com\\.oracle\\.database\\.jdbc.*";
+    static final String DRIVER_JAR_MATCH_REGEX = "com\\.oracle\\.database\\.jdbc";
     static final String NATIVE_IMAGE_RESOURCE_MATCH_REGEX = "/META-INF/native-image/native-image\\.properties";
     static final String NATIVE_IMAGE_REFLECT_CONFIG_MATCH_REGEX = "/META-INF/native-image/reflect-config\\.json";
 


### PR DESCRIPTION
* Quoting the exclude-config pattern fixes the issue:
```
Error: Unknown argument: quarkus-integration-test-jpa-oracle-999-SNAPSHOT-runner
```
* After quoting the pattern we can use a more complex regex to avoid the need for two excludeconfig build items