### PR TITLE
Follow the recommendation to add the name for the credential provider

### DIFF
--- a/integration-tests/bouncycastle-jsse/src/main/java/io/quarkus/it/bouncycastle/SecretProvider.java
+++ b/integration-tests/bouncycastle-jsse/src/main/java/io/quarkus/it/bouncycastle/SecretProvider.java
@@ -4,12 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.credentials.CredentialsProvider;
 
 @ApplicationScoped
 @Unremovable
+@Named("custom-secret-provider")
 public class SecretProvider implements CredentialsProvider {
 
     @Override

--- a/integration-tests/bouncycastle-jsse/src/main/resources/application.properties
+++ b/integration-tests/bouncycastle-jsse/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.http.ssl.certificate.key-store-password-key=keystore-password
 quarkus.http.ssl.certificate.trust-store-file=server-truststore.jks
 quarkus.http.ssl.certificate.trust-store-password-key=truststore-password
 quarkus.http.ssl.certificate.credentials-provider=custom
+quarkus.http.ssl.certificate.credentials-provider-name=custom-secret-provider
 
 quarkus.http.ssl.client-auth=REQUIRED
 quarkus.native.additional-build-args=-H:IncludeResources=.*\\.jks


### PR DESCRIPTION
Follow the recommendation to add the name for the credential provider

https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus.http.ssl.certificate.credentials-provider-name