### PR TITLE
Move Google Cloud Function extensions to stable

### DIFF
--- a/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions-http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,7 +10,7 @@ metadata:
   categories:
   - "cloud"
   guide: "https://quarkus.io/guides/gcp-functions-http"
-  status: "preview"
+  status: "stable"
   codestart:
     name: "google-cloud-functions-http"
     kind: "example"

--- a/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/extensions/google-cloud-functions/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -9,7 +9,7 @@ metadata:
   categories:
   - "cloud"
   guide: "https://quarkus.io/guides/gcp-functions"
-  status: "preview"
+  status: "stable"
   codestart:
     name: "google-cloud-functions"
     kind: "example"


### PR DESCRIPTION
But keep Funqy related one in preview for now as Funqy is still an experimental API.