### PR TITLE
Update to Stork 1.3.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -53,7 +53,7 @@
         <smallrye-reactive-types-converter.version>2.7.0</smallrye-reactive-types-converter.version>
         <smallrye-mutiny-vertx-binding.version>2.28.0</smallrye-mutiny-vertx-binding.version>
         <smallrye-reactive-messaging.version>3.22.0</smallrye-reactive-messaging.version>
-        <smallrye-stork.version>1.3.0</smallrye-stork.version>
+        <smallrye-stork.version>1.3.3</smallrye-stork.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.4</jakarta.el-impl.version>


### PR DESCRIPTION
 reverting the SLF4J API version to 1.7.x (instead of 2.x)