### PR TITLE
Allow same origin requests

### DIFF
--- a/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
+++ b/extensions/vertx-http/deployment/src/test/java/io/quarkus/vertx/http/cors/CORSHandlerTestWildcardOriginCase.java
@@ -50,6 +50,60 @@ class CORSHandlerTestWildcardOriginCase {
     }
 
     @Test
+    void corsSameOriginRequest() {
+        String origin = "http://localhost:8081";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", origin);
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest1() {
+        String origin = "http";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest2() {
+        String origin = "http://local";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest3() {
+        String origin = "http://localhost";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest4() {
+        String origin = "http://localhost:9999";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void corsInvalidSameOriginRequest5() {
+        String origin = "https://localhost:8483";
+        given().header("Origin", origin)
+                .get("/test").then()
+                .statusCode(403)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
     @DisplayName("Returns false 'Access-Control-Allow-Credentials' header on matching origin '*'")
     void corsMatchingOriginWithWildcard() {
         String origin = "*";


### PR DESCRIPTION
Fixes #29542.

Same origin `POST` requests are currently blocked due to the recent changes enforcing the `Origin` header verification for simple (non-preflight) requests. This causes side-effects where the same `Origin` `POST` request is made. 
The workaround which may also be viewed as a recommended solution in such cases is to explicitly list `Origins` representing the current host,  however in some cases in may not scale.

This PR updates the main CORS filter to treat the requests as the same `Origin` requests if:
1. Request URI starts from the `Origin` value
2. Origin URI has a non-null scheme and host
3. Origin URI has a port value or if it has no port then the request URI must not have it set either