### PR TITLE
K8s resource generation

### DIFF
--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddCronJobResourceDecorator.java
@@ -64,11 +64,11 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
 
         // defaults for:
         // - match labels
-        if (jobTemplateSpec.getSelector().getMatchLabels() == null) {
+        if (jobTemplateSpec.buildSelector().getMatchLabels() == null) {
             jobTemplateSpec.editSelector().withMatchLabels(new HashMap<>()).endSelector();
         }
         // - termination grace period seconds
-        if (jobTemplateSpec.getTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
+        if (jobTemplateSpec.buildTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
             jobTemplateSpec.editTemplate().editSpec().withTerminationGracePeriodSeconds(10L).endSpec().endTemplate();
         }
         // - container
@@ -107,7 +107,7 @@ public class AddCronJobResourceDecorator extends ResourceProvidingDecorator<Kube
     }
 
     private boolean containsContainerWithName(CronJobFluent.SpecNested<CronJobBuilder> spec) {
-        var jobTemplate = spec.getJobTemplate();
+        var jobTemplate = spec.buildJobTemplate();
         if (jobTemplate == null
                 || jobTemplate.getSpec() == null
                 || jobTemplate.getSpec().getTemplate() == null

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddJobResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddJobResourceDecorator.java
@@ -54,11 +54,11 @@ public class AddJobResourceDecorator extends ResourceProvidingDecorator<Kubernet
 
         // defaults for:
         // - match labels
-        if (spec.getSelector().getMatchLabels() == null) {
+        if (spec.buildSelector().getMatchLabels() == null) {
             spec.editSelector().withMatchLabels(new HashMap<>()).endSelector();
         }
         // - termination grace period seconds
-        if (spec.getTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
+        if (spec.buildTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
             spec.editTemplate().editSpec().withTerminationGracePeriodSeconds(10L).endSpec().endTemplate();
         }
         // - container
@@ -90,7 +90,7 @@ public class AddJobResourceDecorator extends ResourceProvidingDecorator<Kubernet
     }
 
     private boolean containsContainerWithName(JobFluent.SpecNested<JobBuilder> spec) {
-        List<Container> containers = spec.getTemplate().getSpec().getContainers();
+        List<Container> containers = spec.buildTemplate().getSpec().getContainers();
         return containers == null || containers.stream().anyMatch(c -> name.equals(c.getName()));
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKnativeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKnativeConfig.java
@@ -28,7 +28,7 @@ public class AddPortToKnativeConfig extends Configurator<KnativeConfigFluent<?>>
      * @return True if port with same container port exists.
      */
     private boolean hasPort(KnativeConfigFluent<?> config) {
-        for (Port p : config.getPorts()) {
+        for (Port p : config.buildPorts()) {
             if (p.getContainerPort() == port.getContainerPort()) {
                 return true;
             }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToKubernetesConfig.java
@@ -28,7 +28,7 @@ public class AddPortToKubernetesConfig extends Configurator<KubernetesConfigFlue
      * @return True if port with same container port exists.
      */
     private boolean hasPort(KubernetesConfigFluent<?> config) {
-        for (Port p : config.getPorts()) {
+        for (Port p : config.buildPorts()) {
             if (p.getContainerPort() == port.getContainerPort()) {
                 return true;
             }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToOpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddPortToOpenshiftConfig.java
@@ -28,7 +28,7 @@ public class AddPortToOpenshiftConfig extends Configurator<OpenshiftConfigFluent
      * @return True if port with same container port exists.
      */
     private boolean hasPort(OpenshiftConfigFluent<?> config) {
-        for (Port p : config.getPorts()) {
+        for (Port p : config.buildPorts()) {
             if (p.getContainerPort() == port.getContainerPort()) {
                 return true;
             }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddStatefulSetResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/AddStatefulSetResourceDecorator.java
@@ -65,11 +65,11 @@ public class AddStatefulSetResourceDecorator extends ResourceProvidingDecorator<
             spec.withServiceName(name);
         }
         // - match labels
-        if (spec.getSelector().getMatchLabels() == null) {
+        if (spec.buildSelector().getMatchLabels() == null) {
             spec.editSelector().withMatchLabels(new HashMap<>()).endSelector();
         }
         // - termination grace period seconds
-        if (spec.getTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
+        if (spec.buildTemplate().getSpec().getTerminationGracePeriodSeconds() == null) {
             spec.editTemplate().editSpec().withTerminationGracePeriodSeconds(10L).endSpec().endTemplate();
         }
         // - container
@@ -92,7 +92,7 @@ public class AddStatefulSetResourceDecorator extends ResourceProvidingDecorator<
     }
 
     private boolean containsContainerWithName(StatefulSetFluent.SpecNested<StatefulSetBuilder> spec) {
-        List<Container> containers = spec.getTemplate().getSpec().getContainers();
+        List<Container> containers = spec.buildTemplate().getSpec().getContainers();
         return containers == null || containers.stream().anyMatch(c -> name.equals(c.getName()));
     }
 }

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesConfig.java
@@ -105,8 +105,6 @@ public class KubernetesConfig implements PlatformConfiguration {
 
     /**
      * The arguments
-     *
-     * @return The arguments
      */
     @ConfigItem
     Optional<List<String>> arguments;
@@ -123,6 +121,7 @@ public class KubernetesConfig implements PlatformConfiguration {
      * @deprecated Use the {@code quarkus.kubernetes.ingress.host} instead
      */
     @ConfigItem
+    @Deprecated
     Optional<String> host;
 
     /**
@@ -271,6 +270,7 @@ public class KubernetesConfig implements PlatformConfiguration {
      * @deprecated Use the {@code quarkus.kubernetes.ingress.expose} instead
      */
     @ConfigItem
+    @Deprecated
     boolean expose;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesDeployer.java
@@ -230,8 +230,7 @@ public class KubernetesDeployer {
                             .orElseThrow(() -> new IllegalStateException("Could not retrieve API resource information for:"
                                     + i.getApiVersion() + " " + i.getKind() + ". Is the CRD for the resource available?"));
 
-                    client.genericKubernetesResources(context).withName(i.getMetadata().getName())
-                            .createOrReplace(genericResource);
+                    client.genericKubernetesResources(context).resource(genericResource).createOrReplace();
                 } else {
                     final var r = client.resource(i);
                     if (shouldDeleteExisting(deploymentTarget, i)) {

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/OpenshiftConfig.java
@@ -136,8 +136,6 @@ public class OpenshiftConfig implements PlatformConfiguration {
 
     /**
      * The arguments
-     *
-     * @return The arguments
      */
     @ConfigItem
     Optional<List<String>> arguments;
@@ -154,6 +152,7 @@ public class OpenshiftConfig implements PlatformConfiguration {
      * @deprecated Use the {@code quarkus.openshift.route.host} instead
      */
     @ConfigItem
+    @Deprecated
     Optional<String> host;
 
     /**
@@ -309,6 +308,7 @@ public class OpenshiftConfig implements PlatformConfiguration {
      * @deprecated Use the {@code quarkus.openshift.route.exposition} instead
      */
     @ConfigItem
+    @Deprecated
     boolean expose;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/ProbeConfig.java
@@ -12,12 +12,13 @@ public class ProbeConfig {
 
     /**
      * The http path to use for the probe For this to work, the container port also
-     * needs to be set
+     * needs to be set.
      *
      * Assuming the container port has been set (as per above comment), if
      * execAction or tcpSocketAction are not set, an HTTP probe will be used
      * automatically even if no path is set (which will result in the root path
-     * being used)
+     * being used).
+     * If Smallrye Health is used, the path will automatically be set according to the health check path.
      */
     @ConfigItem
     Optional<String> httpActionPath;
@@ -37,13 +38,13 @@ public class ProbeConfig {
     /**
      * The amount of time to wait before starting to probe.
      */
-    @ConfigItem(defaultValue = "0")
+    @ConfigItem(defaultValue = "5")
     Duration initialDelay;
 
     /**
      * The period in which the action should be called.
      */
-    @ConfigItem(defaultValue = "30s")
+    @ConfigItem(defaultValue = "10s")
     Duration period;
 
     /**

--- a/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentConfigResourceDecorator.java
+++ b/extensions/kubernetes/vanilla/deployment/src/main/java/io/quarkus/kubernetes/deployment/RemoveDeploymentConfigResourceDecorator.java
@@ -20,7 +20,7 @@ public class RemoveDeploymentConfigResourceDecorator extends Decorator<Kubernete
 
     @Override
     public void visit(KubernetesListBuilder builder) {
-        List<HasMetadata> imageStreams = builder.getItems().stream()
+        List<HasMetadata> imageStreams = builder.buildItems().stream()
                 .filter(d -> d instanceof HasMetadata)
                 .map(d -> (HasMetadata) d)
                 .filter(i -> i.getKind().equals(DEPLOYMENT_CONFIG) && i.getMetadata().getName().equalsIgnoreCase(name))

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KnativeWithHealthTest.java
@@ -58,7 +58,7 @@ public class KnativeWithHealthTest {
                                     assertThat(p.getName()).isEqualTo("http1");
                                 });
                                 assertThat(c.getReadinessProbe()).isNotNull().satisfies(p -> {
-                                    assertThat(p.getInitialDelaySeconds()).isEqualTo(0);
+                                    assertThat(p.getInitialDelaySeconds()).isEqualTo(5);
                                     assertProbePath(p, "/q/health/ready");
 
                                     assertNotNull(p.getHttpGet());

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/KubernetesWithHealthTest.java
@@ -72,7 +72,7 @@ public class KubernetesWithHealthTest {
                     assertThat(t.getSpec()).satisfies(podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
-                                assertThat(p.getInitialDelaySeconds()).isEqualTo(0);
+                                assertThat(p.getInitialDelaySeconds()).isEqualTo(5);
                                 assertProbePath(p, "/q/health/ready");
 
                                 assertNotNull(p.getHttpGet());

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/java/io/quarkus/it/kubernetes/OpenshiftWithHealthTest.java
@@ -67,13 +67,13 @@ public class OpenshiftWithHealthTest {
                     podSpec -> {
                         assertThat(podSpec.getContainers()).singleElement().satisfies(container -> {
                             assertThat(container.getReadinessProbe()).isNotNull().satisfies(p -> {
-                                assertThat(p.getPeriodSeconds()).isEqualTo(10);
+                                assertThat(p.getPeriodSeconds()).isEqualTo(15);
                                 assertThat(p.getHttpGet()).satisfies(h1 -> {
                                     assertThat(h1.getPath()).isEqualTo("/q/health/ready");
                                 });
                             });
                             assertThat(container.getLivenessProbe()).isNotNull().satisfies(p -> {
-                                assertThat(p.getPeriodSeconds()).isEqualTo(30);
+                                assertThat(p.getPeriodSeconds()).isEqualTo(10);
                                 assertThat(p.getHttpGet()).isNull();
                                 assertThat(p.getExec()).satisfies(e -> {
                                     assertThat(e.getCommand()).containsOnly("kill");

--- a/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-health.properties
+++ b/integration-tests/kubernetes/quarkus-standard-way/src/test/resources/openshift-with-health.properties
@@ -1,3 +1,3 @@
 quarkus.kubernetes.deployment-target=openshift
-quarkus.openshift.readiness-probe.period=10s
+quarkus.openshift.readiness-probe.period=15s
 quarkus.openshift.liveness-probe.exec-action=kill


### PR DESCRIPTION
As discussed in #29350 I update the probe with an initial delay of 5s and a period of 10s which is the default.
The initial delay can be challenged as a Quarkus apps with good limits (like 1CPU and 512MB) would starts in less than 3s.

I wonder if this shouldn't be documented as a breaking change, WDYT ?

Fixes #29350