### PR TITLE
Fix config editor when using HTTPS

### DIFF
--- a/extensions/vertx-http/dev-console-runtime-spi/src/main/java/io/quarkus/devconsole/runtime/spi/DevConsolePostHandler.java
+++ b/extensions/vertx-http/dev-console-runtime-spi/src/main/java/io/quarkus/devconsole/runtime/spi/DevConsolePostHandler.java
@@ -75,7 +75,7 @@ public abstract class DevConsolePostHandler implements Handler<RoutingContext> {
     protected void actionSuccess(RoutingContext event) {
         if (!event.response().ended()) {
             event.response().setStatusCode(HttpResponseStatus.SEE_OTHER.code()).headers()
-                    .set(HttpHeaderNames.LOCATION, event.request().absoluteURI());
+                    .set(HttpHeaderNames.LOCATION, event.request().uri());
             event.response().end();
         }
     }


### PR DESCRIPTION
Fixes #29431

This is a workaround though. The core of the problem is that when in HTTPS, event.request().absoluteURI() returns an HTTP url, which is wrong and leads to the redirect not working.

/cc @cescoffier 