### PR TITLE
Use -XX:ArchiveClassesAtExit for AppCDS creation in Java 17+

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/shutdown/ShutdownRecorder.java
@@ -30,6 +30,9 @@ public class ShutdownRecorder {
     }
 
     public static void runShutdown() {
+        if (shutdownListeners == null) {
+            return;
+        }
         log.debug("Attempting to gracefully shutdown.");
         try {
             CountDownLatch preShutdown = new CountDownLatch(shutdownListeners.size());


### PR DESCRIPTION
Not only does this simplify the process of generating the AppCDS,
but for some reason it also leads to an archive that is both smaller
and more useful for the JVM (meaning that it reduces startup time
more).

For example using the `rest-json-quickstart` on my machine I got the following:

_Without AppCDS_: **~450ms**
_With old AppCDS_: **~400ms**
_With new AppCDS_: **~340ms**