### PR TITLE
Bump flapdoodle.mongodb.version to 3.5.3

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -169,7 +169,7 @@
         <okhttp.version>3.14.9</okhttp.version><!-- keep in sync with okio -->
         <okio.version>1.17.2</okio.version><!-- keep in sync with okhttp -->
         <hibernate-quarkus-local-cache.version>0.1.1</hibernate-quarkus-local-cache.version>
-        <flapdoodle.mongo.version>3.5.2</flapdoodle.mongo.version>
+        <flapdoodle.mongo.version>3.5.3</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP7</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>
         <quarkus-spring-security-api.version>5.3.Final</quarkus-spring-security-api.version>


### PR DESCRIPTION
Fixes issue on CentOS 9
https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.packageresolver/issues/4